### PR TITLE
Adding support for short signature (eip-2098) in cryptography/ECDSA

### DIFF
--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -24,23 +24,34 @@ library ECDSA {
      * be too long), and then calling {toEthSignedMessageHash} on it.
      */
     function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
-        // Check the signature length
-        if (signature.length != 65) {
-            revert("ECDSA: invalid signature length");
-        }
-
         // Divide the signature in r, s and v variables
         bytes32 r;
         bytes32 s;
         uint8 v;
 
-        // ecrecover takes the signature parameters, and the only way to get them
-        // currently is to use assembly.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            r := mload(add(signature, 0x20))
-            s := mload(add(signature, 0x40))
-            v := byte(0, mload(add(signature, 0x60)))
+        // Check the signature length
+        // - case 65: r,s,v signature (standard)
+        // - case 64: r,vs signature (cf https://eips.ethereum.org/EIPS/eip-2098)
+        if (signature.length == 65) {
+            // ecrecover takes the signature parameters, and the only way to get them
+            // currently is to use assembly.
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                r := mload(add(signature, 0x20))
+                s := mload(add(signature, 0x40))
+                v := byte(0, mload(add(signature, 0x60)))
+            }
+        } else if (signature.length == 64) {
+            // ecrecover takes the signature parameters, and the only way to get them
+            // currently is to use assembly.
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                r := mload(add(signature, 0x20))
+                s := and(mload(add(_sign, 0x40)), 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+                v := add(shr(7, byte(0, mload(add(_sign, 0x40)))), 27)
+            }
+        } else {
+            revert("ECDSA: invalid signature length");
         }
 
         return recover(hash, v, r, s);

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -47,8 +47,8 @@ library ECDSA {
             // solhint-disable-next-line no-inline-assembly
             assembly {
                 r := mload(add(signature, 0x20))
-                s := and(mload(add(_sign, 0x40)), 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
-                v := add(shr(7, byte(0, mload(add(_sign, 0x40)))), 27)
+                s := and(mload(add(signature, 0x40)), 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+                v := add(shr(7, byte(0, mload(add(signature, 0x40)))), 27)
             }
         } else {
             revert("ECDSA: invalid signature length");


### PR DESCRIPTION
[EIP-2098](https://eips.ethereum.org/EIPS/eip-2098) proposes a way to use short, 64 bytes long, signatures instead of the traditional 65 bytes long ones.

This PR updates cryptography/ECDSA to support both 65 (r,s,v) and 64(r,vs) bytes signatures.