### PR TITLE
Test ERC165 support in ERC1155Holder

### DIFF
--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -35,6 +35,10 @@ const INTERFACES = {
     'safeTransferFrom(address,address,uint256,uint256,bytes)',
     'safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)',
   ],
+  ERC1155Receiver: [
+    'onERC1155Received(address,address,uint256,uint256,bytes)',
+    'onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)',
+  ],
 };
 
 const INTERFACE_IDS = {};
@@ -50,7 +54,7 @@ for (const k of Object.getOwnPropertyNames(INTERFACES)) {
 function shouldSupportInterfaces (interfaces = []) {
   describe('Contract interface', function () {
     beforeEach(function () {
-      this.contractUnderTest = this.mock || this.token;
+      this.contractUnderTest = this.mock || this.token || this.holder;
     });
 
     for (const k of interfaces) {

--- a/test/token/ERC1155/ERC1155Holder.test.js
+++ b/test/token/ERC1155/ERC1155Holder.test.js
@@ -6,6 +6,8 @@ const ERC1155Mock = contract.fromArtifact('ERC1155Mock');
 
 const { expect } = require('chai');
 
+const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
+
 describe('ERC1155Holder', function () {
   const [creator] = accounts;
   const uri = 'https://token-cdn-domain/{id}.json';
@@ -18,6 +20,8 @@ describe('ERC1155Holder', function () {
     this.holder = await ERC1155Holder.new();
     await this.multiToken.mintBatch(creator, multiTokenIds, multiTokenAmounts, '0x', { from: creator });
   });
+
+  shouldSupportInterfaces(['ERC165', 'ERC1155Receiver']);
 
   it('receives ERC1155 tokens from a single ID', async function () {
     await this.multiToken.safeTransferFrom(


### PR DESCRIPTION
`ERC1155Holder`'s ERC165 support wasn't being tested.