### PR TITLE
Adding of a "onlyAdminOf" modifier into AccessControl 

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -89,6 +89,14 @@ abstract contract AccessControl is Context {
     }
 
     /**
+     * @dev Throws if called by any account without the ``role``'s adminRole.
+     */
+    modifier onlyAdminOf(bytes32 role) {
+        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: caller must be an admin of the role");
+        _;
+    }
+
+    /**
      * @dev Returns the number of accounts that have `role`. Can be used
      * together with {getRoleMember} to enumerate all bearers of a role.
      */
@@ -132,9 +140,7 @@ abstract contract AccessControl is Context {
      *
      * - the caller must have ``role``'s admin role.
      */
-    function grantRole(bytes32 role, address account) public virtual {
-        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: sender must be an admin to grant");
-
+    function grantRole(bytes32 role, address account) public virtual onlyAdminOf(role) {
         _grantRole(role, account);
     }
 
@@ -147,9 +153,7 @@ abstract contract AccessControl is Context {
      *
      * - the caller must have ``role``'s admin role.
      */
-    function revokeRole(bytes32 role, address account) public virtual {
-        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: sender must be an admin to revoke");
-
+    function revokeRole(bytes32 role, address account) public virtual onlyAdminOf(role) {
         _revokeRole(role, account);
     }
 

--- a/test/access/AccessControl.test.js
+++ b/test/access/AccessControl.test.js
@@ -42,7 +42,7 @@ describe('AccessControl', function () {
     it('non-admin cannot grant role to other accounts', async function () {
       await expectRevert(
         this.accessControl.grantRole(ROLE, authorized, { from: other }),
-        'AccessControl: sender must be an admin to grant'
+        'AccessControl: caller must be an admin of the role'
       );
     });
 
@@ -76,7 +76,7 @@ describe('AccessControl', function () {
       it('non-admin cannot revoke role', async function () {
         await expectRevert(
           this.accessControl.revokeRole(ROLE, authorized, { from: other }),
-          'AccessControl: sender must be an admin to revoke'
+          'AccessControl: caller must be an admin of the role'
         );
       });
 
@@ -170,14 +170,14 @@ describe('AccessControl', function () {
     it('a role\'s previous admins no longer grant roles', async function () {
       await expectRevert(
         this.accessControl.grantRole(ROLE, authorized, { from: admin }),
-        'AccessControl: sender must be an admin to grant'
+        'AccessControl: caller must be an admin of the role'
       );
     });
 
     it('a role\'s previous admins no longer revoke roles', async function () {
       await expectRevert(
         this.accessControl.revokeRole(ROLE, authorized, { from: admin }),
-        'AccessControl: sender must be an admin to revoke'
+        'AccessControl: caller must be an admin of the role'
       );
     });
   });


### PR DESCRIPTION
Added "onlyAdminOf" modifier to merge duplicated check used in "grantRole" and "revokeRole" functions.
I used it into a personal project and I noticed it could be useful for further functions also.

Updated test to merge error messages.