### PR TITLE
Altered modifier from private to internal for _grantRole in AccessCon…

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -180,7 +180,7 @@ abstract contract AccessControl is Context {
         _roles[role].adminRole = adminRole;
     }
 
-    function _grantRole(bytes32 role, address account) private {
+    function _grantRole(bytes32 role, address account) internal {
         if (_roles[role].members.add(account)) {
             emit RoleGranted(role, account, _msgSender());
         }


### PR DESCRIPTION
…trol

Make _grantRole callable from child contracts as a function to add the admin role to the administrator. Using grantRole() would fail due to the require statement checking if the caller is admin, before it's been granted.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #2193

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
