### PR TITLE
Updated ERC777 _beforeTokenTransfer hook calls to match ERC20

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -322,6 +322,8 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         address operator = _msgSender();
 
+        _beforeTokenTransfer(operator, address(0), account, amount);
+
         // Update state variables
         _totalSupply = _totalSupply.add(amount);
         _balances[account] = _balances[account].add(amount);
@@ -381,6 +383,8 @@ contract ERC777 is Context, IERC777, IERC20 {
         require(from != address(0), "ERC777: burn from the zero address");
 
         address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, from, address(0), amount);
 
         _callTokensToSend(operator, from, address(0), amount, data, operatorData);
 

--- a/scripts/gen-nav.js
+++ b/scripts/gen-nav.js
@@ -7,19 +7,19 @@ const startCase = require('lodash.startcase');
 const baseDir = process.argv[2];
 
 const files = proc.execFileSync(
-  'find', [baseDir, '-type', 'f'], { encoding: 'utf8' }
+  'find', [baseDir, '-type', 'f'], { encoding: 'utf8' },
 ).split('\n').filter(s => s !== '');
 
 console.log('.API');
 
 const links = files.map((file) => {
-    const doc = file.replace(baseDir, '');
-    const title = path.parse(file).name;
+  const doc = file.replace(baseDir, '');
+  const title = path.parse(file).name;
 
-    return {
-      xref: `* xref:${doc}[${startCase(title)}]`,
-      title,
-    };
+  return {
+    xref: `* xref:${doc}[${startCase(title)}]`,
+    title,
+  };
 });
 
 // Case-insensitive sort based on titles (so 'token/ERC20' gets sorted as 'erc20')
@@ -28,5 +28,5 @@ const sortedLinks = links.sort(function (a, b) {
 });
 
 for (const link of sortedLinks) {
-   console.log(link.xref);
+  console.log(link.xref);
 }

--- a/scripts/release/update-changelog-release-date.js
+++ b/scripts/release/update-changelog-release-date.js
@@ -27,7 +27,7 @@ if (changelog.indexOf(`## ${version} (unreleased)`) === -1) {
 
 fs.writeFileSync('CHANGELOG.md', changelog.replace(
   `## ${version} (unreleased)`,
-  `## ${version} (${new Date().toISOString().split('T')[0]})`)
+  `## ${version} (${new Date().toISOString().split('T')[0]})`),
 );
 
 cp.execSync('git add CHANGELOG.md', { stdio: 'inherit' });

--- a/test/GSN/ERC721GSNRecipientMock.test.js
+++ b/test/GSN/ERC721GSNRecipientMock.test.js
@@ -41,9 +41,9 @@ describe('ERC721GSNRecipient (integration)', function () {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, this.token.address
-            ), signer
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, this.token.address,
+            ), signer,
+          ),
         );
 
       await testMintToken(this.token, sender, tokenId, { useGSN: true, approveFunction });

--- a/test/GSN/GSNRecipient.test.js
+++ b/test/GSN/GSNRecipient.test.js
@@ -38,13 +38,13 @@ describe('GSNRecipient', function () {
     it('cannot upgrade to the same RelayHub', async function () {
       await expectRevert(
         this.recipient.upgradeRelayHub(singletonRelayHub),
-        'GSNRecipient: new RelayHub is the current one'
+        'GSNRecipient: new RelayHub is the current one',
       );
     });
 
     it('cannot upgrade to the zero address', async function () {
       await expectRevert(
-        this.recipient.upgradeRelayHub(ZERO_ADDRESS), 'GSNRecipient: new RelayHub is the zero address'
+        this.recipient.upgradeRelayHub(ZERO_ADDRESS), 'GSNRecipient: new RelayHub is the zero address',
       );
     });
 

--- a/test/GSN/GSNRecipientSignature.test.js
+++ b/test/GSN/GSNRecipientSignature.test.js
@@ -26,9 +26,9 @@ describe('GSNRecipientSignature', function () {
     it('fails when constructor called with a zero address', async function () {
       await expectRevert(
         GSNRecipientSignatureMock.new(
-          ZERO_ADDRESS
+          ZERO_ADDRESS,
         ),
-        'GSNRecipientSignature: trusted signer is the zero address'
+        'GSNRecipientSignature: trusted signer is the zero address',
       );
     });
   });
@@ -49,9 +49,9 @@ describe('GSNRecipientSignature', function () {
             web3.utils.soliditySha3(
               // the nonce is not signed
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas)
-            ), signer
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas),
+            ), signer,
+          ),
         );
 
       await gsn.expectError(this.recipient.mockFunction({ value: 0, useGSN: true, approveFunction }));
@@ -63,9 +63,9 @@ describe('GSNRecipientSignature', function () {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to
-            ), signer
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to,
+            ), signer,
+          ),
         );
 
       const { tx } = await this.recipient.mockFunction({ value: 0, useGSN: true, approveFunction });
@@ -79,9 +79,9 @@ describe('GSNRecipientSignature', function () {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to
-            ), other
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to,
+            ), other,
+          ),
         );
 
       await gsn.expectError(this.recipient.mockFunction({ value: 0, useGSN: true, approveFunction }));

--- a/test/access/AccessControl.test.js
+++ b/test/access/AccessControl.test.js
@@ -21,7 +21,7 @@ describe('AccessControl', function () {
     it('cannot be called outside the constructor', async function () {
       await expectRevert(
         this.accessControl.setupRole(OTHER_ROLE, other),
-        'AccessControl: roles cannot be setup after construction'
+        'AccessControl: roles cannot be setup after construction',
       );
     });
   });
@@ -51,7 +51,7 @@ describe('AccessControl', function () {
     it('non-admin cannot grant role to other accounts', async function () {
       await expectRevert(
         this.accessControl.grantRole(ROLE, authorized, { from: other }),
-        'AccessControl: sender must be an admin to grant'
+        'AccessControl: sender must be an admin to grant',
       );
     });
 
@@ -85,7 +85,7 @@ describe('AccessControl', function () {
       it('non-admin cannot revoke role', async function () {
         await expectRevert(
           this.accessControl.revokeRole(ROLE, authorized, { from: other }),
-          'AccessControl: sender must be an admin to revoke'
+          'AccessControl: sender must be an admin to revoke',
         );
       });
 
@@ -119,7 +119,7 @@ describe('AccessControl', function () {
       it('only the sender can renounce their roles', async function () {
         await expectRevert(
           this.accessControl.renounceRole(ROLE, authorized, { from: admin }),
-          'AccessControl: can only renounce roles for self'
+          'AccessControl: can only renounce roles for self',
         );
       });
 
@@ -173,14 +173,14 @@ describe('AccessControl', function () {
     it('a role\'s previous admins no longer grant roles', async function () {
       await expectRevert(
         this.accessControl.grantRole(ROLE, authorized, { from: admin }),
-        'AccessControl: sender must be an admin to grant'
+        'AccessControl: sender must be an admin to grant',
       );
     });
 
     it('a role\'s previous admins no longer revoke roles', async function () {
       await expectRevert(
         this.accessControl.revokeRole(ROLE, authorized, { from: admin }),
-        'AccessControl: sender must be an admin to revoke'
+        'AccessControl: sender must be an admin to revoke',
       );
     });
   });

--- a/test/access/Ownable.test.js
+++ b/test/access/Ownable.test.js
@@ -27,14 +27,14 @@ describe('Ownable', function () {
   it('should prevent non-owners from transferring', async function () {
     await expectRevert(
       this.ownable.transferOwnership(other, { from: other }),
-      'Ownable: caller is not the owner'
+      'Ownable: caller is not the owner',
     );
   });
 
   it('should guard ownership against stuck state', async function () {
     await expectRevert(
       this.ownable.transferOwnership(ZERO_ADDRESS, { from: owner }),
-      'Ownable: new owner is the zero address'
+      'Ownable: new owner is the zero address',
     );
   });
 
@@ -48,7 +48,7 @@ describe('Ownable', function () {
   it('should prevent non-owners from renouncement', async function () {
     await expectRevert(
       this.ownable.renounceOwnership({ from: other }),
-      'Ownable: caller is not the owner'
+      'Ownable: caller is not the owner',
     );
   });
 });

--- a/test/cryptography/ECDSA.test.js
+++ b/test/cryptography/ECDSA.test.js
@@ -26,7 +26,7 @@ describe('ECDSA', function () {
       await expectRevert(
         // eslint-disable-next-line max-len
         this.ecdsa.recover(TEST_MESSAGE, '0x01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'),
-        'ECDSA: invalid signature length'
+        'ECDSA: invalid signature length',
       );
     });
   });
@@ -116,7 +116,7 @@ describe('ECDSA', function () {
           // Recover the signer address from the generated message and signature.
           expect(await this.ecdsa.recover(
             toEthSignedMessageHash(TEST_MESSAGE),
-            signature
+            signature,
           )).to.equal(other);
         });
       });

--- a/test/deploy-ready/ERC20MinterPauser.test.js
+++ b/test/deploy-ready/ERC20MinterPauser.test.js
@@ -54,7 +54,7 @@ describe('ERC20MinterPauser', function () {
     it('other accounts cannot mint tokens', async function () {
       await expectRevert(
         this.token.mint(other, amount, { from: other }),
-        'ERC20MinterPauser: must have minter role to mint'
+        'ERC20MinterPauser: must have minter role to mint',
       );
     });
   });
@@ -81,7 +81,7 @@ describe('ERC20MinterPauser', function () {
 
       await expectRevert(
         this.token.mint(other, amount, { from: deployer }),
-        'ERC20Pausable: token transfer while paused'
+        'ERC20Pausable: token transfer while paused',
       );
     });
 

--- a/test/deploy-ready/ERC721MinterPauser.test.js
+++ b/test/deploy-ready/ERC721MinterPauser.test.js
@@ -55,7 +55,7 @@ describe('ERC721MinterPauser', function () {
     it('other accounts cannot mint tokens', async function () {
       await expectRevert(
         this.token.mint(other, tokenId, { from: other }),
-        'ERC721MinterPauser: must have minter role to mint'
+        'ERC721MinterPauser: must have minter role to mint',
       );
     });
   });
@@ -82,7 +82,7 @@ describe('ERC721MinterPauser', function () {
 
       await expectRevert(
         this.token.mint(other, tokenId, { from: deployer }),
-        'ERC721Pausable: token transfer while paused'
+        'ERC721Pausable: token transfer while paused',
       );
     });
 

--- a/test/helpers/sign.js
+++ b/test/helpers/sign.js
@@ -47,7 +47,7 @@ const getSignFor = (contract, signer) => (redeemer, methodName, methodArgs = [])
     if (methodArgs.length > 0) {
       parts.push(
         contract.contract.methods[methodName](...methodArgs.concat([DUMMY_SIGNATURE])).encodeABI()
-          .slice(0, -1 * PADDED_SIGNATURE_SIZE)
+          .slice(0, -1 * PADDED_SIGNATURE_SIZE),
       );
     } else {
       const abi = contract.abi.find(abi => abi.name === methodName);

--- a/test/introspection/ERC1820Implementer.test.js
+++ b/test/introspection/ERC1820Implementer.test.js
@@ -29,9 +29,9 @@ describe('ERC1820Implementer', function () {
     it('reverts when attempting to set as implementer in the registry', async function () {
       await expectRevert(
         this.registry.setInterfaceImplementer(
-          implementee, this.interfaceA, this.implementer.address, { from: implementee }
+          implementee, this.interfaceA, this.implementer.address, { from: implementee },
         ),
-        'Does not implement the interface'
+        'Does not implement the interface',
       );
     });
   });
@@ -58,7 +58,7 @@ describe('ERC1820Implementer', function () {
 
     it('can be set as an implementer for supported interfaces in the registry', async function () {
       await this.registry.setInterfaceImplementer(
-        implementee, this.interfaceA, this.implementer.address, { from: implementee }
+        implementee, this.interfaceA, this.implementer.address, { from: implementee },
       );
 
       expect(await this.registry.getInterfaceImplementer(implementee, this.interfaceA))

--- a/test/payment/PaymentSplitter.test.js
+++ b/test/payment/PaymentSplitter.test.js
@@ -18,31 +18,31 @@ describe('PaymentSplitter', function () {
 
   it('rejects more payees than shares', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee2, payee3], [20, 30]),
-      'PaymentSplitter: payees and shares length mismatch'
+      'PaymentSplitter: payees and shares length mismatch',
     );
   });
 
   it('rejects more shares than payees', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee2], [20, 30, 40]),
-      'PaymentSplitter: payees and shares length mismatch'
+      'PaymentSplitter: payees and shares length mismatch',
     );
   });
 
   it('rejects null payees', async function () {
     await expectRevert(PaymentSplitter.new([payee1, ZERO_ADDRESS], [20, 30]),
-      'PaymentSplitter: account is the zero address'
+      'PaymentSplitter: account is the zero address',
     );
   });
 
   it('rejects zero-valued shares', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee2], [20, 0]),
-      'PaymentSplitter: shares are 0'
+      'PaymentSplitter: shares are 0',
     );
   });
 
   it('rejects repeated payees', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee1], [20, 30]),
-      'PaymentSplitter: account already has shares'
+      'PaymentSplitter: account already has shares',
     );
   });
 
@@ -81,14 +81,14 @@ describe('PaymentSplitter', function () {
 
     it('should throw if no funds to claim', async function () {
       await expectRevert(this.contract.release(payee1),
-        'PaymentSplitter: account is not due payment'
+        'PaymentSplitter: account is not due payment',
       );
     });
 
     it('should throw if non-payee want to claim', async function () {
       await send.ether(payer1, this.contract.address, amount);
       await expectRevert(this.contract.release(nonpayee1),
-        'PaymentSplitter: account has no shares'
+        'PaymentSplitter: account has no shares',
       );
     });
 

--- a/test/payment/escrow/ConditionalEscrow.test.js
+++ b/test/payment/escrow/ConditionalEscrow.test.js
@@ -31,7 +31,7 @@ describe('ConditionalEscrow', function () {
       await this.escrow.deposit(payee, { from: owner, value: amount });
 
       await expectRevert(this.escrow.withdraw(payee, { from: owner }),
-        'ConditionalEscrow: payee is not allowed to withdraw'
+        'ConditionalEscrow: payee is not allowed to withdraw',
       );
     });
   });

--- a/test/payment/escrow/Escrow.behavior.js
+++ b/test/payment/escrow/Escrow.behavior.js
@@ -21,7 +21,7 @@ function shouldBehaveLikeEscrow (owner, [payee1, payee2]) {
 
       it('only the owner can deposit', async function () {
         await expectRevert(this.escrow.deposit(payee1, { from: payee2 }),
-          'Ownable: caller is not the owner'
+          'Ownable: caller is not the owner',
         );
       });
 
@@ -73,7 +73,7 @@ function shouldBehaveLikeEscrow (owner, [payee1, payee2]) {
 
       it('only the owner can withdraw', async function () {
         await expectRevert(this.escrow.withdraw(payee1, { from: payee1 }),
-          'Ownable: caller is not the owner'
+          'Ownable: caller is not the owner',
         );
       });
 

--- a/test/payment/escrow/RefundEscrow.test.js
+++ b/test/payment/escrow/RefundEscrow.test.js
@@ -15,7 +15,7 @@ describe('RefundEscrow', function () {
 
   it('requires a non-null beneficiary', async function () {
     await expectRevert(
-      RefundEscrow.new(ZERO_ADDRESS, { from: owner }), 'RefundEscrow: beneficiary is the zero address'
+      RefundEscrow.new(ZERO_ADDRESS, { from: owner }), 'RefundEscrow: beneficiary is the zero address',
     );
   });
 
@@ -39,21 +39,21 @@ describe('RefundEscrow', function () {
       it('does not refund refundees', async function () {
         await this.escrow.deposit(refundee1, { from: owner, value: amount });
         await expectRevert(this.escrow.withdraw(refundee1),
-          'ConditionalEscrow: payee is not allowed to withdraw'
+          'ConditionalEscrow: payee is not allowed to withdraw',
         );
       });
 
       it('does not allow beneficiary withdrawal', async function () {
         await this.escrow.deposit(refundee1, { from: owner, value: amount });
         await expectRevert(this.escrow.beneficiaryWithdraw(),
-          'RefundEscrow: beneficiary can only withdraw while closed'
+          'RefundEscrow: beneficiary can only withdraw while closed',
         );
       });
     });
 
     it('only the owner can enter closed state', async function () {
       await expectRevert(this.escrow.close({ from: beneficiary }),
-        'Ownable: caller is not the owner'
+        'Ownable: caller is not the owner',
       );
 
       const { logs } = await this.escrow.close({ from: owner });
@@ -69,13 +69,13 @@ describe('RefundEscrow', function () {
 
       it('rejects deposits', async function () {
         await expectRevert(this.escrow.deposit(refundee1, { from: owner, value: amount }),
-          'RefundEscrow: can only deposit while active'
+          'RefundEscrow: can only deposit while active',
         );
       });
 
       it('does not refund refundees', async function () {
         await expectRevert(this.escrow.withdraw(refundee1),
-          'ConditionalEscrow: payee is not allowed to withdraw'
+          'ConditionalEscrow: payee is not allowed to withdraw',
         );
       });
 
@@ -87,20 +87,20 @@ describe('RefundEscrow', function () {
 
       it('prevents entering the refund state', async function () {
         await expectRevert(this.escrow.enableRefunds({ from: owner }),
-          'RefundEscrow: can only enable refunds while active'
+          'RefundEscrow: can only enable refunds while active',
         );
       });
 
       it('prevents re-entering the closed state', async function () {
         await expectRevert(this.escrow.close({ from: owner }),
-          'RefundEscrow: can only close while active'
+          'RefundEscrow: can only close while active',
         );
       });
     });
 
     it('only the owner can enter refund state', async function () {
       await expectRevert(this.escrow.enableRefunds({ from: beneficiary }),
-        'Ownable: caller is not the owner'
+        'Ownable: caller is not the owner',
       );
 
       const { logs } = await this.escrow.enableRefunds({ from: owner });
@@ -116,7 +116,7 @@ describe('RefundEscrow', function () {
 
       it('rejects deposits', async function () {
         await expectRevert(this.escrow.deposit(refundee1, { from: owner, value: amount }),
-          'RefundEscrow: can only deposit while active'
+          'RefundEscrow: can only deposit while active',
         );
       });
 
@@ -130,19 +130,19 @@ describe('RefundEscrow', function () {
 
       it('does not allow beneficiary withdrawal', async function () {
         await expectRevert(this.escrow.beneficiaryWithdraw(),
-          'RefundEscrow: beneficiary can only withdraw while closed'
+          'RefundEscrow: beneficiary can only withdraw while closed',
         );
       });
 
       it('prevents entering the closed state', async function () {
         await expectRevert(this.escrow.close({ from: owner }),
-          'RefundEscrow: can only close while active'
+          'RefundEscrow: can only close while active',
         );
       });
 
       it('prevents re-entering the refund state', async function () {
         await expectRevert(this.escrow.enableRefunds({ from: owner }),
-          'RefundEscrow: can only enable refunds while active'
+          'RefundEscrow: can only enable refunds while active',
         );
       });
     });

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -27,7 +27,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
     shouldBehaveLikeERC20Transfer(errorPrefix, initialHolder, recipient, initialSupply,
       function (from, to, value) {
         return this.token.transfer(to, value, { from });
-      }
+      },
     );
   });
 
@@ -88,7 +88,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
             it('reverts', async function () {
               await expectRevert(this.token.transferFrom(
-                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`
+                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`,
               );
             });
           });
@@ -104,7 +104,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
             it('reverts', async function () {
               await expectRevert(this.token.transferFrom(
-                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds allowance`
+                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds allowance`,
               );
             });
           });
@@ -114,7 +114,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
             it('reverts', async function () {
               await expectRevert(this.token.transferFrom(
-                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`
+                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`,
               );
             });
           });
@@ -131,7 +131,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
         it('reverts', async function () {
           await expectRevert(this.token.transferFrom(
-            tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`
+            tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`,
           );
         });
       });
@@ -144,7 +144,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
       it('reverts', async function () {
         await expectRevert(this.token.transferFrom(
-          tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer from the zero address`
+          tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer from the zero address`,
         );
       });
     });
@@ -154,7 +154,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
     shouldBehaveLikeERC20Approve(errorPrefix, initialHolder, recipient, initialSupply,
       function (owner, spender, amount) {
         return this.token.approve(spender, amount, { from: owner });
-      }
+      },
     );
   });
 }
@@ -166,7 +166,7 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
 
       it('reverts', async function () {
         await expectRevert(transfer.call(this, from, to, amount),
-          `${errorPrefix}: transfer amount exceeds balance`
+          `${errorPrefix}: transfer amount exceeds balance`,
         );
       });
     });
@@ -219,7 +219,7 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
   describe('when the recipient is the zero address', function () {
     it('reverts', async function () {
       await expectRevert(transfer.call(this, from, ZERO_ADDRESS, balance),
-        `${errorPrefix}: transfer to the zero address`
+        `${errorPrefix}: transfer to the zero address`,
       );
     });
   });
@@ -299,7 +299,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
   describe('when the spender is the zero address', function () {
     it('reverts', async function () {
       await expectRevert(approve.call(this, owner, ZERO_ADDRESS, supply),
-        `${errorPrefix}: approve to the zero address`
+        `${errorPrefix}: approve to the zero address`,
       );
     });
   });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -62,7 +62,7 @@ describe('ERC20', function () {
         describe('when there was no approved amount before', function () {
           it('reverts', async function () {
             await expectRevert(this.token.decreaseAllowance(
-              spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero'
+              spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero',
             );
           });
         });
@@ -98,7 +98,7 @@ describe('ERC20', function () {
           it('reverts when more than the full allowance is removed', async function () {
             await expectRevert(
               this.token.decreaseAllowance(spender, approvedAmount.addn(1), { from: initialHolder }),
-              'ERC20: decreased allowance below zero'
+              'ERC20: decreased allowance below zero',
             );
           });
         });
@@ -123,7 +123,7 @@ describe('ERC20', function () {
 
       it('reverts', async function () {
         await expectRevert(this.token.decreaseAllowance(
-          spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero'
+          spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero',
         );
       });
     });
@@ -207,7 +207,7 @@ describe('ERC20', function () {
 
       it('reverts', async function () {
         await expectRevert(
-          this.token.increaseAllowance(spender, amount, { from: initialHolder }), 'ERC20: approve to the zero address'
+          this.token.increaseAllowance(spender, amount, { from: initialHolder }), 'ERC20: approve to the zero address',
         );
       });
     });
@@ -217,7 +217,7 @@ describe('ERC20', function () {
     const amount = new BN(50);
     it('rejects a null account', async function () {
       await expectRevert(
-        this.token.mint(ZERO_ADDRESS, amount), 'ERC20: mint to the zero address'
+        this.token.mint(ZERO_ADDRESS, amount), 'ERC20: mint to the zero address',
       );
     });
 
@@ -256,7 +256,7 @@ describe('ERC20', function () {
     describe('for a non zero account', function () {
       it('rejects burning more than balance', async function () {
         await expectRevert(this.token.burn(
-          initialHolder, initialSupply.addn(1)), 'ERC20: burn amount exceeds balance'
+          initialHolder, initialSupply.addn(1)), 'ERC20: burn amount exceeds balance',
         );
       });
 
@@ -301,7 +301,7 @@ describe('ERC20', function () {
     describe('when the sender is the zero address', function () {
       it('reverts', async function () {
         await expectRevert(this.token.transferInternal(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: transfer from the zero address'
+          'ERC20: transfer from the zero address',
         );
       });
     });
@@ -315,7 +315,7 @@ describe('ERC20', function () {
     describe('when the owner is the zero address', function () {
       it('reverts', async function () {
         await expectRevert(this.token.approveInternal(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: approve from the zero address'
+          'ERC20: approve from the zero address',
         );
       });
     });

--- a/test/token/ERC20/ERC20Capped.test.js
+++ b/test/token/ERC20/ERC20Capped.test.js
@@ -15,7 +15,7 @@ describe('ERC20Capped', function () {
 
   it('requires a non-zero cap', async function () {
     await expectRevert(
-      ERC20Capped.new(name, symbol, new BN(0), { from: minter }), 'ERC20Capped: cap is 0'
+      ERC20Capped.new(name, symbol, new BN(0), { from: minter }), 'ERC20Capped: cap is 0',
     );
   });
 

--- a/test/token/ERC20/ERC20Pausable.test.js
+++ b/test/token/ERC20/ERC20Pausable.test.js
@@ -41,7 +41,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause();
 
         await expectRevert(this.token.transfer(recipient, initialSupply, { from: holder }),
-          'ERC20Pausable: token transfer while paused'
+          'ERC20Pausable: token transfer while paused',
         );
       });
     });
@@ -74,7 +74,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause();
 
         await expectRevert(this.token.transferFrom(
-          holder, recipient, allowance, { from: anotherAccount }), 'ERC20Pausable: token transfer while paused'
+          holder, recipient, allowance, { from: anotherAccount }), 'ERC20Pausable: token transfer while paused',
         );
       });
     });

--- a/test/token/ERC20/ERC20Snapshot.test.js
+++ b/test/token/ERC20/ERC20Snapshot.test.js
@@ -76,7 +76,7 @@ describe('ERC20Snapshot', function () {
             expect(await this.token.totalSupplyAt(this.initialSnapshotId)).to.be.bignumber.equal(initialSupply);
 
             expect(await this.token.totalSupplyAt(this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.totalSupply()
+              await this.token.totalSupply(),
             );
           });
         });
@@ -160,13 +160,13 @@ describe('ERC20Snapshot', function () {
             expect(await this.token.balanceOfAt(other, this.initialSnapshotId)).to.be.bignumber.equal('0');
 
             expect(await this.token.balanceOfAt(initialHolder, this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.balanceOf(initialHolder)
+              await this.token.balanceOf(initialHolder),
             );
             expect(await this.token.balanceOfAt(recipient, this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.balanceOf(recipient)
+              await this.token.balanceOf(recipient),
             );
             expect(await this.token.balanceOfAt(other, this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.balanceOf(other)
+              await this.token.balanceOf(other),
             );
           });
         });
@@ -189,13 +189,13 @@ describe('ERC20Snapshot', function () {
 
             for (const id of this.secondSnapshotIds) {
               expect(await this.token.balanceOfAt(initialHolder, id)).to.be.bignumber.equal(
-                await this.token.balanceOf(initialHolder)
+                await this.token.balanceOf(initialHolder),
               );
               expect(await this.token.balanceOfAt(recipient, id)).to.be.bignumber.equal(
-                await this.token.balanceOf(recipient)
+                await this.token.balanceOf(recipient),
               );
               expect(await this.token.balanceOfAt(other, id)).to.be.bignumber.equal(
-                await this.token.balanceOf(other)
+                await this.token.balanceOf(other),
               );
             }
           });

--- a/test/token/ERC20/SafeERC20.test.js
+++ b/test/token/ERC20/SafeERC20.test.js
@@ -97,7 +97,7 @@ function shouldOnlyRevertOnErrors () {
       it('reverts when decreasing the allowance', async function () {
         await expectRevert(
           this.wrapper.decreaseAllowance(10),
-          'SafeERC20: decreased allowance below zero'
+          'SafeERC20: decreased allowance below zero',
         );
       });
     });
@@ -110,7 +110,7 @@ function shouldOnlyRevertOnErrors () {
       it('reverts when approving a non-zero allowance', async function () {
         await expectRevert(
           this.wrapper.approve(20),
-          'SafeERC20: approve from non-zero to non-zero allowance'
+          'SafeERC20: approve from non-zero to non-zero allowance',
         );
       });
 
@@ -129,7 +129,7 @@ function shouldOnlyRevertOnErrors () {
       it('reverts when decreasing the allowance to a negative value', async function () {
         await expectRevert(
           this.wrapper.decreaseAllowance(200),
-          'SafeERC20: decreased allowance below zero'
+          'SafeERC20: decreased allowance below zero',
         );
       });
     });

--- a/test/token/ERC20/TokenTimelock.test.js
+++ b/test/token/ERC20/TokenTimelock.test.js
@@ -24,7 +24,7 @@ describe('TokenTimelock', function () {
       const pastReleaseTime = (await time.latest()).sub(time.duration.years(1));
       await expectRevert(
         TokenTimelock.new(this.token.address, beneficiary, pastReleaseTime),
-        'TokenTimelock: release time is before current time'
+        'TokenTimelock: release time is before current time',
       );
     });
 

--- a/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
@@ -38,7 +38,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
 
       it('reverts', async function () {
         await expectRevert(this.token.burn(amount, { from: owner }),
-          'ERC20: burn amount exceeds balance'
+          'ERC20: burn amount exceeds balance',
         );
       });
     });
@@ -87,7 +87,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
       it('reverts', async function () {
         await this.token.approve(burner, amount, { from: owner });
         await expectRevert(this.token.burnFrom(owner, amount, { from: burner }),
-          'ERC20: burn amount exceeds balance'
+          'ERC20: burn amount exceeds balance',
         );
       });
     });
@@ -98,7 +98,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
       it('reverts', async function () {
         await this.token.approve(burner, allowance, { from: owner });
         await expectRevert(this.token.burnFrom(owner, allowance.addn(1), { from: burner }),
-          'ERC20: burn amount exceeds allowance'
+          'ERC20: burn amount exceeds allowance',
         );
       });
     });

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -56,7 +56,7 @@ describe('ERC721', function () {
 
       it('reverts when queried for non existent token id', async function () {
         await expectRevert(
-          this.token.tokenURI(nonExistentTokenId), 'ERC721Metadata: URI query for nonexistent token'
+          this.token.tokenURI(nonExistentTokenId), 'ERC721Metadata: URI query for nonexistent token',
         );
       });
 
@@ -67,7 +67,7 @@ describe('ERC721', function () {
 
       it('reverts when setting for non existent token id', async function () {
         await expectRevert(
-          this.token.setTokenURI(nonExistentTokenId, sampleUri), 'ERC721Metadata: URI set of nonexistent token'
+          this.token.setTokenURI(nonExistentTokenId, sampleUri), 'ERC721Metadata: URI set of nonexistent token',
         );
       });
 
@@ -105,7 +105,7 @@ describe('ERC721', function () {
 
         expect(await this.token.exists(firstTokenId)).to.equal(false);
         await expectRevert(
-          this.token.tokenURI(firstTokenId), 'ERC721Metadata: URI query for nonexistent token'
+          this.token.tokenURI(firstTokenId), 'ERC721Metadata: URI query for nonexistent token',
         );
       });
     });
@@ -134,7 +134,7 @@ describe('ERC721', function () {
       context('when querying the zero address', function () {
         it('throws', async function () {
           await expectRevert(
-            this.token.balanceOf(ZERO_ADDRESS), 'ERC721: balance query for the zero address'
+            this.token.balanceOf(ZERO_ADDRESS), 'ERC721: balance query for the zero address',
           );
         });
       });
@@ -154,7 +154,7 @@ describe('ERC721', function () {
 
         it('reverts', async function () {
           await expectRevert(
-            this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
+            this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token',
           );
         });
       });
@@ -259,10 +259,10 @@ describe('ERC721', function () {
           it('keeps same tokens by index', async function () {
             if (!this.token.tokenOfOwnerByIndex) return;
             const tokensListed = await Promise.all(
-              [0, 1].map(i => this.token.tokenOfOwnerByIndex(owner, i))
+              [0, 1].map(i => this.token.tokenOfOwnerByIndex(owner, i)),
             );
             expect(tokensListed.map(t => t.toNumber())).to.have.members(
-              [firstTokenId.toNumber(), secondTokenId.toNumber()]
+              [firstTokenId.toNumber(), secondTokenId.toNumber()],
             );
           });
         });
@@ -271,7 +271,7 @@ describe('ERC721', function () {
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, other, other, tokenId, { from: owner }),
-              'ERC721: transfer of token that is not own'
+              'ERC721: transfer of token that is not own',
             );
           });
         });
@@ -280,7 +280,7 @@ describe('ERC721', function () {
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, other, tokenId, { from: other }),
-              'ERC721: transfer caller is not owner nor approved'
+              'ERC721: transfer caller is not owner nor approved',
             );
           });
         });
@@ -289,7 +289,7 @@ describe('ERC721', function () {
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, other, nonExistentTokenId, { from: owner }),
-              'ERC721: operator query for nonexistent token'
+              'ERC721: operator query for nonexistent token',
             );
           });
         });
@@ -298,7 +298,7 @@ describe('ERC721', function () {
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, ZERO_ADDRESS, tokenId, { from: owner }),
-              'ERC721: transfer to the zero address'
+              'ERC721: transfer to the zero address',
             );
           });
         });
@@ -364,7 +364,7 @@ describe('ERC721', function () {
                     nonExistentTokenId,
                     { from: owner },
                   ),
-                  'ERC721: operator query for nonexistent token'
+                  'ERC721: operator query for nonexistent token',
                 );
               });
             });
@@ -384,7 +384,7 @@ describe('ERC721', function () {
             const invalidReceiver = await ERC721ReceiverMock.new('0x42', false);
             await expectRevert(
               this.token.safeTransferFrom(owner, invalidReceiver.address, tokenId, { from: owner }),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -394,7 +394,7 @@ describe('ERC721', function () {
             const revertingReceiver = await ERC721ReceiverMock.new(RECEIVER_MAGIC_VALUE, true);
             await expectRevert(
               this.token.safeTransferFrom(owner, revertingReceiver.address, tokenId, { from: owner }),
-              'ERC721ReceiverMock: reverting'
+              'ERC721ReceiverMock: reverting',
             );
           });
         });
@@ -404,7 +404,7 @@ describe('ERC721', function () {
             const nonReceiver = this.token;
             await expectRevert(
               this.token.safeTransferFrom(owner, nonReceiver.address, tokenId, { from: owner }),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -443,7 +443,7 @@ describe('ERC721', function () {
             const invalidReceiver = await ERC721ReceiverMock.new('0x42', false);
             await expectRevert(
               this.token.safeMint(invalidReceiver.address, tokenId),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -453,7 +453,7 @@ describe('ERC721', function () {
             const revertingReceiver = await ERC721ReceiverMock.new(RECEIVER_MAGIC_VALUE, true);
             await expectRevert(
               this.token.safeMint(revertingReceiver.address, tokenId),
-              'ERC721ReceiverMock: reverting'
+              'ERC721ReceiverMock: reverting',
             );
           });
         });
@@ -463,7 +463,7 @@ describe('ERC721', function () {
             const nonReceiver = this.token;
             await expectRevert(
               this.token.safeMint(nonReceiver.address, tokenId),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -552,7 +552,7 @@ describe('ERC721', function () {
       context('when the address that receives the approval is the owner', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.approve(owner, tokenId, { from: owner }), 'ERC721: approval to current owner'
+            this.token.approve(owner, tokenId, { from: owner }), 'ERC721: approval to current owner',
           );
         });
       });
@@ -674,7 +674,7 @@ describe('ERC721', function () {
         it('reverts', async function () {
           await expectRevert(
             this.token.getApproved(nonExistentTokenId),
-            'ERC721: approved query for nonexistent token'
+            'ERC721: approved query for nonexistent token',
           );
         });
       });
@@ -682,7 +682,7 @@ describe('ERC721', function () {
       context('when token has been minted ', async function () {
         it('should return the zero address', async function () {
           expect(await this.token.getApproved(firstTokenId)).to.be.equal(
-            ZERO_ADDRESS
+            ZERO_ADDRESS,
           );
         });
 
@@ -714,7 +714,7 @@ describe('ERC721', function () {
       describe('when the index is greater than or equal to the total tokens owned by the given address', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(owner, 2), 'EnumerableSet: index out of bounds'
+            this.token.tokenOfOwnerByIndex(owner, 2), 'EnumerableSet: index out of bounds',
           );
         });
       });
@@ -722,7 +722,7 @@ describe('ERC721', function () {
       describe('when the given address does not own any token', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(other, 0), 'EnumerableSet: index out of bounds'
+            this.token.tokenOfOwnerByIndex(other, 0), 'EnumerableSet: index out of bounds',
           );
         });
       });
@@ -736,7 +736,7 @@ describe('ERC721', function () {
         it('returns correct token IDs for target', async function () {
           expect(await this.token.balanceOf(other)).to.be.bignumber.equal('2');
           const tokensListed = await Promise.all(
-            [0, 1].map(i => this.token.tokenOfOwnerByIndex(other, i))
+            [0, 1].map(i => this.token.tokenOfOwnerByIndex(other, i)),
           );
           expect(tokensListed.map(t => t.toNumber())).to.have.members([firstTokenId.toNumber(),
             secondTokenId.toNumber()]);
@@ -745,7 +745,7 @@ describe('ERC721', function () {
         it('returns empty collection for original owner', async function () {
           expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('0');
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(owner, 0), 'EnumerableSet: index out of bounds'
+            this.token.tokenOfOwnerByIndex(owner, 0), 'EnumerableSet: index out of bounds',
           );
         });
       });
@@ -754,7 +754,7 @@ describe('ERC721', function () {
     describe('tokenByIndex', function () {
       it('should return all tokens', async function () {
         const tokensListed = await Promise.all(
-          [0, 1].map(i => this.token.tokenByIndex(i))
+          [0, 1].map(i => this.token.tokenByIndex(i)),
         );
         expect(tokensListed.map(t => t.toNumber())).to.have.members([firstTokenId.toNumber(),
           secondTokenId.toNumber()]);
@@ -762,7 +762,7 @@ describe('ERC721', function () {
 
       it('should revert if index is greater than supply', async function () {
         await expectRevert(
-          this.token.tokenByIndex(2), 'EnumerableMap: index out of bounds'
+          this.token.tokenByIndex(2), 'EnumerableMap: index out of bounds',
         );
       });
 
@@ -778,10 +778,10 @@ describe('ERC721', function () {
           expect(await this.token.totalSupply()).to.be.bignumber.equal('3');
 
           const tokensListed = await Promise.all(
-            [0, 1, 2].map(i => this.token.tokenByIndex(i))
+            [0, 1, 2].map(i => this.token.tokenByIndex(i)),
           );
           const expectedTokens = [firstTokenId, secondTokenId, newTokenId, anotherNewTokenId].filter(
-            x => (x !== tokenId)
+            x => (x !== tokenId),
           );
           expect(tokensListed.map(t => t.toNumber())).to.have.members(expectedTokens.map(t => t.toNumber()));
         });
@@ -792,7 +792,7 @@ describe('ERC721', function () {
   describe('_mint(address, uint256)', function () {
     it('reverts with a null destination address', async function () {
       await expectRevert(
-        this.token.mint(ZERO_ADDRESS, firstTokenId), 'ERC721: mint to the zero address'
+        this.token.mint(ZERO_ADDRESS, firstTokenId), 'ERC721: mint to the zero address',
       );
     });
 
@@ -827,7 +827,7 @@ describe('ERC721', function () {
   describe('_burn', function () {
     it('reverts when burning a non-existent token id', async function () {
       await expectRevert(
-        this.token.burn(firstTokenId), 'ERC721: owner query for nonexistent token'
+        this.token.burn(firstTokenId), 'ERC721: owner query for nonexistent token',
       );
     });
 
@@ -853,7 +853,7 @@ describe('ERC721', function () {
         it('deletes the token', async function () {
           expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('1');
           await expectRevert(
-            this.token.ownerOf(firstTokenId), 'ERC721: owner query for nonexistent token'
+            this.token.ownerOf(firstTokenId), 'ERC721: owner query for nonexistent token',
           );
         });
 
@@ -869,13 +869,13 @@ describe('ERC721', function () {
           await this.token.burn(secondTokenId, { from: owner });
           expect(await this.token.totalSupply()).to.be.bignumber.equal('0');
           await expectRevert(
-            this.token.tokenByIndex(0), 'EnumerableMap: index out of bounds'
+            this.token.tokenByIndex(0), 'EnumerableMap: index out of bounds',
           );
         });
 
         it('reverts when burning a token id that has been deleted', async function () {
           await expectRevert(
-            this.token.burn(firstTokenId), 'ERC721: owner query for nonexistent token'
+            this.token.burn(firstTokenId), 'ERC721: owner query for nonexistent token',
           );
         });
       });

--- a/test/token/ERC721/ERC721Burnable.test.js
+++ b/test/token/ERC721/ERC721Burnable.test.js
@@ -40,7 +40,7 @@ describe('ERC721Burnable', function () {
         it('burns the given token ID and adjusts the balance of the owner', async function () {
           await expectRevert(
             this.token.ownerOf(tokenId),
-            'ERC721: owner query for nonexistent token'
+            'ERC721: owner query for nonexistent token',
           );
           expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('1');
         });
@@ -64,7 +64,7 @@ describe('ERC721Burnable', function () {
         context('getApproved', function () {
           it('reverts', async function () {
             await expectRevert(
-              this.token.getApproved(tokenId), 'ERC721: approved query for nonexistent token'
+              this.token.getApproved(tokenId), 'ERC721: approved query for nonexistent token',
             );
           });
         });
@@ -73,7 +73,7 @@ describe('ERC721Burnable', function () {
       describe('when the given token ID was not tracked by this contract', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.burn(unknownTokenId, { from: owner }), 'ERC721: operator query for nonexistent token'
+            this.token.burn(unknownTokenId, { from: owner }), 'ERC721: operator query for nonexistent token',
           );
         });
       });

--- a/test/token/ERC721/ERC721Pausable.test.js
+++ b/test/token/ERC721/ERC721Pausable.test.js
@@ -30,22 +30,22 @@ describe('ERC721Pausable', function () {
     it('reverts when trying to transferFrom', async function () {
       await expectRevert(
         this.token.transferFrom(owner, receiver, firstTokenId, { from: owner }),
-        'ERC721Pausable: token transfer while paused'
+        'ERC721Pausable: token transfer while paused',
       );
     });
 
     it('reverts when trying to safeTransferFrom', async function () {
       await expectRevert(
         this.token.safeTransferFrom(owner, receiver, firstTokenId, { from: owner }),
-        'ERC721Pausable: token transfer while paused'
+        'ERC721Pausable: token transfer while paused',
       );
     });
 
     it('reverts when trying to safeTransferFrom with data', async function () {
       await expectRevert(
         this.token.methods['safeTransferFrom(address,address,uint256,bytes)'](
-          owner, receiver, firstTokenId, mockData, { from: owner }
-        ), 'ERC721Pausable: token transfer while paused'
+          owner, receiver, firstTokenId, mockData, { from: owner },
+        ), 'ERC721Pausable: token transfer while paused',
       );
     });
 

--- a/test/token/ERC777/ERC777.behavior.js
+++ b/test/token/ERC777/ERC777.behavior.js
@@ -58,15 +58,15 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
       it('reverts when sending more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
         await expectRevert.unspecified(
-          this.token.operatorSend(holder, recipient, balance.addn(1), data, operatorData, { from: operator })
+          this.token.operatorSend(holder, recipient, balance.addn(1), data, operatorData, { from: operator }),
         );
       });
 
       it('reverts when sending to the zero address', async function () {
         await expectRevert.unspecified(
           this.token.operatorSend(
-            holder, ZERO_ADDRESS, new BN('1'), data, operatorData, { from: operator }
-          )
+            holder, ZERO_ADDRESS, new BN('1'), data, operatorData, { from: operator },
+          ),
         );
       });
     });
@@ -78,7 +78,7 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
 
       it('reverts when sending a non-zero amount', async function () {
         await expectRevert.unspecified(
-          this.token.operatorSend(holder, recipient, new BN('1'), data, operatorData, { from: operator })
+          this.token.operatorSend(holder, recipient, new BN('1'), data, operatorData, { from: operator }),
         );
       });
 
@@ -86,8 +86,8 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
         // This is not yet reflected in the spec
         await expectRevert.unspecified(
           this.token.operatorSend(
-            ZERO_ADDRESS, recipient, new BN('0'), data, operatorData, { from: operator }
-          )
+            ZERO_ADDRESS, recipient, new BN('0'), data, operatorData, { from: operator },
+          ),
         );
       });
     });
@@ -135,7 +135,7 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
       it('reverts when burning more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
         await expectRevert.unspecified(
-          this.token.operatorBurn(holder, balance.addn(1), data, operatorData, { from: operator })
+          this.token.operatorBurn(holder, balance.addn(1), data, operatorData, { from: operator }),
         );
       });
     });
@@ -147,7 +147,7 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
 
       it('reverts when burning a non-zero amount', async function () {
         await expectRevert.unspecified(
-          this.token.operatorBurn(holder, new BN('1'), data, operatorData, { from: operator })
+          this.token.operatorBurn(holder, new BN('1'), data, operatorData, { from: operator }),
         );
       });
 
@@ -155,8 +155,8 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
         // This is not yet reflected in the spec
         await expectRevert.unspecified(
           this.token.operatorBurn(
-            ZERO_ADDRESS, new BN('0'), data, operatorData, { from: operator }
-          )
+            ZERO_ADDRESS, new BN('0'), data, operatorData, { from: operator },
+          ),
         );
       });
     });
@@ -282,7 +282,7 @@ function shouldBehaveLikeERC777InternalMint (recipient, operator, amount, data, 
 
   it('reverts when minting tokens for the zero address', async function () {
     await expectRevert.unspecified(
-      this.token.mintInternal(ZERO_ADDRESS, amount, data, operatorData, { from: operator })
+      this.token.mintInternal(ZERO_ADDRESS, amount, data, operatorData, { from: operator }),
     );
   });
 }
@@ -328,13 +328,13 @@ function shouldBehaveLikeERC777SendBurnMintInternalWithReceiveHook (operator, am
 
     it('operatorSend reverts', async function () {
       await expectRevert.unspecified(
-        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator })
+        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator }),
       );
     });
 
     it('mint (internal) reverts', async function () {
       await expectRevert.unspecified(
-        this.token.mintInternal(this.recipient, amount, data, operatorData, { from: operator })
+        this.token.mintInternal(this.recipient, amount, data, operatorData, { from: operator }),
       );
     });
   });
@@ -389,7 +389,7 @@ function shouldBehaveLikeERC777SendBurnMintInternalWithReceiveHook (operator, am
 
     it('TokensRecipient receives mint (internal) data and is called after state mutation', async function () {
       const { tx } = await this.token.mintInternal(
-        this.recipient, amount, data, operatorData, { from: operator }
+        this.recipient, amount, data, operatorData, { from: operator },
       );
 
       const postRecipientBalance = await this.token.balanceOf(this.recipient);
@@ -422,7 +422,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
 
     it('operatorSend reverts', async function () {
       await expectRevert.unspecified(
-        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator })
+        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator }),
       );
     });
 
@@ -432,7 +432,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
 
     it('operatorBurn reverts', async function () {
       await expectRevert.unspecified(
-        this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator })
+        this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator }),
       );
     });
   });
@@ -491,7 +491,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
       const { tx } = await burnFromHolder(this.token, this.sender, amount, data, { from: this.sender });
 
       await assertTokensToSendCalled(
-        this.token, tx, this.sender, this.sender, ZERO_ADDRESS, amount, data, null, preSenderBalance
+        this.token, tx, this.sender, this.sender, ZERO_ADDRESS, amount, data, null, preSenderBalance,
       );
     });
 
@@ -501,7 +501,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
       const { tx } = await this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator });
 
       await assertTokensToSendCalled(
-        this.token, tx, operator, this.sender, ZERO_ADDRESS, amount, data, operatorData, preSenderBalance
+        this.token, tx, operator, this.sender, ZERO_ADDRESS, amount, data, operatorData, preSenderBalance,
       );
     });
   });

--- a/test/token/ERC777/ERC777.test.js
+++ b/test/token/ERC777/ERC777.test.js
@@ -164,13 +164,13 @@ describe('ERC777', function () {
 
       it('reverts when self-authorizing', async function () {
         await expectRevert(
-          this.token.authorizeOperator(holder, { from: holder }), 'ERC777: authorizing self as operator'
+          this.token.authorizeOperator(holder, { from: holder }), 'ERC777: authorizing self as operator',
         );
       });
 
       it('reverts when self-revoking', async function () {
         await expectRevert(
-          this.token.revokeOperator(holder, { from: holder }), 'ERC777: revoking self as operator'
+          this.token.revokeOperator(holder, { from: holder }), 'ERC777: revoking self as operator',
         );
       });
 
@@ -234,7 +234,7 @@ describe('ERC777', function () {
         it('cannot be revoked for themselves', async function () {
           await expectRevert(
             this.token.revokeOperator(defaultOperatorA, { from: defaultOperatorA }),
-            'ERC777: revoking self as operator'
+            'ERC777: revoking self as operator',
           );
         });
 

--- a/test/utils/Address.test.js
+++ b/test/utils/Address.test.js
@@ -84,7 +84,7 @@ describe('Address', function () {
           await this.contractRecipient.setAcceptEther(false);
           await expectRevert(
             this.mock.sendValue(this.contractRecipient.address, funds),
-            'Address: unable to send value, recipient may have reverted'
+            'Address: unable to send value, recipient may have reverted',
           );
         });
       });

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -15,7 +15,7 @@ describe('Create2', function () {
 
   const encodedParams = web3.eth.abi.encodeParameters(
     ['string', 'string', 'address', 'uint256'],
-    ['MyToken', 'MTKN', deployerAccount, 100]
+    ['MyToken', 'MTKN', deployerAccount, 100],
   ).slice(2);
 
   const constructorByteCode = `${ERC20Mock.bytecode}${encodedParams}`;
@@ -73,20 +73,20 @@ describe('Create2', function () {
   it('should failed deploying a contract in an existent address', async function () {
     await this.factory.deploy(0, saltHex, constructorByteCode, { from: deployerAccount });
     await expectRevert(
-      this.factory.deploy(0, saltHex, constructorByteCode, { from: deployerAccount }), 'Create2: Failed on deploy'
+      this.factory.deploy(0, saltHex, constructorByteCode, { from: deployerAccount }), 'Create2: Failed on deploy',
     );
   });
 
   it('should fail deploying a contract if the bytecode length is zero', async function () {
     await expectRevert(
-      this.factory.deploy(0, saltHex, '0x', { from: deployerAccount }), 'Create2: bytecode length is zero'
+      this.factory.deploy(0, saltHex, '0x', { from: deployerAccount }), 'Create2: bytecode length is zero',
     );
   });
 
   it('should fail deploying a contract if factory contract does not have sufficient balance', async function () {
     await expectRevert(
       this.factory.deploy(1, saltHex, constructorByteCode, { from: deployerAccount }),
-      'Create2: insufficient balance'
+      'Create2: insufficient balance',
     );
   });
 });

--- a/test/utils/EnumerableMap.test.js
+++ b/test/utils/EnumerableMap.test.js
@@ -21,13 +21,13 @@ describe('EnumerableMap', function () {
     expect(keys.length).to.equal(values.length);
 
     await Promise.all(keys.map(async key =>
-      expect(await map.contains(key)).to.equal(true)
+      expect(await map.contains(key)).to.equal(true),
     ));
 
     expect(await map.length()).to.bignumber.equal(keys.length.toString());
 
     expect(await Promise.all(keys.map(key =>
-      map.get(key)
+      map.get(key),
     ))).to.have.same.members(values);
 
     // To compare key-value pairs, we zip keys and values, and convert BNs to
@@ -36,7 +36,7 @@ describe('EnumerableMap', function () {
       const entry = await map.at(index);
       return [entry.key.toString(), entry.value];
     }))).to.have.same.deep.members(
-      zip(keys.map(k => k.toString()), values)
+      zip(keys.map(k => k.toString()), values),
     );
   }
 

--- a/test/utils/EnumerableSet.test.js
+++ b/test/utils/EnumerableSet.test.js
@@ -13,13 +13,13 @@ describe('EnumerableSet', function () {
 
   async function expectMembersMatch (set, values) {
     await Promise.all(values.map(async account =>
-      expect(await set.contains(account)).to.equal(true)
+      expect(await set.contains(account)).to.equal(true),
     ));
 
     expect(await set.length()).to.bignumber.equal(values.length.toString());
 
     expect(await Promise.all([...Array(values.length).keys()].map(index =>
-      set.at(index)
+      set.at(index),
     ))).to.have.same.members(values);
   }
 

--- a/test/utils/Pausable.test.js
+++ b/test/utils/Pausable.test.js
@@ -27,7 +27,7 @@ describe('Pausable', function () {
 
     it('cannot take drastic measure in non-pause', async function () {
       await expectRevert(this.pausable.drasticMeasure(),
-        'Pausable: not paused'
+        'Pausable: not paused',
       );
       expect(await this.pausable.drasticMeasureTaken()).to.equal(false);
     });
@@ -77,7 +77,7 @@ describe('Pausable', function () {
 
           it('should prevent drastic measure', async function () {
             await expectRevert(this.pausable.drasticMeasure(),
-              'Pausable: not paused'
+              'Pausable: not paused',
             );
           });
 

--- a/test/utils/ReentrancyGuard.test.js
+++ b/test/utils/ReentrancyGuard.test.js
@@ -24,13 +24,13 @@ describe('ReentrancyGuard', function () {
 
   it('should not allow local recursion', async function () {
     await expectRevert(
-      this.reentrancyMock.countLocalRecursive(10), 'ReentrancyGuard: reentrant call'
+      this.reentrancyMock.countLocalRecursive(10), 'ReentrancyGuard: reentrant call',
     );
   });
 
   it('should not allow indirect local recursion', async function () {
     await expectRevert(
-      this.reentrancyMock.countThisRecursive(10), 'ReentrancyMock: failed call'
+      this.reentrancyMock.countThisRecursive(10), 'ReentrancyMock: failed call',
     );
   });
 });

--- a/test/utils/SafeCast.test.js
+++ b/test/utils/SafeCast.test.js
@@ -29,14 +29,14 @@ describe('SafeCast', async () => {
       it(`reverts when downcasting 2^${bits} (${maxValue.addn(1)})`, async function () {
         await expectRevert(
           this.safeCast[`toUint${bits}`](maxValue.addn(1)),
-          `SafeCast: value doesn't fit in ${bits} bits`
+          `SafeCast: value doesn't fit in ${bits} bits`,
         );
       });
 
       it(`reverts when downcasting 2^${bits} + 1 (${maxValue.addn(2)})`, async function () {
         await expectRevert(
           this.safeCast[`toUint${bits}`](maxValue.addn(2)),
-          `SafeCast: value doesn't fit in ${bits} bits`
+          `SafeCast: value doesn't fit in ${bits} bits`,
         );
       });
     });
@@ -64,21 +64,21 @@ describe('SafeCast', async () => {
     it('reverts when casting -1', async function () {
       await expectRevert(
         this.safeCast.toUint256(-1),
-        'SafeCast: value must be positive'
+        'SafeCast: value must be positive',
       );
     });
 
     it(`reverts when casting INT256_MIN (${minInt256})`, async function () {
       await expectRevert(
         this.safeCast.toUint256(minInt256),
-        'SafeCast: value must be positive'
+        'SafeCast: value must be positive',
       );
     });
 
     it(`reverts when casting UINT256_MAX (${maxUint256})`, async function () {
       await expectRevert(
         this.safeCast.toUint256(maxUint256),
-        'SafeCast: value must be positive'
+        'SafeCast: value must be positive',
       );
     });
   });
@@ -102,14 +102,14 @@ describe('SafeCast', async () => {
     it(`reverts when casting INT256_MAX + 1 (${maxInt256.addn(1)})`, async function () {
       await expectRevert(
         this.safeCast.toInt256(maxInt256.addn(1)),
-        'SafeCast: value doesn\'t fit in an int256'
+        'SafeCast: value doesn\'t fit in an int256',
       );
     });
 
     it(`reverts when casting UINT256_MAX (${maxUint256})`, async function () {
       await expectRevert(
         this.safeCast.toInt256(maxUint256),
-        'SafeCast: value doesn\'t fit in an int256'
+        'SafeCast: value doesn\'t fit in an int256',
       );
     });
   });


### PR DESCRIPTION
ERC20 calls _beforeTokenTransfer for both _mint and _burn, but ERC777 did not.

I think the ERC20 behaviour is ideal, as we then have hooks into the entire token lifecycle.

ERC777 has been updated to match.
