### PR TITLE
Remove SignatureBouncer from draft docs

### DIFF
--- a/contracts/drafts/README.adoc
+++ b/contracts/drafts/README.adoc
@@ -14,8 +14,6 @@ NOTE: This page is incomplete. We're working to improve it for the next release.
 
 {{Counters}}
 
-{{SignatureBouncer}}
-
 {{SignedSafeMath}}
 
 == ERC 1046


### PR DESCRIPTION
SignatureBouncer was removed in #1879, but we never deleted the entry in the `drafts` page.