### PR TITLE
Add 'deploy-ready' token contracts

### DIFF
--- a/contracts/deploy-ready/ERC20DeployReady.sol
+++ b/contracts/deploy-ready/ERC20DeployReady.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.6.0;
+
+import "../access/AccessControl.sol";
+import "../GSN/Context.sol";
+import "../token/ERC20/ERC20.sol";
+import "../token/ERC20/ERC20Burnable.sol";
+import "../token/ERC20/ERC20Pausable.sol";
+
+contract ERC20DeployReady is Context, AccessControl, ERC20Burnable, ERC20Pausable {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    constructor(string memory name, string memory symbol) public ERC20(name, symbol) {
+        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+
+        _setupRole(MINTER_ROLE, _msgSender());
+        _setupRole(PAUSER_ROLE, _msgSender());
+    }
+
+    function mint(address to, uint256 amount) public {
+        require(hasRole(MINTER_ROLE, _msgSender()), "ERC20DeployReady: must have minter role to mint");
+        _mint(to, amount);
+    }
+
+    function pause() public {
+        require(hasRole(PAUSER_ROLE, _msgSender()), "ERC20DeployReady: must have pauser role to pause");
+        _pause();
+    }
+
+    function unpause() public {
+        require(hasRole(PAUSER_ROLE, _msgSender()), "ERC20DeployReady: must have pauser role to unpause");
+        _unpause();
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Pausable) {
+        super._beforeTokenTransfer(from, to, amount);
+    }
+}

--- a/contracts/deploy-ready/ERC721DeployReady.sol
+++ b/contracts/deploy-ready/ERC721DeployReady.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.6.0;
+
+import "../access/AccessControl.sol";
+import "../GSN/Context.sol";
+import "../token/ERC721/ERC721.sol";
+import "../token/ERC721/ERC721Burnable.sol";
+import "../token/ERC721/ERC721Pausable.sol";
+
+contract ERC721DeployReady is Context, AccessControl, ERC721Burnable, ERC721Pausable {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    constructor(string memory name, string memory symbol) public ERC721(name, symbol) {
+        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+
+        _setupRole(MINTER_ROLE, _msgSender());
+        _setupRole(PAUSER_ROLE, _msgSender());
+    }
+
+    function mint(address to, uint256 tokenId) public {
+        require(hasRole(MINTER_ROLE, _msgSender()), "ERC721DeployReady: must have minter role to mint");
+        _mint(to, tokenId);
+    }
+
+    function pause() public {
+        require(hasRole(PAUSER_ROLE, _msgSender()), "ERC721DeployReady: must have pauser role to pause");
+        _pause();
+    }
+
+    function unpause() public {
+        require(hasRole(PAUSER_ROLE, _msgSender()), "ERC721DeployReady: must have pauser role to unpause");
+        _unpause();
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId) internal override(ERC721, ERC721Pausable) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}

--- a/test/deploy-ready/ERC20DeployReady.test.js
+++ b/test/deploy-ready/ERC20DeployReady.test.js
@@ -1,0 +1,103 @@
+const { accounts, contract, web3 } = require('@openzeppelin/test-environment');
+
+const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { ZERO_ADDRESS } = constants;
+
+const { expect } = require('chai');
+
+const ERC20DeployReady = contract.fromArtifact('ERC20DeployReady');
+
+describe('ERC20DeployReady', function () {
+  const [ deployer, other ] = accounts;
+
+  const name = 'DeployReadyToken';
+  const symbol = 'DRT';
+
+  const amount = new BN('5000');
+
+  const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+  const MINTER_ROLE = web3.utils.soliditySha3('MINTER_ROLE');
+  const PAUSER_ROLE = web3.utils.soliditySha3('PAUSER_ROLE');
+
+  beforeEach(async function () {
+    this.token = await ERC20DeployReady.new(name, symbol, { from: deployer });
+  });
+
+  it('deployer has the default admin role', async function () {
+    expect(await this.token.getRoleMemberCount(DEFAULT_ADMIN_ROLE)).to.be.bignumber.equal('1');
+    expect(await this.token.getRoleMember(DEFAULT_ADMIN_ROLE, 0)).to.equal(deployer);
+  });
+
+  it('deployer has the minter role', async function () {
+    expect(await this.token.getRoleMemberCount(MINTER_ROLE)).to.be.bignumber.equal('1');
+    expect(await this.token.getRoleMember(MINTER_ROLE, 0)).to.equal(deployer);
+  });
+
+  it('deployer has the pauser role', async function () {
+    expect(await this.token.getRoleMemberCount(PAUSER_ROLE)).to.be.bignumber.equal('1');
+    expect(await this.token.getRoleMember(PAUSER_ROLE, 0)).to.equal(deployer);
+  });
+
+  it('minter and pauser role admin is the default admin', async function () {
+    expect(await this.token.getRoleAdmin(MINTER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+    expect(await this.token.getRoleAdmin(PAUSER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+  });
+
+  describe('minting', function () {
+    it('deployer can mint tokens', async function () {
+      const receipt = await this.token.mint(other, amount, { from: deployer });
+      expectEvent(receipt, 'Transfer', { from: ZERO_ADDRESS, to: other, value: amount });
+
+      expect(await this.token.balanceOf(other)).to.be.bignumber.equal(amount);
+    });
+
+    it('other accounts cannot mint tokens', async function () {
+      await expectRevert(
+        this.token.mint(other, amount, { from: other }),
+        'ERC20DeployReady: must have minter role to mint'
+      );
+    })
+  });
+
+  describe('pausing', function () {
+    it('deployer can pause', async function () {
+      const receipt = await this.token.pause({ from: deployer });
+      expectEvent(receipt, 'Paused', { account: deployer });
+
+      expect(await this.token.paused()).to.equal(true);
+    });
+
+    it('deployer can unpause', async function () {
+      await this.token.pause({ from: deployer });
+
+      const receipt = await this.token.unpause({ from: deployer });
+      expectEvent(receipt, 'Unpaused', { account: deployer });
+
+      expect(await this.token.paused()).to.equal(false);
+    });
+
+    it('cannot mint while paused', async function () {
+      await this.token.pause({ from: deployer });
+
+      await expectRevert(
+        this.token.mint(other, amount, { from: deployer }),
+        'ERC20Pausable: token transfer while paused'
+      );
+    });
+
+    it('other accounts cannot pause', async function () {
+      await expectRevert(this.token.pause({ from: other }), 'ERC20DeployReady: must have pauser role to pause');
+    })
+  });
+
+  describe('burning', function () {
+    it('holders can burn their tokens', async function () {
+      await this.token.mint(other, amount, { from: deployer });
+
+      const receipt = await this.token.burn(amount.subn(1), { from: other });
+      expectEvent(receipt, 'Transfer', { from: other, to: ZERO_ADDRESS, value: amount.subn(1) });
+
+      expect(await this.token.balanceOf(other)).to.be.bignumber.equal('1');
+    });
+  });
+});

--- a/test/deploy-ready/ERC721DeployReady.test.js
+++ b/test/deploy-ready/ERC721DeployReady.test.js
@@ -1,0 +1,106 @@
+const { accounts, contract, web3 } = require('@openzeppelin/test-environment');
+
+const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { ZERO_ADDRESS } = constants;
+
+const { expect } = require('chai');
+
+const ERC721DeployReady = contract.fromArtifact('ERC721DeployReady');
+
+describe('ERC721DeployReady', function () {
+  const [ deployer, other ] = accounts;
+
+  const name = 'DeployReadyToken';
+  const symbol = 'DRT';
+
+  const tokenId = new BN('1337');
+
+  const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+  const MINTER_ROLE = web3.utils.soliditySha3('MINTER_ROLE');
+  const PAUSER_ROLE = web3.utils.soliditySha3('PAUSER_ROLE');
+
+  beforeEach(async function () {
+    this.token = await ERC721DeployReady.new(name, symbol, { from: deployer });
+  });
+
+  it('deployer has the default admin role', async function () {
+    expect(await this.token.getRoleMemberCount(DEFAULT_ADMIN_ROLE)).to.be.bignumber.equal('1');
+    expect(await this.token.getRoleMember(DEFAULT_ADMIN_ROLE, 0)).to.equal(deployer);
+  });
+
+  it('deployer has the minter role', async function () {
+    expect(await this.token.getRoleMemberCount(MINTER_ROLE)).to.be.bignumber.equal('1');
+    expect(await this.token.getRoleMember(MINTER_ROLE, 0)).to.equal(deployer);
+  });
+
+  it('deployer has the pauser role', async function () {
+    expect(await this.token.getRoleMemberCount(PAUSER_ROLE)).to.be.bignumber.equal('1');
+    expect(await this.token.getRoleMember(PAUSER_ROLE, 0)).to.equal(deployer);
+  });
+
+  it('minter and pauser role admin is the default admin', async function () {
+    expect(await this.token.getRoleAdmin(MINTER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+    expect(await this.token.getRoleAdmin(PAUSER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+  });
+
+  describe('minting', function () {
+    it('deployer can mint tokens', async function () {
+      const receipt = await this.token.mint(other, tokenId, { from: deployer });
+      expectEvent(receipt, 'Transfer', { from: ZERO_ADDRESS, to: other, tokenId });
+
+      expect(await this.token.balanceOf(other)).to.be.bignumber.equal('1');
+      expect(await this.token.ownerOf(tokenId)).to.equal(other);
+    });
+
+    it('other accounts cannot mint tokens', async function () {
+      await expectRevert(
+        this.token.mint(other, tokenId, { from: other }),
+        'ERC721DeployReady: must have minter role to mint'
+      );
+    })
+  });
+
+  describe('pausing', function () {
+    it('deployer can pause', async function () {
+      const receipt = await this.token.pause({ from: deployer });
+      expectEvent(receipt, 'Paused', { account: deployer });
+
+      expect(await this.token.paused()).to.equal(true);
+    });
+
+    it('deployer can unpause', async function () {
+      await this.token.pause({ from: deployer });
+
+      const receipt = await this.token.unpause({ from: deployer });
+      expectEvent(receipt, 'Unpaused', { account: deployer });
+
+      expect(await this.token.paused()).to.equal(false);
+    });
+
+    it('cannot mint while paused', async function () {
+      await this.token.pause({ from: deployer });
+
+      await expectRevert(
+        this.token.mint(other, tokenId, { from: deployer }),
+        'ERC721Pausable: token transfer while paused'
+      );
+    });
+
+    it('other accounts cannot pause', async function () {
+      await expectRevert(this.token.pause({ from: other }), 'ERC721DeployReady: must have pauser role to pause');
+    })
+  });
+
+  describe('burning', function () {
+    it('holders can burn their tokens', async function () {
+      await this.token.mint(other, tokenId, { from: deployer });
+
+      const receipt = await this.token.burn(tokenId, { from: other });
+
+      expectEvent(receipt, 'Transfer', { from: other, to: ZERO_ADDRESS, tokenId });
+
+      expect(await this.token.balanceOf(other)).to.be.bignumber.equal('0');
+      expect(await this.token.totalSupply()).to.be.bignumber.equal('0');
+    });
+  });
+});


### PR DESCRIPTION
This adds deploy-ready variants for ERC20 and ERC721. These are burnable (holders can burn their tokens), mintable (minters can mint tokens arbitrarily) and pausable (pausers can pause all token transfers).

They will serve both as an example on how to integrate different OpenZeppelin contracts and use Access Control features, and as simple tokens that can be deployed as-is for quick prototyping. Projects that used to rely on ERC20Mintable for these use cases can now switch the deploy-ready variants.

I decided to give the minter and pauser role to the deployer to make using the contracts simpler: no calls to `grantRole` have to be made. However, because the deployer is also the admin of these roles, new minters and pausers can be created.

Fixes https://github.com/OpenZeppelin/openzeppelin-contracts/issues/2163