### PR TITLE
Remove unstructured storage from GSNContext

### DIFF
--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -12,7 +12,7 @@ import "./IRelayHub.sol";
  */
 contract GSNRecipient is IRelayRecipient, GSNContext, GSNBouncerBase {
     function getHubAddr() public view returns (address) {
-        return _getRelayHub();
+        return _relayHub;
     }
 
     // This function is view for future-proofing, it may require reading from
@@ -23,6 +23,6 @@ contract GSNRecipient is IRelayRecipient, GSNContext, GSNBouncerBase {
     }
 
     function _withdrawDeposits(uint256 amount, address payable payee) internal {
-        IRelayHub(_getRelayHub()).withdraw(amount, payee);
+        IRelayHub(_relayHub).withdraw(amount, payee);
     }
 }

--- a/contracts/mocks/GSNContextMock.sol
+++ b/contracts/mocks/GSNContextMock.sol
@@ -7,7 +7,7 @@ import "../GSN/IRelayRecipient.sol";
 // By inheriting from GSNContext, Context's internal functions are overridden automatically
 contract GSNContextMock is ContextMock, GSNContext, IRelayRecipient {
     function getHubAddr() public view returns (address) {
-        return _getRelayHub();
+        return _relayHub;
     }
 
     function acceptRelayedCall(
@@ -37,7 +37,7 @@ contract GSNContextMock is ContextMock, GSNContext, IRelayRecipient {
     }
 
     function getRelayHub() public view returns (address) {
-        return _getRelayHub();
+        return _relayHub;
     }
 
     function upgradeRelayHub(address newRelayHub) public {


### PR DESCRIPTION
It was not necessary. We will use unstructured storage for the upgradeable package only. ([openzeppelin-contracts-ethereum-package](https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package))