### PR TITLE
Update MerkleProof.sol

### DIFF
--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -16,7 +16,7 @@ library MerkleProof {
         for (uint256 i = 0; i < proof.length; i++) {
             bytes32 proofElement = proof[i];
 
-            if (computedHash < proofElement) {
+            if (computedHash <= proofElement) {
                 // Hash(current computed hash + current element of the proof)
                 computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
             } else {


### PR DESCRIPTION
By using <= we can use the first `if` block if the branches are equal.

Traversing the first branch of an `if` is faster.