### PR TITLE
refactor: Accelerate 'average' calculation 

### DIFF
--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -26,6 +26,6 @@ library Math {
      */
     function average(uint256 a, uint256 b) internal pure returns (uint256) {
         // (a + b) / 2 can overflow, so we distribute
-        return (a / 2) + (b / 2) + ((a % 2 + b % 2) / 2);
+        return (a >> 1) + (b >> 1) + ((a & 1) + (b & 1) >> 1);
     }
 }


### PR DESCRIPTION
Using bitwise operation could be faster and consume less gas.
When turning on optimization, now running 'average()' costs only 91.1%
gas than it did, and 94.4% gas on execution deploying this contract
than it did.

The difference would be much greater when optimization is off.