### PR TITLE
Update crowdsales.adoc fix invalid conversion

### DIFF
--- a/docs/modules/ROOT/pages/crowdsales.adoc
+++ b/docs/modules/ROOT/pages/crowdsales.adoc
@@ -120,7 +120,7 @@ contract MyCrowdsaleDeployer {
         Crowdsale crowdsale = new MyCrowdsale(
             1,               // rate, still in TKNbits
             msg.sender,      // send Ether to the deployer
-            address(token)   // the token
+            token            // the token
         );
         // transfer the minter role from this contract (the default)
         // to the crowdsale, so it can mint tokens


### PR DESCRIPTION
Code sample for MyCrowdsaleDeployer in crowdsales.adoc causes TypeError:
```
browser/MyCrowdsaleDeployer.sol:21:13: TypeError: Invalid type for argument in function call. 
Invalid implicit conversion from address to contract IERC20 requested.
            address(token)            // the token
            ^------------^
```
Change: 
```solidity
address(token)   // the token
```
To:
```solidity
token   // the token
```

Reported by community member in the forum: https://forum.openzeppelin.com/t/invalid-implicit-conversion-from-address-to-contract-ierc20-requested/1937

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
