### PR TITLE
Update ReentrancyGuard for Istanbul Hard Fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Improvements
  * `ERC777`: `_burn` is now internal, providing more flexibility and making it easier to create tokens that deflate. ([#1908](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1908))
+ * `ReentrancyGuard`: `_guardCounter` is now reset to `0` after `require` statement in `modifier nonReentrant`. ([#1992](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1992))
 
 ### Breaking changes
  * `ERC165Checker` now requires a minimum Solidity compiler version of 0.5.10. ([#1829](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1829))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Improvements
  * `ERC777`: `_burn` is now internal, providing more flexibility and making it easier to create tokens that deflate. ([#1908](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1908))
- * `ReentrancyGuard`: `_guardCounter` is now reset to `0` after `require` statement in `modifier nonReentrant`. ([#1992](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1992))
+ * `ReentrancyGuard`: greatly improved gas efficiency by using the net gas metering mechanism introduced in the Istanbul hardfork. ([#1992](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1992))
 
 ### Breaking changes
  * `ERC165Checker` now requires a minimum Solidity compiler version of 0.5.10. ([#1829](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1829))

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -11,6 +11,9 @@ pragma solidity ^0.5.0;
  * `nonReentrant` may not call one another. This can be worked around by making
  * those functions `private`, and then adding `external` `nonReentrant` entry
  * points to them.
+ *
+ * _Since v2.5.0:_ this module is now much more gas efficient, given net gas 
+ * metering changes introduced in the Istanbul hardfork.
  */
 contract ReentrancyGuard {
     // counter to allow mutex lock with only one SSTORE operation

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -34,5 +34,6 @@ contract ReentrancyGuard {
         uint256 localCounter = _guardCounter;
         _;
         require(localCounter == _guardCounter, "ReentrancyGuard: reentrant call");
+        _guardCounter = 1;
     }
 }


### PR DESCRIPTION
Changes:
Added L37, `_guardCounter = 1;`

Rationale:
The planned _Istanbul Hard Fork_ will implement [EIP 2200](https://github.com/ethereum/EIPs/blob/e4d4ea348e06c54d0075c400dc7b72430d427ff1/EIPS/eip-2200.md), which implements "net gas metering" for `sstore` operations. If the final value of `_guardCounter` is unchanged relative to the original value of it, a gas refund will be applied and charges for changing the value of `_guardCounter` will effectively not exist. This ends up being cheaper than the current implementation ONLY AFTER Istanbul. Before Istanbul, the added line actually ends up costing more gas.

Note that if `_guardCounter` is `0` initially, the initial cost and subsequent refund will both be larger than if `_guardCounter` is `1` initially. Although in both cases, the net gas cost (`gasCost - gasRefund`) are equal, it's better in terms of cost to have both the gas cost and refund smaller, as there is some limit to the percentage of a gas refund that can actually be realized.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
