### PR TITLE
refactor(Create2):Add revert reason when Create2 deploy fails

### DIFF
--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -20,10 +20,8 @@ library Create2 {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             addr := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
-            if iszero(addr) {
-                revert(0, 0)
-            }
         }
+        require(addr != address(0), "Create2: Failed on deploy");
         return addr;
     }
 

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -50,8 +50,8 @@ contract('Create2', function ([_, deployerAccount, notCreator]) {
 
   it('should failed deploying a contract in an existent address', async function () {
     await this.factory.deploy(saltHex, constructorByteCode, { from: deployerAccount });
-    await expectRevert.unspecified(
-      this.factory.deploy(saltHex, constructorByteCode, { from: deployerAccount })
+    await expectRevert(
+      this.factory.deploy(saltHex, constructorByteCode, { from: deployerAccount }), 'Create2: Failed on deploy'
     );
   });
 });


### PR DESCRIPTION
Fixes #1644 and finish #2013 feature branch

Adds revert reason when Create2 deploy fails, instead of reverting in assembly it checks the value of `addr` against `address(0)`.

This finish the TODO checklist in the feature-create2-2 feature branch.