### PR TITLE
Fix ERC777 potential reentrancy issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
  * `SafeMath`: fix a memory allocation issue by adding new `SafeMath.tryOp(uint,uint)→(bool,uint)` functions. `SafeMath.op(uint,uint,string)→uint` are now deprecated. ([#2462](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2462))
  * `EnumerableMap`: fix a memory allocation issue by adding new `EnumerableMap.tryGet(uint)→(bool,address)` functions. `EnumerableMap.get(uint)→string` is now deprecated. ([#2462](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2462))
 
+### Security Fixes
+
+ * `ERC777`: fix potential reentrancy issues for custom extensions to `ERC777`. ([#2483](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2483))
+
+If you're using our implementation of ERC777 from version 3.3.0 or earlier, and you define a custom `_beforeTokenTransfer` function that writes to a storage variable, you may be vulnerable to a reentrancy attack. If you're affected and would like assistance please write to security@openzeppelin.com. [Read more in the pull request.](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2483)
+
 ## 3.3.0 (2020-11-26)
 
  * Now supports both Solidity 0.6 and 0.7. Compiling with solc 0.7 will result in warnings. Install the `solc-0.7` tag to compile without warnings.

--- a/contracts/mocks/ERC777Mock.sol
+++ b/contracts/mocks/ERC777Mock.sol
@@ -31,7 +31,7 @@ contract ERC777Mock is Context, ERC777 {
         _approve(holder, spender, value);
     }
 
-    function _beforeTokenTransfer(address operator, address from, address to, uint256 amount) internal override {
+    function _beforeTokenTransfer(address, address, address, uint256) internal override {
         emit BeforeTokenTransfer();
     }
 }

--- a/contracts/mocks/ERC777Mock.sol
+++ b/contracts/mocks/ERC777Mock.sol
@@ -6,6 +6,8 @@ import "../utils/Context.sol";
 import "../token/ERC777/ERC777.sol";
 
 contract ERC777Mock is Context, ERC777 {
+    event BeforeTokenTransfer();
+
     constructor(
         address initialHolder,
         uint256 initialBalance,
@@ -27,5 +29,9 @@ contract ERC777Mock is Context, ERC777 {
 
     function approveInternal(address holder, address spender, uint256 value) public {
         _approve(holder, spender, value);
+    }
+
+    function _beforeTokenTransfer(address operator, address from, address to, uint256 amount) internal override {
+        emit BeforeTokenTransfer();
     }
 }

--- a/contracts/mocks/ERC777SenderRecipientMock.sol
+++ b/contracts/mocks/ERC777SenderRecipientMock.sol
@@ -34,6 +34,9 @@ contract ERC777SenderRecipientMock is Context, IERC777Sender, IERC777Recipient, 
         uint256 toBalance
     );
 
+    // Emitted in ERC777Mock. Here for easier decoding
+    event BeforeTokenTransfer();
+
     bool private _shouldRevertSend;
     bool private _shouldRevertReceive;
 

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -390,9 +390,9 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         address operator = _msgSender();
 
-        _beforeTokenTransfer(operator, from, address(0), amount);
-
         _callTokensToSend(operator, from, address(0), amount, data, operatorData);
+
+        _beforeTokenTransfer(operator, from, address(0), amount);
 
         // Update state variables
         _balances[from] = _balances[from].sub(amount, "ERC777: burn amount exceeds balance");

--- a/test/token/ERC777/ERC777.test.js
+++ b/test/token/ERC777/ERC777.test.js
@@ -448,7 +448,7 @@ contract('ERC777', function (accounts) {
     });
   });
 
-  describe.only('relative order of hooks', function () {
+  describe('relative order of hooks', function () {
     beforeEach(async function () {
       await singletons.ERC1820Registry(registryFunder);
       this.sender = await ERC777SenderRecipientMock.new();

--- a/test/token/ERC777/ERC777.test.js
+++ b/test/token/ERC777/ERC777.test.js
@@ -447,4 +447,37 @@ contract('ERC777', function (accounts) {
       expect(await this.token.defaultOperators()).to.deep.equal([]);
     });
   });
+
+  describe.only('relative order of hooks', function () {
+    beforeEach(async function () {
+      await singletons.ERC1820Registry(registryFunder);
+      this.sender = await ERC777SenderRecipientMock.new();
+      await this.sender.registerRecipient(this.sender.address);
+      await this.sender.registerSender(this.sender.address);
+      this.token = await ERC777.new(holder, initialSupply, name, symbol, []);
+      await this.token.send(this.sender.address, 1, '0x', { from: holder });
+    });
+
+    it('send', async function () {
+      const { receipt } = await this.sender.send(this.token.address, anyone, 1, '0x');
+
+      const internalBeforeHook = receipt.logs.findIndex(l => l.event === 'BeforeTokenTransfer');
+      expect(internalBeforeHook).to.be.gte(0);
+      const externalSendHook = receipt.logs.findIndex(l => l.event === 'TokensToSendCalled');
+      expect(externalSendHook).to.be.gte(0);
+
+      expect(externalSendHook).to.be.lt(internalBeforeHook);
+    });
+
+    it('burn', async function () {
+      const { receipt } = await this.sender.burn(this.token.address, 1, '0x');
+
+      const internalBeforeHook = receipt.logs.findIndex(l => l.event === 'BeforeTokenTransfer');
+      expect(internalBeforeHook).to.be.gte(0);
+      const externalSendHook = receipt.logs.findIndex(l => l.event === 'TokensToSendCalled');
+      expect(externalSendHook).to.be.gte(0);
+
+      expect(externalSendHook).to.be.lt(internalBeforeHook);
+    });
+  });
 });


### PR DESCRIPTION
We received a report from @ritzdorf and @antonper about a potential security issue for people extending our ERC777 contract.

One of the characteristics of ERC777 is that it allows reentrancy through the send and receive hooks, so the token needs to be coded carefully to avoid a reentrancy attack. In particular, the contract needs to be in a consistent state whenever an external call is made to an untrusted address. For a detailed writeup about reentrancy check out our article [Reentrancy After Istanbul](https://forum.openzeppelin.com/t/reentrancy-after-istanbul/1742).

The ERC777 contract we provide is safe against reentrancy, because during send and receive hooks it is in a consistent state. However, **extending this contract with a custom `_beforeTokenTransfer` function could allow a reentrancy attack to happen**. More specifically, when burning tokens, `_beforeTokenTransfer` is invoked before the send hook is externally called on the sender while token balances are adjusted afterwards. At the moment of the call to the sender, which can result in reentrancy, state managed by `_beforeTokenTransfer` may not correspond to the actual token balances or total supply.

For example, in a hypothetical `ERC777Snapshot` contract with balance snapshots, a custom `_beforeTokenTransfer` function may keep track of an account's balance history in a new mapping. When the send hook is called on the sender, the balance snapshot history and the current token balances would be out of sync, the kind of inconsistent state that is vulnerable to reentrancy attacks.

#### Am I affected?

If you're using our implementation of ERC777 from version 3.3.0 or earlier, and you define a custom `_beforeTokenTransfer` function that writes to a storage variable, you may be vulnerable to a reentrancy attack. If you're affected and would like assistance please write to `security@openzeppelin.com`.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Changelog entry
