### PR TITLE
Use Address.sendValue instead of address.tranfer in RefundEscrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  * `SafeMath`: fix a memory allocation issue by adding new `SafeMath.tryOp(uint,uint)→(bool,uint)` functions. `SafeMath.op(uint,uint,string)→uint` are now deprecated. ([#2462](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2462))
  * `EnumerableMap`: fix a memory allocation issue by adding new `EnumerableMap.tryGet(uint)→(bool,address)` functions. `EnumerableMap.get(uint)→string` is now deprecated. ([#2462](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2462))
  * `ERC165Checker`: added batch `getSupportedInterfaces`. ([#2469](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2469))
+ * `RefundEscrow`: `beneficiaryWithdraw` will forward all available gas to the beneficiary. ([#2480](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2480))
 
 ### Security Fixes
 

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -80,7 +80,7 @@ contract RefundEscrow is ConditionalEscrow {
      */
     function beneficiaryWithdraw() public virtual {
         require(_state == State.Closed, "RefundEscrow: beneficiary can only withdraw while closed");
-        _beneficiary.transfer(address(this).balance);
+        Address.sendValue(_beneficiary, address(this).balance);
     }
 
     /**

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -80,7 +80,7 @@ contract RefundEscrow is ConditionalEscrow {
      */
     function beneficiaryWithdraw() public virtual {
         require(_state == State.Closed, "RefundEscrow: beneficiary can only withdraw while closed");
-        Address.sendValue(_beneficiary, address(this).balance);
+        _beneficiary.sendValue(address(this).balance);
     }
 
     /**


### PR DESCRIPTION
using `address.tranfer` is bad practice. This avoid issues if `_beneficiary` is a smart contract.