### PR TITLE
ERC20: Prevent transfer to the token contract

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -209,6 +209,7 @@ contract ERC20 is Context, IERC20 {
     function _transfer(address sender, address recipient, uint256 amount) internal virtual {
         require(sender != address(0), "ERC20: transfer from the zero address");
         require(recipient != address(0), "ERC20: transfer to the zero address");
+        require(recipient != address(this), "ERC20: transfer to the token contract");
 
         _beforeTokenTransfer(sender, recipient, amount);
 


### PR DESCRIPTION
There's been a bit of discussion on Twitter today about preventing token transfers to the token contract, after a user lost about $35k worth of YFI.

https://twitter.com/dmihal/status/1293128845994995713
https://twitter.com/nanexcool/status/1293224689146486787

I threw together this PR to open the discussion on blocking transfers to the token contract.