### PR TITLE
Redirect docs.openzeppelin.org to docs root

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "docsite-build"
 
 [[redirects]]
   from = "/"
-  to = "https://docs.openzeppelin.com/contracts"
+  to = "https://docs.openzeppelin.com/"
   status = 301
   force = true
 


### PR DESCRIPTION
https://docs.openzeppelin.org was redirecting to the contracts documentation, instead of the documentation landing.
