### PR TITLE
adds Proxies factory library

### DIFF
--- a/contracts/proxy/Proxies.sol
+++ b/contracts/proxy/Proxies.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+import "./TransparentUpgradeableProxy.sol";
+
+/**
+ * @dev Proxy Factory library to create multiple proxy instances at runtime
+ *
+ * These functions implement a simple Factory pattern that can be used to deploy
+ * multiple proxy instances when the implementation contract needs to be reused. 
+ */
+library Proxies {
+  // Contains the address of the implementation used for the proxies it creates.
+  struct ProxyFactory { address implementation; }
+
+  /**
+   * @dev Returns the ProxyFactory struct with the impementation contract address.
+   * 
+   * Initializes the factory struct by deploying the implementation contract and
+   * storing its address.
+  */
+  function newFactory(bytes memory creationCode) internal returns (ProxyFactory memory) {
+    address implementationAddr = _deployImplementation(creationCode);
+    ProxyFactory memory factory = ProxyFactory(implementationAddr);
+    return factory;
+  }
+
+  /**
+   * @dev Deploys a Proxy instance with `admin` and initialized with `initializerData
+   *
+  */
+  function deploy(ProxyFactory storage self,address admin, bytes memory initializerData) internal {
+    new TransparentUpgradeableProxy(self.implementation, admin, initializerData);
+  }
+
+  /**
+   * @dev Returns the address of the deployed implementation contract.
+   *
+   * Creates the implementation contract with `creationCode`.
+  */
+  function _deployImplementation(bytes memory creationCode) private returns (address) {
+    address payable addr;
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      addr := create(0, add(creationCode, 0x20), mload(creationCode))
+      if iszero(extcodesize(addr)) {
+        revert(0, 0)
+      }
+    }
+    return addr;
+  }
+}


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->
2339
<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #2339 

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

Implements a Proxy Factory Library names `Proxies` which allows to deploy multiple proxy instances when the implementation contract needs to be reused. 

This library can be utilized from a `Factory` contract which should provide the `creationCode` for the Implementation contract to deploy, the proxy `admin` address and the encoded `initializerData`. 

This PR is in DRAFT but wanted to check if its going in the right direction and what additional functionality we should include.

Pending tasks:
* Mockup Factory Contract
* Tests
* Docs
