### PR TITLE
Update ERC721.sol  :  call for `_isApprovedOrOwner` is optimized

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -141,9 +141,6 @@ contract ERC721 is Context, ERC165, IERC721 {
      * @param tokenId uint256 ID of the token to be transferred
      */
     function transferFrom(address from, address to, uint256 tokenId) public {
-        //solhint-disable-next-line max-line-length
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
-
         _transferFrom(from, to, tokenId);
     }
 
@@ -175,7 +172,6 @@ contract ERC721 is Context, ERC165, IERC721 {
      * @param _data bytes data to send along with a safe transfer check
      */
     function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory _data) public {
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
         _safeTransferFrom(from, to, tokenId, _data);
     }
 
@@ -302,6 +298,8 @@ contract ERC721 is Context, ERC165, IERC721 {
     function _transferFrom(address from, address to, uint256 tokenId) internal {
         require(ownerOf(tokenId) == from, "ERC721: transfer of token that is not own");
         require(to != address(0), "ERC721: transfer to the zero address");
+        //solhint-disable-next-line max-line-length
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
 
         _clearApproval(tokenId);
 


### PR DESCRIPTION
Moved the codes calling `_isApprovedOrOwner` function.

Current codes call `_isApprovedOrOwner` function from `transferFrom(from, to, tokenId)` and `safeTransferFrom(from, to, tokenId, data)` respectively.  But it is possible to call the function from `_transferFrom` function without affecting any logic.  So, proposed codes removed calling `_isApprovedOrOwner` function from `transferFrom(from, to, tokenId)` and `safeTransferFrom(from, to, tokenId, data)` functions and added it into `_transferFrom` function instead.

The effect or benefit of the proposed code is that the `_transferFrom` function become more coherent and reusable.   Code readability also improved a little cause all preconditions for transfer are placed inside `_transferFrom` function.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
