### PR TITLE
Add readme notices with link to docs site

### DIFF
--- a/contracts/GSN/README.adoc
+++ b/contracts/GSN/README.adoc
@@ -1,7 +1,7 @@
 = Gas Station Network (GSN)
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/gsn.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/gsn
 
 This set of contracts provide all the tools required to make a contract callable via the https://gsn.openzeppelin.com[Gas Station Network].
 

--- a/contracts/GSN/README.adoc
+++ b/contracts/GSN/README.adoc
@@ -1,5 +1,8 @@
 = Gas Station Network (GSN)
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/gsn.
+
 This set of contracts provide all the tools required to make a contract callable via the https://gsn.openzeppelin.com[Gas Station Network].
 
 TIP: If you're new to the GSN, head over to our xref:learn::sending-gasless-transactions.adoc[overview of the system] and basic guide to xref:ROOT:gsn.adoc[creating a GSN-capable contract].

--- a/contracts/access/README.adoc
+++ b/contracts/access/README.adoc
@@ -1,7 +1,7 @@
 = Access
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/access.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/access
 
 Contract modules for authorization and access control mechanisms.
 

--- a/contracts/access/README.adoc
+++ b/contracts/access/README.adoc
@@ -1,5 +1,8 @@
 = Access
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/access.
+
 Contract modules for authorization and access control mechanisms.
 
 == Contracts

--- a/contracts/cryptography/README.adoc
+++ b/contracts/cryptography/README.adoc
@@ -1,7 +1,7 @@
 = Cryptography
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/cryptography.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/cryptography
 
 This collection of libraries provides simple and safe ways to use different cryptographic primitives.
 

--- a/contracts/cryptography/README.adoc
+++ b/contracts/cryptography/README.adoc
@@ -1,5 +1,8 @@
 = Cryptography
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/cryptography.
+
 This collection of libraries provides simple and safe ways to use different cryptographic primitives.
 
 == Libraries

--- a/contracts/introspection/README.adoc
+++ b/contracts/introspection/README.adoc
@@ -1,7 +1,7 @@
 = Introspection
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/introspection.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/introspection
 
 This set of interfaces and contracts deal with https://en.wikipedia.org/wiki/Type_introspection[type introspection] of contracts, that is, examining which functions can be called on them. This is usually referred to as a contract's _interface_.
 

--- a/contracts/introspection/README.adoc
+++ b/contracts/introspection/README.adoc
@@ -1,5 +1,8 @@
 = Introspection
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/introspection.
+
 This set of interfaces and contracts deal with https://en.wikipedia.org/wiki/Type_introspection[type introspection] of contracts, that is, examining which functions can be called on them. This is usually referred to as a contract's _interface_.
 
 Ethereum contracts have no native concept of an interface, so applications must usually simply trust they are not making an incorrect call. For trusted setups this is a non-issue, but often unknown and untrusted third-party addresses need to be interacted with. There may even not be any direct calls to them! (e.g. `ERC20` tokens may be sent to a contract that lacks a way to transfer them out of it, locking them forever). In these cases, a contract _declaring_ its interface can be very helpful in preventing errors.

--- a/contracts/math/README.adoc
+++ b/contracts/math/README.adoc
@@ -1,5 +1,8 @@
 = Math
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/math.
+
 These are math-related utilities.
 
 == Libraries

--- a/contracts/math/README.adoc
+++ b/contracts/math/README.adoc
@@ -1,7 +1,7 @@
 = Math
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/math.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/math
 
 These are math-related utilities.
 

--- a/contracts/payment/README.adoc
+++ b/contracts/payment/README.adoc
@@ -1,7 +1,7 @@
 = Payment
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/payment.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/payment
 
 Utilities related to sending and receiving payments. Examples are {PullPayment}, which implements the best security practices when sending funds to third parties, and {PaymentSplitter} to receive incoming payments among a number of beneficiaries.
 

--- a/contracts/payment/README.adoc
+++ b/contracts/payment/README.adoc
@@ -1,5 +1,8 @@
 = Payment
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/payment.
+
 Utilities related to sending and receiving payments. Examples are {PullPayment}, which implements the best security practices when sending funds to third parties, and {PaymentSplitter} to receive incoming payments among a number of beneficiaries.
 
 TIP: When transferring funds to and from untrusted third parties, there is always a security risk of reentrancy. If you would like to learn more about this and ways to protect against it, check out our blog post https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].

--- a/contracts/presets/README.adoc
+++ b/contracts/presets/README.adoc
@@ -1,7 +1,7 @@
 = Presets
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/presets.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/presets
 
 These contracts integrate different Ethereum standards (ERCs) with custom extensions and modules, showcasing common configurations that are ready to deploy **without having to write any Solidity code**.
 

--- a/contracts/presets/README.adoc
+++ b/contracts/presets/README.adoc
@@ -1,5 +1,8 @@
 = Presets
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/presets.
+
 These contracts integrate different Ethereum standards (ERCs) with custom extensions and modules, showcasing common configurations that are ready to deploy **without having to write any Solidity code**.
 
 They can be used as-is for quick prototyping and testing, but are **also suitable for production environments**.

--- a/contracts/token/ERC1155/README.adoc
+++ b/contracts/token/ERC1155/README.adoc
@@ -1,7 +1,7 @@
 = ERC 1155
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc1155.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc1155
 
 This set of interfaces and contracts are all related to the https://eips.ethereum.org/EIPS/eip-1155[ERC1155 Multi Token Standard].
 

--- a/contracts/token/ERC1155/README.adoc
+++ b/contracts/token/ERC1155/README.adoc
@@ -1,5 +1,8 @@
 = ERC 1155
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc1155.
+
 This set of interfaces and contracts are all related to the https://eips.ethereum.org/EIPS/eip-1155[ERC1155 Multi Token Standard].
 
 The EIP consists of three interfaces which fulfill different roles, found here as {IERC1155}, {IERC1155MetadataURI} and {IERC1155Receiver}.

--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -1,5 +1,8 @@
 = ERC 20
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc20.
+
 This set of interfaces, contracts, and utilities are all related to the https://eips.ethereum.org/EIPS/eip-20[ERC20 Token Standard].
 
 TIP: For an overview of ERC20 tokens and a walkthrough on how to create a token contract read our xref:ROOT:erc20.adoc[ERC20 guide].

--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -1,7 +1,7 @@
 = ERC 20
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc20.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc20
 
 This set of interfaces, contracts, and utilities are all related to the https://eips.ethereum.org/EIPS/eip-20[ERC20 Token Standard].
 

--- a/contracts/token/ERC721/README.adoc
+++ b/contracts/token/ERC721/README.adoc
@@ -1,5 +1,8 @@
 = ERC 721
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc721.
+
 This set of interfaces, contracts, and utilities are all related to the https://eips.ethereum.org/EIPS/eip-721[ERC721 Non-Fungible Token Standard].
 
 TIP: For a walkthrough on how to create an ERC721 token read our xref:ROOT:erc721.adoc[ERC721 guide].

--- a/contracts/token/ERC721/README.adoc
+++ b/contracts/token/ERC721/README.adoc
@@ -1,7 +1,7 @@
 = ERC 721
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc721.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc721
 
 This set of interfaces, contracts, and utilities are all related to the https://eips.ethereum.org/EIPS/eip-721[ERC721 Non-Fungible Token Standard].
 

--- a/contracts/token/ERC777/README.adoc
+++ b/contracts/token/ERC777/README.adoc
@@ -1,7 +1,7 @@
 = ERC 777
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc777.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc777
 
 This set of interfaces and contracts are all related to the [ERC777 token standard](https://eips.ethereum.org/EIPS/eip-777).
 

--- a/contracts/token/ERC777/README.adoc
+++ b/contracts/token/ERC777/README.adoc
@@ -1,4 +1,8 @@
 = ERC 777
+
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc777.
+
 This set of interfaces and contracts are all related to the [ERC777 token standard](https://eips.ethereum.org/EIPS/eip-777).
 
 TIP: For an overview of ERC777 tokens and a walkthrough on how to create a token contract read our xref:ROOT:erc777.adoc[ERC777 guide].

--- a/contracts/utils/README.adoc
+++ b/contracts/utils/README.adoc
@@ -1,5 +1,8 @@
 = Utilities
 
+[.readme-notice]
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/utils.
+
 Miscellaneous contracts and libraries containing utility functions you can use to improve security, work with new data types, or safely use low-level primitives.
 
 Security tools include:

--- a/contracts/utils/README.adoc
+++ b/contracts/utils/README.adoc
@@ -1,7 +1,7 @@
 = Utilities
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/utils.
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/utils
 
 Miscellaneous contracts and libraries containing utility functions you can use to improve security, work with new data types, or safely use low-level primitives.
 


### PR DESCRIPTION
This PR adds a notice at the top of each contract README with a link to the docs site. It should be hidden in the published site.