### PR TITLE
Tooling to verify signatures with support for ERC1271

### DIFF
--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity >=0.6.0 <0.9.0;
 
 interface IERC1271 {
   /**

--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+interface IERC1271 {
+  /**
+   * @dev Should return whether the signature provided is valid for the provided data
+   * @param hash      Hash of the data to be signed
+   * @param signature Signature byte array associated with _data
+   */
+  function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue);
+}

--- a/contracts/mocks/ERC1271WalletMock.sol
+++ b/contracts/mocks/ERC1271WalletMock.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity ^0.8.0;
 
 import "../access/Ownable.sol";
 import "../cryptography/ECDSA.sol";
 import "../interfaces/IERC1271.sol";
 
 contract ERC1271WalletMock is Ownable, IERC1271 {
-    constructor(address originalOwner) public {
+    constructor(address originalOwner) {
         transferOwnership(originalOwner);
     }
 

--- a/contracts/mocks/ERC1271WalletMock.sol
+++ b/contracts/mocks/ERC1271WalletMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "../access/Ownable.sol";
+import "../cryptography/ECDSA.sol";
+import "../interfaces/IERC1271.sol";
+
+contract ERC1271WalletMock is Ownable, IERC1271 {
+    constructor(address originalOwner) public {
+        transferOwnership(originalOwner);
+    }
+
+    function isValidSignature(bytes32 hash, bytes memory signature) public view override returns (bytes4 magicValue) {
+        return ECDSA.recover(hash, signature) == owner() ? this.isValidSignature.selector : bytes4(0);
+    }
+}

--- a/contracts/mocks/SignatureCheckerMock.sol
+++ b/contracts/mocks/SignatureCheckerMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity ^0.8.0;
 
 import "../utils/SignatureChecker.sol";
 

--- a/contracts/mocks/SignatureCheckerMock.sol
+++ b/contracts/mocks/SignatureCheckerMock.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "../utils/SignatureChecker.sol";
+
+contract SignatureCheckerMock {
+    using SignatureChecker for address;
+
+    function isValidSignature(address signer, bytes32 hash, bytes memory signature) public view returns (bool) {
+        return signer.isValidSignature(hash, signature);
+    }
+}

--- a/contracts/utils/SignatureChecker.sol
+++ b/contracts/utils/SignatureChecker.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "../cryptography/ECDSA.sol";
+import "../interfaces/IERC1271.sol";
+import "./Address.sol";
+
+library SignatureChecker {
+    function isValidSignature(address signer, bytes32 hash, bytes memory signature) internal view returns (bool) {
+        if (Address.isContract(signer)) {
+            bytes4 selector = IERC1271(0).isValidSignature.selector;
+            (bool success, bytes memory returndata) = signer.staticcall(abi.encodeWithSelector(selector, hash, signature));
+            return success && abi.decode(returndata, (bytes4)) == selector;
+        } else {
+            return ECDSA.recover(hash, signature) == signer;
+        }
+    }
+}

--- a/test/utils/SignatureChecker.test.js
+++ b/test/utils/SignatureChecker.test.js
@@ -1,0 +1,71 @@
+const { toEthSignedMessageHash, fixSignature } = require('../helpers/sign');
+
+const { expect } = require('chai');
+
+const SignatureCheckerMock = artifacts.require('SignatureCheckerMock');
+const ERC1271WalletMock = artifacts.require('ERC1271WalletMock');
+
+const TEST_MESSAGE = web3.utils.sha3('OpenZeppelin');
+const WRONG_MESSAGE = web3.utils.sha3('Nope');
+
+contract('SignatureChecker (ERC1271)', function (accounts) {
+  const [signer, other] = accounts;
+
+  before('deploying', async function () {
+    this.signaturechecker = await SignatureCheckerMock.new();
+    this.wallet = await ERC1271WalletMock.new(signer);
+    this.signature = fixSignature(await web3.eth.sign(TEST_MESSAGE, signer));
+  });
+
+  context('EOA account', function () {
+    it('with matching signer and signature', async function () {
+      expect(await this.signaturechecker.isValidSignature(
+        signer,
+        toEthSignedMessageHash(TEST_MESSAGE),
+        this.signature,
+      )).to.equal(true);
+    });
+
+    it('with invalid signer', async function () {
+      expect(await this.signaturechecker.isValidSignature(
+        other,
+        toEthSignedMessageHash(TEST_MESSAGE),
+        this.signature,
+      )).to.equal(false);
+    });
+
+    it('with invalid signature', async function () {
+      expect(await this.signaturechecker.isValidSignature(
+        signer,
+        toEthSignedMessageHash(WRONG_MESSAGE),
+        this.signature,
+      )).to.equal(false);
+    });
+  });
+
+  context('ERC1271 wallet', function () {
+    it('with matching signer and signature', async function () {
+      expect(await this.signaturechecker.isValidSignature(
+        this.wallet.address,
+        toEthSignedMessageHash(TEST_MESSAGE),
+        this.signature,
+      )).to.equal(true);
+    });
+
+    it('with invalid signer', async function () {
+      expect(await this.signaturechecker.isValidSignature(
+        this.signaturechecker.address,
+        toEthSignedMessageHash(TEST_MESSAGE),
+        this.signature,
+      )).to.equal(false);
+    });
+
+    it('with invalid signature', async function () {
+      expect(await this.signaturechecker.isValidSignature(
+        this.wallet.address,
+        toEthSignedMessageHash(WRONG_MESSAGE),
+        this.signature,
+      )).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
SignatureChecker is a library for seamless verification of signature with support for both EOA (ECDSA) and smart contract wallets (ERC1271).

While still being a draft, this ERC is supported by smart contract wallets such as Argent.

I believe this feature could greatly improve the compatibility of dapps that relies message signatures with such wallets. In particular since Argent is now able to sign message (including ERC721 typedData) through WalletConnect. 