### PR TITLE
Rename CREATE2 argument from bytecodeHash to bytecode and add new method for precomputed bytecode hash

### DIFF
--- a/contracts/mocks/Create2Impl.sol
+++ b/contracts/mocks/Create2Impl.sol
@@ -20,4 +20,8 @@ contract Create2Impl {
     function computeAddress(bytes32 salt, bytes memory code, address deployer) public pure returns (address) {
         return Create2.computeAddress(salt, code, deployer);
     }
+
+    function computeAddress(bytes32 salt, bytes32 codeHash, address deployer) public pure returns (address) {
+        return Create2.computeAddress(salt, codeHash, deployer);
+    }
 }

--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -39,10 +39,17 @@ library Create2 {
      * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
      * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
      */
-    function computeAddress(bytes32 salt, bytes memory bytecodeHash, address deployer) internal pure returns (address) {
-        bytes32 bytecodeHashHash = keccak256(bytecodeHash);
+    function computeAddress(bytes32 salt, bytes memory bytecode, address deployer) internal pure returns (address) {
+        return computeAddress(salt, keccak256(bytecode), deployer);
+    }
+
+    /**
+     * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
+     * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
+     */
+    function computeAddress(bytes32 salt, bytes32 bytecodeHash, address deployer) internal pure returns (address) {
         bytes32 _data = keccak256(
-            abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHashHash)
+            abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHash)
         );
         return address(bytes20(_data << 96));
     }

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -7,7 +7,7 @@ const Create2Impl = contract.fromArtifact('Create2Impl');
 const ERC20Mock = contract.fromArtifact('ERC20Mock');
 const ERC20 = contract.fromArtifact('ERC20');
 
-describe.only('Create2', function () {
+describe('Create2', function () {
   const [deployerAccount] = accounts;
 
   const salt = 'salt message';

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -7,7 +7,7 @@ const Create2Impl = contract.fromArtifact('Create2Impl');
 const ERC20Mock = contract.fromArtifact('ERC20Mock');
 const ERC20 = contract.fromArtifact('ERC20');
 
-describe('Create2', function () {
+describe.only('Create2', function () {
   const [deployerAccount] = accounts;
 
   const salt = 'salt message';
@@ -30,7 +30,15 @@ describe('Create2', function () {
 
   it('should compute the correct contract address with deployer', async function () {
     const onChainComputed = await this.factory
-      .computeAddress(saltHex, constructorByteCode, deployerAccount);
+      .methods['computeAddress(bytes32,bytes,address)'](saltHex, constructorByteCode, deployerAccount);
+    const offChainComputed =
+      computeCreate2Address(saltHex, constructorByteCode, deployerAccount);
+    expect(onChainComputed).to.equal(offChainComputed);
+  });
+
+  it('should compute the correct contract address with deployer and bytecode hash', async function () {
+    const onChainComputed = await this.factory
+    .methods['computeAddress(bytes32,bytes32,address)'](saltHex, web3.utils.keccak256(constructorByteCode), deployerAccount);
     const offChainComputed =
       computeCreate2Address(saltHex, constructorByteCode, deployerAccount);
     expect(onChainComputed).to.equal(offChainComputed);

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -38,7 +38,9 @@ describe('Create2', function () {
 
   it('should compute the correct contract address with deployer and bytecode hash', async function () {
     const onChainComputed = await this.factory
-    .methods['computeAddress(bytes32,bytes32,address)'](saltHex, web3.utils.keccak256(constructorByteCode), deployerAccount);
+      .methods['computeAddress(bytes32,bytes32,address)'](
+        saltHex, web3.utils.keccak256(constructorByteCode), deployerAccount
+      );
     const offChainComputed =
       computeCreate2Address(saltHex, constructorByteCode, deployerAccount);
     expect(onChainComputed).to.equal(offChainComputed);


### PR DESCRIPTION
1. Rename argument from `bytecodeHash` to `bytecode`
2. Add new method for precomputed bytecode hash argument