### PR TITLE
Fix bouncer signature tests

### DIFF
--- a/test/GSN/GSNBouncerSignature.test.js
+++ b/test/GSN/GSNBouncerSignature.test.js
@@ -32,6 +32,7 @@ contract('GSNBouncerSignature', function ([_, signer, other]) {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // the nonce is not signed
+              // eslint-disable-next-line max-len
               data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas)
             ), signer
           )

--- a/test/GSN/GSNBouncerSignature.test.js
+++ b/test/GSN/GSNBouncerSignature.test.js
@@ -32,7 +32,7 @@ contract('GSNBouncerSignature', function ([_, signer, other]) {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // the nonce is not signed
-              data.relayerAddress, data.from, data.encodedFunctionCall, data.txFee, data.gasPrice, data.gas
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas)
             ), signer
           )
         );
@@ -62,7 +62,7 @@ contract('GSNBouncerSignature', function ([_, signer, other]) {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relay_address, data.from, data.encodedFunctionCall, data.txfee, data.gasPrice, data.gas, data.nonce, data.relayHubAddress, data.to
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to
             ), other
           )
         );


### PR DESCRIPTION
As noted by @crazyrabbitLTC in this [forum post](https://forum.openzeppelin.com/t/gsnsignaturebouncer-tests-not-passing-on-my-local-machine/1332), some GSN tests were failing for the wrong reason (wrong types). We should eventually have specific GSN assertions to prevent this.