### PR TITLE
Minor syntax change on IERC721Receiver.sol to conform to OZ format

### DIFF
--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -17,6 +17,5 @@ interface IERC721Receiver {
      *
      * The selector can be obtained in Solidity with `IERC721.onERC721Received.selector`.
      */
-    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
-    external returns (bytes4);
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data) external returns (bytes4);
 }


### PR DESCRIPTION
Slight nit on spacing to reduce # of lines // conform to other OZ function syntax