### PR TITLE
Adhere to naming convention

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,6 +4,7 @@
     "func-order": "off",
     "mark-callable-contracts": "off",
     "no-empty-blocks": "off",
-    "compiler-version": ["error", "^0.6.0"]
+    "compiler-version": ["error", "^0.6.0"],
+    "private-vars-leading-underscore": "error"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  * `Address`: removed `toPayable`, use `payable(address)` instead. ([#2133](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2133))
  * `ERC777`: `_send`, `_mint` and `_burn` now use the caller as the operator. ([#2134](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2134))
  * `ERC777`: removed `_callsTokensToSend` and `_callTokensReceived`. ([#2134](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2134))
+ * `ERC165Checker`: functions no longer have a leading underscore. ([#2150](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2150))
 
 ## 2.5.0 (2020-02-04)
 

--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -19,11 +19,11 @@ abstract contract GSNRecipient is IRelayRecipient, Context {
     // Default RelayHub address, deployed on mainnet and all testnets at the same address
     address private _relayHub = 0xD216153c06E857cD7f72665E0aF1d7D82172F494;
 
-    uint256 constant private RELAYED_CALL_ACCEPTED = 0;
-    uint256 constant private RELAYED_CALL_REJECTED = 11;
+    uint256 constant private _RELAYED_CALL_ACCEPTED = 0;
+    uint256 constant private _RELAYED_CALL_REJECTED = 11;
 
     // How much gas is forwarded to postRelayedCall
-    uint256 constant internal POST_RELAYED_CALL_MAX_GAS = 100000;
+    uint256 constant internal _POST_RELAYED_CALL_MAX_GAS = 100000;
 
     /**
      * @dev Emitted when a contract changes its {IRelayHub} contract to a new one.
@@ -170,14 +170,14 @@ abstract contract GSNRecipient is IRelayRecipient, Context {
      * This overload forwards `context` to _preRelayedCall and _postRelayedCall.
      */
     function _approveRelayedCall(bytes memory context) internal pure returns (uint256, bytes memory) {
-        return (RELAYED_CALL_ACCEPTED, context);
+        return (_RELAYED_CALL_ACCEPTED, context);
     }
 
     /**
      * @dev Return this in acceptRelayedCall to impede execution of a relayed call. No fees will be charged.
      */
     function _rejectRelayedCall(uint256 errorCode) internal pure returns (uint256, bytes memory) {
-        return (RELAYED_CALL_REJECTED + errorCode, "");
+        return (_RELAYED_CALL_REJECTED + errorCode, "");
     }
 
     /*

--- a/contracts/GSN/GSNRecipientERC20Fee.sol
+++ b/contracts/GSN/GSNRecipientERC20Fee.sol
@@ -97,7 +97,7 @@ contract GSNRecipientERC20Fee is GSNRecipient {
         // actualCharge is an _estimated_ charge, which assumes postRelayedCall will use all available gas.
         // This implementation's gas cost can be roughly estimated as 10k gas, for the two SSTORE operations in an
         // ERC20 transfer.
-        uint256 overestimation = _computeCharge(POST_RELAYED_CALL_MAX_GAS.sub(10000), gasPrice, transactionFee);
+        uint256 overestimation = _computeCharge(_POST_RELAYED_CALL_MAX_GAS.sub(10000), gasPrice, transactionFee);
         actualCharge = actualCharge.sub(overestimation);
 
         // After the relayed call has been executed and the actual charge estimated, the excess pre-charge is returned
@@ -113,7 +113,7 @@ contract GSNRecipientERC20Fee is GSNRecipient {
  */
 // solhint-disable-next-line contract-name-camelcase
 contract __unstable__ERC20Owned is ERC20, ERC20Detailed, Ownable {
-    uint256 private constant UINT256_MAX = 2**256 - 1;
+    uint256 private constant _UINT256_MAX = 2**256 - 1;
 
     constructor(string memory name, string memory symbol, uint8 decimals) public ERC20Detailed(name, symbol, decimals) { }
 
@@ -125,7 +125,7 @@ contract __unstable__ERC20Owned is ERC20, ERC20Detailed, Ownable {
     // The owner has 'infinite' allowance for all token holders
     function allowance(address tokenOwner, address spender) public view override(ERC20, IERC20) returns (uint256) {
         if (spender == owner()) {
-            return UINT256_MAX;
+            return _UINT256_MAX;
         } else {
             return super.allowance(tokenOwner, spender);
         }

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -19,7 +19,7 @@ library ERC165Checker {
     /**
      * @dev Returns true if `account` supports the {IERC165} interface,
      */
-    function _supportsERC165(address account) internal view returns (bool) {
+    function supportsERC165(address account) internal view returns (bool) {
         // Any contract that implements ERC165 must explicitly indicate support of
         // InterfaceId_ERC165 and explicitly indicate non-support of InterfaceId_Invalid
         return _supportsERC165Interface(account, _INTERFACE_ID_ERC165) &&
@@ -32,9 +32,9 @@ library ERC165Checker {
      *
      * See {IERC165-supportsInterface}.
      */
-    function _supportsInterface(address account, bytes4 interfaceId) internal view returns (bool) {
+    function supportsInterface(address account, bytes4 interfaceId) internal view returns (bool) {
         // query support of both ERC165 as per the spec and support of _interfaceId
-        return _supportsERC165(account) &&
+        return supportsERC165(account) &&
             _supportsERC165Interface(account, interfaceId);
     }
 
@@ -47,9 +47,9 @@ library ERC165Checker {
      *
      * See {IERC165-supportsInterface}.
      */
-    function _supportsAllInterfaces(address account, bytes4[] memory interfaceIds) internal view returns (bool) {
+    function supportsAllInterfaces(address account, bytes4[] memory interfaceIds) internal view returns (bool) {
         // query support of ERC165 itself
-        if (!_supportsERC165(account)) {
+        if (!supportsERC165(account)) {
             return false;
         }
 
@@ -72,7 +72,7 @@ library ERC165Checker {
      * identifier interfaceId, false otherwise
      * @dev Assumes that account contains a contract that supports ERC165, otherwise
      * the behavior of this method is undefined. This precondition can be checked
-     * with the `supportsERC165` method in this library.
+     * with {supportsERC165}.
      * Interface identification is specified in ERC-165.
      */
     function _supportsERC165Interface(address account, bytes4 interfaceId) private view returns (bool) {

--- a/contracts/introspection/ERC1820Implementer.sol
+++ b/contracts/introspection/ERC1820Implementer.sol
@@ -11,7 +11,7 @@ import "./IERC1820Implementer.sol";
  * registration to be complete.
  */
 contract ERC1820Implementer is IERC1820Implementer {
-    bytes32 constant private ERC1820_ACCEPT_MAGIC = keccak256(abi.encodePacked("ERC1820_ACCEPT_MAGIC"));
+    bytes32 constant private _ERC1820_ACCEPT_MAGIC = keccak256(abi.encodePacked("ERC1820_ACCEPT_MAGIC"));
 
     mapping(bytes32 => mapping(address => bool)) private _supportedInterfaces;
 
@@ -19,7 +19,7 @@ contract ERC1820Implementer is IERC1820Implementer {
      * See {IERC1820Implementer-canImplementInterfaceForAddress}.
      */
     function canImplementInterfaceForAddress(bytes32 interfaceHash, address account) external view override returns (bytes32) {
-        return _supportedInterfaces[interfaceHash][account] ? ERC1820_ACCEPT_MAGIC : bytes32(0x00);
+        return _supportedInterfaces[interfaceHash][account] ? _ERC1820_ACCEPT_MAGIC : bytes32(0x00);
     }
 
     /**

--- a/contracts/math/SignedSafeMath.sol
+++ b/contracts/math/SignedSafeMath.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.6.0;
  * @dev Signed math operations with safety checks that revert on error.
  */
 library SignedSafeMath {
-    int256 constant private INT256_MIN = -2**255;
+    int256 constant private _INT256_MIN = -2**255;
 
     /**
      * @dev Multiplies two signed integers, reverts on overflow.
@@ -18,7 +18,7 @@ library SignedSafeMath {
             return 0;
         }
 
-        require(!(a == -1 && b == INT256_MIN), "SignedSafeMath: multiplication overflow");
+        require(!(a == -1 && b == _INT256_MIN), "SignedSafeMath: multiplication overflow");
 
         int256 c = a * b;
         require(c / a == b, "SignedSafeMath: multiplication overflow");
@@ -31,7 +31,7 @@ library SignedSafeMath {
      */
     function div(int256 a, int256 b) internal pure returns (int256) {
         require(b != 0, "SignedSafeMath: division by zero");
-        require(!(b == -1 && a == INT256_MIN), "SignedSafeMath: division overflow");
+        require(!(b == -1 && a == _INT256_MIN), "SignedSafeMath: division overflow");
 
         int256 c = a / b;
 

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -5,13 +5,13 @@ import "../utils/Arrays.sol";
 contract ArraysImpl {
     using Arrays for uint256[];
 
-    uint256[] private array;
+    uint256[] private _array;
 
-    constructor (uint256[] memory _array) public {
-        array = _array;
+    constructor (uint256[] memory array) public {
+        _array = array;
     }
 
-    function findUpperBound(uint256 _element) external view returns (uint256) {
-        return array.findUpperBound(_element);
+    function findUpperBound(uint256 element) external view returns (uint256) {
+        return _array.findUpperBound(element);
     }
 }

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -6,14 +6,14 @@ contract ERC165CheckerMock {
     using ERC165Checker for address;
 
     function supportsERC165(address account) public view returns (bool) {
-        return account._supportsERC165();
+        return account.supportsERC165();
     }
 
     function supportsInterface(address account, bytes4 interfaceId) public view returns (bool) {
-        return account._supportsInterface(interfaceId);
+        return account.supportsInterface(interfaceId);
     }
 
     function supportsAllInterfaces(address account, bytes4[] memory interfaceIds) public view returns (bool) {
-        return account._supportsAllInterfaces(interfaceIds);
+        return account.supportsAllInterfaces(interfaceIds);
     }
 }

--- a/contracts/mocks/ERC777SenderRecipientMock.sol
+++ b/contracts/mocks/ERC777SenderRecipientMock.sol
@@ -37,8 +37,8 @@ contract ERC777SenderRecipientMock is Context, IERC777Sender, IERC777Recipient, 
 
     IERC1820Registry private _erc1820 = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
 
-    bytes32 constant private TOKENS_SENDER_INTERFACE_HASH = keccak256("ERC777TokensSender");
-    bytes32 constant private TOKENS_RECIPIENT_INTERFACE_HASH = keccak256("ERC777TokensRecipient");
+    bytes32 constant private _TOKENS_SENDER_INTERFACE_HASH = keccak256("ERC777TokensSender");
+    bytes32 constant private _TOKENS_RECIPIENT_INTERFACE_HASH = keccak256("ERC777TokensRecipient");
 
     function tokensToSend(
         address operator,
@@ -103,7 +103,7 @@ contract ERC777SenderRecipientMock is Context, IERC777Sender, IERC777Recipient, 
     }
 
     function senderFor(address account) public {
-        _registerInterfaceForAddress(TOKENS_SENDER_INTERFACE_HASH, account);
+        _registerInterfaceForAddress(_TOKENS_SENDER_INTERFACE_HASH, account);
 
         address self = address(this);
         if (account == self) {
@@ -112,11 +112,11 @@ contract ERC777SenderRecipientMock is Context, IERC777Sender, IERC777Recipient, 
     }
 
     function registerSender(address sender) public {
-        _erc1820.setInterfaceImplementer(address(this), TOKENS_SENDER_INTERFACE_HASH, sender);
+        _erc1820.setInterfaceImplementer(address(this), _TOKENS_SENDER_INTERFACE_HASH, sender);
     }
 
     function recipientFor(address account) public {
-        _registerInterfaceForAddress(TOKENS_RECIPIENT_INTERFACE_HASH, account);
+        _registerInterfaceForAddress(_TOKENS_RECIPIENT_INTERFACE_HASH, account);
 
         address self = address(this);
         if (account == self) {
@@ -125,7 +125,7 @@ contract ERC777SenderRecipientMock is Context, IERC777Sender, IERC777Recipient, 
     }
 
     function registerRecipient(address recipient) public {
-        _erc1820.setInterfaceImplementer(address(this), TOKENS_RECIPIENT_INTERFACE_HASH, recipient);
+        _erc1820.setInterfaceImplementer(address(this), _TOKENS_RECIPIENT_INTERFACE_HASH, recipient);
     }
 
     function setShouldRevertSend(bool shouldRevert) public {

--- a/contracts/mocks/EnumerableSetMock.sol
+++ b/contracts/mocks/EnumerableSetMock.sol
@@ -7,31 +7,31 @@ contract EnumerableSetMock{
 
     event TransactionResult(bool result);
 
-    EnumerableSet.AddressSet private set;
+    EnumerableSet.AddressSet private _set;
 
     function contains(address value) public view returns (bool) {
-        return set.contains(value);
+        return _set.contains(value);
     }
 
     function add(address value) public {
-        bool result = set.add(value);
+        bool result = _set.add(value);
         emit TransactionResult(result);
     }
 
     function remove(address value) public {
-        bool result = set.remove(value);
+        bool result = _set.remove(value);
         emit TransactionResult(result);
     }
 
     function enumerate() public view returns (address[] memory) {
-        return set.enumerate();
+        return _set.enumerate();
     }
 
     function length() public view returns (uint256) {
-        return set.length();
+        return _set.length();
     }
 
     function get(uint256 index) public view returns (address) {
-        return set.get(index);
+        return _set.get(index);
     }
 }

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -11,19 +11,19 @@ contract ReentrancyMock is ReentrancyGuard {
     }
 
     function callback() external nonReentrant {
-        count();
+        _count();
     }
 
     function countLocalRecursive(uint256 n) public nonReentrant {
         if (n > 0) {
-            count();
+            _count();
             countLocalRecursive(n - 1);
         }
     }
 
     function countThisRecursive(uint256 n) public nonReentrant {
         if (n > 0) {
-            count();
+            _count();
             // solhint-disable-next-line avoid-low-level-calls
             (bool success,) = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
             require(success, "ReentrancyMock: failed call");
@@ -31,12 +31,12 @@ contract ReentrancyMock is ReentrancyGuard {
     }
 
     function countAndCall(ReentrancyAttack attacker) public nonReentrant {
-        count();
+        _count();
         bytes4 func = bytes4(keccak256("callback()"));
         attacker.callSender(func);
     }
 
-    function count() private {
+    function _count() private {
         counter += 1;
     }
 }

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -18,11 +18,11 @@ library SafeERC20 {
     using Address for address;
 
     function safeTransfer(IERC20 token, address to, uint256 value) internal {
-        callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
     }
 
     function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
-        callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
     }
 
     function safeApprove(IERC20 token, address spender, uint256 value) internal {
@@ -33,17 +33,17 @@ library SafeERC20 {
         require((value == 0) || (token.allowance(address(this), spender) == 0),
             "SafeERC20: approve from non-zero to non-zero allowance"
         );
-        callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
     }
 
     function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {
         uint256 newAllowance = token.allowance(address(this), spender).add(value);
-        callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
     }
 
     function safeDecreaseAllowance(IERC20 token, address spender, uint256 value) internal {
         uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
-        callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
     }
 
     /**
@@ -52,7 +52,7 @@ library SafeERC20 {
      * @param token The token targeted by the call.
      * @param data The call data (encoded using abi.encode or one of its variants).
      */
-    function callOptionalReturn(IERC20 token, bytes memory data) private {
+    function _callOptionalReturn(IERC20 token, bytes memory data) private {
         // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
         // we're implementing it ourselves.
 

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -41,11 +41,11 @@ contract ERC777 is Context, IERC777, IERC20 {
     // See https://github.com/ethereum/solidity/issues/4024.
 
     // keccak256("ERC777TokensSender")
-    bytes32 constant private TOKENS_SENDER_INTERFACE_HASH =
+    bytes32 constant private _TOKENS_SENDER_INTERFACE_HASH =
         0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895;
 
     // keccak256("ERC777TokensRecipient")
-    bytes32 constant private TOKENS_RECIPIENT_INTERFACE_HASH =
+    bytes32 constant private _TOKENS_RECIPIENT_INTERFACE_HASH =
         0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b;
 
     // This isn't ever read from - it's only used to respond to the defaultOperators query.
@@ -440,7 +440,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     )
         private
     {
-        address implementer = ERC1820_REGISTRY.getInterfaceImplementer(from, TOKENS_SENDER_INTERFACE_HASH);
+        address implementer = ERC1820_REGISTRY.getInterfaceImplementer(from, _TOKENS_SENDER_INTERFACE_HASH);
         if (implementer != address(0)) {
             IERC777Sender(implementer).tokensToSend(operator, from, to, amount, userData, operatorData);
         }
@@ -468,7 +468,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     )
         private
     {
-        address implementer = ERC1820_REGISTRY.getInterfaceImplementer(to, TOKENS_RECIPIENT_INTERFACE_HASH);
+        address implementer = ERC1820_REGISTRY.getInterfaceImplementer(to, _TOKENS_RECIPIENT_INTERFACE_HASH);
         if (implementer != address(0)) {
             IERC777Recipient(implementer).tokensReceived(operator, from, to, amount, userData, operatorData);
         } else if (requireReceptionAck) {

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -28,7 +28,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     using SafeMath for uint256;
     using Address for address;
 
-    IERC1820Registry constant internal ERC1820_REGISTRY = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
+    IERC1820Registry constant internal _ERC1820_REGISTRY = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
 
     mapping(address => uint256) private _balances;
 
@@ -78,8 +78,8 @@ contract ERC777 is Context, IERC777, IERC20 {
         }
 
         // register interfaces
-        ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC777Token"), address(this));
-        ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC20Token"), address(this));
+        _ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC777Token"), address(this));
+        _ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC20Token"), address(this));
     }
 
     /**
@@ -440,7 +440,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     )
         private
     {
-        address implementer = ERC1820_REGISTRY.getInterfaceImplementer(from, _TOKENS_SENDER_INTERFACE_HASH);
+        address implementer = _ERC1820_REGISTRY.getInterfaceImplementer(from, _TOKENS_SENDER_INTERFACE_HASH);
         if (implementer != address(0)) {
             IERC777Sender(implementer).tokensToSend(operator, from, to, amount, userData, operatorData);
         }
@@ -468,7 +468,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     )
         private
     {
-        address implementer = ERC1820_REGISTRY.getInterfaceImplementer(to, _TOKENS_RECIPIENT_INTERFACE_HASH);
+        address implementer = _ERC1820_REGISTRY.getInterfaceImplementer(to, _TOKENS_RECIPIENT_INTERFACE_HASH);
         if (implementer != address(0)) {
             IERC777Recipient(implementer).tokensReceived(operator, from, to, amount, userData, operatorData);
         } else if (requireReceptionAck) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3890,7 +3890,8 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "7.0.0",
@@ -4103,6 +4104,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -4190,6 +4192,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
       "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0",
@@ -4200,6 +4203,7 @@
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
           "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -4218,6 +4222,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -4227,12 +4232,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -4240,17 +4247,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -4273,6 +4283,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
       "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -4282,6 +4293,7 @@
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
           "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -4300,6 +4312,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -4309,12 +4322,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -4322,17 +4337,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -5272,6 +5290,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -5279,7 +5298,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -5601,7 +5621,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -5746,6 +5767,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -5924,15 +5946,6 @@
         "is-obj": "^1.0.0"
       }
     },
-    "dotignore": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
@@ -6026,7 +6039,8 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -7238,21 +7252,6 @@
         }
       }
     },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
-        }
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7554,6 +7553,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
       },
@@ -7561,7 +7561,8 @@
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
         }
       }
     },
@@ -7604,7 +7605,8 @@
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -7787,6 +7789,61 @@
             "@babel/highlight": "^7.8.3"
           }
         },
+        "@babel/core": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+          "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helpers": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "json5": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+              "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
+          }
+        },
         "@babel/generator": {
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
@@ -7833,6 +7890,16 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
           "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
           "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
+          "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
             "@babel/types": "^7.8.3"
           }
         },
@@ -7957,6 +8024,77 @@
             }
           }
         },
+        "@istanbuljs/load-nyc-config": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+          "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+          "requires": {
+            "camelcase": "^5.3.1",
+            "find-up": "^4.1.0",
+            "js-yaml": "^3.13.1",
+            "resolve-from": "^5.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+            },
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+              "requires": {
+                "p-locate": "^4.1.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+              "requires": {
+                "p-limit": "^2.2.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            },
+            "path-exists": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+            },
+            "resolve-from": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+              "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+            }
+          }
+        },
+        "@istanbuljs/schema": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+          "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
+        },
         "@samverschueren/stream-to-observable": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -7994,15 +8132,20 @@
             "@types/node": "*"
           }
         },
+        "@types/color-name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+        },
         "@types/node": {
           "version": "13.5.2",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
           "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA=="
         },
-        "@types/underscore": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.2.tgz",
-          "integrity": "sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg=="
+        "@types/parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "@types/web3": {
           "version": "1.2.2",
@@ -8131,18 +8274,17 @@
         "@webassemblyjs/ieee754": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-          "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g=="
+          "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
         },
         "@webassemblyjs/leb128": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
           "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
-          "dependencies": {
-            "long": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-              "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-            }
+          "requires": {
+            "@xtuc/long": "4.2.2"
           }
         },
         "@webassemblyjs/utf8": {
@@ -8210,7 +8352,8 @@
             "@webassemblyjs/floating-point-hex-parser": "1.8.5",
             "@webassemblyjs/helper-api-error": "1.8.5",
             "@webassemblyjs/helper-code-frame": "1.8.5",
-            "@webassemblyjs/helper-fsm": "1.8.5"
+            "@webassemblyjs/helper-fsm": "1.8.5",
+            "@xtuc/long": "4.2.2"
           }
         },
         "@webassemblyjs/wast-printer": {
@@ -8219,8 +8362,19 @@
           "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
           "requires": {
             "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5"
+            "@webassemblyjs/wast-parser": "1.8.5",
+            "@xtuc/long": "4.2.2"
           }
+        },
+        "@xtuc/ieee754": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+          "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+        },
+        "@xtuc/long": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+          "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "abstract-leveldown": {
           "version": "3.0.0",
@@ -8240,10 +8394,10 @@
             "negotiator": "0.6.2"
           }
         },
-        "acorn-dynamic-import": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-          "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg=="
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
         },
         "acorn-jsx": {
           "version": "5.1.0",
@@ -8256,6 +8410,22 @@
           "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
           "dev": true,
           "optional": true
+        },
+        "aggregate-error": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+          "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          },
+          "dependencies": {
+            "indent-string": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+              "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+            }
+          }
         },
         "ajv": {
           "version": "6.11.0",
@@ -8364,8 +8534,7 @@
         "archy": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-          "dev": true
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "argparse": {
           "version": "1.0.10",
@@ -8418,6 +8587,16 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "array-includes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0",
+            "is-string": "^1.0.5"
+          }
         },
         "array-initial": {
           "version": "1.1.0",
@@ -8479,28 +8658,19 @@
             }
           }
         },
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "requires": {
-            "array-uniq": "^1.0.1"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-        },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        "array.prototype.flat": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+          "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1"
+          }
         },
         "asn1": {
           "version": "0.2.4",
@@ -9791,28 +9961,75 @@
           "requires": {
             "chownr": "^1.1.2",
             "figgy-pudding": "^3.5.1",
+            "fs-minipass": "^2.0.0",
             "glob": "^7.1.4",
             "graceful-fs": "^4.2.2",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^5.1.1",
+            "minipass": "^3.0.0",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
+            "p-map": "^3.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^2.7.1",
             "ssri": "^7.0.0",
             "unique-filename": "^1.1.1"
           },
           "dependencies": {
+            "fs-minipass": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+              "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
             "lru-cache": {
               "version": "5.1.1",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
               "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
               "requires": {
                 "yallist": "^3.0.2"
+              },
+              "dependencies": {
+                "yallist": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                  "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                }
               }
             },
-            "y18n": {
+            "minipass": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "p-map": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+              "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+              "requires": {
+                "aggregate-error": "^3.0.0"
+              }
+            },
+            "yallist": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
             }
           }
         },
@@ -9896,34 +10113,17 @@
             "make-dir": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw=="
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+              "requires": {
+                "semver": "^6.0.0"
+              }
             },
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
           }
-        },
-        "caller-callsite": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-          "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-          "requires": {
-            "callsites": "^2.0.0"
-          },
-          "dependencies": {
-            "callsites": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
-            }
-          }
-        },
-        "caller-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8="
         },
         "callsites": {
           "version": "3.1.0",
@@ -10026,11 +10226,6 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "circular-json": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
-        },
         "class-utils": {
           "version": "0.3.6",
           "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -10051,6 +10246,11 @@
               }
             }
           }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
         },
         "cli-cursor": {
           "version": "3.1.0",
@@ -10313,8 +10513,19 @@
             "aproba": "^1.1.1",
             "fs-write-stream-atomic": "^1.0.8",
             "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
             "rimraf": "^2.5.4",
             "run-queue": "^1.0.0"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            }
           }
         },
         "copy-descriptor": {
@@ -10362,8 +10573,11 @@
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
           "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
           "requires": {
+            "@types/parse-json": "^4.0.0",
             "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0"
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
           },
           "dependencies": {
             "parse-json": {
@@ -10373,8 +10587,14 @@
               "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "json-parse-better-errors": "^1.0.1",
+                "lines-and-columns": "^1.1.6"
               }
+            },
+            "path-type": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+              "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
             }
           }
         },
@@ -10394,33 +10614,6 @@
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
-          }
-        },
-        "cp-file": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-          "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^2.0.0",
-            "nested-error-stacks": "^2.0.0",
-            "pify": "^4.0.1",
-            "safe-buffer": "^5.0.1"
-          },
-          "dependencies": {
-            "make-dir": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-              "requires": {
-                "pify": "^4.0.1"
-              }
-            },
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
             }
           }
         },
@@ -10482,7 +10675,18 @@
           "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "requires": {
             "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0"
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          },
+          "dependencies": {
+            "which": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
           }
         },
         "crypto-browserify": {
@@ -10530,16 +10734,10 @@
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
           "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
         },
-        "date-now": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-          "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10808,25 +11006,6 @@
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
           "dev": true
         },
-        "del": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-          "requires": {
-            "globby": "^6.1.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "pify": "^3.0.0",
-            "rimraf": "^2.2.8"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-            }
-          }
-        },
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -10897,6 +11076,15 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
           "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+        },
+        "dotignore": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+          "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
         },
         "drbg.js": {
           "version": "1.0.1",
@@ -11035,7 +11223,19 @@
           "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
           "requires": {
             "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
             "tapable": "^1.0.0"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            }
           }
         },
         "errno": {
@@ -11153,6 +11353,7 @@
             "@babel/code-frame": "^7.0.0",
             "ajv": "^6.10.0",
             "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
             "debug": "^4.0.1",
             "doctrine": "^3.0.0",
             "eslint-scope": "^5.0.0",
@@ -11163,6 +11364,7 @@
             "esutils": "^2.0.2",
             "file-entry-cache": "^5.0.1",
             "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
             "globals": "^12.1.0",
             "ignore": "^4.0.6",
             "import-fresh": "^3.0.0",
@@ -11174,10 +11376,12 @@
             "levn": "^0.3.0",
             "lodash": "^4.17.14",
             "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
             "optionator": "^0.8.3",
             "progress": "^2.0.0",
             "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
             "strip-ansi": "^5.2.0",
             "strip-json-comments": "^3.0.1",
             "table": "^5.2.3",
@@ -11208,12 +11412,39 @@
                 "supports-color": "^5.3.0"
               }
             },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              },
+              "dependencies": {
+                "semver": {
+                  "version": "5.7.1",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                  "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
+              }
+            },
             "debug": {
               "version": "4.1.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "requires": {
                 "ms": "^2.1.1"
+              }
+            },
+            "glob-parent": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+              "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+              "requires": {
+                "is-glob": "^4.0.1"
               }
             },
             "globals": {
@@ -11223,6 +11454,37 @@
               "requires": {
                 "type-fest": "^0.8.1"
               }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -11298,7 +11560,26 @@
         "eslint-plugin-es": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
-          "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng=="
+          "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+          "requires": {
+            "eslint-utils": "^2.0.0",
+            "regexpp": "^3.0.0"
+          },
+          "dependencies": {
+            "eslint-utils": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+              "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+              "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+              }
+            },
+            "regexpp": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+              "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+            }
+          }
         },
         "eslint-plugin-import": {
           "version": "2.20.0",
@@ -11410,8 +11691,31 @@
           "integrity": "sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==",
           "requires": {
             "eslint-plugin-es": "^3.0.0",
+            "eslint-utils": "^2.0.0",
+            "ignore": "^5.1.1",
             "minimatch": "^3.0.4",
-            "resolve": "^1.10.1"
+            "resolve": "^1.10.1",
+            "semver": "^6.1.0"
+          },
+          "dependencies": {
+            "eslint-utils": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+              "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+              "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+              }
+            },
+            "ignore": {
+              "version": "5.1.4",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+              "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
           }
         },
         "eslint-plugin-promise": {
@@ -11451,6 +11755,7 @@
           "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
           "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
           "requires": {
+            "acorn": "^7.1.0",
             "acorn-jsx": "^5.1.0",
             "eslint-visitor-keys": "^1.1.0"
           }
@@ -11697,6 +12002,18 @@
                         "safe-buffer": "^5.1.1",
                         "secp256k1": "^3.0.1"
                       }
+                    },
+                    "keccak": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
+                      }
                     }
                   }
                 },
@@ -11723,20 +12040,18 @@
                     "keccak": "^2.0.0",
                     "rlp": "^2.2.3",
                     "secp256k1": "^3.0.1"
-                  },
-                  "dependencies": {
-                    "keccak": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-                      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                      "dev": true,
-                      "requires": {
-                        "bindings": "^1.5.0",
-                        "inherits": "^2.0.4",
-                        "nan": "^2.14.0",
-                        "safe-buffer": "^5.2.0"
-                      }
-                    }
+                  }
+                },
+                "keccak": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+                  "dev": true,
+                  "requires": {
+                    "bindings": "^1.5.0",
+                    "inherits": "^2.0.4",
+                    "nan": "^2.14.0",
+                    "safe-buffer": "^5.2.0"
                   }
                 }
               }
@@ -11955,6 +12270,18 @@
                         "safe-buffer": "^5.1.1",
                         "secp256k1": "^3.0.1"
                       }
+                    },
+                    "keccak": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
+                      }
                     }
                   }
                 },
@@ -11981,20 +12308,18 @@
                     "keccak": "^2.0.0",
                     "rlp": "^2.2.3",
                     "secp256k1": "^3.0.1"
-                  },
-                  "dependencies": {
-                    "keccak": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-                      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                      "dev": true,
-                      "requires": {
-                        "bindings": "^1.5.0",
-                        "inherits": "^2.0.4",
-                        "nan": "^2.14.0",
-                        "safe-buffer": "^5.2.0"
-                      }
-                    }
+                  }
+                },
+                "keccak": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+                  "dev": true,
+                  "requires": {
+                    "bindings": "^1.5.0",
+                    "inherits": "^2.0.4",
+                    "nan": "^2.14.0",
+                    "safe-buffer": "^5.2.0"
                   }
                 }
               }
@@ -12223,6 +12548,41 @@
             "rustbn.js": "~0.2.0",
             "safe-buffer": "^5.1.1",
             "util.promisify": "^1.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "dev": true,
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^2.0.0",
+                "rlp": "^2.2.3",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "keccak": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+              "dev": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "inherits": "^2.0.4",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.2.0"
+              }
+            },
+            "nan": {
+              "version": "2.14.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+              "dev": true
+            }
           }
         },
         "ethereumjs-wallet": {
@@ -12250,6 +12610,7 @@
           "requires": {
             "aes-js": "3.0.0",
             "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
             "hash.js": "1.1.3",
             "js-sha3": "0.5.7",
             "scrypt-js": "2.0.4",
@@ -12262,17 +12623,6 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-            },
-            "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
-              }
             },
             "hash.js": {
               "version": "1.1.3",
@@ -12355,9 +12705,35 @@
           "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
           "requires": {
             "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
             "npm-run-path": "^4.0.0",
             "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "is-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+              "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+            },
+            "p-finally": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+              "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+            }
           }
         },
         "expand-brackets": {
@@ -12467,6 +12843,21 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "ext": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+          "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+          "requires": {
+            "type": "^2.0.0"
+          },
+          "dependencies": {
+            "type": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+              "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
             }
           }
         },
@@ -12759,7 +13150,10 @@
             "make-dir": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw=="
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+              "requires": {
+                "semver": "^6.0.0"
+              }
             },
             "p-limit": {
               "version": "2.2.2",
@@ -12787,11 +13181,6 @@
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
               "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
             },
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-            },
             "pkg-dir": {
               "version": "4.2.0",
               "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -12799,6 +13188,11 @@
               "requires": {
                 "find-up": "^4.0.0"
               }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
           }
         },
@@ -12842,14 +13236,45 @@
           "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
           "dev": true
         },
+        "flat": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+          "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+          "requires": {
+            "is-buffer": "~2.0.3"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+              "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+            }
+          }
+        },
         "flat-cache": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
           "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
           "requires": {
             "flatted": "^2.0.0",
+            "rimraf": "2.6.3",
             "write": "1.0.3"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
+        },
+        "flatted": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+          "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
         },
         "flow-stoplight": {
           "version": "1.0.0",
@@ -12865,11 +13290,6 @@
             "inherits": "^2.0.3",
             "readable-stream": "^2.3.6"
           }
-        },
-        "fn-name": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-          "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
         },
         "for-each": {
           "version": "0.3.3",
@@ -12899,32 +13319,8 @@
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
           "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
           "requires": {
+            "cross-spawn": "^7.0.0",
             "signal-exit": "^3.0.2"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "which": "^1.2.9"
-              }
-            },
-            "lru-cache": {
-              "version": "4.1.5",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-            }
           }
         },
         "forever-agent": {
@@ -12968,6 +13364,11 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
           }
+        },
+        "fromentries": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+          "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ=="
         },
         "fs-constants": {
           "version": "1.0.0",
@@ -13296,6 +13697,11 @@
                 "npm-normalize-package-bin": "^1.0.1"
               }
             },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
             "npm-packlist": {
               "version": "1.4.7",
               "bundled": true,
@@ -13513,20 +13919,15 @@
           "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
           "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
-        "g-status": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/g-status/-/g-status-2.0.2.tgz",
-          "integrity": "sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==",
-          "requires": {
-            "arrify": "^1.0.1",
-            "matcher": "^1.0.0",
-            "simple-git": "^1.85.0"
-          }
-        },
         "generic-pool": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz",
           "integrity": "sha1-+XGN7agvoSXtXEPjQcmiFadm2aM="
+        },
+        "gensync": {
+          "version": "1.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+          "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
         },
         "get-caller-file": {
           "version": "1.0.3",
@@ -13538,11 +13939,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
           "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
-        },
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
         },
         "get-stream": {
           "version": "4.1.0",
@@ -13648,11 +14044,6 @@
             "resolve-dir": "^1.0.0"
           }
         },
-        "global-modules-path": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/global-modules-path/-/global-modules-path-2.3.1.tgz",
-          "integrity": "sha512-y+shkf4InI7mPRHSo2b/k6ix6+NLDtyccYv86whhxrSGX9wjPX1VMITmrDbE1eh7zkzhiWtW2sHklJYoQ62Cxg=="
-        },
         "global-prefix": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
@@ -13670,25 +14061,6 @@
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
           "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-            }
-          }
         },
         "glogg": {
           "version": "1.0.2",
@@ -13886,7 +14258,15 @@
           "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
           "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
           "requires": {
+            "is-stream": "^2.0.0",
             "type-fest": "^0.8.0"
+          },
+          "dependencies": {
+            "is-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+              "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+            }
           }
         },
         "hdkey": {
@@ -13945,6 +14325,11 @@
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
           "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
         },
+        "html-escaper": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+          "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
+        },
         "http-cache-semantics": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
@@ -13989,6 +14374,11 @@
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
           "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
         },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+        },
         "humanize": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
@@ -13999,13 +14389,47 @@
           "resolved": "https://registry.npmjs.org/husky/-/husky-4.0.10.tgz",
           "integrity": "sha512-Ptm4k2DqOwxeK/kzu5RaJmNRoGvESrgDXObFcZ8aJZcyXyMBHhM2FqZj6zYKdetadmP3wCwxEHCBuB9xGlRp8A==",
           "requires": {
+            "chalk": "^3.0.0",
             "ci-info": "^2.0.0",
             "cosmiconfig": "^6.0.0",
+            "opencollective-postinstall": "^2.0.2",
             "pkg-dir": "^4.2.0",
             "please-upgrade-node": "^3.2.0",
-            "slash": "^3.0.0"
+            "slash": "^3.0.0",
+            "which-pm-runs": "^1.0.0"
           },
           "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            },
             "find-up": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -14014,6 +14438,11 @@
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
               }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "locate-path": {
               "version": "5.0.0",
@@ -14044,24 +14473,10 @@
               "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
               "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
             },
-            "parse-json": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-              "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
-              }
-            },
             "path-exists": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
               "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-            },
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             },
             "pkg-dir": {
               "version": "4.2.0",
@@ -14071,20 +14486,18 @@
                 "find-up": "^4.0.0"
               }
             },
-            "read-pkg": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-              "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
-              "requires": {
-                "normalize-package-data": "^2.3.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0"
-              }
-            },
             "slash": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
               "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+            },
+            "supports-color": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
             }
           }
         },
@@ -14136,22 +14549,8 @@
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
           "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
           "requires": {
-            "parent-module": "^1.0.0"
-          },
-          "dependencies": {
-            "caller-path": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-              "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-              "requires": {
-                "caller-callsite": "^2.0.0"
-              }
-            },
-            "resolve-from": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-              "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-            }
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           }
         },
         "import-local": {
@@ -14159,7 +14558,61 @@
           "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
           "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
           "requires": {
+            "pkg-dir": "^3.0.0",
             "resolve-cwd": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            }
           }
         },
         "imurmurhash": {
@@ -14171,6 +14624,11 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "infer-owner": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
         },
         "inflight": {
           "version": "1.0.6",
@@ -14250,13 +14708,34 @@
               "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
               "requires": {
                 "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+              },
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "6.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                  "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                  "requires": {
+                    "ansi-regex": "^5.0.0"
+                  }
+                }
               }
             },
             "strip-ansi": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                }
+              }
             },
             "supports-color": {
               "version": "5.5.0",
@@ -14321,6 +14800,12 @@
             }
           }
         },
+        "is-arguments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+          "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+          "dev": true
+        },
         "is-arrayish": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -14343,14 +14828,6 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
           "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
-        },
-        "is-ci": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-          "requires": {
-            "ci-info": "^2.0.0"
-          }
         },
         "is-data-descriptor": {
           "version": "0.1.4",
@@ -14391,11 +14868,6 @@
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
-        },
-        "is-directory": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-          "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
         },
         "is-extendable": {
           "version": "0.1.1",
@@ -14495,27 +14967,6 @@
             "symbol-observable": "^1.1.0"
           }
         },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-          "requires": {
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -14556,11 +15007,6 @@
             "is-unc-path": "^1.0.0"
           }
         },
-        "is-resolvable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
-        },
         "is-retry-allowed": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
@@ -14570,6 +15016,11 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-string": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
         },
         "is-symbol": {
           "version": "1.0.3",
@@ -14654,13 +15105,60 @@
           "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
           "integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
           "requires": {
+            "@babel/core": "^7.7.5",
             "@babel/parser": "^7.7.5",
             "@babel/template": "^7.7.4",
             "@babel/traverse": "^7.7.4",
+            "@istanbuljs/schema": "^0.1.2",
             "istanbul-lib-coverage": "^3.0.0",
             "semver": "^6.3.0"
           },
           "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "istanbul-lib-processinfo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+          "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+          "requires": {
+            "archy": "^1.0.0",
+            "cross-spawn": "^7.0.0",
+            "istanbul-lib-coverage": "^3.0.0-alpha.1",
+            "make-dir": "^3.0.0",
+            "p-map": "^3.0.0",
+            "rimraf": "^3.0.0",
+            "uuid": "^3.3.3"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+              "requires": {
+                "semver": "^6.0.0"
+              }
+            },
+            "p-map": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+              "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+              "requires": {
+                "aggregate-error": "^3.0.0"
+              }
+            },
+            "rimraf": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
             "semver": {
               "version": "6.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -14678,20 +15176,31 @@
             "supports-color": "^7.1.0"
           },
           "dependencies": {
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            },
             "make-dir": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw=="
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+              "requires": {
+                "semver": "^6.0.0"
+              }
             },
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             },
             "supports-color": {
               "version": "7.1.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g=="
+              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
             }
           }
         },
@@ -14712,19 +15221,6 @@
               "requires": {
                 "ms": "^2.1.1"
               }
-            },
-            "make-dir": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-              "requires": {
-                "pify": "^4.0.1"
-              }
-            },
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
             }
           }
         },
@@ -14733,6 +15229,7 @@
           "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
           "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
           "requires": {
+            "html-escaper": "^2.0.0",
             "istanbul-lib-report": "^3.0.0"
           }
         },
@@ -14743,6 +15240,25 @@
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+          "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "js-scrypt": {
@@ -14981,6 +15497,11 @@
           "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
           "dev": true
         },
+        "level-concat-iterator": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+          "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
+        },
         "level-errors": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
@@ -15122,6 +15643,14 @@
             }
           }
         },
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        },
         "level-ws": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
@@ -15224,6 +15753,11 @@
             "resolve": "^1.1.7"
           }
         },
+        "lines-and-columns": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+          "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
         "lint-staged": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.0.0.tgz",
@@ -15232,10 +15766,13 @@
             "chalk": "^3.0.0",
             "commander": "^4.0.1",
             "cosmiconfig": "^6.0.0",
+            "debug": "^4.1.1",
             "dedent": "^0.7.0",
             "execa": "^3.4.0",
             "listr": "^0.14.3",
             "log-symbols": "^3.0.0",
+            "micromatch": "^4.0.2",
+            "normalize-path": "^3.0.0",
             "please-upgrade-node": "^3.2.0",
             "stringify-object": "^3.3.0"
           },
@@ -15245,7 +15782,16 @@
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "requires": {
-                "@types/color-name": "^1.1.1"
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "braces": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+              "requires": {
+                "fill-range": "^7.0.1"
               }
             },
             "chalk": {
@@ -15257,20 +15803,79 @@
                 "supports-color": "^7.1.0"
               }
             },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            },
             "commander": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
               "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
             },
-            "pify": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "fill-range": {
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+              "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+              "requires": {
+                "to-regex-range": "^5.0.1"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            },
+            "is-number": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            },
+            "micromatch": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+              "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+              }
+            },
+            "normalize-path": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
             },
             "supports-color": {
               "version": "7.1.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g=="
+              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+              "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+              "requires": {
+                "is-number": "^7.0.0"
+              }
             }
           }
         },
@@ -15288,13 +15893,6 @@
             "listr-verbose-renderer": "^0.5.0",
             "p-map": "^2.0.0",
             "rxjs": "^6.3.3"
-          },
-          "dependencies": {
-            "p-map": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-              "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-            }
           }
         },
         "listr-silent-renderer": {
@@ -15619,11 +16217,6 @@
             }
           }
         },
-        "long": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
-        },
         "looper": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
@@ -15743,14 +16336,6 @@
             }
           }
         },
-        "matcher": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
-          "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
-          "requires": {
-            "escape-string-regexp": "^1.0.4"
-          }
-        },
         "md5.js": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -15766,6 +16351,16 @@
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
         "memdown": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
@@ -15775,7 +16370,8 @@
             "functional-red-black-tree": "~1.0.1",
             "immediate": "~3.2.3",
             "inherits": "~2.0.1",
-            "ltgt": "~2.2.0"
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.2.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -15783,13 +16379,10 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
               "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
               "requires": {
+                "level-concat-iterator": "~2.0.0",
+                "level-supports": "~1.0.0",
                 "xtend": "~4.0.0"
               }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
@@ -15812,13 +16405,10 @@
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
-        "merge-source-map": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-          "requires": {
-            "source-map": "^0.6.1"
-          }
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "merkle-patricia-tree": {
           "version": "2.3.2",
@@ -16028,6 +16618,75 @@
             "yallist": "^3.0.0"
           }
         },
+        "minipass-collect": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+          "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+          "requires": {
+            "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            }
+          }
+        },
+        "minipass-flush": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+          "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+          "requires": {
+            "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            }
+          }
+        },
+        "minipass-pipeline": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+          "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+          "requires": {
+            "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            }
+          }
+        },
         "minizlib": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
@@ -16090,32 +16749,153 @@
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.0.tgz",
           "integrity": "sha512-CirsOPbO3jU86YKjjMzFLcXIb5YiGLUrjrXFHoJ3e2z9vWiaZVCZQ2+gtRGMPWF+nFhN6AWwLM/juzAQ6KRkbA==",
           "requires": {
+            "ansi-colors": "3.2.3",
             "browser-stdout": "1.3.1",
+            "chokidar": "3.3.0",
+            "debug": "3.2.6",
             "diff": "3.5.0",
             "escape-string-regexp": "1.0.5",
+            "find-up": "3.0.0",
             "glob": "7.1.3",
             "growl": "1.10.5",
             "he": "1.2.0",
             "js-yaml": "3.13.1",
+            "log-symbols": "2.2.0",
             "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
             "ms": "2.1.1",
             "node-environment-flags": "1.0.6",
             "object.assign": "4.1.0",
+            "strip-json-comments": "2.0.1",
             "supports-color": "6.0.0",
             "which": "1.3.1",
             "wide-align": "1.1.3",
+            "yargs": "13.3.0",
+            "yargs-parser": "13.1.1",
             "yargs-unparser": "1.6.0"
           },
           "dependencies": {
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+            "ansi-colors": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+              "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
             },
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "anymatch": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+              "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+              "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+              }
+            },
+            "binary-extensions": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+              "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+            },
+            "braces": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+              "requires": {
+                "fill-range": "^7.0.1"
+              }
+            },
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "chokidar": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+              "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+              "requires": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.1",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.2.0"
+              }
+            },
+            "cliui": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+              "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+              "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+            },
+            "fill-range": {
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+              "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+              "requires": {
+                "to-regex-range": "^5.0.1"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "fsevents": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+              "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+              "optional": true
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
             },
             "glob": {
               "version": "7.1.3",
@@ -16130,10 +16910,128 @@
                 "path-is-absolute": "^1.0.0"
               }
             },
+            "glob-parent": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+              "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+              "requires": {
+                "is-glob": "^4.0.1"
+              }
+            },
+            "is-binary-path": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+              "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+              "requires": {
+                "binary-extensions": "^2.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "is-number": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+              "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+              "requires": {
+                "chalk": "^2.0.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
             "ms": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+            },
+            "p-limit": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "readdirp": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+              "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+              "requires": {
+                "picomatch": "^2.0.4"
+              }
+            },
+            "require-main-filename": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
             },
             "supports-color": {
               "version": "6.0.0",
@@ -16141,6 +17039,60 @@
               "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
               "requires": {
                 "has-flag": "^3.0.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+              "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+              "requires": {
+                "is-number": "^7.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            },
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+              "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            },
+            "yargs": {
+              "version": "13.3.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+              "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+              "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "13.1.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
               }
             }
           }
@@ -16163,8 +17115,19 @@
             "aproba": "^1.1.1",
             "copy-concurrently": "^1.0.0",
             "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
             "rimraf": "^2.5.4",
             "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            }
           }
         },
         "ms": {
@@ -16226,11 +17189,6 @@
           "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
           "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
         },
-        "nested-error-stacks": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-          "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
-        },
         "next-tick": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -16240,6 +17198,22 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "node-environment-flags": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+          "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3",
+            "semver": "^5.7.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -16325,6 +17299,14 @@
             }
           }
         },
+        "node-preload": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+          "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+          "requires": {
+            "process-on-spawn": "^1.0.0"
+          }
+        },
         "normalize-package-data": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -16365,37 +17347,12 @@
             "once": "^1.3.2"
           }
         },
-        "npm-path": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
-          "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
-          "requires": {
-            "which": "^1.2.10"
-          }
-        },
         "npm-run-path": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "requires": {
             "path-key": "^3.0.0"
-          }
-        },
-        "npm-which": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
-          "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-          "requires": {
-            "commander": "^2.9.0",
-            "npm-path": "^2.0.2",
-            "which": "^1.2.10"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-              "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
-            }
           }
         },
         "number-is-nan": {
@@ -16424,6 +17381,8 @@
           "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
           "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
           "requires": {
+            "@istanbuljs/load-nyc-config": "^1.0.0",
+            "@istanbuljs/schema": "^0.1.2",
             "caching-transform": "^4.0.0",
             "convert-source-map": "^1.7.0",
             "decamelize": "^1.2.0",
@@ -16434,12 +17393,17 @@
             "istanbul-lib-coverage": "^3.0.0",
             "istanbul-lib-hook": "^3.0.0",
             "istanbul-lib-instrument": "^4.0.0",
+            "istanbul-lib-processinfo": "^2.0.2",
             "istanbul-lib-report": "^3.0.0",
             "istanbul-lib-source-maps": "^4.0.0",
             "istanbul-reports": "^3.0.0",
             "js-yaml": "^3.13.1",
             "make-dir": "^3.0.0",
+            "node-preload": "^0.2.0",
+            "p-map": "^3.0.0",
+            "process-on-spawn": "^1.0.0",
             "resolve-from": "^5.0.0",
+            "rimraf": "^3.0.0",
             "signal-exit": "^3.0.2",
             "spawn-wrap": "^2.0.0",
             "test-exclude": "^6.0.0",
@@ -16457,7 +17421,8 @@
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "requires": {
-                "@types/color-name": "^1.1.1"
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
               }
             },
             "camelcase": {
@@ -16475,10 +17440,18 @@
                 "wrap-ansi": "^6.2.0"
               }
             },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
             },
             "find-up": {
               "version": "4.1.0",
@@ -16510,7 +17483,10 @@
             "make-dir": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw=="
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+              "requires": {
+                "semver": "^6.0.0"
+              }
             },
             "p-limit": {
               "version": "2.2.2",
@@ -16528,6 +17504,14 @@
                 "p-limit": "^2.2.0"
               }
             },
+            "p-map": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+              "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+              "requires": {
+                "aggregate-error": "^3.0.0"
+              }
+            },
             "p-try": {
               "version": "2.2.0",
               "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -16537,11 +17521,6 @@
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
               "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-            },
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
             },
             "require-main-filename": {
               "version": "2.0.0",
@@ -16553,11 +17532,25 @@
               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
               "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
             },
+            "rimraf": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            },
             "string-width": {
               "version": "4.2.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
               "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
               "requires": {
+                "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.0"
               }
@@ -16662,6 +17655,12 @@
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
           "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
         },
+        "object-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+          "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+          "dev": true
+        },
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
@@ -16710,7 +17709,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
           "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.0-next.1"
@@ -16742,6 +17740,17 @@
           "requires": {
             "for-own": "^1.0.0",
             "make-iterator": "^1.0.0"
+          }
+        },
+        "object.values": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
           }
         },
         "oboe": {
@@ -16776,21 +17785,10 @@
             "mimic-fn": "^2.1.0"
           }
         },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-            }
-          }
+        "opencollective-postinstall": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+          "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
         },
         "optionator": {
           "version": "0.8.3",
@@ -16801,7 +17799,8 @@
             "fast-levenshtein": "~2.0.6",
             "levn": "~0.3.0",
             "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
           }
         },
         "ordered-read-streams": {
@@ -16918,6 +17917,14 @@
             "readable-stream": "^2.1.5"
           }
         },
+        "parent-module": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+          "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+          "requires": {
+            "callsites": "^3.0.0"
+          }
+        },
         "parse-asn1": {
           "version": "5.1.5",
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -17000,11 +18007,6 @@
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -17076,6 +18078,11 @@
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
+        "picomatch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+          "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -17120,33 +18127,23 @@
             "semver-compare": "^1.0.0"
           }
         },
-        "pluralize": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
-        },
         "portfinder": {
           "version": "1.0.25",
           "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
           "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+          "requires": {
+            "async": "^2.6.2",
+            "debug": "^3.1.1",
+            "mkdirp": "^0.5.1"
+          },
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
-                "ms": "2.0.0"
+                "minimist": "0.0.8"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -17198,6 +18195,14 @@
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
+        "process-on-spawn": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+          "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+          "requires": {
+            "fromentries": "^1.2.0"
+          }
+        },
         "progress": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -17218,11 +18223,6 @@
             "set-immediate-shim": "^1.0.1"
           }
         },
-        "property-expr": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-          "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
-        },
         "proxy-addr": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -17240,7 +18240,8 @@
         "pseudomap": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "dev": true
         },
         "psl": {
           "version": "1.7.0",
@@ -17516,6 +18517,16 @@
             "safe-regex": "^1.1.0"
           }
         },
+        "regexp.prototype.flags": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+          "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1"
+          }
+        },
         "regexpp": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -17667,14 +18678,6 @@
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
-        "require-uncached": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-          "requires": {
-            "caller-path": "^0.1.0"
-          }
-        },
         "resolve": {
           "version": "1.14.2",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
@@ -17789,11 +18792,6 @@
           "requires": {
             "is-promise": "^2.1.0"
           }
-        },
-        "run-node": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
-          "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A=="
         },
         "run-queue": {
           "version": "1.0.3",
@@ -18113,24 +19111,6 @@
             "simple-concat": "^1.0.0"
           }
         },
-        "simple-git": {
-          "version": "1.124.0",
-          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.124.0.tgz",
-          "integrity": "sha512-ks9mBoO4ODQy/xGLC8Cc+YDvj/hho/IKgPhi6h5LI/sA+YUdHc3v0DEoHzM29VmulubpGCxMJUSFmyXNsjNMEA==",
-          "requires": {
-            "debug": "^4.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
         "slash": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -18288,6 +19268,7 @@
             "js-sha3": "0.8.0",
             "memorystream": "^0.3.1",
             "require-from-string": "^2.0.0",
+            "semver": "^5.5.0",
             "tmp": "0.0.33"
           },
           "dependencies": {
@@ -18320,6 +19301,11 @@
               "requires": {
                 "graceful-fs": "^4.1.6"
               }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
             },
             "tmp": {
               "version": "0.0.33",
@@ -18380,7 +19366,41 @@
           "requires": {
             "foreground-child": "^2.0.0",
             "is-windows": "^1.0.2",
-            "signal-exit": "^3.0.2"
+            "make-dir": "^3.0.0",
+            "rimraf": "^3.0.0",
+            "signal-exit": "^3.0.2",
+            "which": "^2.0.1"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+              "requires": {
+                "semver": "^6.0.0"
+              }
+            },
+            "rimraf": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            },
+            "which": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
           }
         },
         "spdx-correct": {
@@ -18452,7 +19472,23 @@
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
           "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
           "requires": {
-            "figgy-pudding": "^3.5.1"
+            "figgy-pudding": "^3.5.1",
+            "minipass": "^3.1.1"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            }
           }
         },
         "stack-trace": {
@@ -18460,11 +19496,6 @@
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
           "dev": true
-        },
-        "staged-git-files": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
-          "integrity": "sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA=="
         },
         "static-extend": {
           "version": "0.1.2",
@@ -18554,11 +19585,6 @@
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
-        "string-argv": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
-          "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY="
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -18573,9 +19599,28 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
           "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.0-next.1",
+            "function-bind": "^1.1.1"
+          }
+        },
+        "string.prototype.trimleft": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1"
+          }
+        },
+        "string.prototype.trimright": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+          "requires": {
+            "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
           }
         },
@@ -18624,6 +19669,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
+        "strip-final-newline": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
@@ -18723,11 +19773,6 @@
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
           "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
         },
-        "synchronous-promise": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz",
-          "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg=="
-        },
         "table": {
           "version": "5.4.6",
           "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -18807,26 +19852,6 @@
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
-            },
-            "resolve": {
-              "version": "1.14.2",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-              "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
-              "dev": true,
-              "requires": {
-                "path-parse": "^1.0.6"
-              }
-            },
-            "string.prototype.trim": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
-              "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
-              "dev": true,
-              "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1",
-                "function-bind": "^1.1.1"
-              }
             }
           }
         },
@@ -18910,6 +19935,7 @@
           "requires": {
             "cacache": "^13.0.1",
             "find-cache-dir": "^3.2.0",
+            "jest-worker": "^24.9.0",
             "schema-utils": "^2.6.1",
             "serialize-javascript": "^2.1.2",
             "source-map": "^0.6.1",
@@ -18922,115 +19948,9 @@
           "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
           "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
           "requires": {
+            "@istanbuljs/schema": "^0.1.2",
             "glob": "^7.1.4",
             "minimatch": "^3.0.4"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "load-json-file": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "parse-json": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-              "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
-              }
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "path-type": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-              "requires": {
-                "pify": "^3.0.0"
-              }
-            },
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-            },
-            "read-pkg": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-              "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-              "requires": {
-                "find-up": "^3.0.0",
-                "read-pkg": "^3.0.0"
-              }
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-            }
           }
         },
         "text-table": {
@@ -19173,11 +20093,6 @@
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
         },
-        "toposort": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-          "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
-        },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -19290,144 +20205,6 @@
           "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
           "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
           "dev": true
-        },
-        "uglify-js": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-          "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-              "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-              "optional": true
-            }
-          }
-        },
-        "uglifyjs-webpack-plugin": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-          "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-          "requires": {
-            "cacache": "^10.0.4",
-            "find-cache-dir": "^1.0.0",
-            "schema-utils": "^0.4.5",
-            "source-map": "^0.6.1",
-            "uglify-es": "^3.3.4",
-            "webpack-sources": "^1.1.0",
-            "worker-farm": "^1.5.2"
-          },
-          "dependencies": {
-            "cacache": {
-              "version": "10.0.4",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-              "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-              "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
-              }
-            },
-            "commander": {
-              "version": "2.13.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-            },
-            "find-cache-dir": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-              "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-              "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
-              }
-            },
-            "lru-cache": {
-              "version": "4.1.5",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "mississippi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-              "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-              "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-              }
-            },
-            "pump": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "schema-utils": {
-              "version": "0.4.7",
-              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-              "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-              "requires": {
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0"
-              }
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-              "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            },
-            "uglify-es": {
-              "version": "3.3.9",
-              "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-              "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-              "requires": {
-                "commander": "~2.13.0",
-                "source-map": "~0.6.1"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-            }
-          }
         },
         "ultron": {
           "version": "1.1.1",
@@ -20138,46 +20915,6 @@
               "requires": {
                 "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
-              },
-              "dependencies": {
-                "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                  "dev": true,
-                  "requires": {
-                    "bn.js": "^4.11.8",
-                    "ethereumjs-util": "^6.0.0"
-                  },
-                  "dependencies": {
-                    "ethereumjs-util": {
-                      "version": "6.2.0",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-                      "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-                      "dev": true,
-                      "requires": {
-                        "@types/bn.js": "^4.11.3",
-                        "bn.js": "^4.11.0",
-                        "create-hash": "^1.1.2",
-                        "ethjs-util": "0.1.6",
-                        "keccak": "^2.0.0",
-                        "rlp": "^2.2.3",
-                        "secp256k1": "^3.0.1"
-                      }
-                    }
-                  }
-                },
-                "keccak": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                  "dev": true,
-                  "requires": {
-                    "bindings": "^1.5.0",
-                    "inherits": "^2.0.4",
-                    "nan": "^2.14.0",
-                    "safe-buffer": "^5.2.0"
-                  }
-                }
               }
             },
             "ethereum-common": {
@@ -20189,6 +20926,7 @@
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
@@ -20198,11 +20936,13 @@
                   "version": "6.2.0",
                   "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
                   "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+                  "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
                     "ethjs-util": "0.1.6",
+                    "keccak": "^2.0.0",
                     "rlp": "^2.2.3",
                     "secp256k1": "^3.0.1"
                   }
@@ -20264,6 +21004,20 @@
                 "rlp": "^2.0.0",
                 "safe-buffer": "^5.1.1",
                 "secp256k1": "^3.0.1"
+              },
+              "dependencies": {
+                "keccak": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                  "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                  "dev": true,
+                  "requires": {
+                    "bindings": "^1.2.1",
+                    "inherits": "^2.0.3",
+                    "nan": "^2.2.1",
+                    "safe-buffer": "^5.1.0"
+                  }
+                }
               }
             },
             "ethereumjs-vm": {
@@ -20312,6 +21066,18 @@
                         "safe-buffer": "^5.1.1",
                         "secp256k1": "^3.0.1"
                       }
+                    },
+                    "keccak": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                      "dev": true,
+                      "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
+                      }
                     }
                   }
                 },
@@ -20338,22 +21104,20 @@
                     "keccak": "^2.0.0",
                     "rlp": "^2.2.3",
                     "secp256k1": "^3.0.1"
-                  },
-                  "dependencies": {
-                    "keccak": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-                      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                      "dev": true,
-                      "requires": {
-                        "bindings": "^1.5.0",
-                        "inherits": "^2.0.4",
-                        "nan": "^2.14.0",
-                        "safe-buffer": "^5.2.0"
-                      }
-                    }
                   }
                 }
+              }
+            },
+            "keccak": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+              "dev": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "inherits": "^2.0.4",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.2.0"
               }
             },
             "nan": {
@@ -20449,23 +21213,149 @@
             "@webassemblyjs/helper-module-context": "1.8.5",
             "@webassemblyjs/wasm-edit": "1.8.5",
             "@webassemblyjs/wasm-parser": "1.8.5",
+            "acorn": "^6.2.1",
             "ajv": "^6.10.2",
             "ajv-keywords": "^3.4.1",
             "chrome-trace-event": "^1.0.2",
             "enhanced-resolve": "^4.1.0",
+            "eslint-scope": "^4.0.3",
             "json-parse-better-errors": "^1.0.2",
             "loader-runner": "^2.4.0",
             "loader-utils": "^1.2.3",
             "memory-fs": "^0.4.1",
             "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.1",
             "neo-async": "^2.6.1",
             "node-libs-browser": "^2.2.1",
             "schema-utils": "^1.0.0",
             "tapable": "^1.1.3",
+            "terser-webpack-plugin": "^1.4.3",
             "watchpack": "^1.6.0",
             "webpack-sources": "^1.4.1"
           },
           "dependencies": {
+            "acorn": {
+              "version": "6.4.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+            },
+            "cacache": {
+              "version": "12.0.3",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+              "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+              "requires": {
+                "bluebird": "^3.5.5",
+                "chownr": "^1.1.1",
+                "figgy-pudding": "^3.5.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.1.15",
+                "infer-owner": "^1.0.3",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.3",
+                "ssri": "^6.0.1",
+                "unique-filename": "^1.1.1",
+                "y18n": "^4.0.0"
+              }
+            },
+            "eslint-scope": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+              "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "find-cache-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+              "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lru-cache": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "make-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+              "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            },
             "schema-utils": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -20475,6 +21365,40 @@
                 "ajv-errors": "^1.0.0",
                 "ajv-keywords": "^3.1.0"
               }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            },
+            "ssri": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+              "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+              "requires": {
+                "figgy-pudding": "^3.5.1"
+              }
+            },
+            "terser-webpack-plugin": {
+              "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+              "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+              "requires": {
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^2.1.2",
+                "source-map": "^0.6.1",
+                "terser": "^4.1.2",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
+              }
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             }
           }
         },
@@ -20483,8 +21407,16 @@
           "resolved": "https://registry.npmjs.org/webpack-bundle-size-analyzer/-/webpack-bundle-size-analyzer-3.1.0.tgz",
           "integrity": "sha512-8WlTT6uuCxZgZYNnCB0pRGukWRGH+Owg+HsqQUe1Zexakdno1eDYO+lE7ihBo9G0aCCZCJa8JWjYr9eLYfZrBA==",
           "requires": {
+            "commander": "^2.19.0",
             "filesize": "^3.6.1",
             "humanize": "0.0.9"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            }
           }
         },
         "webpack-cli": {
@@ -20493,11 +21425,15 @@
           "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
           "requires": {
             "chalk": "2.4.2",
+            "cross-spawn": "6.0.5",
+            "enhanced-resolve": "4.1.0",
             "findup-sync": "3.0.0",
+            "global-modules": "2.0.0",
             "import-local": "2.0.0",
             "interpret": "1.2.0",
             "loader-utils": "1.2.3",
             "supports-color": "6.1.0",
+            "v8-compile-cache": "2.0.3",
             "yargs": "13.2.4"
           },
           "dependencies": {
@@ -20525,7 +21461,18 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "requires": {
                 "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
               }
             },
             "cliui": {
@@ -20534,7 +21481,49 @@
               "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
               "requires": {
                 "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0"
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+            },
+            "enhanced-resolve": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+              "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "tapable": "^1.0.0"
+              }
+            },
+            "execa": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
               }
             },
             "find-up": {
@@ -20543,6 +21532,29 @@
               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "requires": {
                 "locate-path": "^3.0.0"
+              }
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+            },
+            "global-modules": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+              "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+              "requires": {
+                "global-prefix": "^3.0.0"
+              }
+            },
+            "global-prefix": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+              "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+              "requires": {
+                "ini": "^1.3.5",
+                "kind-of": "^6.0.2",
+                "which": "^1.3.1"
               }
             },
             "invert-kv": {
@@ -20572,14 +21584,12 @@
                 "path-exists": "^3.0.0"
               }
             },
-            "mem": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-              "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+            "npm-run-path": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
               "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
+                "path-key": "^2.0.0"
               }
             },
             "os-locale": {
@@ -20587,6 +21597,7 @@
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
               "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
               "requires": {
+                "execa": "^1.0.0",
                 "lcid": "^2.0.0",
                 "mem": "^4.0.0"
               }
@@ -20617,11 +21628,40 @@
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
             },
+            "path-key": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            },
+            "require-main-filename": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            },
             "string-width": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
               "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "requires": {
+                "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^5.1.0"
               }
@@ -20642,10 +21682,30 @@
                 "has-flag": "^3.0.0"
               }
             },
+            "v8-compile-cache": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+              "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w=="
+            },
             "which-module": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
               "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            },
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+              "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             },
             "yargs": {
               "version": "13.2.4",
@@ -20654,11 +21714,14 @@
               "requires": {
                 "cliui": "^5.0.0",
                 "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
                 "os-locale": "^3.1.0",
                 "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
                 "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
                 "yargs-parser": "^13.1.0"
               }
             },
@@ -20732,10 +21795,23 @@
           "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
           "dev": true
         },
-        "wordwrap": {
+        "which-pm-runs": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+          "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+          "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "word-wrap": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         },
         "worker-farm": {
           "version": "1.7.0",
@@ -20763,7 +21839,20 @@
         "write": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig=="
+          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+          "requires": {
+            "mkdirp": "^0.5.1"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            }
+          }
         },
         "write-file-atomic": {
           "version": "3.0.1",
@@ -20860,6 +21949,14 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
+        "yaml": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+          "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+          "requires": {
+            "@babel/runtime": "^7.6.3"
+          }
+        },
         "yargs": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
@@ -20890,6 +21987,178 @@
             "camelcase": "^3.0.0"
           }
         },
+        "yargs-unparser": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+          "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+          "requires": {
+            "flat": "^4.1.0",
+            "lodash": "^4.17.15",
+            "yargs": "^13.3.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+            },
+            "cliui": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+              "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+              "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.15",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+            },
+            "p-limit": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "require-main-filename": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            },
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+              "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            },
+            "yargs": {
+              "version": "13.3.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+              "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+              "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "13.1.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
+          }
+        },
         "yauzl": {
           "version": "2.10.0",
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -20897,19 +22166,6 @@
           "requires": {
             "buffer-crc32": "~0.2.3",
             "fd-slicer": "~1.1.0"
-          }
-        },
-        "yup": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
-          "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "fn-name": "~2.0.1",
-            "lodash": "^4.17.11",
-            "property-expr": "^1.5.0",
-            "synchronous-promise": "^2.0.6",
-            "toposort": "^2.0.2"
           }
         }
       }
@@ -28049,7 +29305,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -28428,12 +29685,6 @@
         }
       }
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -28484,7 +29735,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -28526,7 +29778,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-function": {
       "version": "1.0.1",
@@ -28624,12 +29877,14 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -30737,6 +31992,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
       "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
@@ -30745,7 +32001,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -30805,12 +32062,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
       "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
       "dev": true
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "optional": true
     },
     "npm-programmatic": {
       "version": "0.0.12",
@@ -30900,18 +32151,14 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
-    },
-    "object-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -30926,6 +32173,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -30936,7 +32184,8 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         }
       }
     },
@@ -30944,6 +32193,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -30953,6 +32203,7 @@
           "version": "1.17.5",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
           "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -30971,6 +32222,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -30980,12 +32232,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -30993,17 +32247,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -31023,6 +32280,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -31034,6 +32292,7 @@
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
           "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -31052,6 +32311,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -31061,12 +32321,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -31074,17 +32336,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -31217,6 +32482,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -31269,7 +32535,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "pako": {
       "version": "1.0.10",
@@ -31281,6 +32548,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       },
@@ -31288,7 +32556,8 @@
         "callsites": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
         }
       }
     },
@@ -31356,7 +32625,8 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -31849,84 +33119,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexp.prototype.flags": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        }
-      }
-    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -32008,7 +33200,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -32393,7 +33586,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -32776,9 +33970,9 @@
       }
     },
     "solhint": {
-      "version": "3.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-3.0.0-rc.5.tgz",
-      "integrity": "sha512-6Yv9GmOXN5iVRfkHNYClccQFBpkrTMG3BD1mlXBM4quz0bj6muCko7Md/lGqdV9Mmrx7RSsxjV1g7ugxaavXow==",
+      "version": "3.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-3.0.0-rc.6.tgz",
+      "integrity": "sha512-HzNvpzCSePrK+6zS8aFWBJyoc2b0ch6o5CibOZ3hBS7rAE/FgDGtayNgSddDk0v6zfD5xCWfLqp/ZoIyWHHpJg==",
       "dev": true,
       "requires": {
         "ajv": "^6.6.1",
@@ -33550,6 +34744,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -33558,12 +34753,14 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -33593,6 +34790,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -33601,7 +34799,8 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         }
       }
     },
@@ -33609,6 +34808,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -33617,7 +34817,8 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         }
       }
     },
@@ -35753,12 +36954,14 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
@@ -35975,6 +37178,7 @@
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -35983,7 +37187,8 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         }
       }
     },
@@ -35991,6 +37196,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
       "requires": {
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
@@ -36000,12 +37206,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
           "requires": {
             "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
@@ -36016,6 +37224,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -36023,12 +37232,14 @@
         "get-caller-file": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -36037,12 +37248,14 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -36050,12 +37263,14 @@
         "require-main-filename": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -36066,6 +37281,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -36074,6 +37290,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -36083,12 +37300,14 @@
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
         },
         "yargs": {
           "version": "13.3.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
           "requires": {
             "cliui": "^5.0.0",
             "find-up": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash.startcase": "^4.4.0",
     "micromatch": "^4.0.2",
     "mocha": "^7.1.1",
-    "solhint": "^3.0.0-rc.5",
+    "solhint": "^3.0.0-rc.6",
     "solidity-coverage": "github:rotcivegaf/solidity-coverage#5875f5b7bc74d447f3312c9c0e9fc7814b482477",
     "solidity-docgen": "^0.4.1"
   },


### PR DESCRIPTION
Part of #2086.

This uses the work done in https://github.com/protofire/solhint/issues/90 to add the `private-vars-leading-underscore` linter rule, which requires that:

 * all private and internal contract functions and variables have a leading underscore
 * all public contract functions and internal library functions don't have a leading underscore

I also fixed instances where we're not adhering to this convention.