### PR TITLE
Fix function state mutability warning

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -113,7 +113,7 @@ contract ERC777 is Context, IERC777, IERC20 {
      *
      * This implementation always returns `1`.
      */
-    function granularity() public view override returns (uint256) {
+    function granularity() public pure override returns (uint256) {
         return 1;
     }
 


### PR DESCRIPTION
Hi @frangio, on upgrading to `3.2.0-solc-0.7` release, I noticed that the commit from the PR #2327 wasn't included. But it's there in `solc-0.7` branch but seems it got missed out in this release branch.

I understand that this is a release branch so any more changes are not added to it, but can you merge this PR in the next release branch if it were to be created from this branch instead of `solc-0.7`?