### PR TITLE
Fix multiplication overflow of int256

### DIFF
--- a/contracts/math/SignedSafeMath.sol
+++ b/contracts/math/SignedSafeMath.sol
@@ -20,7 +20,7 @@ library SignedSafeMath {
             return 0;
         }
 
-        require(!(a == -1 && b == _INT256_MIN), "SignedSafeMath: multiplication overflow");
+        require(!((a == -1 && b == _INT256_MIN) || (b == -1 && a == _INT256_MIN)), "SignedSafeMath: multiplication overflow");
 
         int256 c = a * b;
         require(c / a == b, "SignedSafeMath: multiplication overflow");


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

There is no overflow checking for `SignedSafeMath.mul(_INT256_MIN, -1)`, this PR fix it.

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
