### PR TITLE
Implementation of ERC667 (extension of ERC20)

### DIFF
--- a/contracts/token/ERC20/ERC667.sol
+++ b/contracts/token/ERC20/ERC667.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity ^0.8.0;
 
 import "../../GSN/Context.sol";
 import "../../utils/Address.sol";
@@ -27,9 +27,9 @@ abstract contract ERC667 is Context, ERC20, IERC667 {
      *
      * Emits a {Transfer} event.
      */
-    function transferAndCall(address receiver, uint amount, bytes memory _data) public virtual override returns (bool) {
+    function transferAndCall(address receiver, uint amount, bytes memory data) public virtual override returns (bool) {
         _transfer(_msgSender(), receiver, amount);
-        require(_checkOnERC667Received(_msgSender(), receiver, amount, _data), "ERC667: transferAndCall to non ERC667Receiver implementer");
+        require(_checkOnERC667Received(_msgSender(), receiver, amount, data), "ERC667: transferAndCall to non ERC667Receiver implementer");
         return true;
     }
 
@@ -40,17 +40,15 @@ abstract contract ERC667 is Context, ERC20, IERC667 {
      * @param from address representing the tokens sender
      * @param receiver target address that will receive the tokens
      * @param amount quantity of tokens transfered
-     * @param _data bytes optional data to send along with the call
+     * @param data bytes optional data to send along with the call
      * @return bool whether the call correctly returned the expected value
      */
-    function _checkOnERC667Received(address from, address receiver, uint256 amount, bytes memory _data) private returns (bool)
+    function _checkOnERC667Received(address from, address receiver, uint256 amount, bytes memory data) private returns (bool)
     {
-        bytes memory returndata = receiver.functionCall(abi.encodeWithSelector(
-            IERC667Receiver.onTokenTransfer.selector,
-            from,
-            amount,
-            _data
-        ), "ERC667: transferAndCall to non ERC667Receiver implementer");
-        return abi.decode(returndata, (bool));
+        try IERC667Receiver(receiver).onTokenTransfer(from, amount, data) returns (bool success) {
+            return success;
+        } catch {
+            return false;
+        }
     }
 }

--- a/contracts/token/ERC20/ERC667.sol
+++ b/contracts/token/ERC20/ERC667.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "../../GSN/Context.sol";
+import "../../utils/Address.sol";
+import "./ERC20.sol";
+import "./IERC667.sol";
+import "./IERC667Receiver.sol";
+
+/**
+ * @title ERC667 Token standard
+ *
+ * @dev Extension of {ERC20} that allows direct transfer of tokens to smart
+ * contracts that bypass the approve-transfer pattern.
+ *
+ * see https://github.com/ethereum/EIPs/issues/677
+ */
+abstract contract ERC667 is Context, ERC20, IERC667 {
+    using Address for address;
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient` and
+     * call {IERC667Receiver-onTokenTransfer}` on the recipient.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferAndCall(address receiver, uint amount, bytes memory _data) public virtual override returns (bool) {
+        _transfer(_msgSender(), receiver, amount);
+        require(_checkOnERC667Received(_msgSender(), receiver, amount, _data), "ERC667: transferAndCall to non ERC667Receiver implementer");
+        return true;
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC667Receiver-onTokenTransfer} on a
+     * target address.
+     *
+     * @param from address representing the tokens sender
+     * @param receiver target address that will receive the tokens
+     * @param amount quantity of tokens transfered
+     * @param _data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected value
+     */
+    function _checkOnERC667Received(address from, address receiver, uint256 amount, bytes memory _data) private returns (bool)
+    {
+        bytes memory returndata = receiver.functionCall(abi.encodeWithSelector(
+            IERC667Receiver.onTokenTransfer.selector,
+            from,
+            amount,
+            _data
+        ), "ERC667: transferAndCall to non ERC667Receiver implementer");
+        return abi.decode(returndata, (bool));
+    }
+}

--- a/contracts/token/ERC20/IERC667.sol
+++ b/contracts/token/ERC20/IERC667.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity >=0.6.0 <0.9.0;
 
 /**
  * @dev Interface of the ERC667 standard as defined in the EIP.

--- a/contracts/token/ERC20/IERC667.sol
+++ b/contracts/token/ERC20/IERC667.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @dev Interface of the ERC667 standard as defined in the EIP.
+ */
+interface IERC667 {
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient` and
+     * call {IERC667Receiver-onTokenTransfer} on the recipient.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferAndCall(address receiver, uint amount, bytes calldata data) external returns (bool success);
+}

--- a/contracts/token/ERC20/IERC667Receiver.sol
+++ b/contracts/token/ERC20/IERC667Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity >=0.6.0 <0.9.0;
 
 /**
  * @dev Interface of the ERC667 standard as defined in the EIP.

--- a/contracts/token/ERC20/IERC667Receiver.sol
+++ b/contracts/token/ERC20/IERC667Receiver.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @dev Interface of the ERC667 standard as defined in the EIP.
+ */
+interface IERC667Receiver {
+    /**
+     * @dev Callback triggered by {IERC667-transferAndCall}. Can revert or
+     * return false to reject transfer. This callback is triggered AFTER the
+     * token are transfered and the corresponding balances have been updated.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     */
+    function onTokenTransfer(address from, uint256 amount, bytes calldata data) external returns (bool success);
+}


### PR DESCRIPTION
ERC667 proposes an extension to ERC20 that adds a `transferAndCall` mechanism which is usefull send tokens to smart contracts and have them react to the transfer. This mechanism bypass the usual `approve-transfer` process.

This is just a wild proposal, and as such does not include tests. I'll add the tests at a later time if this proposal is well received.