### PR TITLE
Merkle function support pre-hashed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  * `SafeMath`: fix a memory allocation issue by adding new `SafeMath.tryOp(uint,uint)→(bool,uint)` functions. `SafeMath.op(uint,uint,string)→uint` are now deprecated. ([#2462](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2462))
  * `EnumerableMap`: fix a memory allocation issue by adding new `EnumerableMap.tryGet(uint)→(bool,address)` functions. `EnumerableMap.get(uint)→string` is now deprecated. ([#2462](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2462))
  * `ERC165Checker`: added batch `getSupportedInterfaces`. ([#2469](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2469))
+ * `merkleTree.js`: added supported for pre-hashed inputs. ([#2477](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2477))
 
 ## 3.3.0 (2020-11-26)
 

--- a/test/helpers/merkleTree.js
+++ b/test/helpers/merkleTree.js
@@ -2,8 +2,14 @@ const { keccak256, keccakFromString, bufferToHex } = require('ethereumjs-util');
 
 class MerkleTree {
   constructor (elements) {
-    // Filter empty strings and hash elements
-    this.elements = elements.filter(el => el).map(el => keccakFromString(el));
+    // Filter empty strings and convert elements to 32 byte hash if it is not one already
+    this.elements = elements.filter(el => el).map(
+      el => (
+        (el.length !== 32 || !Buffer.isBuffer(el))
+          ? keccakFromString(el)
+          : el
+      )
+    );
 
     // Sort elements
     this.elements.sort(Buffer.compare);


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #2476

This allows the Merkle tree to work with Buffer inputs, in addition to the existing kinds of inputs it accepts.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [x] Changelog entry
