### PR TITLE
SafeERC20 safeBalanceOf and safeAllowance for proxy-based tokens

### DIFF
--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -4,6 +4,11 @@ import "./IERC20.sol";
 import "../../math/SafeMath.sol";
 import "../../utils/Address.sol";
 
+interface IERC20WithNonViewMethods {
+    function balanceOf(address account) external returns (uint256);
+    function allowance(address owner, address spender) external returns (uint256);
+}
+
 /**
  * @title SafeERC20
  * @dev Wrappers around ERC20 operations that throw on failure (when the token
@@ -16,6 +21,14 @@ import "../../utils/Address.sol";
 library SafeERC20 {
     using SafeMath for uint256;
     using Address for address;
+
+    function safeBalanceOf(IERC20 token, address account) external returns (uint256) {
+        return IERC20WithNonViewMethods(address(token)).balanceOf(account);
+    }
+
+    function safeAllowance(IERC20 token, address owner, address spender) external returns (uint256) {
+        return IERC20WithNonViewMethods(address(token)).allowance(owner, spender);
+    }
 
     function safeTransfer(IERC20 token, address to, uint256 value) internal {
         callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));


### PR DESCRIPTION
~`DELEGATECALL` inside `STATICCALL` produces a `REVERT`, so I just replaced `STATICALL` with `CALL`.~

~This PR solves problem:~
- ~Calling view methonds of proxy-based token smart contract from **Solidity**~

~Should also think how to fix problem:~
- ~Calling view methonds of proxy-based token smart contract from **Web3**~