### PR TITLE
Add note about default admin role security

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -36,7 +36,7 @@ import "../GSN/Context.sol";
  * {_setRoleAdmin}.
  *
  * WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
- * grant and revoke this role. Extra precautions should be taken when managing
+ * grant and revoke this role. Extra precautions should be taken to secure
  * accounts that have been granted it.
  */
 abstract contract AccessControl is Context {

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -34,6 +34,10 @@ import "../GSN/Context.sol";
  * that only accounts with this role will be able to grant or revoke other
  * roles. More complex role relationships can be created by using
  * {_setRoleAdmin}.
+ *
+ * WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
+ * grant and revoke this role. Extra precautions should be taken when managing
+ * accounts that have been granted it.
  */
 abstract contract AccessControl is Context {
     using EnumerableSet for EnumerableSet.AddressSet;


### PR DESCRIPTION
It may not be obvious that the default admin being, well, the default admin, lets it grant and revoke any role in the system _including_ the default admin role, which leads to a need for increased security.