### PR TITLE
Make Context abstract

### DIFF
--- a/contracts/GSN/Context.sol
+++ b/contracts/GSN/Context.sol
@@ -10,11 +10,7 @@ pragma solidity ^0.6.0;
  *
  * This contract is only required for intermediate, library-like contracts.
  */
-contract Context {
-    // Empty internal constructor, to prevent people from mistakenly deploying
-    // an instance of this contract, which should be used via inheritance.
-    constructor () internal { }
-
+abstract contract Context {
     function _msgSender() internal view virtual returns (address payable) {
         return msg.sender;
     }


### PR DESCRIPTION
Other instances where we could do the same if we moved state variable initialization outside of the constructor:

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/3f2382278a238547b95716772f806dddcbccc7f9/contracts/utils/ReentrancyGuard.sol#L22-L30

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/3f2382278a238547b95716772f806dddcbccc7f9/contracts/utils/Pausable.sol#L30-L32