### PR TITLE
Adapt proxies to Contracts conventions

### DIFF
--- a/contracts/proxy/Initializable.sol
+++ b/contracts/proxy/Initializable.sol
@@ -15,7 +15,7 @@ pragma solidity >=0.4.24 <0.7.0;
  * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
  * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
  */
-contract Initializable {
+abstract contract Initializable {
 
     /**
      * @dev Indicates that the contract has been initialized.

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -52,7 +52,7 @@ abstract contract Proxy {
      * This function does not return to its internall call site, it will return directly to the external caller.
      */
     function _fallback() internal {
-        _willFallback();
+        _beforeFallback();
         _delegate(_implementation());
     }
 
@@ -76,8 +76,8 @@ abstract contract Proxy {
      * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
      * call, or as part of the Solidity `fallback` or `receive` functions.
      * 
-     * If overriden should call `super._willFallback()`.
+     * If overriden should call `super._beforeFallback()`.
      */
-    function _willFallback() internal virtual {
+    function _beforeFallback() internal virtual {
     }
 }

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -92,7 +92,9 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * NOTE: Only the admin can call this function. See {ProxyAdmin-changeProxyAdmin}.
      */
     function changeAdmin(address newAdmin) external ifAdmin {
-        _changeAdmin(newAdmin);
+        require(newAdmin != address(0), "TransparentUpgradeableProxy: new admin is the zero address");
+        emit AdminChanged(_admin(), newAdmin);
+        _setAdmin(newAdmin);
     }
 
     /**
@@ -127,17 +129,6 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
         assembly {
             adm := sload(slot)
         }
-    }
-
-    /**
-     * @dev Changes the admin of the proxy.
-     * 
-     * Emits an {AdminChanged} event.
-     */
-    function _changeAdmin(address newAdmin) internal {
-        require(newAdmin != address(0), "TransparentUpgradeableProxy: new admin is the zero address");
-        emit AdminChanged(_admin(), newAdmin);
-        _setAdmin(newAdmin);
     }
 
     /**

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -92,9 +92,7 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * NOTE: Only the admin can call this function. See {ProxyAdmin-changeProxyAdmin}.
      */
     function changeAdmin(address newAdmin) external ifAdmin {
-        require(newAdmin != address(0), "TransparentUpgradeableProxy: new admin is the zero address");
-        emit AdminChanged(_admin(), newAdmin);
-        _setAdmin(newAdmin);
+        _changeAdmin(newAdmin);
     }
 
     /**
@@ -129,6 +127,17 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
         assembly {
             adm := sload(slot)
         }
+    }
+
+    /**
+     * @dev Changes the admin of the proxy.
+     * 
+     * Emits an {AdminChanged} event.
+     */
+    function _changeAdmin(address newAdmin) internal {
+        require(newAdmin != address(0), "TransparentUpgradeableProxy: new admin is the zero address");
+        emit AdminChanged(_admin(), newAdmin);
+        _setAdmin(newAdmin);
     }
 
     /**

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -144,10 +144,10 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
     }
 
     /**
-     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_willFallback}.
+     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
      */
-    function _willFallback() internal override virtual {
+    function _beforeFallback() internal override virtual {
         require(msg.sender != _admin(), "TransparentUpgradeableProxy: admin cannot fallback to proxy target");
-        super._willFallback();
+        super._beforeFallback();
     }
 }

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -134,7 +134,7 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
     /**
      * @dev Stores a new address in the EIP1967 admin slot.
      */
-    function _setAdmin(address newAdmin) internal {
+    function _setAdmin(address newAdmin) private {
         bytes32 slot = _ADMIN_SLOT;
 
         // solhint-disable-next-line no-inline-assembly

--- a/contracts/proxy/UpgradeableProxy.sol
+++ b/contracts/proxy/UpgradeableProxy.sol
@@ -67,7 +67,7 @@ contract UpgradeableProxy is Proxy {
     /**
      * @dev Stores a new address in the EIP1967 implementation slot.
      */
-    function _setImplementation(address newImplementation) internal {
+    function _setImplementation(address newImplementation) private {
         require(Address.isContract(newImplementation), "UpgradeableProxy: new implementation is not a contract");
 
         bytes32 slot = _IMPLEMENTATION_SLOT;


### PR DESCRIPTION
- Renames `_willFallback` to `_beforeFallback`, in line with the existing hooks we have like `_beforeTokenTransfer`.
- Makes private the low level setters `_setImplementation` (`_upgradeTo` remains internal) and `_setAdmin`.
- Makes `Initializable` an abstract contract, to signal that it's not meant to be deployed on its own.