### PR TITLE
Allow overriding of ERC1155 functions

### DIFF
--- a/contracts/mocks/ERC1155Mock.sol
+++ b/contracts/mocks/ERC1155Mock.sol
@@ -24,12 +24,4 @@ contract ERC1155Mock is ERC1155 {
     function burnBatch(address owner, uint256[] memory ids, uint256[] memory values) public {
         _burnBatch(owner, ids, values);
     }
-
-    function doSafeTransferAcceptanceCheck(address operator, address from, address to, uint256 id, uint256 value, bytes memory data) public {
-        _doSafeTransferAcceptanceCheck(operator, from, to, id, value, data);
-    }
-
-    function doSafeBatchTransferAcceptanceCheck(address operator, address from, address to, uint256[] memory ids, uint256[] memory values, bytes memory data) public {
-        _doSafeBatchTransferAcceptanceCheck(operator, from, to, ids, values, data);
-    }
 }

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -99,7 +99,7 @@ contract ERC1155 is ERC165, IERC1155
      * @param operator address to set the approval
      * @param approved representing the status of the approval to be set
      */
-    function setApprovalForAll(address operator, bool approved) external override virtual {
+    function setApprovalForAll(address operator, bool approved) public virtual override {
         require(msg.sender != operator, "ERC1155: cannot set approval status for self");
         _operatorApprovals[msg.sender][operator] = approved;
         emit ApprovalForAll(msg.sender, operator, approved);
@@ -130,11 +130,11 @@ contract ERC1155 is ERC165, IERC1155
         address to,
         uint256 id,
         uint256 value,
-        bytes calldata data
+        bytes memory data
     )
-        external
-        override
+        public
         virtual
+        override
     {
         require(to != address(0), "ERC1155: target address must be non-zero");
         require(
@@ -164,13 +164,13 @@ contract ERC1155 is ERC165, IERC1155
     function safeBatchTransferFrom(
         address from,
         address to,
-        uint256[] calldata ids,
-        uint256[] calldata values,
-        bytes calldata data
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
     )
-        external
-        override
+        public
         virtual
+        override
     {
         require(ids.length == values.length, "ERC1155: IDs and values must have same lengths");
         require(to != address(0), "ERC1155: target address must be non-zero");

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -275,8 +275,7 @@ contract ERC1155 is ERC165, IERC1155
         uint256 value,
         bytes memory data
     )
-        internal
-        virtual
+        private
     {
         if(to.isContract()) {
             require(
@@ -295,8 +294,7 @@ contract ERC1155 is ERC165, IERC1155
         uint256[] memory values,
         bytes memory data
     )
-        internal
-        virtual
+        private
     {
         if(to.isContract()) {
             require(


### PR DESCRIPTION
Following #2162, this PR changes some `external` ERC1155 functions to `public` so that they can be properly overridden.

It also removes some internals from the API (like https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2134 did).