### PR TITLE
added transfer event

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -24,6 +24,9 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable 
     using EnumerableSet for EnumerableSet.UintSet;
     using EnumerableMap for EnumerableMap.UintToAddressMap;
     using Strings for uint256;
+    
+    // transfer event
+    event Transfer(address from, address to, uint tokenId);
 
     // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
     // which can be also obtained as `IERC721Receiver(0).onERC721Received.selector`


### PR DESCRIPTION
the contract had called the transfer event that didn't exist. causing a "Returned values aren't valid, did it run Out of Gas?" error
