### PR TITLE
feat: allow user to approve contract for safe(Batch)TransferFrom

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -149,8 +149,10 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     {
         require(to != address(0), "ERC1155: transfer to the zero address");
         require(
-            from == _msgSender() || isApprovedForAll(from, _msgSender()),
-            "ERC1155: caller is not owner nor approved"
+            from == _msgSender() ||
+            isApprovedForAll(from, _msgSender()) ||
+            isApprovedForAll(from, address(this)),
+            "ERC1155: transfer caller is not owner nor approved"
         );
 
         address operator = _msgSender();
@@ -182,7 +184,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
         require(to != address(0), "ERC1155: transfer to the zero address");
         require(
-            from == _msgSender() || isApprovedForAll(from, _msgSender()),
+            from == _msgSender() ||
+            isApprovedForAll(from, _msgSender()) ||
+            isApprovedForAll(from, address(this)),
             "ERC1155: transfer caller is not owner nor approved"
         );
 


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes: Nil

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

## What

- Both `safeTransferFrom` and `safeBatchTransferFrom` do this test `from == _msgSender() || isApprovedForAll(from, _msgSender())`, and I've modiifed them to do this test instead: `from == _msgSender() || isApprovedForAll(from, _msgSender()) || isApprovedForAll(from, address(this)`

## Why

- The addition of `isApprovedForAll(from, address(this)` allows for an account to specify that the smart contract is allowed to transfer tokens on its behalf
- The account is still in control of whether to allow this using `setApprovalForAll(address operator, bool approved)`
- This check currently occurs before (and outside of) `_beforeTokenTransfer(address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)`, so it is not possible to override that "hook" to enable this behaviour.
- The use case in mind is to allow token swaps in a single transaction, which is of particular value to enable, since the ERC1155 token standard allows multiple types of tokens

## Example

- `accountA` has 10 of `tokenA` and `accountB` has 5 of `tokenB`, which both accounts wish to swap
- `accountA` calls `setApprovalForAll(SMART_CONTRACT_ADDRESS, true)`
- `accountB` calls a function in the smart contract that does both of the following:
  1. sends 5x `tokenB` to `accountA` --> this already works, since `accountB` is `msg.sender`
  2. sends 10x `tokenA` to `accountB`--> this cannot work right now, since `accountA` is not the message sender. also neither `accountA` and `accountB` do not (and should not) want to call `setApprovalForAll` on each others' addreses.

## Notes

- I'm creating this PR to start a discussion first, so I'm marking it as "draft"
- As I'm aware there are likely several other things to consider that have yet to be considered
- Also, no tests yet - those can come post-discussion!


<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
