### PR TITLE
Fix link to GSN overview

### DIFF
--- a/contracts/GSN/README.adoc
+++ b/contracts/GSN/README.adoc
@@ -4,7 +4,7 @@ _Available since v2.4.0._
 
 This set of contracts provide all the tools required to make a contract callable via the https://gsn.openzeppelin.com[Gas Station Network].
 
-TIP: If you're new to the GSN, head over to our xref:learn/sending-gasless-transactions.adoc[overview of the system] and basic guide to xref:ROOT:gsn.adoc[creating a GSN-capable contract].
+TIP: If you're new to the GSN, head over to our xref:learn::sending-gasless-transactions.adoc[overview of the system] and basic guide to xref:ROOT:gsn.adoc[creating a GSN-capable contract].
 
 The core contract a recipient must inherit from is {GSNRecipient}: it includes all necessary interfaces, as well as some helper methods to make interacting with the GSN easier.
 

--- a/contracts/GSN/README.adoc
+++ b/contracts/GSN/README.adoc
@@ -4,7 +4,7 @@ _Available since v2.4.0._
 
 This set of contracts provide all the tools required to make a contract callable via the https://gsn.openzeppelin.com[Gas Station Network].
 
-TIP: If you're new to the GSN, head over to our xref:openzeppelin::gsn/what-is-the-gsn.adoc[overview of the system] and basic guide to xref:ROOT:gsn.adoc[creating a GSN-capable contract].
+TIP: If you're new to the GSN, head over to our xref:learn/sending-gasless-transactions.adoc[overview of the system] and basic guide to xref:ROOT:gsn.adoc[creating a GSN-capable contract].
 
 The core contract a recipient must inherit from is {GSNRecipient}: it includes all necessary interfaces, as well as some helper methods to make interacting with the GSN easier.
 


### PR DESCRIPTION
@frangio is this the right way to include a link to a different component? IIRC documents that go through solidity-docgen sometimes require special treatment.