### PR TITLE
Rename permit arguments to match the spec

### DIFF
--- a/contracts/drafts/ERC20Permit.sol
+++ b/contracts/drafts/ERC20Permit.sol
@@ -35,7 +35,7 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712 {
     /**
      * @dev See {IERC20Permit-permit}.
      */
-    function permit(address owner, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public virtual override {
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public virtual override {
         // solhint-disable-next-line not-rely-on-time
         require(block.timestamp <= deadline, "ERC20Permit: expired deadline");
 
@@ -44,7 +44,7 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712 {
                 _PERMIT_TYPEHASH,
                 owner,
                 spender,
-                amount,
+                value,
                 _nonces[owner].current(),
                 deadline
             )
@@ -56,7 +56,7 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712 {
         require(signer == owner, "ERC20Permit: invalid signature");
 
         _nonces[owner].increment();
-        _approve(owner, spender, amount);
+        _approve(owner, spender, value);
     }
 
     /**

--- a/contracts/drafts/IERC20Permit.sol
+++ b/contracts/drafts/IERC20Permit.sol
@@ -12,7 +12,7 @@ pragma solidity >=0.6.0 <0.8.0;
  */
 interface IERC20Permit {
     /**
-     * @dev Sets `amount` as the allowance of `spender` over `owner`'s tokens,
+     * @dev Sets `value` as the allowance of `spender` over `owner`'s tokens,
      * given `owner`'s signed approval.
      *
      * IMPORTANT: The same issues {IERC20-approve} has related to transaction
@@ -32,7 +32,7 @@ interface IERC20Permit {
      * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
      * section].
      */
-    function permit(address owner, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 
     /**
      * @dev Returns the current nonce for `owner`. This value must be


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

[EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) has the following interface for permit:
`function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s)`

Note that third argument is called `value` which is also reflected in `_PERMIT_TYPEHASH`.

It is probably better to follow the spec and use the same argument names as in EIP and in the typehash.

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
