### PR TITLE
Rearrange erc721metadata layout to mimic eth-pkg

### DIFF
--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -12,11 +12,11 @@ contract ERC721Metadata is Context, ERC165, ERC721, IERC721Metadata {
     // Token symbol
     string private _symbol;
 
-    // Base URI
-    string private _baseURI;
-
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
+
+    // Base URI
+    string private _baseURI;
 
     /*
      *     bytes4(keccak256('name()')) == 0x06fdde03


### PR DESCRIPTION
In https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/pull/76, we are rearranging the erc721metadata contract storage layout, so the new variable is added at the end. This commit applies the same change to the vanilla contracts repository, so migration from 2.5 to 3.0 is easier for users using the transpiler.

I'm unsure whether this should be merged into 2.5 as well to release a 2.5.1. I'm pushing it to master for now.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->