### PR TITLE
Update SafeERC20.sol

### DIFF
--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -12,7 +12,7 @@ import "../../utils/Address.sol";
  * contract returns false). Tokens that return no value (and instead revert or
  * throw on failure) are also supported, non-reverting calls are assumed to be
  * successful.
- * To use this library you can add a `using SafeERC20 for ERC20;` statement to your contract,
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
  * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
  */
 library SafeERC20 {


### PR DESCRIPTION
tweak intro dev comment to reflect more typical use case, wrapping an `IERC20` reference for a deposit contract using others' ERC-20 tokens. 

I might be mistaken ~ but typically SafeERC20 won't be used in conjunction with ERC20 for OZ token deployments?