### PR TITLE
Make _msgSender() payable

### DIFF
--- a/contracts/GSN/Context.sol
+++ b/contracts/GSN/Context.sol
@@ -16,7 +16,7 @@ contract Context {
     constructor () internal { }
     // solhint-disable-previous-line no-empty-blocks
 
-    function _msgSender() internal view returns (address) {
+    function _msgSender() internal view returns (address payable) {
         return msg.sender;
     }
 

--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -75,7 +75,7 @@ contract GSNRecipient is IRelayRecipient, Context, GSNBouncerBase {
      *
      * IMPORTANT: Contracts derived from {GSNRecipient} should never use `msg.sender`, and use {_msgSender} instead.
      */
-    function _msgSender() internal view returns (address) {
+    function _msgSender() internal view returns (address payable) {
         if (msg.sender != _relayHub) {
             return msg.sender;
         } else {
@@ -97,7 +97,7 @@ contract GSNRecipient is IRelayRecipient, Context, GSNBouncerBase {
         }
     }
 
-    function _getRelayedCallSender() private pure returns (address result) {
+    function _getRelayedCallSender() private pure returns (address payable result) {
         // We need to read 20 bytes (an address) located at array index msg.data.length - 20. In memory, the array
         // is prefixed with a 32-byte length value, so we first add 32 to get the memory read index. However, doing
         // so would leave the address in the upper 20 bytes of the 32-byte word, which is inconvenient and would


### PR DESCRIPTION
`msg.sender` is `payable`, so `_msgSender()` should be too to make it a drop-in replacement.

Note that there's a proposal to [change this](https://github.com/ethereum/solidity/issues/6452), but since it involves a breaking change, we'll have plenty of time to respond if it goes go through.