### PR TITLE
feat: add baseTokenURI to ERC721Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### New features:
  * `SafeCast.toUintXX`: new library for integer downcasting, which allows for safe operation on smaller types (e.g. `uint32`) when combined with `SafeMath`. ([#1926](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1926))
+ * Add flexbility and save gass when setting a token URI by adding a base token URI to the ERC721Metadata.sol implementation.
+
+### Improvements:
+ * `tokenURI` from `external` to `public` making possible calling it with `super`.
 
 ## 2.4.0 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@
 
 ### New features:
  * `SafeCast.toUintXX`: new library for integer downcasting, which allows for safe operation on smaller types (e.g. `uint32`) when combined with `SafeMath`. ([#1926](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1926))
- * Add flexibility and save gas when setting a token URI by adding a base token URI to the ERC721Metadata.sol implementation.
-
-### Improvements:
- * `tokenURI` from `external` to `public` making possible calling it with `super`.
+ * `ERC721Metadata`: added `baseURI`, which can be used for dramatic gas savings when all token URIs share a prefix (e.g. `http://api.myapp.com/tokens/<id>`). ([#1970](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1970))
 
 ### Breaking changes:
  * `ERC165Checker` now requires a minimum Solidity compiler version of 0.5.10. ([#1829](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1829))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features:
  * `SafeCast.toUintXX`: new library for integer downcasting, which allows for safe operation on smaller types (e.g. `uint32`) when combined with `SafeMath`. ([#1926](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1926))
- * Add flexbility and save gass when setting a token URI by adding a base token URI to the ERC721Metadata.sol implementation.
+ * Add flexibility and save gas when setting a token URI by adding a base token URI to the ERC721Metadata.sol implementation.
 
 ### Improvements:
  * `tokenURI` from `external` to `public` making possible calling it with `super`.

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -30,8 +30,4 @@ contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, E
     function setBaseTokenURI(string memory baseURI) public {
         _setBaseTokenURI(baseURI);
     }
-
-    function baseTokenURI() public view returns (string memory) {
-        return _baseTokenURI();
-    }
 }

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -26,4 +26,12 @@ contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, E
     function setTokenURI(uint256 tokenId, string memory uri) public {
         _setTokenURI(tokenId, uri);
     }
+
+    function setBaseTokenURI(string memory baseURI) public {
+        _setBaseTokenURI(baseURI);
+    }
+
+    function baseTokenURI() public view returns (string memory) {
+        return _baseTokenURI();
+    }
 }

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -27,7 +27,7 @@ contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, E
         _setTokenURI(tokenId, uri);
     }
 
-    function setBaseTokenURI(string memory baseURI) public {
-        _setBaseTokenURI(baseURI);
+    function setBaseURI(string memory baseURI) public {
+        _setBaseURI(baseURI);
     }
 }

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -12,6 +12,9 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     // Token symbol
     string private _symbol;
 
+    // Base URI
+    string private _baseURI;
+
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
 
@@ -56,7 +59,16 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * Throws if the token ID does not exist. May return an empty string.
      * @param tokenId uint256 ID of the token to query
      */
-    function tokenURI(uint256 tokenId) external view returns (string memory) {
+    function tokenURI(uint256 tokenId) public view returns (string memory) {
+        return string(abi.encodePacked(_baseTokenURI(), _tokenURI(tokenId)));
+    }
+
+    /**
+     * @dev Internal returns an URI for a given token ID.
+     * Throws if the token ID does not exist. May return an empty string.
+     * @param tokenId uint256 ID of the token to query
+     */
+    function _tokenURI(uint256 tokenId) internal view returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
         return _tokenURIs[tokenId];
     }
@@ -70,6 +82,22 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     function _setTokenURI(uint256 tokenId, string memory uri) internal {
         require(_exists(tokenId), "ERC721Metadata: URI set of nonexistent token");
         _tokenURIs[tokenId] = uri;
+    }
+
+    /**
+     * @dev Internal function to get the base token URI.
+     * @return string representing the base token URI
+     */
+    function _baseTokenURI() internal view returns (string memory) {
+        return _baseURI;
+    }
+
+    /**
+     * @dev Internal function to set the base token URI.
+     * @param uri string base URI to assign
+     */
+    function _setBaseTokenURI(string memory uri) internal {
+        _baseURI = uri;
     }
 
     /**

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -58,7 +58,7 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * @dev Returns the URI for a given token ID. May return an empty string.
      *
      * If the token's URI is non-empty and a base URI was set (via
-     * {_setBaseTokenURI}), it will be added to the token ID's URI as a prefix.
+     * {_setBaseURI}), it will be added to the token ID's URI as a prefix.
      *
      * Reverts if the token ID does not exist.
      */
@@ -81,7 +81,7 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * Reverts if the token ID does not exist.
      *
      * TIP: if all token IDs share a prefix (e.g. if your URIs look like
-     * `http://api.myproject.com/token/<id>`), use {_setBaseTokenURI} to store
+     * `http://api.myproject.com/token/<id>`), use {_setBaseURI} to store
      * it and save gas.
      */
     function _setTokenURI(uint256 tokenId, string memory uri) internal {
@@ -93,7 +93,7 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * @dev Internal function to set the base URI for all token IDs. It is
      * automatically added as a prefix to the value returned in {tokenURI}.
      */
-    function _setBaseTokenURI(string memory uri) internal {
+    function _setBaseURI(string memory uri) internal {
         _baseURI = uri;
     }
 

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -55,10 +55,12 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Returns the concatenation of the base token URI with the URI for a given token ID.
-     * Throws if the token ID does not exist. May return an empty string.
-     * The usage of concatenation here reduces gas costs when setting a token URI.
-     * @param tokenId uint256 ID of the token to query
+     * @dev Returns the URI for a given token ID. May return an empty string.
+     *
+     * If the token's URI is non-empty and a base URI was set (via
+     * {_setBaseTokenURI}), it will be added to the token ID's URI as a prefix.
+     *
+     * Reverts if the token ID does not exist.
      */
     function tokenURI(uint256 tokenId) public view returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
@@ -75,9 +77,12 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
 
     /**
      * @dev Internal function to set the token URI for a given token.
+     *
      * Reverts if the token ID does not exist.
-     * @param tokenId uint256 ID of the token to set its URI
-     * @param uri string URI to assign
+     *
+     * TIP: if all token IDs share a prefix (e.g. if your URIs look like
+     * `http://api.myproject.com/token/<id>`), use {_setBaseTokenURI} to store
+     * it and save gas.
      */
     function _setTokenURI(uint256 tokenId, string memory uri) internal {
         require(_exists(tokenId), "ERC721Metadata: URI set of nonexistent token");
@@ -85,8 +90,8 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Internal function to set the base token URI.
-     * @param uri string base URI to assign
+     * @dev Internal function to set the base URI for all token IDs. It is
+     * automatically added as a prefix to the value returned in {tokenURI}.
      */
     function _setBaseTokenURI(string memory uri) internal {
         _baseURI = uri;

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -62,7 +62,7 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      *
      * Reverts if the token ID does not exist.
      */
-    function tokenURI(uint256 tokenId) public view returns (string memory) {
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
 
         string memory uri = _tokenURIs[tokenId];

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -65,13 +65,14 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     function tokenURI(uint256 tokenId) external view returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
 
-        string memory uri = _tokenURIs[tokenId];
+        string memory tokenURI = _tokenURIs[tokenId];
 
         // Even if there is a base URI, it is only appended to non-empty token-specific URIs
-        if (bytes(uri).length == 0) {
+        if (bytes(tokenURI).length == 0) {
             return "";
         } else {
-            return string(abi.encodePacked(_baseURI, uri));
+            // abi.encodePacked is being used to concatenate strings
+            return string(abi.encodePacked(_baseURI, tokenURI));
         }
     }
 
@@ -84,9 +85,9 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * `http://api.myproject.com/token/<id>`), use {_setBaseURI} to store
      * it and save gas.
      */
-    function _setTokenURI(uint256 tokenId, string memory uri) internal {
+    function _setTokenURI(uint256 tokenId, string memory tokenURI) internal {
         require(_exists(tokenId), "ERC721Metadata: URI set of nonexistent token");
-        _tokenURIs[tokenId] = uri;
+        _tokenURIs[tokenId] = tokenURI;
     }
 
     /**
@@ -95,8 +96,8 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      *
      * _Available since v2.5.0._
      */
-    function _setBaseURI(string memory uri) internal {
-        _baseURI = uri;
+    function _setBaseURI(string memory baseURI) internal {
+        _baseURI = baseURI;
     }
 
     /**

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -92,6 +92,8 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     /**
      * @dev Internal function to set the base URI for all token IDs. It is
      * automatically added as a prefix to the value returned in {tokenURI}.
+     *
+     * _Available since v2.5.0._
      */
     function _setBaseURI(string memory uri) internal {
         _baseURI = uri;

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -61,17 +61,16 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * @param tokenId uint256 ID of the token to query
      */
     function tokenURI(uint256 tokenId) public view returns (string memory) {
-        return string(abi.encodePacked(_baseTokenURI(), _tokenURI(tokenId)));
-    }
-
-    /**
-     * @dev Internal returns an URI for a given token ID.
-     * Throws if the token ID does not exist. May return an empty string.
-     * @param tokenId uint256 ID of the token to query
-     */
-    function _tokenURI(uint256 tokenId) internal view returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
-        return _tokenURIs[tokenId];
+
+        string memory uri = _tokenURIs[tokenId];
+
+        // Even if there is a base URI, it is only appended to non-empty token-specific URIs
+        if (bytes(uri).length == 0) {
+            return "";
+        } else {
+            return string(abi.encodePacked(_baseURI, uri));
+        }
     }
 
     /**
@@ -83,15 +82,6 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     function _setTokenURI(uint256 tokenId, string memory uri) internal {
         require(_exists(tokenId), "ERC721Metadata: URI set of nonexistent token");
         _tokenURIs[tokenId] = uri;
-    }
-
-    /**
-     * @dev Internal function to get the base token URI.
-     * @notice that each token URI will be concatenated to this value when calling tokenURI.
-     * @return string representing the base token URI
-     */
-    function _baseTokenURI() internal view returns (string memory) {
-        return _baseURI;
     }
 
     /**

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -65,14 +65,14 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     function tokenURI(uint256 tokenId) external view returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
 
-        string memory tokenURI = _tokenURIs[tokenId];
+        string memory _tokenURI = _tokenURIs[tokenId];
 
         // Even if there is a base URI, it is only appended to non-empty token-specific URIs
-        if (bytes(tokenURI).length == 0) {
+        if (bytes(_tokenURI).length == 0) {
             return "";
         } else {
             // abi.encodePacked is being used to concatenate strings
-            return string(abi.encodePacked(_baseURI, tokenURI));
+            return string(abi.encodePacked(_baseURI, _tokenURI));
         }
     }
 
@@ -85,9 +85,9 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
      * `http://api.myproject.com/token/<id>`), use {_setBaseURI} to store
      * it and save gas.
      */
-    function _setTokenURI(uint256 tokenId, string memory tokenURI) internal {
+    function _setTokenURI(uint256 tokenId, string memory _tokenURI) internal {
         require(_exists(tokenId), "ERC721Metadata: URI set of nonexistent token");
-        _tokenURIs[tokenId] = tokenURI;
+        _tokenURIs[tokenId] = _tokenURI;
     }
 
     /**

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -55,8 +55,9 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Returns an URI for a given token ID.
+     * @dev Returns the concatenation of the base token URI with the URI for a given token ID.
      * Throws if the token ID does not exist. May return an empty string.
+     * The usage of concatenation here reduces gas costs when setting a token URI.
      * @param tokenId uint256 ID of the token to query
      */
     function tokenURI(uint256 tokenId) public view returns (string memory) {
@@ -86,6 +87,7 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
 
     /**
      * @dev Internal function to get the base token URI.
+     * @notice that each token URI will be concatenated to this value when calling tokenURI.
      * @return string representing the base token URI
      */
     function _baseTokenURI() internal view returns (string memory) {

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -77,6 +77,15 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     }
 
     /**
+    * @dev Returns the base URI set via {_setBaseURI}. This will be
+    * automatically added as a preffix in {tokenURI} to each token's URI, when
+    * they are non-empty.
+    */
+    function baseURI() external view returns (string memory) {
+        return _baseURI;
+    }
+
+    /**
      * @dev Internal function to set the token URI for a given token.
      *
      * Reverts if the token ID does not exist.

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -105,6 +105,11 @@ contract('ERC721Full', function ([
           );
         });
 
+        it('base URI can be set', async function () {
+          await this.token.setBaseURI(baseURI);
+          expect(await this.token.baseURI()).to.equal(baseURI);
+        });
+
         it('base URI is added as a prefix to the token URI', async function () {
           await this.token.setBaseURI(baseURI);
           await this.token.setTokenURI(firstTokenId, sampleUri);

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -106,23 +106,23 @@ contract('ERC721Full', function ([
         });
 
         it('base URI is added as a prefix to the token URI', async function () {
-          await this.token.setBaseTokenURI(baseURI);
+          await this.token.setBaseURI(baseURI);
           await this.token.setTokenURI(firstTokenId, sampleUri);
 
           expect(await this.token.tokenURI(firstTokenId)).to.be.equal(baseURI + sampleUri);
         });
 
         it('token URI can be changed by changing the base URI', async function () {
-          await this.token.setBaseTokenURI(baseURI);
+          await this.token.setBaseURI(baseURI);
           await this.token.setTokenURI(firstTokenId, sampleUri);
 
           const newBaseURI = 'https://api.com/v2/';
-          await this.token.setBaseTokenURI(newBaseURI);
+          await this.token.setBaseURI(newBaseURI);
           expect(await this.token.tokenURI(firstTokenId)).to.be.equal(newBaseURI + sampleUri);
         });
 
         it('token URI is empty for tokens with no URI but with base URI', async function () {
-          await this.token.setBaseTokenURI(baseURI);
+          await this.token.setBaseURI(baseURI);
 
           expect(await this.token.tokenURI(firstTokenId)).to.be.equal('');
         });

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -72,8 +72,8 @@ contract('ERC721Full', function ([
     });
 
     describe('metadata', function () {
+      const baseURI = 'https://api.com/v1/';
       const sampleUri = 'mock://mytoken';
-
       it('has a name', async function () {
         expect(await this.token.name()).to.be.equal(name);
       });
@@ -82,9 +82,30 @@ contract('ERC721Full', function ([
         expect(await this.token.symbol()).to.be.equal(symbol);
       });
 
+      it('sets and returns the base token URI', async function () {
+        await this.token.setBaseTokenURI(baseURI);
+        expect(await this.token.baseTokenURI()).to.be.equal(baseURI);
+      });
+
       it('sets and returns metadata for a token id', async function () {
         await this.token.setTokenURI(firstTokenId, sampleUri);
         expect(await this.token.tokenURI(firstTokenId)).to.be.equal(sampleUri);
+      });
+
+      it('sets and returns metadata for a token id with base token URI set', async function () {
+        await this.token.setBaseTokenURI(baseURI);
+        await this.token.setTokenURI(firstTokenId, sampleUri);
+        expect(await this.token.tokenURI(firstTokenId)).to.be.equal(baseURI + sampleUri);
+      });
+
+      it('changes base token URI set', async function () {
+        await this.token.setBaseTokenURI(baseURI);
+        await this.token.setTokenURI(firstTokenId, sampleUri);
+        expect(await this.token.tokenURI(firstTokenId)).to.be.equal(baseURI + sampleUri);
+
+        const newBaseURI = 'https://api.com/v2/';
+        await this.token.setBaseTokenURI(baseURI);
+        expect(await this.token.tokenURI(firstTokenId)).to.be.equal(newBaseURI + sampleUri);
       });
 
       it('reverts when setting metadata for non existent token id', async function () {

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -104,7 +104,7 @@ contract('ERC721Full', function ([
         expect(await this.token.tokenURI(firstTokenId)).to.be.equal(baseURI + sampleUri);
 
         const newBaseURI = 'https://api.com/v2/';
-        await this.token.setBaseTokenURI(baseURI);
+        await this.token.setBaseTokenURI(newBaseURI);
         expect(await this.token.tokenURI(firstTokenId)).to.be.equal(newBaseURI + sampleUri);
       });
 


### PR DESCRIPTION
Fixes #1745

- Add a private string`baseURI` variable.
- Functions to set and expose `baseURI`. 
- Concatenate  each `tokenURI` the `baseURI`
- `tokenURI()` from `external` to `public`.
- New  `_tokenURI()` function to expose the `tokenURI` isolated without the base.

Notes: I used `_baseURI` as `private` and `_baseTokenURI`  as `internal` to not change the existing ERC721Metadata interface.


