### PR TITLE
Add indicators for events and modifiers in docs

### DIFF
--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -66,7 +66,7 @@
 {{#each modifiers}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
+==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.visibility]#modifier#
 
 {{natspec.devdoc}}
 
@@ -84,7 +84,7 @@
 {{#each events}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}})]`
+==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.visibility]#event#
 
 {{natspec.devdoc}}
 


### PR DESCRIPTION
Changes the docs template so that events and modifiers show `event` and `modifier` in the same place that now functions show `internal` or `public`.

See Netlify's deploy preview.