### PR TITLE
feat: improve testing for ERC20Snapshot

### DIFF
--- a/test/token/ERC20/ERC20Snapshot.test.js
+++ b/test/token/ERC20/ERC20Snapshot.test.js
@@ -134,7 +134,7 @@ describe('ERC20Snapshot', function () {
       context('with balance changes after the snapshot', function () {
         beforeEach(async function () {
           await this.token.transfer(recipient, new BN('10'), { from: initialHolder });
-          await this.token.mint(recipient, new BN('50'));
+          await this.token.mint(other, new BN('50'));
           await this.token.burn(initialHolder, new BN('20'));
         });
 


### PR DESCRIPTION

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

**Rationale:**  We detected in a previous implementation of `ERC20Snapshot.sol` that some errors on the `mint` function (i.e: updating the incorrect account snapshot) were not being detected properly in the unit tests. 

The reason was that errors were not captured on `mint` and `burn` because the `transfer` operation (which was done at the same time/snapshot) was already taking care of tracking the correct balances for the `initialHolder` and `recipient` accounts. So this was preventing to properly test individually the snapshot update for `mint` and/or `burn`.  The way the contract behaves 

Refer to this PR for additional information: #2328 

**Solution**:  This PR solves this issue by simply adding the `other` account for the `mint` operation. This ensures each of the individual actions (`transfer`, `mint`, `burn`) are evaluated independently.

By adding this simple change we improve the granularity for the testing the `ERC20Snapshot.sol`, ensuring the account balances are properly updated in each operation. 