### PR TITLE
Remove TokenVesting reference from TokenTimelock docstrings

### DIFF
--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -10,8 +10,6 @@ import "./SafeERC20.sol";
  *
  * Useful for simple vesting schedules like "advisors get all of their tokens
  * after 1 year".
- *
- * For a more complete vesting schedule, see {TokenVesting}.
  */
 contract TokenTimelock {
     using SafeERC20 for IERC20;


### PR DESCRIPTION
Simply removing an outdated reference to `TokenVesting` contract found in the `TokenTimelock` contract.
