### PR TITLE
Avoid ERC20 Approval event to be emitted by transfer and transferFrom methods

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -97,7 +97,7 @@ contract ERC20 is Context, IERC20 {
      */
     function transferFrom(address sender, address recipient, uint256 amount) public returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        _approveSilent(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
         return true;
     }
 
@@ -197,6 +197,17 @@ contract ERC20 is Context, IERC20 {
     }
 
     /**
+     * @dev This is private method for `transfer` and `transferFrom`,
+     * behaves similar to `_approve` but not emits `Approval` event
+     */
+    function _approveSilent(address owner, address spender, uint256 amount) private {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+    }
+
+    /**
      * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
      *
      * This is internal function is equivalent to `approve`, and can be used to
@@ -210,10 +221,7 @@ contract ERC20 is Context, IERC20 {
      * - `spender` cannot be the zero address.
      */
     function _approve(address owner, address spender, uint256 amount) internal {
-        require(owner != address(0), "ERC20: approve from the zero address");
-        require(spender != address(0), "ERC20: approve to the zero address");
-
-        _allowances[owner][spender] = amount;
+        _approveSilent(owner, spender, amount);
         emit Approval(owner, spender, amount);
     }
 
@@ -221,10 +229,10 @@ contract ERC20 is Context, IERC20 {
      * @dev Destroys `amount` tokens from `account`.`amount` is then deducted
      * from the caller's allowance.
      *
-     * See {_burn} and {_approve}.
+     * See {_burn} and {_approveSilent}.
      */
     function _burnFrom(address account, uint256 amount) internal {
         _burn(account, amount);
-        _approve(account, _msgSender(), _allowances[account][_msgSender()].sub(amount, "ERC20: burn amount exceeds allowance"));
+        _approveSilent(account, _msgSender(), _allowances[account][_msgSender()].sub(amount, "ERC20: burn amount exceeds allowance"));
     }
 }

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -71,16 +71,6 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
                 value: amount,
               });
             });
-
-            it('emits an approval event', async function () {
-              const { logs } = await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
-
-              expectEvent.inLogs(logs, 'Approval', {
-                owner: tokenOwner,
-                spender: spender,
-                value: await this.token.allowance(tokenOwner, spender),
-              });
-            });
           });
 
           describe('when the token owner does not have enough balance', function () {

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -316,14 +316,6 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
             expect(event.args.value).to.be.bignumber.equal(amount);
           });
-
-          it('emits an Approval event', async function () {
-            expectEvent.inLogs(this.logs, 'Approval', {
-              owner: initialHolder,
-              spender: spender,
-              value: await this.token.allowance(initialHolder, spender),
-            });
-          });
         });
       };
 


### PR DESCRIPTION
Related issue: https://github.com/OpenZeppelin/openzeppelin-contracts/issues/1955