### PR TITLE
Update ERC20.sol

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -52,7 +52,7 @@ contract ERC20 is Context, IERC20 {
      * All three of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor (string memory name_, string memory symbol_) public {
+    constructor (string memory name_, string memory symbol_) {
         _name = name_;
         _symbol = symbol_;
         _decimals = 18;


### PR DESCRIPTION
Removing `public` in the constructor.

Fixes #

<!-- 2. Describe the changes introduced in this pull request. -->
The compiler in Remix etc gives the following warning:
```
Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient. constructor (string memory name_, string memory symbol_) public { ^ (Relevant source part starts here and spans across multiple lines).
```
This PR fixes the issue by removing the redundant `public`

