### PR TITLE
Support compiling with solc 0.7

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,8 +4,9 @@
     "func-order": "off",
     "mark-callable-contracts": "off",
     "no-empty-blocks": "off",
-    "compiler-version": ["error", "^0.6.0"],
+    "compiler-version": "off",
     "private-vars-leading-underscore": "error",
-    "reason-string": "off"
+    "reason-string": "off",
+    "func-visibility": ["error", { "ignoreConstructors": true }]
   }
 }

--- a/contracts/GSN/Context.sol
+++ b/contracts/GSN/Context.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /*
  * @dev Provides information about the current execution context, including the

--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IRelayRecipient.sol";
 import "./IRelayHub.sol";

--- a/contracts/GSN/GSNRecipientERC20Fee.sol
+++ b/contracts/GSN/GSNRecipientERC20Fee.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./GSNRecipient.sol";
 import "../math/SafeMath.sol";
@@ -86,6 +86,8 @@ contract GSNRecipientERC20Fee is GSNRecipient {
 
         // The maximum token charge is pre-charged from the user
         _token.safeTransferFrom(from, address(this), maxPossibleCharge);
+
+        return 0;
     }
 
     /**

--- a/contracts/GSN/GSNRecipientSignature.sol
+++ b/contracts/GSN/GSNRecipientSignature.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./GSNRecipient.sol";
 import "../cryptography/ECDSA.sol";

--- a/contracts/GSN/IRelayHub.sol
+++ b/contracts/GSN/IRelayHub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface for `RelayHub`, the core contract of the GSN. Users should not need to interact with this contract

--- a/contracts/GSN/IRelayRecipient.sol
+++ b/contracts/GSN/IRelayRecipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Base interface for a contract that will be called via the GSN from {IRelayHub}.

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/EnumerableSet.sol";
 import "../utils/Address.sol";

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 /**
@@ -15,7 +15,7 @@ import "../GSN/Context.sol";
  * `onlyOwner`, which can be applied to your functions to restrict their use to
  * the owner.
  */
-contract Ownable is Context {
+abstract contract Ownable is Context {
     address private _owner;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);

--- a/contracts/access/TimelockController.sol
+++ b/contracts/access/TimelockController.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.9 <0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "./../math/SafeMath.sol";

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev These functions deal with verification of Merkle trees (hash trees),

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IERC165.sol";
 
@@ -10,7 +10,7 @@ import "./IERC165.sol";
  * Contracts may inherit from this and call {_registerInterface} to declare
  * their support of an interface.
  */
-contract ERC165 is IERC165 {
+abstract contract ERC165 is IERC165 {
     /*
      * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 /**
  * @dev Library used to query support of an interface declared via {IERC165}.

--- a/contracts/introspection/ERC1820Implementer.sol
+++ b/contracts/introspection/ERC1820Implementer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IERC1820Implementer.sol";
 

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface of the ERC165 standard, as defined in the

--- a/contracts/introspection/IERC1820Implementer.sol
+++ b/contracts/introspection/IERC1820Implementer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface for an ERC1820 implementer, as defined in the

--- a/contracts/introspection/IERC1820Registry.sol
+++ b/contracts/introspection/IERC1820Registry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface of the global ERC1820 Registry, as defined in the
@@ -59,7 +59,7 @@ interface IERC1820Registry {
      * queried for support, unless `implementer` is the caller. See
      * {IERC1820Implementer-canImplementInterfaceForAddress}.
      */
-    function setInterfaceImplementer(address account, bytes32 interfaceHash, address implementer) external;
+    function setInterfaceImplementer(address account, bytes32 _interfaceHash, address implementer) external;
 
     /**
      * @dev Returns the implementer of `interfaceHash` for `account`. If no such
@@ -70,7 +70,7 @@ interface IERC1820Registry {
      *
      * `account` being the zero address is an alias for the caller's address.
      */
-    function getInterfaceImplementer(address account, bytes32 interfaceHash) external view returns (address);
+    function getInterfaceImplementer(address account, bytes32 _interfaceHash) external view returns (address);
 
     /**
      * @dev Returns the interface hash for an `interfaceName`, as defined in the

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Standard math utilities missing in the Solidity language.

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/contracts/math/SignedSafeMath.sol
+++ b/contracts/math/SignedSafeMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @title SignedSafeMath

--- a/contracts/mocks/AccessControlMock.sol
+++ b/contracts/mocks/AccessControlMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../access/AccessControl.sol";
 

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/Address.sol";
 

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/Arrays.sol";
 

--- a/contracts/mocks/CallReceiverMock.sol
+++ b/contracts/mocks/CallReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 contract CallReceiverMock {
     string public sharedAnswer;

--- a/contracts/mocks/ClashingImplementation.sol
+++ b/contracts/mocks/ClashingImplementation.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 
 /**

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../payment/escrow/ConditionalEscrow.sol";
 

--- a/contracts/mocks/ContextMock.sol
+++ b/contracts/mocks/ContextMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 

--- a/contracts/mocks/CountersImpl.sol
+++ b/contracts/mocks/CountersImpl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/Counters.sol";
 

--- a/contracts/mocks/Create2Impl.sol
+++ b/contracts/mocks/Create2Impl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/Create2.sol";
 import "../introspection/ERC1820Implementer.sol";

--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 abstract contract Impl {
   function version() public pure virtual returns (string memory); 

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../cryptography/ECDSA.sol";
 

--- a/contracts/mocks/ERC1155BurnableMock.sol
+++ b/contracts/mocks/ERC1155BurnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC1155/ERC1155Burnable.sol";
 

--- a/contracts/mocks/ERC1155Mock.sol
+++ b/contracts/mocks/ERC1155Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC1155/ERC1155.sol";
 

--- a/contracts/mocks/ERC1155PausableMock.sol
+++ b/contracts/mocks/ERC1155PausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC1155Mock.sol";
 import "../token/ERC1155/ERC1155Pausable.sol";

--- a/contracts/mocks/ERC1155ReceiverMock.sol
+++ b/contracts/mocks/ERC1155ReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC1155/IERC1155Receiver.sol";
 import "./ERC165Mock.sol";

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/mocks/ERC165/ERC165NotSupported.sol
+++ b/contracts/mocks/ERC165/ERC165NotSupported.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 contract ERC165NotSupported { }

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../introspection/ERC165Checker.sol";
 

--- a/contracts/mocks/ERC165Mock.sol
+++ b/contracts/mocks/ERC165Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../introspection/ERC165.sol";
 

--- a/contracts/mocks/ERC1820ImplementerMock.sol
+++ b/contracts/mocks/ERC1820ImplementerMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../introspection/ERC1820Implementer.sol";
 

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC20/ERC20Burnable.sol";
 

--- a/contracts/mocks/ERC20CappedMock.sol
+++ b/contracts/mocks/ERC20CappedMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC20/ERC20Capped.sol";
 

--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC20/ERC20Pausable.sol";
 

--- a/contracts/mocks/ERC20SnapshotMock.sol
+++ b/contracts/mocks/ERC20SnapshotMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC20/ERC20Snapshot.sol";
 

--- a/contracts/mocks/ERC721BurnableMock.sol
+++ b/contracts/mocks/ERC721BurnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC721/ERC721Burnable.sol";
 

--- a/contracts/mocks/ERC721GSNRecipientMock.sol
+++ b/contracts/mocks/ERC721GSNRecipientMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC721/ERC721.sol";
 import "../GSN/GSNRecipient.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC721/ERC721Pausable.sol";
 

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../token/ERC721/IERC721Receiver.sol";
 

--- a/contracts/mocks/ERC777Mock.sol
+++ b/contracts/mocks/ERC777Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 import "../token/ERC777/ERC777.sol";

--- a/contracts/mocks/ERC777SenderRecipientMock.sol
+++ b/contracts/mocks/ERC777SenderRecipientMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 import "../token/ERC777/IERC777.sol";

--- a/contracts/mocks/EnumerableMapMock.sol
+++ b/contracts/mocks/EnumerableMapMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/EnumerableMap.sol";
 

--- a/contracts/mocks/EnumerableSetMock.sol
+++ b/contracts/mocks/EnumerableSetMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/EnumerableSet.sol";
 

--- a/contracts/mocks/EtherReceiverMock.sol
+++ b/contracts/mocks/EtherReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 contract EtherReceiverMock {
     bool private _acceptEther;

--- a/contracts/mocks/GSNRecipientERC20FeeMock.sol
+++ b/contracts/mocks/GSNRecipientERC20FeeMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/GSNRecipient.sol";
 import "../GSN/GSNRecipientERC20Fee.sol";

--- a/contracts/mocks/GSNRecipientMock.sol
+++ b/contracts/mocks/GSNRecipientMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ContextMock.sol";
 import "../GSN/GSNRecipient.sol";

--- a/contracts/mocks/GSNRecipientSignatureMock.sol
+++ b/contracts/mocks/GSNRecipientSignatureMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/GSNRecipient.sol";
 import "../GSN/GSNRecipientSignature.sol";

--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../proxy/Initializable.sol";
 

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../math/Math.sol";
 

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import { MerkleProof } from "../cryptography/MerkleProof.sol";
 

--- a/contracts/mocks/MultipleInheritanceInitializableMocks.sol
+++ b/contracts/mocks/MultipleInheritanceInitializableMocks.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../proxy/Initializable.sol";
 

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../access/Ownable.sol";
 

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/Pausable.sol";
 

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../payment/PullPayment.sol";
 

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 contract ReentrancyAttack is Context {

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/ReentrancyGuard.sol";
 import "./ReentrancyAttack.sol";

--- a/contracts/mocks/RegressionImplementation.sol
+++ b/contracts/mocks/RegressionImplementation.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../proxy/Initializable.sol";
 

--- a/contracts/mocks/SafeCastMock.sol
+++ b/contracts/mocks/SafeCastMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/SafeCast.sol";
 

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 import "../token/ERC20/IERC20.sol";

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/mocks/SignedSafeMathMock.sol
+++ b/contracts/mocks/SignedSafeMathMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../math/SignedSafeMath.sol";
 

--- a/contracts/mocks/SingleInheritanceInitializableMocks.sol
+++ b/contracts/mocks/SingleInheritanceInitializableMocks.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../proxy/Initializable.sol";
 

--- a/contracts/mocks/StringsMock.sol
+++ b/contracts/mocks/StringsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../utils/Strings.sol";
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openzeppelin/contracts",
   "description": "Secure Smart Contract library for Solidity",
-  "version": "3.2.0",
+  "version": "3.2.2-solc-0.7",
   "files": [
     "**/*.sol",
     "/build/contracts/*.json",

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 import "../math/SafeMath.sol";
@@ -39,13 +39,13 @@ contract PaymentSplitter is Context {
      * All addresses in `payees` must be non-zero. Both arrays must have the same non-zero length, and there must be no
      * duplicates in `payees`.
      */
-    constructor (address[] memory payees, uint256[] memory shares) public payable {
+    constructor (address[] memory payees, uint256[] memory shares_) public payable {
         // solhint-disable-next-line max-line-length
-        require(payees.length == shares.length, "PaymentSplitter: payees and shares length mismatch");
+        require(payees.length == shares_.length, "PaymentSplitter: payees and shares length mismatch");
         require(payees.length > 0, "PaymentSplitter: no payees");
 
         for (uint256 i = 0; i < payees.length; i++) {
-            _addPayee(payees[i], shares[i]);
+            _addPayee(payees[i], shares_[i]);
         }
     }
 

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 import "./escrow/Escrow.sol";
 
@@ -22,7 +22,7 @@ import "./escrow/Escrow.sol";
  * instead of Solidity's `transfer` function. Payees can query their due
  * payments with {payments}, and retrieve them with {withdrawPayments}.
  */
-contract PullPayment {
+abstract contract PullPayment {
     Escrow private _escrow;
 
     constructor () internal {

--- a/contracts/payment/escrow/ConditionalEscrow.sol
+++ b/contracts/payment/escrow/ConditionalEscrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./Escrow.sol";
 

--- a/contracts/payment/escrow/Escrow.sol
+++ b/contracts/payment/escrow/Escrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../math/SafeMath.sol";
 import "../../access/Ownable.sol";

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ConditionalEscrow.sol";
 
@@ -25,11 +25,11 @@ contract RefundEscrow is ConditionalEscrow {
 
     /**
      * @dev Constructor.
-     * @param beneficiary The beneficiary of the deposits.
+     * @param beneficiary_ The beneficiary of the deposits.
      */
-    constructor (address payable beneficiary) public {
-        require(beneficiary != address(0), "RefundEscrow: beneficiary is the zero address");
-        _beneficiary = beneficiary;
+    constructor (address payable beneficiary_) public {
+        require(beneficiary_ != address(0), "RefundEscrow: beneficiary is the zero address");
+        _beneficiary = beneficiary_;
         _state = State.Active;
     }
 

--- a/contracts/presets/ERC1155PresetMinterPauser.sol
+++ b/contracts/presets/ERC1155PresetMinterPauser.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../access/AccessControl.sol";
 import "../GSN/Context.sol";

--- a/contracts/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/presets/ERC20PresetMinterPauser.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../access/AccessControl.sol";
 import "../GSN/Context.sol";

--- a/contracts/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/presets/ERC721PresetMinterPauserAutoId.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../access/AccessControl.sol";
 import "../GSN/Context.sol";

--- a/contracts/proxy/Initializable.sol
+++ b/contracts/proxy/Initializable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 // solhint-disable-next-line compiler-version
-pragma solidity >=0.4.24 <0.7.0;
+pragma solidity >=0.4.24 <0.8.0;
 
 
 /**

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM

--- a/contracts/proxy/ProxyAdmin.sol
+++ b/contracts/proxy/ProxyAdmin.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../access/Ownable.sol";
 import "./TransparentUpgradeableProxy.sol";

--- a/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./UpgradeableProxy.sol";
 
@@ -30,9 +30,9 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
      * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.
      */
-    constructor(address _logic, address _admin, bytes memory _data) public payable UpgradeableProxy(_logic, _data) {
+    constructor(address _logic, address admin_, bytes memory _data) public payable UpgradeableProxy(_logic, _data) {
         assert(_ADMIN_SLOT == bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
-        _setAdmin(_admin);
+        _setAdmin(admin_);
     }
 
     /**
@@ -67,8 +67,8 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
      */
-    function admin() external ifAdmin returns (address) {
-        return _admin();
+    function admin() external ifAdmin returns (address admin_) {
+        admin_ = _admin();
     }
 
     /**
@@ -80,8 +80,8 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function implementation() external ifAdmin returns (address) {
-        return _implementation();
+    function implementation() external ifAdmin returns (address implementation_) {
+        implementation_ = _implementation();
     }
 
     /**

--- a/contracts/proxy/UpgradeableProxy.sol
+++ b/contracts/proxy/UpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./Proxy.sol";
 import "../utils/Address.sol";

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IERC1155.sol";
 import "./IERC1155MetadataURI.sol";
@@ -52,8 +52,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     /**
      * @dev See {_setURI}.
      */
-    constructor (string memory uri) public {
-        _setURI(uri);
+    constructor (string memory uri_) public {
+        _setURI(uri_);
 
         // register the supported interfaces to conform to ERC1155 via ERC165
         _registerInterface(_INTERFACE_ID_ERC1155);

--- a/contracts/token/ERC1155/ERC1155Burnable.sol
+++ b/contracts/token/ERC1155/ERC1155Burnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC1155.sol";
 

--- a/contracts/token/ERC1155/ERC1155Holder.sol
+++ b/contracts/token/ERC1155/ERC1155Holder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC1155Receiver.sol";
 

--- a/contracts/token/ERC1155/ERC1155Pausable.sol
+++ b/contracts/token/ERC1155/ERC1155Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC1155.sol";
 import "../../utils/Pausable.sol";

--- a/contracts/token/ERC1155/ERC1155Receiver.sol
+++ b/contracts/token/ERC1155/ERC1155Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IERC1155Receiver.sol";
 import "../../introspection/ERC165.sol";
@@ -9,7 +9,7 @@ import "../../introspection/ERC165.sol";
  * @dev _Available since v3.1._
  */
 abstract contract ERC1155Receiver is ERC165, IERC1155Receiver {
-    constructor() public {
+    constructor() internal {
         _registerInterface(
             ERC1155Receiver(0).onERC1155Received.selector ^
             ERC1155Receiver(0).onERC1155BatchReceived.selector

--- a/contracts/token/ERC1155/IERC1155.sol
+++ b/contracts/token/ERC1155/IERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/token/ERC1155/IERC1155MetadataURI.sol
+++ b/contracts/token/ERC1155/IERC1155MetadataURI.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 import "./IERC1155.sol";
 

--- a/contracts/token/ERC1155/IERC1155Receiver.sol
+++ b/contracts/token/ERC1155/IERC1155Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../GSN/Context.sol";
 import "./IERC20.sol";
@@ -52,9 +52,9 @@ contract ERC20 is Context, IERC20 {
      * All three of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor (string memory name, string memory symbol) public {
-        _name = name;
-        _symbol = symbol;
+    constructor (string memory name_, string memory symbol_) public {
+        _name = name_;
+        _symbol = symbol_;
         _decimals = 18;
     }
 

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../GSN/Context.sol";
 import "./ERC20.sol";
@@ -11,6 +11,8 @@ import "./ERC20.sol";
  * recognized off-chain (via event analysis).
  */
 abstract contract ERC20Burnable is Context, ERC20 {
+    using SafeMath for uint256;
+
     /**
      * @dev Destroys `amount` tokens from the caller.
      *

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC20.sol";
 
@@ -8,15 +8,17 @@ import "./ERC20.sol";
  * @dev Extension of {ERC20} that adds a cap to the supply of tokens.
  */
 abstract contract ERC20Capped is ERC20 {
+    using SafeMath for uint256;
+
     uint256 private _cap;
 
     /**
      * @dev Sets the value of the `cap`. This value is immutable, it can only be
      * set once during construction.
      */
-    constructor (uint256 cap) public {
-        require(cap > 0, "ERC20Capped: cap is 0");
-        _cap = cap;
+    constructor (uint256 cap_) internal {
+        require(cap_ > 0, "ERC20Capped: cap is 0");
+        _cap = cap_;
     }
 
     /**

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC20.sol";
 import "../../utils/Pausable.sol";

--- a/contracts/token/ERC20/ERC20Snapshot.sol
+++ b/contracts/token/ERC20/ERC20Snapshot.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../math/SafeMath.sol";
 import "../../utils/Arrays.sol";

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./SafeERC20.sol";
 
@@ -23,12 +23,12 @@ contract TokenTimelock {
     // timestamp when token release is enabled
     uint256 private _releaseTime;
 
-    constructor (IERC20 token, address beneficiary, uint256 releaseTime) public {
+    constructor (IERC20 token_, address beneficiary_, uint256 releaseTime_) public {
         // solhint-disable-next-line not-rely-on-time
-        require(releaseTime > block.timestamp, "TokenTimelock: release time is before current time");
-        _token = token;
-        _beneficiary = beneficiary;
-        _releaseTime = releaseTime;
+        require(releaseTime_ > block.timestamp, "TokenTimelock: release time is before current time");
+        _token = token_;
+        _beneficiary = beneficiary_;
+        _releaseTime = releaseTime_;
     }
 
     /**

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../GSN/Context.sol";
 import "./IERC721.sol";
@@ -90,9 +90,9 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable 
     /**
      * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
      */
-    constructor (string memory name, string memory symbol) public {
-        _name = name;
-        _symbol = symbol;
+    constructor (string memory name_, string memory symbol_) public {
+        _name = name_;
+        _symbol = symbol_;
 
         // register the supported interfaces to conform to ERC721 via ERC165
         _registerInterface(_INTERFACE_ID_ERC721);

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../GSN/Context.sol";
 import "./ERC721.sol";

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./IERC721Receiver.sol";
 

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC721.sol";
 import "../../utils/Pausable.sol";

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @title ERC721 token receiver interface

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../../GSN/Context.sol";
 import "./IERC777.sol";
@@ -67,14 +67,14 @@ contract ERC777 is Context, IERC777, IERC20 {
      * @dev `defaultOperators` may be an empty array.
      */
     constructor(
-        string memory name,
-        string memory symbol,
-        address[] memory defaultOperators
+        string memory name_,
+        string memory symbol_,
+        address[] memory defaultOperators_
     ) public {
-        _name = name;
-        _symbol = symbol;
+        _name = name_;
+        _symbol = symbol_;
 
-        _defaultOperatorsArray = defaultOperators;
+        _defaultOperatorsArray = defaultOperators_;
         for (uint256 i = 0; i < _defaultOperatorsArray.length; i++) {
             _defaultOperators[_defaultOperatorsArray[i]] = true;
         }

--- a/contracts/token/ERC777/IERC777.sol
+++ b/contracts/token/ERC777/IERC777.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface of the ERC777Token standard as defined in the EIP.

--- a/contracts/token/ERC777/IERC777Recipient.sol
+++ b/contracts/token/ERC777/IERC777Recipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface of the ERC777TokensRecipient standard as defined in the EIP.

--- a/contracts/token/ERC777/IERC777Sender.sol
+++ b/contracts/token/ERC777/IERC777Sender.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Interface of the ERC777TokensSender standard as defined in the EIP.

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2 <0.8.0;
 
 /**
  * @dev Collection of functions related to the address type

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../math/Math.sol";
 

--- a/contracts/utils/Counters.sol
+++ b/contracts/utils/Counters.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Helper to make usage of the `CREATE2` EVM opcode easier and safer.

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Library for managing an enumerable variant of Solidity's

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Library for managing

--- a/contracts/utils/Pausable.sol
+++ b/contracts/utils/Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "../GSN/Context.sol";
 
@@ -13,7 +13,7 @@ import "../GSN/Context.sol";
  * the functions of your contract. Note that they will not be pausable by
  * simply including this module, only once the modifiers are put in place.
  */
-contract Pausable is Context {
+abstract contract Pausable is Context {
     /**
      * @dev Emitted when the pause is triggered by `account`.
      */

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev Contract module that helps prevent reentrant calls to a function.
@@ -18,7 +18,7 @@ pragma solidity ^0.6.0;
  * to protect against it, check out our blog post
  * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
  */
-contract ReentrancyGuard {
+abstract contract ReentrancyGuard {
     // Booleans are more expensive than uint256 or any type that takes up a full
     // word because each write operation emits an extra SLOAD to first read the
     // slot's contents, replace the bits taken up by the boolean, and then write

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 
 /**

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 /**
  * @dev String operations.


### PR DESCRIPTION
This brings some of the changes of the `solc-0.7` branch over to the main release, using a pragma that supports both 0.6 and 0.7. Compilation with 0.7 will result in a lot of warnings. Removing those warnings is what the `solc-0.7` branch and release are about.

