### PR TITLE
Fixing really minor typo in ERC20.sol

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -177,7 +177,7 @@ contract ERC20 is Context, IERC20 {
         emit Transfer(address(0), account, amount);
     }
 
-     /**
+    /**
      * @dev Destroys `amount` tokens from `account`, reducing the
      * total supply.
      *


### PR DESCRIPTION
This is a really minor typo that @Skyge found, referenced in https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1875, I forgot to make a follow-up PR. Just corrected the positioning of a comment.

```
/** (< === here)
 *
 */
```