### PR TITLE
Adjust for chainid becoming view in 0.8.0.

### DIFF
--- a/contracts/drafts/EIP712.sol
+++ b/contracts/drafts/EIP712.sol
@@ -96,7 +96,8 @@ abstract contract EIP712 {
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparatorV4(), structHash));
     }
 
-    function _getChainId() private pure returns (uint256 chainId) {
+    function _getChainId() private view returns (uint256 chainId) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
         // solhint-disable-next-line no-inline-assembly
         assembly {
             chainId := chainid()

--- a/contracts/mocks/EIP712External.sol
+++ b/contracts/mocks/EIP712External.sol
@@ -22,7 +22,8 @@ contract EIP712External is EIP712 {
         require(recoveredSigner == signer);
     }
 
-    function getChainId() external pure returns (uint256 chainId) {
+    function getChainId() external view returns (uint256 chainId) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
         // solhint-disable-next-line no-inline-assembly
         assembly {
             chainId := chainid()

--- a/contracts/mocks/ERC20PermitMock.sol
+++ b/contracts/mocks/ERC20PermitMock.sol
@@ -14,7 +14,8 @@ contract ERC20PermitMock is ERC20Permit {
         _mint(initialAccount, initialBalance);
     }
 
-    function getChainId() external pure returns (uint256 chainId) {
+    function getChainId() external view returns (uint256 chainId) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
         // solhint-disable-next-line no-inline-assembly
         assembly {
             chainId := chainid()


### PR DESCRIPTION
Borrowed the mutability warning silencing hack from other parts of OpenZeppelin.

I think it makes sense to add this change to pre-0.8.0, just to ensure users of these contracts are aware of the semantic changes related to chainid's mutability. This is practically a bug fix, see https://github.com/ethereum/solidity/issues/10090