### PR TITLE
Create BurnerRole.sol

### DIFF
--- a/contracts/access/roles/BurnerRole.sol
+++ b/contracts/access/roles/BurnerRole.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.5.0;
+
+import "../../GSN/Context.sol";
+import "../Roles.sol";
+
+contract BurnerRole is Context {
+    using Roles for Roles.Role;
+
+    event BurnerAdded(address indexed account);
+    event BurnerRemoved(address indexed account);
+
+    Roles.Role private _burners;
+
+    modifier onlyBurner() {
+        require(isBurner(_msgSender()), "BurnerRole: caller does not have the Burner role");
+        _;
+    }
+
+    function isBurner(address account) public view returns (bool) {
+        return _burners.has(account);
+    }
+
+    function addBurner(address account) public onlyBurner {
+        _addBurner(account);
+    }
+
+    function renounceBurner() public {
+        _removeBurner(_msgSender());
+    }
+
+    function _addBurner(address account) internal {
+        _burners.add(account);
+        emit BurnerAdded(account);
+    }
+
+    function _removeBurner(address account) internal {
+        _burners.remove(account);
+        emit BurnerRemoved(account);
+    }
+}


### PR DESCRIPTION
Creates role for operator burns of tokens. For example, in the case of NFTs, tokens might represent certain certifications or other accreditation. There may be cases where a private key is lost and a central operator, such as a DAO, might then act to burn the balance at the lost address, or otherwise act to enforce rules associated with token registry.