### PR TITLE
Add CircleCI status badge and update continuous integration instruction.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,9 @@ npm linter
 or you can simply run CircleCI locally
 ```bash
 circleci local execute --job build
+circleci local execute --job lint
 circleci local execute --job test
+circleci local execute --job coverage
 ```
 *Note*: requires installing CircleCI and docker locally on your machine.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # <img src="logo.png" alt="OpenZeppelin" height="40px">
 
 [![NPM Package](https://img.shields.io/npm/v/@openzeppelin/contracts.svg)](https://www.npmjs.org/package/@openzeppelin/contracts)
-[![Build Status](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts.svg?branch=master)](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts)
+[![Travis Build Status](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts.svg?branch=master)](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts)
+[![CircleCI Build Status](https://circleci.com/gh/OpenZeppelin/openzeppelin-contracts/tree/master.svg?style=svg)](https://circleci.com/gh/OpenZeppelin/openzeppelin-contracts/tree/master)
 [![Coverage Status](https://coveralls.io/repos/github/OpenZeppelin/openzeppelin-contracts/badge.svg?branch=master)](https://coveralls.io/github/OpenZeppelin/openzeppelin-contracts?branch=master)
 
 **OpenZeppelin Contracts is a library for secure smart contract development.** It provides implementations of standards like ERC20 and ERC721 which you can deploy as-is or extend to suit your needs, as well as Solidity components to build custom contracts and more complex decentralized systems.


### PR DESCRIPTION
A follow up of #1839 now that the previous commit to add CircleCI is checked in.
Reviewers please go ahead to confirm that CircleCI integration for OpenZeppelin/openzeppelin-contracts is up and running and then approve and merge this PR.