### PR TITLE
Fix the GSNBouncerERC20Fee token decimals to 18

### DIFF
--- a/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol
+++ b/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol
@@ -27,11 +27,10 @@ contract GSNBouncerERC20Fee is GSNBouncerBase {
     __unstable__ERC20PrimaryAdmin private _token;
 
     /**
-     * @dev The arguments to the constructor are the details that the gas payment token will have: `name`, `symbol`, and
-     * `decimals`.
+     * @dev The arguments to the constructor are the details that the gas payment token will have: `name` and `symbol`.
      */
-    constructor(string memory name, string memory symbol, uint8 decimals) public {
-        _token = new __unstable__ERC20PrimaryAdmin(name, symbol, decimals);
+    constructor(string memory name, string memory symbol) public {
+        _token = new __unstable__ERC20PrimaryAdmin(name, symbol);
     }
 
     /**
@@ -114,7 +113,7 @@ contract GSNBouncerERC20Fee is GSNBouncerBase {
 contract __unstable__ERC20PrimaryAdmin is ERC20, ERC20Detailed, Secondary {
     uint256 private constant UINT256_MAX = 2**256 - 1;
 
-    constructor(string memory name, string memory symbol, uint8 decimals) public ERC20Detailed(name, symbol, decimals) {
+    constructor(string memory name, string memory symbol) public ERC20Detailed(name, symbol, 18) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol
+++ b/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol
@@ -27,7 +27,7 @@ contract GSNBouncerERC20Fee is GSNBouncerBase {
     __unstable__ERC20PrimaryAdmin private _token;
 
     /**
-     * @dev The arguments to the constructor are the details that the gas payment token will have: `name` and `symbol`.
+     * @dev The arguments to the constructor are the details that the gas payment token will have: `name` and `symbol`. `decimals` is hard-coded to 18.
      */
     constructor(string memory name, string memory symbol) public {
         _token = new __unstable__ERC20PrimaryAdmin(name, symbol);

--- a/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol
+++ b/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol
@@ -30,7 +30,7 @@ contract GSNBouncerERC20Fee is GSNBouncerBase {
      * @dev The arguments to the constructor are the details that the gas payment token will have: `name` and `symbol`. `decimals` is hard-coded to 18.
      */
     constructor(string memory name, string memory symbol) public {
-        _token = new __unstable__ERC20PrimaryAdmin(name, symbol);
+        _token = new __unstable__ERC20PrimaryAdmin(name, symbol, 18);
     }
 
     /**
@@ -113,7 +113,7 @@ contract GSNBouncerERC20Fee is GSNBouncerBase {
 contract __unstable__ERC20PrimaryAdmin is ERC20, ERC20Detailed, Secondary {
     uint256 private constant UINT256_MAX = 2**256 - 1;
 
-    constructor(string memory name, string memory symbol) public ERC20Detailed(name, symbol, 18) {
+    constructor(string memory name, string memory symbol, uint8 decimals) public ERC20Detailed(name, symbol, decimals) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/contracts/mocks/GSNBouncerERC20FeeMock.sol
+++ b/contracts/mocks/GSNBouncerERC20FeeMock.sol
@@ -4,7 +4,7 @@ import "../GSN/GSNRecipient.sol";
 import "../GSN/bouncers/GSNBouncerERC20Fee.sol";
 
 contract GSNBouncerERC20FeeMock is GSNRecipient, GSNBouncerERC20Fee {
-    constructor(string memory name, string memory symbol, uint8 decimals) public GSNBouncerERC20Fee(name, symbol, decimals) {
+    constructor(string memory name, string memory symbol) public GSNBouncerERC20Fee(name, symbol) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/docs/modules/ROOT/pages/gsn-bouncers.adoc
+++ b/docs/modules/ROOT/pages/gsn-bouncers.adoc
@@ -100,12 +100,10 @@ NOTE: Always use `_preRelayedCall` and `_postRelayedCall` functions.  Internal `
 
 Your GSN recipient contract needs to inherit from `GSNRecipient` and `GSNBouncerERC20Fee` along with appropriate xref:access-control.adoc[access control] (for token minting), set the token details in the constructor of `GSNBouncerERC20Fee` and create a public `mint` function suitably protected by your chosen access control as per the following sample code (which uses the xref:api:access.adoc#MinterRole[MinterRole]):
 
-NOTE: The token must have decimals of 18 to match that of ether, due to the baked-in exchange rate of 1:1.
-
 [source,solidity]
 ----
 contract MyContract is GSNRecipient, GSNBouncerERC20Fee, MinterRole {
-    constructor() public GSNBouncerERC20Fee("FeeToken", "FEE", 18) {
+    constructor() public GSNBouncerERC20Fee("FeeToken", "FEE") {
     }
 
     function mint(address account, uint256 amount) public onlyMinter {

--- a/docs/modules/ROOT/pages/gsn-bouncers.adoc
+++ b/docs/modules/ROOT/pages/gsn-bouncers.adoc
@@ -45,7 +45,7 @@ On the other hand, you need to have a backend server, microservice, or lambda fu
 
 === How does GSNBouncerSignature work?
 
-`GSNBouncerSignature` decides whether or not to accept the relayed call based on the included signature. 
+`GSNBouncerSignature` decides whether or not to accept the relayed call based on the included signature.
 
 The `acceptRelayedCall` implementation recovers the address from the signature of the relayed call parameters in `approvalData` and compares to the trusted signer.
 If the included signature matches the trusted signer, the relayed call is approved.
@@ -62,7 +62,7 @@ Your GSN recipient contract needs to inherit from `GSNRecipient` and `GSNBouncer
 contract MyContract is GSNRecipient, GSNBouncerSignature {
     constructor(address trustedSigner) public GSNBouncerSignature(trustedSigner) {
     }
-}  
+}
 ----
 
 == GSNBouncerERC20Fee
@@ -80,7 +80,7 @@ NOTE: *Users do not need to call approve* on their tokens for your recipient con
 
 === How does GSNBouncerERC20Fee work?
 
-`GSNBouncerERC20Fee` decides to approve or reject relayed calls based on the balance of the users tokens.  
+`GSNBouncerERC20Fee` decides to approve or reject relayed calls based on the balance of the users tokens.
 
 The `acceptRelayedCall` function implementation checks the users token balance.
 If the user doesn't have enough tokens the relayed call gets rejected with an error of `INSUFFICIENT_BALANCE`.
@@ -94,7 +94,7 @@ The maximum amount of tokens required is transferred in `_preRelayedCall` to pro
 
 NOTE: The gas cost estimation is not 100% accurate, we may tweak it further down the road.
 
-NOTE: Always use `_preRelayedCall` and `_postRelayedCall` functions.  Internal `_preRelayedCall` and `_postRelayedCall` functions are used instead of public `preRelayedCall` and `postRelayedCall` functions, as the public functions are prevented from being called by non-RelayHub contracts. 
+NOTE: Always use `_preRelayedCall` and `_postRelayedCall` functions.  Internal `_preRelayedCall` and `_postRelayedCall` functions are used instead of public `preRelayedCall` and `postRelayedCall` functions, as the public functions are prevented from being called by non-RelayHub contracts.
 
 === How to use GSNBouncerERC20Fee
 
@@ -118,13 +118,13 @@ You can create your own Custom Bouncer!  For example, your Custom Bouncer could 
 
 Your Custom Bouncer can inherit from `GSNBouncerBase` and must implement the `acceptRelayedCall` function.
 
-Your `acceptRelayedCall` implementation decides whether or not to accept the relayed call.  
-If your logic accepts the relayed call then you should return `_approveRelayedCall`.  
+Your `acceptRelayedCall` implementation decides whether or not to accept the relayed call.
+If your logic accepts the relayed call then you should return `_approveRelayedCall`.
 If your logic rejects the relayed call then you should return `_rejectRelayedCall` with an error code.
 See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/GSN/bouncers/GSNBouncerSignature.sol[GSNBouncerSignature.sol] as an example implementation.
 
-For Custom Bouncers charging end users, `_postRelayedCall` and `_preRelayedCall` should be implemented to handle the charging.  
-Your `_preRelayedCall` implementation should take the maximum possible charge, with your `_postRelayedCall` implementation refunding any difference from the actual charge once the relayed call has been made.  
+For Custom Bouncers charging end users, `_postRelayedCall` and `_preRelayedCall` should be implemented to handle the charging.
+Your `_preRelayedCall` implementation should take the maximum possible charge, with your `_postRelayedCall` implementation refunding any difference from the actual charge once the relayed call has been made.
 When returning `_approveRelayedCall` to approve the relayed call, the end users address, `maxPossibleCharge`, `transactionFee` and `gasPrice` data can also be returned so that the data can be used in `_preRelayedCall` and `_postRelayedCall`.
 See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v2.4.0/contracts/GSN/bouncers/GSNBouncerERC20Fee.sol[GSNBouncerERC20Fee.sol] as an example implementation.
 

--- a/test/GSN/GSNBouncerERC20Fee.test.js
+++ b/test/GSN/GSNBouncerERC20Fee.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, expectEvent } = require('openzeppelin-test-helpers');
+const { ether, expectEvent } = require('openzeppelin-test-helpers');
 const gsn = require('@openzeppelin/gsn-helpers');
 
 const { expect } = require('chai');

--- a/test/GSN/GSNBouncerERC20Fee.test.js
+++ b/test/GSN/GSNBouncerERC20Fee.test.js
@@ -10,10 +10,9 @@ const IRelayHub = artifacts.require('IRelayHub');
 contract('GSNBouncerERC20Fee', function ([_, sender, other]) {
   const name = 'FeeToken';
   const symbol = 'FTKN';
-  const decimals = new BN('18');
 
   beforeEach(async function () {
-    this.recipient = await GSNBouncerERC20FeeMock.new(name, symbol, decimals);
+    this.recipient = await GSNBouncerERC20FeeMock.new(name, symbol);
     this.token = await ERC20Detailed.at(await this.recipient.token());
   });
 
@@ -26,8 +25,8 @@ contract('GSNBouncerERC20Fee', function ([_, sender, other]) {
       expect(await this.token.symbol()).to.equal(symbol);
     });
 
-    it('has decimals', async function () {
-      expect(await this.token.decimals()).to.be.bignumber.equal(decimals);
+    it('has 18 decimals', async function () {
+      expect(await this.token.decimals()).to.be.bignumber.equal('18');
     });
   });
 


### PR DESCRIPTION
Not only reduces unnecessary complexity of the API but is also probably a good idea because of the 1:1 token to ether rate.