### PR TITLE
Remove unused `Address` library in ERC20.sol

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.6.0;
 import "../../GSN/Context.sol";
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";
-import "../../utils/Address.sol";
 
 /**
  * @dev Implementation of the {IERC20} interface.
@@ -33,7 +32,6 @@ import "../../utils/Address.sol";
  */
 contract ERC20 is Context, IERC20 {
     using SafeMath for uint256;
-    using Address for address;
 
     mapping (address => uint256) private _balances;
 


### PR DESCRIPTION
The current implementation of ERC20.sol in the OZ contracts seems to have an unused import of the Address library. This PR removes the import statement and header reference 'using Address for address.'
