### PR TITLE
isContract: Test common case first

### DIFF
--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -27,7 +27,7 @@ library Address {
         bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
         // solhint-disable-next-line no-inline-assembly
         assembly { codehash := extcodehash(account) }
-        return (codehash != 0x0 && codehash != accountHash);
+        return (codehash != accountHash && codehash != 0x0);
     }
 
     /**


### PR DESCRIPTION
`isContract` is called on every ERC-721 transfer, and possibly in other places.

This is a slight optimization for the common case that the function is called on an externally-owned account.

Currently, this is EOA is checked last. With this change it is checked first and shorted circuited.

Impact: millions of gas overall.

Need to confirm that this PR actually reduces gas. This would be easier if gas costs were shown in the CI tests.