### PR TITLE
Transfer replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### New features:
  * `Address.toPayable`: added a helper to convert between address types without having to resort to low-level casting. ([#1773](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1773))
  * Facilities to make metatransaction-enabled contracts through the Gas Station Network. ([#1844](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1844))
- * `Address.sendEther`: added a replacement to Solidity's `transfer`, removing the fixed gas stipend. ([#1961](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1961))
+ * `Address.sendValue`: added a replacement to Solidity's `transfer`, removing the fixed gas stipend. ([#1961](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1961))
 
 ### Improvements:
  * `Address.isContract`: switched from `extcodesize` to `extcodehash` for less gas usage. ([#1802](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1802))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### New features:
  * `Address.toPayable`: added a helper to convert between address types without having to resort to low-level casting. ([#1773](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1773))
  * Facilities to make metatransaction-enabled contracts through the Gas Station Network. ([#1844](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1844))
+ * `Address.sendEther`: added a replacement to Solidity's `transfer`, removing the fixed gas stipend. ([#1961](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1961))
 
 ### Improvements:
  * `Address.isContract`: switched from `extcodesize` to `extcodehash` for less gas usage. ([#1802](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1802))

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -11,9 +11,9 @@ contract AddressImpl {
         return Address.toPayable(account);
     }
 
-    function sendEther(address payable receiver, uint256 amount) external {
-        Address.sendEther(receiver, amount);
+    function sendValue(address payable receiver, uint256 amount) external {
+        Address.sendValue(receiver, amount);
     }
 
-    function () external payable { } // sendEther's tests require the contract to hold Ether
+    function () external payable { } // sendValue's tests require the contract to hold Ether
 }

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -10,4 +10,10 @@ contract AddressImpl {
     function toPayable(address account) external pure returns (address payable) {
         return Address.toPayable(account);
     }
+
+    function sendEther(address payable receiver, uint256 amount) external {
+        Address.sendEther(receiver, amount);
+    }
+
+    function () external payable { } // sendEther's tests require the contract to hold Ether
 }

--- a/contracts/mocks/EtherReceiverMock.sol
+++ b/contracts/mocks/EtherReceiverMock.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+contract EtherReceiverMock {
+    bool private _acceptEther;
+
+    function setAcceptEther(bool acceptEther) public {
+        _acceptEther = acceptEther;
+    }
+
+    function () external payable {
+        if (!_acceptEther) {
+            revert();
+        }
+    }
+}

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -40,4 +40,12 @@ library Address {
     function toPayable(address account) internal pure returns (address payable) {
         return address(uint160(account));
     }
+
+    function sendEther(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: not enough ether to send");
+
+        // solhint-disable-next-line avoid-call-value
+        (bool success, ) = recipient.call.value(amount)("");
+        require(success, "Address: unable to send ether");
+    }
 }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -41,6 +41,22 @@ library Address {
         return address(uint160(account));
     }
 
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendEther} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
     function sendEther(address payable recipient, uint256 amount) internal {
         require(address(this).balance >= amount, "Address: not enough ether to send");
 

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -48,7 +48,7 @@ library Address {
      * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
      * of certain opcodes, possibly making contracts go over the 2300 gas limit
      * imposed by `transfer`, making them unable to receive funds via
-     * `transfer`. {sendEther} removes this limitation.
+     * `transfer`. {sendValue} removes this limitation.
      *
      * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
      *
@@ -57,11 +57,11 @@ library Address {
      * {ReentrancyGuard} or the
      * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
      */
-    function sendEther(address payable recipient, uint256 amount) internal {
-        require(address(this).balance >= amount, "Address: not enough ether to send");
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
 
         // solhint-disable-next-line avoid-call-value
         (bool success, ) = recipient.call.value(amount)("");
-        require(success, "Address: unable to send ether");
+        require(success, "Address: unable to send value, recipient may have reverted");
     }
 }

--- a/test/utils/Address.test.js
+++ b/test/utils/Address.test.js
@@ -1,10 +1,11 @@
-const { constants } = require('@openzeppelin/test-helpers');
+const { balance, constants, ether, expectRevert, send } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 
 const AddressImpl = artifacts.require('AddressImpl');
 const SimpleToken = artifacts.require('SimpleToken');
+const EtherReceiver = artifacts.require('EtherReceiverMock');
 
-contract('Address', function ([_, other]) {
+contract('Address', function ([_, recipient, other]) {
   const ALL_ONES_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF';
 
   beforeEach(async function () {
@@ -33,6 +34,72 @@ contract('Address', function ([_, other]) {
 
     it('should return a payable address when the account is the all ones address', async function () {
       expect(await this.mock.toPayable(ALL_ONES_ADDRESS)).to.equal(ALL_ONES_ADDRESS);
+    });
+  });
+
+  describe('sendEther', function () {
+    beforeEach(async function () {
+      this.recipientTracker = await balance.tracker(recipient);
+    });
+
+    context('when sender contract has no funds', function () {
+      it('sends 0 wei', async function () {
+        await this.mock.sendEther(other, 0);
+
+        expect(await this.recipientTracker.delta()).to.be.bignumber.equal('0');
+      });
+
+      it('reverts when sending non-zero amounts', async function () {
+        await expectRevert(this.mock.sendEther(other, 1), 'Address: not enough ether to send');
+      });
+    });
+
+    context('when sender contract has funds', function () {
+      const funds = ether('1');
+      beforeEach(async function () {
+        await send.ether(other, this.mock.address, funds);
+      });
+
+      it('sends 0 wei', async function () {
+        await this.mock.sendEther(recipient, 0);
+        expect(await this.recipientTracker.delta()).to.be.bignumber.equal('0');
+      });
+
+      it('sends non-zero amounts', async function () {
+        await this.mock.sendEther(recipient, funds.subn(1));
+        expect(await this.recipientTracker.delta()).to.be.bignumber.equal(funds.subn(1));
+      });
+
+      it('sends the whole balance', async function () {
+        await this.mock.sendEther(recipient, funds);
+        expect(await this.recipientTracker.delta()).to.be.bignumber.equal(funds);
+        expect(await balance.current(this.mock.address)).to.be.bignumber.equal('0');
+      });
+
+      it('reverts when sending more than the balance', async function () {
+        await expectRevert(this.mock.sendEther(recipient, funds.addn(1)), 'Address: not enough ether to send');
+      });
+
+      context('with contract recipient', function () {
+        beforeEach(async function () {
+          this.contractRecipient = await EtherReceiver.new();
+        });
+
+        it('sends funds', async function () {
+          const tracker = await balance.tracker(this.contractRecipient.address);
+
+          await this.contractRecipient.setAcceptEther(true);
+          await this.mock.sendEther(this.contractRecipient.address, funds);
+          expect(await tracker.delta()).to.be.bignumber.equal(funds);
+        });
+
+        it('reverts on recipient revert', async function () {
+          await this.contractRecipient.setAcceptEther(false);
+          await expectRevert(
+            this.mock.sendEther(this.contractRecipient.address, funds), 'Address: unable to send ether'
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds a replacement for Solidity's `transfer`, which imposes a fixed gas limit of 2300. While useful to prevent reentrancy issues, this has proved to be an issue due to gas repricings, like the one [EIP1884](https://eips.ethereum.org/EIPS/eip-1884) will introduce on the Instanbul hardfork.

Given that the code to imitate `transfer` is tricky and cryptic, having a helper method to do it is a good idea.