### PR TITLE
Add available since notice to TimelockController docs

### DIFF
--- a/contracts/access/TimelockController.sol
+++ b/contracts/access/TimelockController.sol
@@ -18,6 +18,8 @@ import "./AccessControl.sol";
  * is in charge of proposing (resp executing) operations. A common use case is
  * to position this {TimelockController} as the owner of a smart contract, with
  * a multisig or a DAO as the sole proposer.
+ *
+ * _Available since v3.3._
  */
 contract TimelockController is AccessControl {
 


### PR DESCRIPTION
I was wondering why I couldn't find the contracts, until I noticed I was using the wrong release. This should be in the docs, not on the release page (see e.g. the [ERC1155 docs](https://docs.openzeppelin.com/contracts/3.x/api/token/erc1155#IERC1155)).