### PR TITLE
Silence npm init output

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -12,7 +12,7 @@ rm -rf build/
 mkdir -p "$SOLC_05_DIR"
 
 cd "$SOLC_05_DIR"
-npm init --yes
+npm init --yes > /dev/null
 npm install --save-dev truffle@5.0.0
 
 rm -rf contracts


### PR DESCRIPTION
The compilation script in the solc 0.5 branch runs `npm init -y` in a subdirectory, which prints to stdout. It would be nice to silence that because it might be confusing, specially since some people are installing this branch for preliminary support for solc 0.5.