### PR TITLE
Set types

### DIFF
--- a/contracts/utils/SetTypes/AddressSet.sol
+++ b/contracts/utils/SetTypes/AddressSet.sol
@@ -33,10 +33,13 @@ library AddressSet {
      */    
     function remove(Set storage self, address key) internal {
         require(exists(self, key), "AddressSet: key does not exist in the set.");
-        address keyToMove = self.keyList[count(self)-1];
+        uint last = count(self) - 1;
+        address keyToMove = self.keyList[last];
         uint rowToReplace = self.keyPointers[key];
-        self.keyPointers[keyToMove] = rowToReplace;
-        self.keyList[rowToReplace] = keyToMove;
+        if(rowToReplace != last) {
+            self.keyPointers[keyToMove] = rowToReplace;
+            self.keyList[rowToReplace] = keyToMove;
+        }
         delete self.keyPointers[key];
         self.keyList.length--;
     }

--- a/contracts/utils/SetTypes/AddressSet.sol
+++ b/contracts/utils/SetTypes/AddressSet.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @notice Key sets with enumeration and delete. Uses mappings for random
+ * and existence checks and dynamic arrays for enumeration. Key uniqueness is enforced. 
+ * @dev Sets are unordered. Delete operations reorder keys. All operations have a 
+ * fixed gas cost at any scale, O(1). 
+ */
+
+library AddressSet {
+    
+    struct Set {
+        mapping(address => uint) keyPointers;
+        address[] keyList;
+    }
+
+    /**
+     * @notice insert a key. 
+     * @dev duplicate keys are not permitted.
+     * @param self storage pointer to a Set. 
+     * @param key value to insert.
+     */    
+    function insert(Set storage self, address key) internal {
+        require(!exists(self, key), "AddressSet: key already exists in the set.");
+        self.keyPointers[key] = self.keyList.push(key)-1;
+    }
+
+    /**
+     * @notice remove a key.
+     * @dev key to remove must exist. 
+     * @param self storage pointer to a Set.
+     * @param key value to remove.
+     */    
+    function remove(Set storage self, address key) internal {
+        require(exists(self, key), "AddressSet: key does not exist in the set.");
+        address keyToMove = self.keyList[count(self)-1];
+        uint rowToReplace = self.keyPointers[key];
+        self.keyPointers[keyToMove] = rowToReplace;
+        self.keyList[rowToReplace] = keyToMove;
+        delete self.keyPointers[key];
+        self.keyList.length--;
+    }
+
+    /**
+     * @notice count the keys.
+     * @param self storage pointer to a Set. 
+     */       
+    function count(Set storage self) internal view returns(uint) {
+        return(self.keyList.length);
+    }
+
+    /**
+     * @notice check if a key is in the Set.
+     * @param self storage pointer to a Set.
+     * @param key value to check. 
+     * @return bool true: Set member, false: not a Set member.
+     */  
+    function exists(Set storage self, address key) internal view returns(bool) {
+        if(self.keyList.length == 0) return false;
+        return self.keyList[self.keyPointers[key]] == key;
+    }
+
+    /**
+     * @notice fetch a key by row (enumerate).
+     * @param self storage pointer to a Set.
+     * @param index row to enumerate. Must be < count() - 1.
+     */      
+    function keyAtIndex(Set storage self, uint index) internal view returns(address) {
+        return self.keyList[index];
+    }
+
+    /**
+     * @notice destroy the Set. The Set will have zero members.
+     * @dev does not prune mapped data. Enumerate keys and delete individually
+     * to fully remove.
+     * @param self storage pointer to a Set. 
+     */    
+    function nukeSet(Set storage self) public {
+        delete self.keyList;
+    }
+}

--- a/contracts/utils/SetTypes/Bytes32Set.sol
+++ b/contracts/utils/SetTypes/Bytes32Set.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @notice Key sets with enumeration and delete. Uses mappings for random
+ * and existence checks and dynamic arrays for enumeration. Key uniqueness is enforced. 
+ * @dev Sets are unordered. Delete operations reorder keys. All operations have a 
+ * fixed gas cost at any scale, O(1). 
+ */
+
+library Bytes32Set {
+    
+    struct Set {
+        mapping(bytes32 => uint) keyPointers;
+        bytes32[] keyList;
+    }
+    
+    /**
+     * @notice insert a key. 
+     * @dev duplicate keys are not permitted.
+     * @param self storage pointer to a Set. 
+     * @param key value to insert.
+     */
+    function insert(Set storage self, bytes32 key) internal {
+        require(!exists(self, key), "Bytes32Set: key already exists in the set.");
+        self.keyPointers[key] = self.keyList.push(key)-1;
+    }
+
+    /**
+     * @notice remove a key.
+     * @dev key to remove must exist. 
+     * @param self storage pointer to a Set.
+     * @param key value to remove.
+     */
+    function remove(Set storage self, bytes32 key) internal {
+        require(exists(self, key), "Bytes32Set: key does not exist in the set.");
+        bytes32 keyToMove = self.keyList[count(self)-1];
+        uint rowToReplace = self.keyPointers[key];
+        self.keyPointers[keyToMove] = rowToReplace;
+        self.keyList[rowToReplace] = keyToMove;
+        delete self.keyPointers[key];
+        self.keyList.length--;
+    }
+
+    /**
+     * @notice count the keys.
+     * @param self storage pointer to a Set. 
+     */    
+    function count(Set storage self) internal view returns(uint) {
+        return(self.keyList.length);
+    }
+    
+    /**
+     * @notice check if a key is in the Set.
+     * @param self storage pointer to a Set.
+     * @param key value to check. 
+     * @return bool true: Set member, false: not a Set member.
+     */
+    function exists(Set storage self, bytes32 key) internal view returns(bool) {
+        if(self.keyList.length == 0) return false;
+        return self.keyList[self.keyPointers[key]] == key;
+    }
+
+    /**
+     * @notice fetch a key by row (enumerate).
+     * @param self storage pointer to a Set.
+     * @param index row to enumerate. Must be < count() - 1.
+     */    
+    function keyAtIndex(Set storage self, uint index) internal view returns(bytes32) {
+        return self.keyList[index];
+    }
+    
+    /**
+     * @notice destroy the Set. The Set will have zero members.
+     * @dev does not prune mapped data. Enumerate keys and delete individually
+     * to fully remove.
+     * @param self storage pointer to a Set. 
+     */
+    function nukeSet(Set storage self) public {
+        delete self.keyList;
+    }
+}

--- a/contracts/utils/SetTypes/Bytes32Set.sol
+++ b/contracts/utils/SetTypes/Bytes32Set.sol
@@ -33,10 +33,13 @@ library Bytes32Set {
      */
     function remove(Set storage self, bytes32 key) internal {
         require(exists(self, key), "Bytes32Set: key does not exist in the set.");
-        bytes32 keyToMove = self.keyList[count(self)-1];
+        uint last = count(self) - 1;
+        bytes32 keyToMove = self.keyList[last];
         uint rowToReplace = self.keyPointers[key];
-        self.keyPointers[keyToMove] = rowToReplace;
-        self.keyList[rowToReplace] = keyToMove;
+        if(rowToReplace != last) {
+            self.keyPointers[keyToMove] = rowToReplace;
+            self.keyList[rowToReplace] = keyToMove;
+        }
         delete self.keyPointers[key];
         self.keyList.length--;
     }

--- a/contracts/utils/SetTypes/SetTypeExamples.sol
+++ b/contracts/utils/SetTypes/SetTypeExamples.sol
@@ -1,0 +1,149 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @notice Key sets with enumeration and delete. Uses mappings for random
+ * and existence checks and dynamic arrays for enumeration. Key uniqueness is enforced. 
+ * @dev Sets are unordered. Delete operations reorder keys. All operations have a 
+ * fixed gas cost at any scale, O(1). 
+ */
+
+import "./Bytes32Set.sol";
+import "./AddressSet.sol";
+import "./UintSet.sol";
+import "./StringSet.sol";
+
+contract ExampleBytes32Set {
+    
+    using Bytes32Set for Bytes32Set.Set;
+    Bytes32Set.Set set;
+    
+    event LogUpdate(address sender, string action, bytes32 key);
+    
+    function exists(bytes32 key) public view returns(bool) {
+        return set.exists(key);
+    }
+    
+    function insert(bytes32 key) public {
+        set.insert(key);
+        emit LogUpdate(msg.sender, "insert", key);
+    }
+    
+    function remove(bytes32 key) public {
+        set.remove(key);
+        emit LogUpdate(msg.sender, "remove", key);
+    }
+    
+    function count() public view returns(uint) {
+        return set.count();
+    }
+    
+    function keyAtIndex(uint index) public view returns(bytes32) {
+        return set.keyAtIndex(index);
+    }
+    
+    function nukeSet() public {
+        set.nukeSet();
+    }
+}
+
+contract ExampleAddressSet {
+    
+    using AddressSet for AddressSet.Set;
+    AddressSet.Set set;
+    
+    event LogUpdate(address sender, string action, address key);
+    
+    function exists(address key) public view returns(bool) {
+        return set.exists(key);
+    }
+    
+    function insert(address key) public {
+        set.insert(key);
+        emit LogUpdate(msg.sender, "insert", key);
+    }
+    
+    function remove(address key) public {
+        set.remove(key);
+        emit LogUpdate(msg.sender, "remove", key);
+    }
+    
+    function count() public view returns(uint) {
+        return set.count();
+    }
+    
+    function keyAtIndex(uint index) public view returns(address) {
+        return set.keyAtIndex(index);
+    }
+    
+    function nukeSet() public {
+        set.nukeSet();
+    }
+}
+
+contract ExampleUintSet {
+    
+    using UintSet for UintSet.Set;
+    UintSet.Set set;
+    
+    event LogUpdate(address sender, string action, uint key);
+    
+    function exists(uint key) public view returns(bool) {
+        return set.exists(key);
+    }
+    
+    function insert(uint key) public {
+        set.insert(key);
+        emit LogUpdate(msg.sender, "insert", key);
+    }
+    
+    function remove(uint key) public {
+        set.remove(key);
+        emit LogUpdate(msg.sender, "remove", key);
+    }
+    
+    function count() public view returns(uint) {
+        return set.count();
+    }
+    
+    function keyAtIndex(uint index) public view returns(uint) {
+        return set.keyAtIndex(index);
+    }
+    
+    function nukeSet() public {
+        set.nukeSet();
+    }
+}
+
+contract ExampleStringSet {
+    
+    using StringSet for StringSet.Set;
+    StringSet.Set set;
+    
+    event LogUpdate(address sender, string action, string key);
+    
+    function exists(string memory key) public view returns(bool) {
+        return set.exists(key);
+    }
+    
+    function insert(string memory key) public {
+        set.insert(key);
+        emit LogUpdate(msg.sender, "insert", key);
+    }
+    
+    function remove(string memory key) public {
+        set.remove(key);
+        emit LogUpdate(msg.sender, "remove", key);
+    }
+    
+    function count() public view returns(uint) {
+        return set.count();
+    }
+    
+    function keyAtIndex(uint index) public view returns(string memory) {
+        return set.keyAtIndex(index);
+    }
+    
+    function nukeSet() public {
+        set.nukeSet();
+    }
+}

--- a/contracts/utils/SetTypes/StringSet.sol
+++ b/contracts/utils/SetTypes/StringSet.sol
@@ -1,0 +1,83 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @notice Key sets with enumeration and delete. Uses mappings for random
+ * and existence checks and dynamic arrays for enumeration. Key uniqueness is enforced. 
+ * @dev Sets are unordered. Delete operations reorder keys. All operations have a 
+ * fixed gas cost at any scale, O(1). 
+ */
+
+library StringSet {
+    
+    struct Set {
+        mapping(bytes32 => uint) keyPointers;
+        mapping(bytes32 => string) strings;
+        string[] keyList;
+    }
+
+    /**
+     * @notice insert a key. 
+     * @dev duplicate keys are not permitted.
+     * @param self storage pointer to a Set. 
+     * @param key value to insert.
+     */ 
+    function insert(Set storage self, string memory key) internal {
+        require(!exists(self, key), "StringSet: key already exists in the set.");
+        self.keyPointers[toBytes32(key)] = self.keyList.push(key)-1;
+    }
+
+    /**
+     * @notice remove a key.
+     * @dev key to remove must exist. 
+     * @param self storage pointer to a Set.
+     * @param key value to remove.
+     */  
+    function remove(Set storage self, string memory key) internal {
+        require(exists(self, key), "StringSet: key does not exist in the set.");
+        string memory keyToMove = self.keyList[count(self)-1];
+        uint rowToReplace = self.keyPointers[toBytes32(key)];
+        self.keyPointers[toBytes32(keyToMove)] = rowToReplace;
+        self.keyList[rowToReplace] = keyToMove;
+        delete self.keyPointers[toBytes32(key)];
+        self.keyList.length--;
+    }
+    
+    function count(Set storage self) internal view returns(uint) {
+        return(self.keyList.length);
+    }
+
+    /**
+     * @notice check if a key is in the Set.
+     * @param self storage pointer to a Set.
+     * @param key value to check. 
+     * @return bool true: Set member, false: not a Set member.
+     */ 
+    function exists(Set storage self, string memory key) internal view returns (bool) {
+        if(self.keyList.length == 0) return false;
+        return toBytes32(self.keyList[self.keyPointers[toBytes32(key)]]) == toBytes32(key);
+    }
+
+    /**
+     * @notice fetch a key by row (enumerate).
+     * @param self storage pointer to a Set.
+     * @param index row to enumerate. Must be < count() - 1.
+     */      
+    function keyAtIndex(Set storage self, uint index) internal view returns (string memory) {
+        return self.keyList[index];
+    }
+
+    
+    /**
+     * @notice destroy the Set. The Set will have zero members.
+     * @dev does not prune mapped data. Enumerate keys and delete individually
+     * to fully remove.
+     * @param self storage pointer to a Set. 
+     */     
+    function nukeSet(Set storage self) public {
+        delete self.keyList;
+    }
+    
+    function toBytes32(string memory s) private pure returns (bytes32) {
+        return(keccak256(bytes(s)));
+    }
+}

--- a/contracts/utils/SetTypes/StringSet.sol
+++ b/contracts/utils/SetTypes/StringSet.sol
@@ -34,10 +34,13 @@ library StringSet {
      */  
     function remove(Set storage self, string memory key) internal {
         require(exists(self, key), "StringSet: key does not exist in the set.");
-        string memory keyToMove = self.keyList[count(self)-1];
+        uint last = count(self) - 1;
+        string memory keyToMove = self.keyList[last];
         uint rowToReplace = self.keyPointers[_toBytes32(key)];
-        self.keyPointers[_toBytes32(keyToMove)] = rowToReplace;
-        self.keyList[rowToReplace] = keyToMove;
+        if(rowToReplace != last) {
+            self.keyPointers[_toBytes32(keyToMove)] = rowToReplace;
+            self.keyList[rowToReplace] = keyToMove;
+        }
         delete self.keyPointers[_toBytes32(key)];
         self.keyList.length--;
     }

--- a/contracts/utils/SetTypes/StringSet.sol
+++ b/contracts/utils/SetTypes/StringSet.sol
@@ -23,7 +23,7 @@ library StringSet {
      */ 
     function insert(Set storage self, string memory key) internal {
         require(!exists(self, key), "StringSet: key already exists in the set.");
-        self.keyPointers[toBytes32(key)] = self.keyList.push(key)-1;
+        self.keyPointers[_toBytes32(key)] = self.keyList.push(key)-1;
     }
 
     /**
@@ -35,10 +35,10 @@ library StringSet {
     function remove(Set storage self, string memory key) internal {
         require(exists(self, key), "StringSet: key does not exist in the set.");
         string memory keyToMove = self.keyList[count(self)-1];
-        uint rowToReplace = self.keyPointers[toBytes32(key)];
-        self.keyPointers[toBytes32(keyToMove)] = rowToReplace;
+        uint rowToReplace = self.keyPointers[_toBytes32(key)];
+        self.keyPointers[_toBytes32(keyToMove)] = rowToReplace;
         self.keyList[rowToReplace] = keyToMove;
-        delete self.keyPointers[toBytes32(key)];
+        delete self.keyPointers[_toBytes32(key)];
         self.keyList.length--;
     }
     
@@ -54,7 +54,7 @@ library StringSet {
      */ 
     function exists(Set storage self, string memory key) internal view returns (bool) {
         if(self.keyList.length == 0) return false;
-        return toBytes32(self.keyList[self.keyPointers[toBytes32(key)]]) == toBytes32(key);
+        return _toBytes32(self.keyList[self.keyPointers[_toBytes32(key)]]) == _toBytes32(key);
     }
 
     /**
@@ -77,7 +77,7 @@ library StringSet {
         delete self.keyList;
     }
     
-    function toBytes32(string memory s) private pure returns (bytes32) {
+    function _toBytes32(string memory s) private pure returns (bytes32) {
         return(keccak256(bytes(s)));
     }
 }

--- a/contracts/utils/SetTypes/UintSet.sol
+++ b/contracts/utils/SetTypes/UintSet.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @notice Key sets with enumeration and delete. Uses mappings for random
+ * and existence checks and dynamic arrays for enumeration. Key uniqueness is enforced. 
+ * @dev Sets are unordered. Delete operations reorder keys. All operations have a 
+ * fixed gas cost at any scale, O(1). 
+ */
+
+library UintSet {
+    
+    struct Set {
+        mapping(uint => uint) keyPointers;
+        uint[] keyList;
+    }
+
+    /**
+     * @notice insert a key. 
+     * @dev duplicate keys are not permitted.
+     * @param self storage pointer to a Set. 
+     * @param key value to insert.
+     */       
+    function insert(Set storage self, uint key) internal {
+        require(!exists(self, key), "UintSet: key already exists in the set.");
+        self.keyPointers[key] = self.keyList.push(key)-1;
+    }
+
+    /**
+     * @notice remove a key.
+     * @dev key to remove must exist. 
+     * @param self storage pointer to a Set.
+     * @param key value to remove.
+     */  
+    function remove(Set storage self, uint key) internal {
+        require(exists(self, key), "UintSet: key does not exist in the set.");
+        uint keyToMove = self.keyList[count(self)-1];
+        uint rowToReplace = self.keyPointers[key];
+        self.keyPointers[keyToMove] = rowToReplace;
+        self.keyList[rowToReplace] = keyToMove;
+        delete self.keyPointers[key];
+        self.keyList.length--;
+    }
+
+    /**
+     * @notice count the keys.
+     * @param self storage pointer to a Set. 
+     */   
+    function count(Set storage self) internal view returns(uint) {
+        return(self.keyList.length);
+    }
+
+    /**
+     * @notice check if a key is in the Set.
+     * @param self storage pointer to a Set.
+     * @param key value to check. 
+     * @return bool true: Set member, false: not a Set member.
+     */  
+    function exists(Set storage self, uint key) internal view returns(bool) {
+        if(self.keyList.length == 0) return false;
+        return self.keyList[self.keyPointers[key]] == key;
+    }
+
+    /**
+     * @notice fetch a key by row (enumerate).
+     * @param self storage pointer to a Set.
+     * @param index row to enumerate. Must be < count() - 1.
+     */      
+    function keyAtIndex(Set storage self, uint index) internal view returns(uint) {
+        return self.keyList[index];
+    }
+    
+    /**
+     * @notice destroy the Set. The Set will have zero members.
+     * @dev does not prune mapped data. Enumerate keys and delete individually
+     * to fully remove.
+     * @param self storage pointer to a Set. 
+     */  
+    function nukeSet(Set storage self) public {
+        delete self.keyList;
+    }
+}

--- a/contracts/utils/SetTypes/UintSet.sol
+++ b/contracts/utils/SetTypes/UintSet.sol
@@ -33,10 +33,13 @@ library UintSet {
      */  
     function remove(Set storage self, uint key) internal {
         require(exists(self, key), "UintSet: key does not exist in the set.");
-        uint keyToMove = self.keyList[count(self)-1];
+        uint last = count(self) - 1;
+        uint keyToMove = self.keyList[last];
         uint rowToReplace = self.keyPointers[key];
-        self.keyPointers[keyToMove] = rowToReplace;
-        self.keyList[rowToReplace] = keyToMove;
+        if(rowToReplace != last) {
+            self.keyPointers[keyToMove] = rowToReplace;
+            self.keyList[rowToReplace] = keyToMove;
+        }
         delete self.keyPointers[key];
         self.keyList.length--;
     }


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2061
Implementation of an address Enumerable Set

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

There are use-cases for enumerable sets of most scalar types. `address` is appropriate user-oriented cases such as memberships, followers, privileges, etc. `bytes32` is appropriate for any sort of contract-generated UID such as a hash generated on the fly. While almost anything can be converted to a `bytes32` for a uniqueness test, in practice I found the caller code is ugly (e.g. `toBytes32(whatever)`) and it's usually best to tweak the basic idea to accommodate keys that are natural from the caller's perspective. I added a `string` variant to show how a hash can be used internally to make it work. 

Implementations are libraries that create Set types. Operations are O(1). Enumeration is done by the caller, one row at a time as I'm not comfortable with returning lists of unbounded size in one move. (`count()` and `keyAtIndex(uint row)`). In my opinion, calling for the entire list is wasteful and risky in most use-cases.  

E.g.

Get started:
```
import "./AddressSet.sol";
using AddressSet for AddressSet.Set;
AddressSet.set addressSet;
```
Typical usage:

Insert
`addressSet.insert(msg.sender);`

Remove
`addressSet.remove(msg.sender);`

Check
`if(addressSet.exists(msg.sender)) { ... }`

Enumerate (Count)
`uint count = addressSet.count();`

Enumerate (Fetch)
`address user = addressSet.keyAtIndex(row);`

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->

I realize there is a merged candidate implementation, so this is a little late to the party. I will go ahead and create unit tests and address other feedback if there is interest in this approach. I'm not sure where you would want to put it but a little folder of SetTypes (4 given) seemed intuitive to me. 
