### PR TITLE
Use bytes1 and avoid using the obsolete byte type

### DIFF
--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -26,7 +26,7 @@ library Strings {
         uint256 index = digits - 1;
         temp = value;
         while (temp != 0) {
-            buffer[index--] = byte(uint8(48 + temp % 10));
+            buffer[index--] = bytes1(uint8(48 + temp % 10));
             temp /= 10;
         }
         return string(buffer);


### PR DESCRIPTION
`byte` is (and always has been) an alias of `bytes1`, but it provides no benefit over it (perhaps just confusion) and `utils/Create2.sol` already follows this pattern.