### PR TITLE
Fix display of array arguments in documentation

### DIFF
--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -3,7 +3,7 @@
 {{~/inline~}}
 
 {{#each linkable}}
-:{{name}}: xref:#{{anchor}}[`{{name}}`]
+:{{name}}: pass:normal[xref:#{{anchor}}[`{{name}}`]]
 {{/each}}
 
 [.contract]

--- a/docs/contract.hbs
+++ b/docs/contract.hbs
@@ -1,9 +1,9 @@
 {{~#*inline "typed-variable-array"~}}
-{{#each .}}[.var-type\]#{{typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
+{{#each .}}[.var-type]#{{typeName}}#{{#if name}} [.var-name]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
 {{~/inline~}}
 
 {{#each linkable}}
-:{{name}}: pass:normal[xref:#{{anchor}}[`{{name}}`]]
+:{{name}}: xref:#{{anchor}}[`{{name}}`]
 {{/each}}
 
 [.contract]
@@ -66,7 +66,7 @@
 {{#each ownModifiers}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#modifier#
+==== `{{name}}({{> typed-variable-array args}})` [.item-kind]#modifier#
 
 {{natspec.devdoc}}
 
@@ -75,7 +75,7 @@
 {{#each ownFunctions}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]` [.item-kind]#{{visibility}}#
+==== `{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}` [.item-kind]#{{visibility}}#
 
 {{natspec.devdoc}}
 
@@ -84,7 +84,7 @@
 {{#each ownEvents}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#event#
+==== `{{name}}({{> typed-variable-array args}})` [.item-kind]#event#
 
 {{natspec.devdoc}}
 


### PR DESCRIPTION
I don't recall why I added the `pass:normal` macro, but I looked through the generated site and couldn't find any problem caused by removing it. And this fixes the issues with displaying array arguments.