### PR TITLE
Fix/solc 0.7.4 warnings #2391

### DIFF
--- a/contracts/GSN/GSNRecipientERC20Fee.sol
+++ b/contracts/GSN/GSNRecipientERC20Fee.sol
@@ -86,6 +86,8 @@ contract GSNRecipientERC20Fee is GSNRecipient {
 
         // The maximum token charge is pre-charged from the user
         _token.safeTransferFrom(from, address(this), maxPossibleCharge);
+
+        return 0;
     }
 
     /**

--- a/contracts/introspection/IERC1820Registry.sol
+++ b/contracts/introspection/IERC1820Registry.sol
@@ -59,7 +59,7 @@ interface IERC1820Registry {
      * queried for support, unless `implementer` is the caller. See
      * {IERC1820Implementer-canImplementInterfaceForAddress}.
      */
-    function setInterfaceImplementer(address account, bytes32 interfaceHash, address implementer) external;
+    function setInterfaceImplementer(address account, bytes32 _interfaceHash, address implementer) external;
 
     /**
      * @dev Returns the implementer of `interfaceHash` for `account`. If no such
@@ -70,7 +70,7 @@ interface IERC1820Registry {
      *
      * `account` being the zero address is an alias for the caller's address.
      */
-    function getInterfaceImplementer(address account, bytes32 interfaceHash) external view returns (address);
+    function getInterfaceImplementer(address account, bytes32 _interfaceHash) external view returns (address);
 
     /**
      * @dev Returns the interface hash for an `interfaceName`, as defined in the

--- a/contracts/mocks/GSNRecipientMock.sol
+++ b/contracts/mocks/GSNRecipientMock.sol
@@ -13,7 +13,7 @@ contract GSNRecipientMock is ContextMock, GSNRecipient {
 
     function acceptRelayedCall(address, address, bytes calldata, uint256, uint256, uint256, uint256, bytes calldata, uint256)
         external
-        view
+        pure
         override
         returns (uint256, bytes memory)
     {

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -39,13 +39,13 @@ contract PaymentSplitter is Context {
      * All addresses in `payees` must be non-zero. Both arrays must have the same non-zero length, and there must be no
      * duplicates in `payees`.
      */
-    constructor (address[] memory payees, uint256[] memory shares) payable {
+    constructor (address[] memory payees, uint256[] memory shares_) payable {
         // solhint-disable-next-line max-line-length
-        require(payees.length == shares.length, "PaymentSplitter: payees and shares length mismatch");
+        require(payees.length == shares_.length, "PaymentSplitter: payees and shares length mismatch");
         require(payees.length > 0, "PaymentSplitter: no payees");
 
         for (uint256 i = 0; i < payees.length; i++) {
-            _addPayee(payees[i], shares[i]);
+            _addPayee(payees[i], shares_[i]);
         }
     }
 

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -25,11 +25,11 @@ contract RefundEscrow is ConditionalEscrow {
 
     /**
      * @dev Constructor.
-     * @param beneficiary The beneficiary of the deposits.
+     * @param beneficiary_ The beneficiary of the deposits.
      */
-    constructor (address payable beneficiary) {
-        require(beneficiary != address(0), "RefundEscrow: beneficiary is the zero address");
-        _beneficiary = beneficiary;
+    constructor (address payable beneficiary_) {
+        require(beneficiary_ != address(0), "RefundEscrow: beneficiary is the zero address");
+        _beneficiary = beneficiary_;
         _state = State.Active;
     }
 

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -30,9 +30,9 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
      * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.
      */
-    constructor(address _logic, address _admin, bytes memory _data) payable UpgradeableProxy(_logic, _data) {
+    constructor(address _logic, address admin_, bytes memory _data) payable UpgradeableProxy(_logic, _data) {
         assert(_ADMIN_SLOT == bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
-        _setAdmin(_admin);
+        _setAdmin(admin_);
     }
 
     /**

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -67,8 +67,8 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
      */
-    function admin() external ifAdmin returns (address) {
-        return _admin();
+    function admin() external ifAdmin returns (address admin_) {
+        admin_ = _admin();
     }
 
     /**
@@ -80,8 +80,8 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function implementation() external ifAdmin returns (address) {
-        return _implementation();
+    function implementation() external ifAdmin returns (address implementation_) {
+        implementation_ = _implementation();
     }
 
     /**

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -52,8 +52,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     /**
      * @dev See {_setURI}.
      */
-    constructor (string memory uri) {
-        _setURI(uri);
+    constructor (string memory uri_) {
+        _setURI(uri_);
 
         // register the supported interfaces to conform to ERC1155 via ERC165
         _registerInterface(_INTERFACE_ID_ERC1155);

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -54,9 +54,9 @@ contract ERC20 is Context, IERC20 {
      * All three of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor (string memory name, string memory symbol) {
-        _name = name;
-        _symbol = symbol;
+    constructor (string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
         _decimals = 18;
     }
 

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -16,9 +16,9 @@ abstract contract ERC20Capped is ERC20 {
      * @dev Sets the value of the `cap`. This value is immutable, it can only be
      * set once during construction.
      */
-    constructor (uint256 cap) {
-        require(cap > 0, "ERC20Capped: cap is 0");
-        _cap = cap;
+    constructor (uint256 cap_) {
+        require(cap_ > 0, "ERC20Capped: cap is 0");
+        _cap = cap_;
     }
 
     /**

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -23,12 +23,12 @@ contract TokenTimelock {
     // timestamp when token release is enabled
     uint256 private _releaseTime;
 
-    constructor (IERC20 token, address beneficiary, uint256 releaseTime) {
+    constructor (IERC20 token_, address beneficiary_, uint256 releaseTime_) {
         // solhint-disable-next-line not-rely-on-time
-        require(releaseTime > block.timestamp, "TokenTimelock: release time is before current time");
-        _token = token;
-        _beneficiary = beneficiary;
-        _releaseTime = releaseTime;
+        require(releaseTime_ > block.timestamp, "TokenTimelock: release time is before current time");
+        _token = token_;
+        _beneficiary = beneficiary_;
+        _releaseTime = releaseTime_;
     }
 
     /**

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -90,9 +90,9 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable 
     /**
      * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
      */
-    constructor (string memory name, string memory symbol) {
-        _name = name;
-        _symbol = symbol;
+    constructor (string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
 
         // register the supported interfaces to conform to ERC721 via ERC165
         _registerInterface(_INTERFACE_ID_ERC721);

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -67,14 +67,14 @@ contract ERC777 is Context, IERC777, IERC20 {
      * @dev `defaultOperators` may be an empty array.
      */
     constructor(
-        string memory name,
-        string memory symbol,
-        address[] memory defaultOperators
+        string memory name_,
+        string memory symbol_,
+        address[] memory defaultOperators_
     ) {
-        _name = name;
-        _symbol = symbol;
+        _name = name_;
+        _symbol = symbol_;
 
-        _defaultOperatorsArray = defaultOperators;
+        _defaultOperatorsArray = defaultOperators_;
         for (uint256 i = 0; i < _defaultOperatorsArray.length; i++) {
             _defaultOperators[_defaultOperatorsArray[i]] = true;
         }


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #2391

This PR aims to remove plenty of warnings that show up when compiling contracts with solc `0.7.4`.

There were three kinds of warnings:

1. declaration shadowing
```
WARNING
  contracts/proxy/TransparentUpgradeableProxy.sol:33:33: Warning: This declaration shadows an existing declaration.
      constructor(address _logic, address _admin, bytes memory _data) payable UpgradeableProxy(_logic, _data) {
                                  ^------------^
  contracts/proxy/TransparentUpgradeableProxy.sol:126:5: The shadowed declaration is here:
      function _admin() internal view returns (address adm) {
      ^ (Relevant source part starts here and spans across multiple lines).
```

2. return variable
```
WARNING
  contracts/proxy/TransparentUpgradeableProxy.sol:70:48: Warning: Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
      function admin() external ifAdmin returns (address) {
                                                 ^-----^
```

3. state mutability
```
WARNING
  contracts/mocks/GSNRecipientMock.sol:14:5: Warning: Function state mutability can be restricted to pure
      function acceptRelayedCall(address, address, bytes calldata, uint256, uint256, uint256, uint256, bytes calldata, uint256)
      ^ (Relevant source part starts here and spans across multiple lines).
```

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

1. To prevent declaration shadowing, contract method arguments are suffixed with an underscore. Given that `name` naming is generally used for public vars or functions and `_name` naming for private vars or functions. Just to mention, this convention is already present in OpenZeppelin contracts and many other projects use this convention. Also, many devs use underscore prepending to function args to prevent shadowing but since solc 0.7.4, the compiler highlights if that shadows functions too (which were missed before). So having an alternate convention for arguments easily solves the problem. Inspired from [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/e5fbbda9bac49039847a7ed20c1d966766ecc64a/contracts/token/ERC20/ERC20.sol#L287), the convention of having `name_` naming for function arguments to prevent shadowing is taken in this PR in the first commit.

2. The second commit tries to silence this warning.

3. The third commit simply changes `view` to `pure`.

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->

Please let me know if this is fine or any changes that need to be done.