### PR TITLE
Use bytes32 explicitly for Create2.computeAddress()

### DIFF
--- a/contracts/mocks/Create2Impl.sol
+++ b/contracts/mocks/Create2Impl.sol
@@ -13,15 +13,11 @@ contract Create2Impl {
         Create2.deploy(salt, type(ERC20).creationCode);
     }
 
-    function computeAddress(bytes32 salt, bytes memory code) public view returns (address) {
-        return Create2.computeAddress(salt, code);
+    function computeAddress(bytes32 salt, bytes32 codeHash) public view returns (address) {
+        return Create2.computeAddress(salt, codeHash);
     }
 
-    function computeAddress(bytes32 salt, bytes memory code, address deployer) public pure returns (address) {
-        return Create2.computeAddress(salt, code, deployer);
-    }
-
-    function computeAddress(bytes32 salt, bytes32 codeHash, address deployer) public pure returns (address) {
+    function computeAddressWithDeployer(bytes32 salt, bytes32 codeHash, address deployer) public pure returns (address) {
         return Create2.computeAddress(salt, codeHash, deployer);
     }
 }

--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -28,19 +28,11 @@ library Create2 {
     }
 
     /**
-     * @dev Returns the address where a contract will be stored if deployed via {deploy}. Any change in the `bytecode`
+     * @dev Returns the address where a contract will be stored if deployed via {deploy}. Any change in the `bytecodeHash`
      * or `salt` will result in a new destination address.
      */
-    function computeAddress(bytes32 salt, bytes memory bytecode) internal view returns (address) {
-        return computeAddress(salt, bytecode, address(this));
-    }
-
-    /**
-     * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
-     * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
-     */
-    function computeAddress(bytes32 salt, bytes memory bytecode, address deployer) internal pure returns (address) {
-        return computeAddress(salt, keccak256(bytecode), deployer);
+    function computeAddress(bytes32 salt, bytes32 bytecodeHash) internal view returns (address) {
+        return computeAddress(salt, bytecodeHash, address(this));
     }
 
     /**

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -7,7 +7,7 @@ const Create2Impl = contract.fromArtifact('Create2Impl');
 const ERC20Mock = contract.fromArtifact('ERC20Mock');
 const ERC20 = contract.fromArtifact('ERC20');
 
-describe.only('Create2', function () {
+describe('Create2', function () {
   const [deployerAccount] = accounts;
 
   const salt = 'salt message';

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -7,7 +7,7 @@ const Create2Impl = contract.fromArtifact('Create2Impl');
 const ERC20Mock = contract.fromArtifact('ERC20Mock');
 const ERC20 = contract.fromArtifact('ERC20');
 
-describe('Create2', function () {
+describe.only('Create2', function () {
   const [deployerAccount] = accounts;
 
   const salt = 'salt message';
@@ -22,7 +22,7 @@ describe('Create2', function () {
 
   it('should compute the correct contract address', async function () {
     const onChainComputed = await this.factory
-      .computeAddress(saltHex, constructorByteCode);
+      .computeAddress(saltHex, web3.utils.keccak256(constructorByteCode));
     const offChainComputed =
       computeCreate2Address(saltHex, constructorByteCode, this.factory.address);
     expect(onChainComputed).to.equal(offChainComputed);
@@ -30,17 +30,7 @@ describe('Create2', function () {
 
   it('should compute the correct contract address with deployer', async function () {
     const onChainComputed = await this.factory
-      .methods['computeAddress(bytes32,bytes,address)'](saltHex, constructorByteCode, deployerAccount);
-    const offChainComputed =
-      computeCreate2Address(saltHex, constructorByteCode, deployerAccount);
-    expect(onChainComputed).to.equal(offChainComputed);
-  });
-
-  it('should compute the correct contract address with deployer and bytecode hash', async function () {
-    const onChainComputed = await this.factory
-      .methods['computeAddress(bytes32,bytes32,address)'](
-        saltHex, web3.utils.keccak256(constructorByteCode), deployerAccount
-      );
+      .computeAddressWithDeployer(saltHex, web3.utils.keccak256(constructorByteCode), deployerAccount);
     const offChainComputed =
       computeCreate2Address(saltHex, constructorByteCode, deployerAccount);
     expect(onChainComputed).to.equal(offChainComputed);


### PR DESCRIPTION
This possibly would push users to cache hash of the bytecode, to increate computation efficiency.