### PR TITLE
Use trySub to avoid memory allocation

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -157,7 +157,10 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
 
         _beforeTokenTransfer(operator, from, to, _asSingletonArray(id), _asSingletonArray(amount), data);
 
-        _balances[id][from] = _balances[id][from].sub(amount, "ERC1155: insufficient balance for transfer");
+        (bool success, uint256 newBalance) = _balances[id][from].trySub(amount);
+        require(success, "ERC1155: insufficient balance for transfer");
+        _balances[id][from] = newBalance;
+
         _balances[id][to] = _balances[id][to].add(amount);
 
         emit TransferSingle(operator, from, to, id, amount);

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -151,7 +151,10 @@ contract ERC20 is Context, IERC20 {
      */
     function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+
+        (bool success, uint256 newAllowance) = _allowances[sender][_msgSender()].trySub(amount);
+        require(success, "ERC20: transfer amount exceeds allowance");
+        _approve(sender, _msgSender(), newAllowance);
         return true;
     }
 
@@ -187,7 +190,9 @@ contract ERC20 is Context, IERC20 {
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        (bool success, uint256 newAllowance) = _allowances[_msgSender()][spender].trySub(subtractedValue);
+        require(success, "ERC20: decreased allowance below zero");
+        _approve(_msgSender(), spender, newAllowance);
         return true;
     }
 
@@ -211,7 +216,10 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(sender, recipient, amount);
 
-        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        (bool success, uint256 newBalance) = _balances[sender].trySub(amount);
+        require(success, "ERC20: transfer amount exceeds balance");
+        _balances[sender] = newBalance;
+
         _balances[recipient] = _balances[recipient].add(amount);
         emit Transfer(sender, recipient, amount);
     }
@@ -251,7 +259,10 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(account, address(0), amount);
 
-        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        (bool success, uint256 newBalance) = _balances[account].trySub(amount);
+        require(success, "ERC20: burn amount exceeds balance");
+        _balances[account] = newBalance;
+
         _totalSupply = _totalSupply.sub(amount);
         emit Transfer(account, address(0), amount);
     }

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -34,7 +34,8 @@ abstract contract ERC20Burnable is Context, ERC20 {
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
-        uint256 decreasedAllowance = allowance(account, _msgSender()).sub(amount, "ERC20: burn amount exceeds allowance");
+        (bool success, uint256 decreasedAllowance) = allowance(account, _msgSender()).trySub(amount);
+        require(success, "ERC20: burn amount exceeds allowance");
 
         _approve(account, _msgSender(), decreasedAllowance);
         _burn(account, amount);

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -51,7 +51,8 @@ library SafeERC20 {
     }
 
     function safeDecreaseAllowance(IERC20 token, address spender, uint256 value) internal {
-        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        (bool success, uint256 newAllowance) = token.allowance(address(this), spender).trySub(value);
+        require(success, "SafeERC20: decreased allowance below zero");
         _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
     }
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -113,7 +113,9 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable 
      * @dev See {IERC721-ownerOf}.
      */
     function ownerOf(uint256 tokenId) public view override returns (address) {
-        return _tokenOwners.get(tokenId, "ERC721: owner query for nonexistent token");
+        (bool success, address owner) = _tokenOwners.tryGet(tokenId);
+        require(success, "ERC721: owner query for nonexistent token");
+        return owner;
     }
 
     /**

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -289,7 +289,10 @@ contract ERC777 is Context, IERC777, IERC20 {
         _callTokensToSend(spender, holder, recipient, amount, "", "");
 
         _move(spender, holder, recipient, amount, "", "");
-        _approve(holder, spender, _allowances[holder][spender].sub(amount, "ERC777: transfer amount exceeds allowance"));
+
+        (bool success, uint256 newApproval) = _allowances[holder][spender].trySub(amount);
+        require(success, "ERC777: transfer amount exceeds allowance");
+        _approve(holder, spender, newApproval);
 
         _callTokensReceived(spender, holder, recipient, amount, "", "", false);
 
@@ -395,7 +398,10 @@ contract ERC777 is Context, IERC777, IERC20 {
         _callTokensToSend(operator, from, address(0), amount, data, operatorData);
 
         // Update state variables
-        _balances[from] = _balances[from].sub(amount, "ERC777: burn amount exceeds balance");
+        (bool success, uint256 newBalance) = _balances[from].trySub(amount);
+        require(success, "ERC777: burn amount exceeds balance");
+        _balances[from] = newBalance;
+
         _totalSupply = _totalSupply.sub(amount);
 
         emit Burned(operator, from, amount, data, operatorData);
@@ -414,7 +420,10 @@ contract ERC777 is Context, IERC777, IERC20 {
     {
         _beforeTokenTransfer(operator, from, to, amount);
 
-        _balances[from] = _balances[from].sub(amount, "ERC777: transfer amount exceeds balance");
+        (bool success, uint256 newBalance) = _balances[from].trySub(amount);
+        require(success, "ERC777: transfer amount exceeds balance");
+        _balances[from] = newBalance;
+
         _balances[to] = _balances[to].add(amount);
 
         emit Sent(operator, from, to, amount, userData, operatorData);


### PR DESCRIPTION
Use the new `SafeMath.trySub(uint256,uint256)` functions to avoid memory leaks caused by `SafeMath.sub(uint256,uint256,string)`

#### PR Checklist

- [x] Tests
- [ ] Changelog entry
