### PR TITLE
Design tweaks to documentation template

### DIFF
--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -2,9 +2,9 @@
 {{#each .}}[.var-type\]#{{typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
 {{~/inline~}}
 
-{{#linkable}}
+{{#each linkable}}
 :{{name}}: pass:normal[xref:#{{anchor}}[`{{name}}`]]
-{{/linkable}}
+{{/each}}
 
 [.contract]
 [[{{anchor}}]]
@@ -16,16 +16,16 @@
 [.contract-index]
 .Modifiers
 --
-{{#inheritedItems}}
+{{#each inheritedItems}}
 {{#unless @first}}
 [.contract-subindex-inherited]
 .{{contract.name}}
 {{/unless}}
-{{#modifiers}}
+{{#each modifiers}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
-{{/modifiers}}
+{{/each}}
 
-{{/inheritedItems}}
+{{/each}}
 --
 {{/if}}
 
@@ -33,16 +33,16 @@
 [.contract-index]
 .Functions
 --
-{{#inheritedItems}}
+{{#each inheritedItems}}
 {{#unless @first}}
 [.contract-subindex-inherited]
 .{{contract.name}}
 {{/unless}}
-{{#functions}}
+{{#each functions}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
-{{/functions}}
+{{/each}}
 
-{{/inheritedItems}}
+{{/each}}
 --
 {{/if}}
 
@@ -50,42 +50,42 @@
 [.contract-index]
 .Events
 --
-{{#inheritedItems}}
+{{#each inheritedItems}}
 {{#unless @first}}
 [.contract-subindex-inherited]
 .{{contract.name}}
 {{/unless}}
-{{#events}}
+{{#each events}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
-{{/events}}
+{{/each}}
 
-{{/inheritedItems}}
+{{/each}}
 --
 {{/if}}
 
-{{#modifiers}}
+{{#each modifiers}}
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
 
 {{natspec.devdoc}}
 
-{{/modifiers}}
+{{/each}}
 
-{{#functions}}
+{{#each functions}}
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]` [.visibility]#{{visibility}}#
 
 {{natspec.devdoc}}
 
-{{/functions}}
+{{/each}}
 
-{{#events}}
+{{#each events}}
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
 
 {{natspec.devdoc}}
 
-{{/events}}
+{{/each}}

--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -1,3 +1,7 @@
+{{~#*inline "typed-variable-array"~}}
+{{#each .}}[.var-type\]#{{typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
+{{~/inline~}}
+
 {{#linkable}}
 :{{name}}: pass:normal[xref:#{{anchor}}[`{{name}}`]]
 {{/linkable}}
@@ -53,7 +57,7 @@
 {{#ownModifiers}}
 [.contract-item]
 [[{{anchor}}]]
-==== `{{name}}({{args}})`
+==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
 
 {{natspec.devdoc}}
 
@@ -62,7 +66,7 @@
 {{#ownFunctions}}
 [.contract-item]
 [[{{anchor}}]]
-==== `{{name}}({{args}}){{#if outputs}} → {{outputs}}{{/if}}`
+==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]`
 
 {{natspec.devdoc}}
 
@@ -71,7 +75,7 @@
 {{#ownEvents}}
 [.contract-item]
 [[{{anchor}}]]
-==== `{{name}}({{args}})`
+==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
 
 {{natspec.devdoc}}
 

--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -16,16 +16,16 @@
 [.contract-index]
 .Modifiers
 --
-{{#inheritance}}
+{{#inheritedItems}}
 {{#unless @first}}
 [.contract-subindex-inherited]
-.{{name}}
+.{{contract.name}}
 {{/unless}}
-{{#ownModifiers}}
+{{#modifiers}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
-{{/ownModifiers}}
+{{/modifiers}}
 
-{{/inheritance}}
+{{/inheritedItems}}
 --
 {{/if}}
 
@@ -33,16 +33,16 @@
 [.contract-index]
 .Functions
 --
-{{#inheritance}}
+{{#inheritedItems}}
 {{#unless @first}}
 [.contract-subindex-inherited]
-.{{name}}
+.{{contract.name}}
 {{/unless}}
-{{#ownFunctions}}
+{{#functions}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
-{{/ownFunctions}}
+{{/functions}}
 
-{{/inheritance}}
+{{/inheritedItems}}
 --
 {{/if}}
 
@@ -50,42 +50,42 @@
 [.contract-index]
 .Events
 --
-{{#inheritance}}
+{{#inheritedItems}}
 {{#unless @first}}
 [.contract-subindex-inherited]
-.{{name}}
+.{{contract.name}}
 {{/unless}}
-{{#ownEvents}}
+{{#events}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
-{{/ownEvents}}
+{{/events}}
 
-{{/inheritance}}
+{{/inheritedItems}}
 --
 {{/if}}
 
-{{#ownModifiers}}
+{{#modifiers}}
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
 
 {{natspec.devdoc}}
 
-{{/ownModifiers}}
+{{/modifiers}}
 
-{{#ownFunctions}}
+{{#functions}}
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]` [.visibility]#{{visibility}}#
 
 {{natspec.devdoc}}
 
-{{/ownFunctions}}
+{{/functions}}
 
-{{#ownEvents}}
+{{#events}}
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
 
 {{natspec.devdoc}}
 
-{{/ownEvents}}
+{{/events}}

--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -11,31 +11,43 @@
 {{#if modifiers}}
 [.contract-index]
 .Modifiers
+--
 {{#inheritance}}
+{{#unless @first}}.{{name}}{{/unless}}
 {{#ownModifiers}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownModifiers}}
+
 {{/inheritance}}
+--
 {{/if}}
 
 {{#if functions}}
 [.contract-index]
 .Functions
+--
 {{#inheritance}}
+{{#unless @first}}.{{name}}{{/unless}}
 {{#ownFunctions}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownFunctions}}
+
 {{/inheritance}}
+--
 {{/if}}
 
 {{#if events}}
 [.contract-index]
 .Events
+--
 {{#inheritance}}
+{{#unless @first}}.{{name}}{{/unless}}
 {{#ownEvents}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownEvents}}
+
 {{/inheritance}}
+--
 {{/if}}
 
 {{#ownModifiers}}

--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -17,7 +17,10 @@
 .Modifiers
 --
 {{#inheritance}}
-{{#unless @first}}.{{name}}{{/unless}}
+{{#unless @first}}
+[.contract-subindex-inherited]
+.{{name}}
+{{/unless}}
 {{#ownModifiers}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownModifiers}}
@@ -31,7 +34,10 @@
 .Functions
 --
 {{#inheritance}}
-{{#unless @first}}.{{name}}{{/unless}}
+{{#unless @first}}
+[.contract-subindex-inherited]
+.{{name}}
+{{/unless}}
 {{#ownFunctions}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownFunctions}}
@@ -45,7 +51,10 @@
 .Events
 --
 {{#inheritance}}
-{{#unless @first}}.{{name}}{{/unless}}
+{{#unless @first}}
+[.contract-subindex-inherited]
+.{{name}}
+{{/unless}}
 {{#ownEvents}}
 * xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownEvents}}

--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -13,7 +13,7 @@
 .Modifiers
 {{#inheritance}}
 {{#ownModifiers}}
-* xref:#{{anchor}}[`{{signature}}`]
+* xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownModifiers}}
 {{/inheritance}}
 {{/if}}
@@ -23,7 +23,7 @@
 .Functions
 {{#inheritance}}
 {{#ownFunctions}}
-* xref:#{{anchor}}[`{{signature}}`]
+* xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownFunctions}}
 {{/inheritance}}
 {{/if}}
@@ -33,7 +33,7 @@
 .Events
 {{#inheritance}}
 {{#ownEvents}}
-* xref:#{{anchor}}[`{{signature}}`]
+* xref:#{{anchor}}[`{{name}}({{args.names}})`]
 {{/ownEvents}}
 {{/inheritance}}
 {{/if}}


### PR DESCRIPTION
In the API reference, this separates the functions listed in each contract according to the contract where they were defined. See https://github.com/OpenZeppelin/docs.openzeppelin.com/pull/28 for the corresponding style changes.