### PR TITLE
Update ReentrancyGuard.sol with minor gas cost saving

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -30,7 +30,7 @@ contract ReentrancyGuard {
     // amount. Since refunds are capped to a percentage of the total
     // transaction's gas, it is best to keep them low in cases like this one, to
     // increase the likelihood of the full refund coming into effect.
-    uint256 private constant _NOT_ENTERED;
+    uint256 private constant _NOT_ENTERED = 0;
     uint256 private constant _ENTERED = 1;
 
     uint256 private _status;

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -30,8 +30,8 @@ contract ReentrancyGuard {
     // amount. Since refunds are capped to a percentage of the total
     // transaction's gas, it is best to keep them low in cases like this one, to
     // increase the likelihood of the full refund coming into effect.
-    uint256 private constant _NOT_ENTERED = 1;
-    uint256 private constant _ENTERED = 2;
+    uint256 private constant _NOT_ENTERED;
+    uint256 private constant _ENTERED = 1;
 
     uint256 private _status;
 


### PR DESCRIPTION
set non-entered uint256 value to 0 rather than 1 (gas savings?)