### PR TITLE
Modify token presets "mint" function as virtual to allow extending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Improvements
  * `ReentrancyGuard`: reduced overhead of using the `nonReentrant` modifier. ([#2171](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2171))
  * `AccessControl`: added a `RoleAdminChanged` event to `_setAdminRole`. ([#2214](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2214))
+ * Made all `public` functions in the token preset contracts `virtual`. ([#2257](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2257))
 
 ## 3.0.1 (2020-04-27)
 

--- a/contracts/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/presets/ERC20PresetMinterPauser.sol
@@ -48,7 +48,7 @@ contract ERC20PresetMinterPauser is Context, AccessControl, ERC20Burnable, ERC20
      *
      * - the caller must have the `MINTER_ROLE`.
      */
-    function mint(address to, uint256 amount) public {
+    function mint(address to, uint256 amount) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC20PresetMinterPauser: must have minter role to mint");
         _mint(to, amount);
     }

--- a/contracts/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/presets/ERC20PresetMinterPauser.sol
@@ -62,7 +62,7 @@ contract ERC20PresetMinterPauser is Context, AccessControl, ERC20Burnable, ERC20
      *
      * - the caller must have the `PAUSER_ROLE`.
      */
-    function pause() public {
+    function pause() public virtual {
         require(hasRole(PAUSER_ROLE, _msgSender()), "ERC20PresetMinterPauser: must have pauser role to pause");
         _pause();
     }
@@ -76,12 +76,12 @@ contract ERC20PresetMinterPauser is Context, AccessControl, ERC20Burnable, ERC20
      *
      * - the caller must have the `PAUSER_ROLE`.
      */
-    function unpause() public {
+    function unpause() public virtual {
         require(hasRole(PAUSER_ROLE, _msgSender()), "ERC20PresetMinterPauser: must have pauser role to unpause");
         _unpause();
     }
 
-    function _beforeTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Pausable) {
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override(ERC20, ERC20Pausable) {
         super._beforeTokenTransfer(from, to, amount);
     }
 }

--- a/contracts/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/presets/ERC721PresetMinterPauserAutoId.sol
@@ -59,7 +59,7 @@ contract ERC721PresetMinterPauserAutoId is Context, AccessControl, ERC721Burnabl
      *
      * - the caller must have the `MINTER_ROLE`.
      */
-    function mint(address to) public {
+    function mint(address to) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC721PresetMinterPauserAutoId: must have minter role to mint");
 
         // We can just use balanceOf to create the new tokenId because tokens

--- a/contracts/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/presets/ERC721PresetMinterPauserAutoId.sol
@@ -77,7 +77,7 @@ contract ERC721PresetMinterPauserAutoId is Context, AccessControl, ERC721Burnabl
      *
      * - the caller must have the `PAUSER_ROLE`.
      */
-    function pause() public {
+    function pause() public virtual {
         require(hasRole(PAUSER_ROLE, _msgSender()), "ERC721PresetMinterPauserAutoId: must have pauser role to pause");
         _pause();
     }
@@ -91,12 +91,12 @@ contract ERC721PresetMinterPauserAutoId is Context, AccessControl, ERC721Burnabl
      *
      * - the caller must have the `PAUSER_ROLE`.
      */
-    function unpause() public {
+    function unpause() public virtual {
         require(hasRole(PAUSER_ROLE, _msgSender()), "ERC721PresetMinterPauserAutoId: must have pauser role to unpause");
         _unpause();
     }
 
-    function _beforeTokenTransfer(address from, address to, uint256 tokenId) internal override(ERC721, ERC721Pausable) {
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId) internal virtual override(ERC721, ERC721Pausable) {
         super._beforeTokenTransfer(from, to, tokenId);
     }
 }


### PR DESCRIPTION
1. Discussion (one-sided at the time of this request) of this PR can be found here: https://forum.openzeppelin.com/t/erc721presetminterpauserautoid-mint-function-and-tokenid/2780/8

2. The preset `mint` function is not `override`-able by parent contracts as it is not marked as `virtual`. Since `mint` is not part of the ERC721 or ERC20 standard, and the ability to user `super` and OZ's outstanding presets exists, why not allow for more flexibility?