### PR TITLE
Remove in-constructor requirements

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -164,12 +164,17 @@ abstract contract AccessControl is Context {
      * event. Note that unlike {grantRole}, this function doesn't perform any
      * checks on the calling account.
      *
-     * Requirements:
+     * [WARNING]
+     * ====
+     * This function should only be called from the constructor when setting
+     * up the initial roles for the system.
      *
-     * - this function can only be called from a constructor.
+     * It being callable by other means goes against the spirit of
+     * {AccessControl}, as there would be ways to grant roles not tracked by
+     * {getRoleMemberCount} and {getRoleMember}.
+     * ====
      */
     function _setupRole(bytes32 role, address account) internal virtual {
-        require(!address(this).isContract(), "AccessControl: roles cannot be setup after construction");
         _grantRole(role, account);
     }
 

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -169,9 +169,8 @@ abstract contract AccessControl is Context {
      * This function should only be called from the constructor when setting
      * up the initial roles for the system.
      *
-     * It being callable by other means goes against the spirit of
-     * {AccessControl}, as there would be ways to grant roles not tracked by
-     * {getRoleMemberCount} and {getRoleMember}.
+     * Using this function in any other way is effectively circumventing the admin
+     * system imposed by {AccessControl}.
      * ====
      */
     function _setupRole(bytes32 role, address account) internal virtual {

--- a/contracts/mocks/AccessControlMock.sol
+++ b/contracts/mocks/AccessControlMock.sol
@@ -10,8 +10,4 @@ contract AccessControlMock is AccessControl {
     function setRoleAdmin(bytes32 roleId, bytes32 adminRoleId) public {
         _setRoleAdmin(roleId, adminRoleId);
     }
-
-    function setupRole(bytes32 roleId, address account) public {
-        _setupRole(roleId, account);
-    }
 }

--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -6,8 +6,4 @@ contract ERC20DecimalsMock is ERC20 {
     constructor (string memory name, string memory symbol, uint8 decimals) public ERC20(name, symbol) {
         _setupDecimals(decimals);
     }
-
-    function setupDecimals(uint8 decimals) public {
-        _setupDecimals(decimals);
-    }
 }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -279,12 +279,11 @@ contract ERC20 is Context, IERC20 {
     /**
      * @dev Sets {decimals} to a value other than the default one of 18.
      *
-     * Requirements:
-     *
-     * - this function can only be called from a constructor.
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
      */
     function _setupDecimals(uint8 decimals_) internal {
-        require(!address(this).isContract(), "ERC20: decimals cannot be changed after construction");
         _decimals = decimals_;
     }
 

--- a/test/access/AccessControl.test.js
+++ b/test/access/AccessControl.test.js
@@ -17,15 +17,6 @@ describe('AccessControl', function () {
     this.accessControl = await AccessControlMock.new({ from: admin });
   });
 
-  describe('_setupRole', function () {
-    it('cannot be called outside the constructor', async function () {
-      await expectRevert(
-        this.accessControl.setupRole(OTHER_ROLE, other),
-        'AccessControl: roles cannot be setup after construction'
-      );
-    });
-  });
-
   describe('default admin', function () {
     it('deployer has default admin role', async function () {
       expect(await this.accessControl.hasRole(DEFAULT_ADMIN_ROLE, admin)).to.equal(true);

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -44,12 +44,6 @@ describe('ERC20', function () {
       const token = await ERC20DecimalsMock.new(name, symbol, decimals);
       expect(await token.decimals()).to.be.bignumber.equal(decimals);
     });
-
-    it('reverts if setting decimals after construction', async function () {
-      const token = await ERC20DecimalsMock.new(name, symbol, decimals);
-
-      await expectRevert(token.setupDecimals(decimals.addn(1)), 'ERC20: decimals cannot be changed after construction');
-    });
   });
 
   shouldBehaveLikeERC20('ERC20', initialSupply, initialHolder, recipient, anotherAccount);


### PR DESCRIPTION
The requirement for `_setupRole` and `_setupDecimals` to only be callable inside a constructor was too restrictive for no good reasons: a warning should be enough.

There are scenarios where these may need to be called outside of a constructor, such as during a state migration after a contract code upgrade.

Fixes #2193
Closes #2194