### PR TITLE
[Feature] Implemented Granting and Claiming Ownership.

### DIFF
--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -17,8 +17,10 @@ import "../GSN/Context.sol";
  */
 contract Ownable is Context {
     address private _owner;
+    address private _grantedOwner;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event OwnershipGranted(address indexed grantedOwner);
 
     /**
      * @dev Initializes the contract setting the deployer as the initial owner.
@@ -34,6 +36,13 @@ contract Ownable is Context {
      */
     function owner() public view returns (address) {
         return _owner;
+    }
+
+    /**
+     * @dev Returns the address of the currently granted owner.
+     */
+     function grantedOwner() public view returns (address) {
+        return _grantedOwner;
     }
 
     /**
@@ -64,5 +73,27 @@ contract Ownable is Context {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         emit OwnershipTransferred(_owner, newOwner);
         _owner = newOwner;
+    }
+
+		/**
+     * @dev Grants ownership of the contract to a new account (`newOwner`).
+     * Ownership has to be claimed by the new account and granting can be
+     * revoked until then (`grantOwnership(address(0))`).
+     * Can only be called by the current owner.
+     */
+    function grantOwnership(address newOwner) public virtual onlyOwner {
+        emit OwnershipGranted(newOwner);
+        _grantedOwner = newOwner;
+    }
+
+    /**
+     * @dev Claims granted ownership of the contract for a new account (`_grantedOwner`).
+     * Can only be called by the currently granted owner.
+     */
+    function claimOwnership() public virtual {
+        require(_grantedOwner == _msgSender(), "Ownable: caller is not the granted owner");
+        emit OwnershipTransferred(_owner, _grantedOwner);
+        _owner = _grantedOwner;
+        _grantedOwner = address(0);
     }
 }

--- a/test/access/Ownable.test.js
+++ b/test/access/Ownable.test.js
@@ -55,4 +55,40 @@ describe('Ownable', function () {
       );
     });
   });
+
+  describe('grant and claim ownership', function () {
+    it('grants ownership', async function () {
+      const receipt = await this.ownable.grantOwnership(other, { from: owner });
+      expectEvent(receipt, 'OwnershipGranted');
+
+      expect(await this.ownable.grantedOwner()).to.equal(other);
+    });
+
+    it('prevents non-owners from granting', async function () {
+      await expectRevert(
+        this.ownable.grantOwnership(other, { from: other }),
+        'Ownable: caller is not the owner',
+      );
+    });
+
+    it('prevents non-granted-owners from claiming ownership', async function () {
+      await expectRevert(
+        this.ownable.claimOwnership({ from: owner }),
+        'Ownable: caller is not the granted owner',
+      );
+    });
+
+    it('grants ownership and claims it', async function () {
+      let receipt = await this.ownable.grantOwnership(other, { from: owner });
+      expectEvent(receipt, 'OwnershipGranted');
+
+      expect(await this.ownable.grantedOwner()).to.equal(other);
+
+      receipt = await this.ownable.claimOwnership({ from: other });
+      expectEvent(receipt, 'OwnershipTransferred');
+
+      expect(await this.ownable.owner()).to.equal(other);
+      expect(await this.ownable.grantedOwner()).to.equal(ZERO_ADDRESS);
+    });
+  });
 });


### PR DESCRIPTION
https://github.com/OpenZeppelin/openzeppelin-contracts/issues/2369

Maybe `AccessControl` also solves this already but I think it's just nice to have in the wide spread Ownable.

```solidity
/**
 * @dev Grants ownership of the contract to a new account (`newOwner`).
 * Ownership has to be claimed by the new account and granting can be
 * revoked until then (`grantOwnership(address(0))`).
 * Can only be called by the current owner.
 */
function grantOwnership(address newOwner) public virtual onlyOwner {
    emit OwnershipGranted(newOwner);
    _grantedOwner = newOwner;
}

/**
 * @dev Claims granted ownership of the contract for a new account (`_grantedOwner`).
 * Can only be called by the currently granted owner.
 */
function claimOwnership() public virtual {
    require(_grantedOwner == _msgSender(), "Ownable: caller is not the granted owner");
    emit OwnershipTransferred(_owner, _grantedOwner);
    _owner = _grantedOwner;
    _grantedOwner = address(0);
}
```
