### PR TITLE
Fixes broken link in ERC20 comment.

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -15,8 +15,7 @@ import "../../utils/Address.sol";
  * For a generic mechanism see {ERC20PresetMinterPauser}.
  *
  * TIP: For a detailed writeup see our guide
- * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
- * to implement supply mechanisms].
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226
  *
  * We have followed general OpenZeppelin guidelines: functions revert instead
  * of returning `false` on failure. This behavior is nonetheless conventional


### PR DESCRIPTION
Hard newlines are the devil, which was part of the problem, but even if I removed the hard newline from the middle of the link it still didn't work.  Removing the `[...]` from the end of the link seems to have resolved the issue, which is what this commit does.