### PR TITLE
Making "uint" explicit as "uint256" within SignatureBouncerMock.sol

### DIFF
--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -28,13 +28,13 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function checkValidSignatureAndData(address account, bytes memory, uint, bytes memory signature)
+    function checkValidSignatureAndData(address account, bytes memory, uint256, bytes memory signature)
         public view returns (bool)
     {
         return _isValidSignatureAndData(account, signature);
     }
 
-    function onlyWithValidSignatureAndData(uint, bytes memory signature)
+    function onlyWithValidSignatureAndData(uint256, bytes memory signature)
         public onlyValidSignatureAndData(signature) view
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -176,7 +176,7 @@ contract ERC20 is IERC20 {
         emit Transfer(address(0), account, amount);
     }
 
-     /**
+    /**
      * @dev Destroys `amount` tokens from `account`, reducing the
      * total supply.
      *


### PR DESCRIPTION
This is a really minor change I wanted to suggest. I was looking over the repo, and noticed that this contract has an implicit type via usage of `uint`, and thought that changing it to `uint256` would be safe.

I ran the tests, and there are 27 that are failing which are unrelated to this change, I think. To be sure, I cloned a separate copy and ran the tests, and got the same results, so I imagine it is ok to make a PR?

Thanks!
Luiserebii~

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
