### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2019 zOS Global Limited
+Copyright (c) 2016-2020 zOS Global Limited
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
noticed that license left off at '2019.' I am not sure of position of company, but just added a bump to reflect '2020' 
