### PR TITLE
Make ERC1820 address constant

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -28,7 +28,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     using SafeMath for uint256;
     using Address for address;
 
-    IERC1820Registry private _erc1820 = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
+    IERC1820Registry constant private _erc1820 = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
 
     mapping(address => uint256) private _balances;
 


### PR DESCRIPTION
There's no point in using up a storage slot, given that the registry address will not change.