### PR TITLE
Fix ERC1155 URI example

### DIFF
--- a/docs/modules/ROOT/pages/erc1155.adoc
+++ b/docs/modules/ROOT/pages/erc1155.adoc
@@ -45,7 +45,7 @@ contract GameItems is ERC1155 {
     uint256 public constant SWORD = 3;
     uint256 public constant SHIELD = 4;
 
-    constructor() public ERC1155("https://game.example/api/item/{1}.json") {
+    constructor() public ERC1155("https://game.example/api/item/{id}.json") {
         _mint(msg.sender, GOLD, 10**18, "");
         _mint(msg.sender, SILVER, 10**27, "");
         _mint(msg.sender, THORS_HAMMER, 1, "");


### PR DESCRIPTION
The current ERC1155 example has an invalid URI for ID substitution.
```solidity
ERC1155("https://game.example/api/item/{1}.json")
```

This should be
```solidity
ERC1155("https://game.example/api/item/{id}.json")
```