### PR TITLE
Revokable contract with Revoker Role

### DIFF
--- a/contracts/access/README.adoc
+++ b/contracts/access/README.adoc
@@ -14,6 +14,8 @@ NOTE: This page is incomplete. We're working to improve it for the next release.
 
 {{PauserRole}}
 
+{{RevokerRole}}
+
 {{SignerRole}}
 
 {{WhitelistAdminRole}}

--- a/contracts/access/roles/RevokerRole.sol
+++ b/contracts/access/roles/RevokerRole.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.5.0;
+
+import "../../GSN/Context.sol";
+import "../Roles.sol";
+
+contract RevokerRole is Context {
+    using Roles for Roles.Role;
+
+    event RevokerAdded(address indexed account);
+    event RevokerRemoved(address indexed account);
+
+    Roles.Role private _revokers;
+
+    constructor () internal {
+        _addRevoker(_msgSender());
+    }
+
+    modifier onlyRevoker() {
+        require(isRevoker(_msgSender()), "RevokerRole: caller does not have the Revoker role");
+        _;
+    }
+
+    function isRevoker(address account) public view returns (bool) {
+        return _revokers.has(account);
+    }
+
+    function addRevoker(address account) public onlyRevoker {
+        _addRevoker(account);
+    }
+
+    function renounceRevoker() public {
+        _removeRevoker(_msgSender());
+    }
+
+    function _addRevoker(address account) internal {
+        _revokers.add(account);
+        emit RevokerAdded(account);
+    }
+
+    function _removeRevoker(address account) internal {
+        _revokers.remove(account);
+        emit RevokerRemoved(account);
+    }
+}

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -4,8 +4,8 @@ import "../GSN/Context.sol";
 import "../access/roles/PauserRole.sol";
 
 /**
- * @dev Contract module which allows children to implement an emergency stop
- * mechanism that can be triggered by an authorized account.
+ * @dev Contract module which allows children to implement an emergency pause
+ * mechanism that can be triggered and undone by an authorized account.
  *
  * This module is used through inheritance. It will make available the
  * modifiers `whenNotPaused` and `whenPaused`, which can be applied to

--- a/contracts/lifecycle/README.adoc
+++ b/contracts/lifecycle/README.adoc
@@ -3,3 +3,7 @@
 == Pausable
 
 {{Pausable}}
+
+== Revokable
+
+{{Revokable}}

--- a/contracts/lifecycle/Revokable.sol
+++ b/contracts/lifecycle/Revokable.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.5.0;
+
+import "../GSN/Context.sol";
+import "../access/roles/RevokerRole.sol";
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account, to permanently
+ * disable certain contract functions.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifier `whenNotRevoked`, which can be applied to
+ * the functions of your contract. Note that they will not be revokable by
+ * simply including this module, only once the modifier are put in place.
+ */
+contract Revokable is Context, RevokerRole {
+    /**
+     * @dev Emitted when the revoke is triggered by a revoker (`account`).
+     */
+    event Revoked(address account);
+
+    bool private _revoked;
+
+    /**
+     * @dev Initializes the contract in not revoked state. Assigns the Revoker role
+     * to the deployer.
+     */
+    constructor () internal {
+        _revoked = false;
+    }
+
+    /**
+     * @dev Returns true if the contract is revoked, and false otherwise.
+     */
+    function revoked() public view returns (bool) {
+        return _revoked;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not revoked.
+     */
+    modifier whenNotRevoked() {
+        require(!_revoked, "Revokable: revoked");
+        _;
+    }
+
+    /**
+     * @dev Called by a revoker to revoke, triggers revoked state.
+     */
+    function revoke() public onlyRevoker whenNotRevoked {
+        _revoked = true;
+        emit Revoked(_msgSender());
+    }
+}

--- a/contracts/mocks/RevokableMock.sol
+++ b/contracts/mocks/RevokableMock.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.0;
+
+import "../lifecycle/Revokable.sol";
+import "./RevokerRoleMock.sol";
+
+// mock class using Revokable
+contract RevokableMock is Revokable, RevokerRoleMock {
+    bool public drasticMeasureTaken;
+    uint256 public count;
+
+    constructor () public {
+        drasticMeasureTaken = false;
+        count = 0;
+    }
+
+    function normalProcess() external whenNotRevoked {
+        count++;
+    }
+
+    function drasticMeasure() external whenPaused {
+        drasticMeasureTaken = true;
+    }
+}

--- a/contracts/mocks/RevokerRoleMock.sol
+++ b/contracts/mocks/RevokerRoleMock.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+import "../access/roles/RevokerRole.sol";
+
+contract RevokerRoleMock is RevokerRole {
+    function removeRevoker(address account) public {
+        _removeRevoker(account);
+    }
+
+    function onlyRevokerMock() public view onlyRevoker {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    // Causes a compilation error if super._removeRevoker is not internal
+    function _removeRevoker(address account) internal {
+        super._removeRevoker(account);
+    }
+}

--- a/test/access/roles/RevokerRole.test.js
+++ b/test/access/roles/RevokerRole.test.js
@@ -1,0 +1,15 @@
+const { accounts, contract } = require('@openzeppelin/test-environment');
+
+const { shouldBehaveLikePublicRole } = require('../../behaviors/access/roles/PublicRole.behavior');
+const RevokerRoleMock = contract.fromArtifact('RevokerRoleMock');
+
+describe('RevokerRole', function () {
+  const [ revoker, otherRevoker, ...otherAccounts ] = accounts;
+
+  beforeEach(async function () {
+    this.contract = await RevokerRoleMock.new({ from: revoker });
+    await this.contract.addRevoker(otherRevoker, { from: revoker });
+  });
+
+  shouldBehaveLikePublicRole(revoker, otherRevoker, otherAccounts, 'revoker');
+});

--- a/test/lifecycle/Revokable.test.js
+++ b/test/lifecycle/Revokable.test.js
@@ -5,13 +5,13 @@ const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/Public
 
 const { expect } = require('chai');
 
-const RevoableMock = contract.fromArtifact('RevoableMock');
+const RevokableMock = contract.fromArtifact('RevokableMock');
 
 describe('Revokable', function () {
   const [ revoker, otherRevoker, other, ...otherAccounts ] = accounts;
 
   beforeEach(async function () {
-    this.revokable = await RevoableMock.new({ from: revoker });
+    this.revokable = await RevokableMock.new({ from: revoker });
   });
 
   describe('revoker role', function () {

--- a/test/lifecycle/Revokable.test.js
+++ b/test/lifecycle/Revokable.test.js
@@ -1,0 +1,74 @@
+const { accounts, contract } = require('@openzeppelin/test-environment');
+
+const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/PublicRole.behavior');
+
+const { expect } = require('chai');
+
+const RevoableMock = contract.fromArtifact('RevoableMock');
+
+describe('Revokable', function () {
+  const [ revoker, otherRevoker, other, ...otherAccounts ] = accounts;
+
+  beforeEach(async function () {
+    this.revokable = await RevoableMock.new({ from: revoker });
+  });
+
+  describe('revoker role', function () {
+    beforeEach(async function () {
+      this.contract = this.revokable;
+      await this.contract.addRevoker(otherRevoker, { from: revoker });
+    });
+
+    shouldBehaveLikePublicRole(revoker, otherRevoker, otherAccounts, 'revoker');
+  });
+
+  context('when not revoked', function () {
+    beforeEach(async function () {
+      expect(await this.revokable.revoked()).to.equal(false);
+    });
+
+    it('can perform normal process in non-revoked', async function () {
+      expect(await this.revokable.count()).to.be.bignumber.equal('0');
+
+      await this.revokable.normalProcess({ from: other });
+      expect(await this.revokable.count()).to.be.bignumber.equal('1');
+    });
+
+    describe('revoking', function () {
+      it('is revokable by the revoker', async function () {
+        await this.revokable.revoke({ from: revoker });
+        expect(await this.revokable.revoked()).to.equal(true);
+      });
+
+      it('reverts when revoking from non-revoker', async function () {
+        await expectRevert(this.revokable.revoke({ from: other }),
+          'RevokerRole: caller does not have the Revoker role'
+        );
+      });
+
+      context('when revoked', function () {
+        beforeEach(async function () {
+          ({ logs: this.logs } = await this.revokable.revoke({ from: revoker }));
+        });
+
+        it('emits a Revoked event', function () {
+          expectEvent.inLogs(this.logs, 'Revoked', { account: revoker });
+        });
+
+        it('cannot perform normal process while revoked', async function () {
+          await expectRevert(this.revokable.normalProcess({ from: other }), 'Revokable: revoked');
+        });
+
+        it('can take a drastic measure while revoked', async function () {
+          await this.revokable.drasticMeasure({ from: other });
+          expect(await this.revokable.drasticMeasureTaken()).to.equal(true);
+        });
+
+        it('reverts when re-revoking', async function () {
+          await expectRevert(this.revokable.revoke({ from: revoker }), 'Revokable: revoked');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request corresponds to issue #2036 
This issue has yet to be discussed, but as I had already written the code before opening it, I chose to create the PR for reference while discussing the issue.

Please, do read #2036 and join the discussion.

Fixes #

*Changes for this PR are in the lifecycle and the access folders*

* Added RevokerRole contract in *access*
This is a new role that corresponds to the Revokeble contract described below.

* Added Revokable contract in *lifecycle*
This contract allows any account with the Revoker role to call a revoke method, which permanently revokes the current contract. This adds a whenNotRevoked modifier that reverts if the contract is revoked. Revoking cannot be undone, similarly to Pausing, but permanent. (View #2036)