### PR TITLE
Add missing requirements to ERC777

### DIFF
--- a/contracts/mocks/ERC777Mock.sol
+++ b/contracts/mocks/ERC777Mock.sol
@@ -23,4 +23,8 @@ contract ERC777Mock is Context, ERC777 {
     ) public {
         _mint(operator, to, amount, userData, operatorData);
     }
+
+    function approveInternal(address holder, address spender, uint256 value) public {
+        _approve(holder, spender, value);
+    }
 }

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -408,10 +408,13 @@ contract ERC777 is Context, IERC777, IERC20 {
         emit Transfer(from, to, amount);
     }
 
+    /**
+     * @dev See {ERC20-_approve}.
+     *
+     * Note that accounts cannot have allowance issued by their operators.
+     */
     function _approve(address holder, address spender, uint256 value) internal {
-        // TODO: restore this require statement if this function becomes internal, or is called at a new callsite. It is
-        // currently unnecessary.
-        //require(holder != address(0), "ERC777: approve from the zero address");
+        require(holder != address(0), "ERC777: approve from the zero address");
         require(spender != address(0), "ERC777: approve to the zero address");
 
         _allowances[holder][spender] = value;

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -352,6 +352,7 @@ contract ERC777 is Context, IERC777, IERC20 {
     )
         internal
     {
+        require(operator != address(0), "ERC777: operator is the zero address");
         require(from != address(0), "ERC777: send from the zero address");
         require(to != address(0), "ERC777: send to the zero address");
 


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-contracts/issues/2208 for the v2.5.0 branch.

https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2027 made `_send`, `_approve`, `_callTokensToSend` and `_callTokensReceived` `internal`. We failed to identify that some of these functions contained arguments that were not validated: when they were `private`, this validation was performed at their callsite. This code was included in the v2.5.0 release.

Then, https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2134 got merged, which made the hook methods `private` again, and removed the `operator` argument from `_send` (the one that was unchecked). This code was published in v3.0.0.

This PR addresses the issues on the v2.5.0 release (and targets that branch). Once merged, v2.5.1 will be released and the branch merged back into `master`, only keeping the fix for `_approve` (the only unprotected function in v3.0.0). That will then become v3.0.1.

Because of this, I only added tests for the `require` statement in `_approve`: the other one will only exist in the v2.5.1 branch.