### PR TITLE
Align comments in ERC721 interface

### DIFF
--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -117,8 +117,8 @@ interface IERC721 is IERC165 {
       *
       * Requirements:
       *
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
+      * - `from` cannot be the zero address.
+      * - `to` cannot be the zero address.
       * - `tokenId` token must exist and be owned by `from`.
       * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
       * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.


### PR DESCRIPTION
Comments in [IERC721.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/1e8cb4b4a401dc9666be1fc45eeed48bcf32dbe4/contracts/token/ERC721/IERC721.sol#L120) is not aligned.