### PR TITLE
Remove SafeMathMock compilation warnings

### DIFF
--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -25,23 +25,25 @@ contract SafeMathMock {
         return SafeMath.tryMod(a, b);
     }
 
-    function add(uint256 a, uint256 b) public pure returns (uint256) {
+    // using the do* naming convention to avoid warnings due to clashing opcode names
+
+    function doAdd(uint256 a, uint256 b) public pure returns (uint256) {
         return SafeMath.add(a, b);
     }
 
-    function sub(uint256 a, uint256 b) public pure returns (uint256) {
+    function doSub(uint256 a, uint256 b) public pure returns (uint256) {
         return SafeMath.sub(a, b);
     }
 
-    function mul(uint256 a, uint256 b) public pure returns (uint256) {
+    function doMul(uint256 a, uint256 b) public pure returns (uint256) {
         return SafeMath.mul(a, b);
     }
 
-    function div(uint256 a, uint256 b) public pure returns (uint256) {
+    function doDiv(uint256 a, uint256 b) public pure returns (uint256) {
         return SafeMath.div(a, b);
     }
 
-    function mod(uint256 a, uint256 b) public pure returns (uint256) {
+    function doMod(uint256 a, uint256 b) public pure returns (uint256) {
         return SafeMath.mod(a, b);
     }
 

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -167,14 +167,14 @@ contract('SafeMath', function (accounts) {
         const a = new BN('5678');
         const b = new BN('1234');
 
-        await testCommutative(this.safeMath.add, a, b, a.add(b));
+        await testCommutative(this.safeMath.doAdd, a, b, a.add(b));
       });
 
       it('reverts on addition overflow', async function () {
         const a = MAX_UINT256;
         const b = new BN('1');
 
-        await testFailsCommutative(this.safeMath.add, a, b, 'SafeMath: addition overflow');
+        await testFailsCommutative(this.safeMath.doAdd, a, b, 'SafeMath: addition overflow');
       });
     });
 
@@ -183,14 +183,14 @@ contract('SafeMath', function (accounts) {
         const a = new BN('5678');
         const b = new BN('1234');
 
-        expect(await this.safeMath.sub(a, b)).to.be.bignumber.equal(a.sub(b));
+        expect(await this.safeMath.doSub(a, b)).to.be.bignumber.equal(a.sub(b));
       });
 
       it('reverts if subtraction result would be negative', async function () {
         const a = new BN('1234');
         const b = new BN('5678');
 
-        await expectRevert(this.safeMath.sub(a, b), 'SafeMath: subtraction overflow');
+        await expectRevert(this.safeMath.doSub(a, b), 'SafeMath: subtraction overflow');
       });
     });
 
@@ -199,21 +199,21 @@ contract('SafeMath', function (accounts) {
         const a = new BN('1234');
         const b = new BN('5678');
 
-        await testCommutative(this.safeMath.mul, a, b, a.mul(b));
+        await testCommutative(this.safeMath.doMul, a, b, a.mul(b));
       });
 
       it('multiplies by zero correctly', async function () {
         const a = new BN('0');
         const b = new BN('5678');
 
-        await testCommutative(this.safeMath.mul, a, b, '0');
+        await testCommutative(this.safeMath.doMul, a, b, '0');
       });
 
       it('reverts on multiplication overflow', async function () {
         const a = MAX_UINT256;
         const b = new BN('2');
 
-        await testFailsCommutative(this.safeMath.mul, a, b, 'SafeMath: multiplication overflow');
+        await testFailsCommutative(this.safeMath.doMul, a, b, 'SafeMath: multiplication overflow');
       });
     });
 
@@ -222,28 +222,28 @@ contract('SafeMath', function (accounts) {
         const a = new BN('5678');
         const b = new BN('5678');
 
-        expect(await this.safeMath.div(a, b)).to.be.bignumber.equal(a.div(b));
+        expect(await this.safeMath.doDiv(a, b)).to.be.bignumber.equal(a.div(b));
       });
 
       it('divides zero correctly', async function () {
         const a = new BN('0');
         const b = new BN('5678');
 
-        expect(await this.safeMath.div(a, b)).to.be.bignumber.equal('0');
+        expect(await this.safeMath.doDiv(a, b)).to.be.bignumber.equal('0');
       });
 
       it('returns complete number result on non-even division', async function () {
         const a = new BN('7000');
         const b = new BN('5678');
 
-        expect(await this.safeMath.div(a, b)).to.be.bignumber.equal('1');
+        expect(await this.safeMath.doDiv(a, b)).to.be.bignumber.equal('1');
       });
 
       it('reverts on division by zero', async function () {
         const a = new BN('5678');
         const b = new BN('0');
 
-        await expectRevert(this.safeMath.div(a, b), 'SafeMath: division by zero');
+        await expectRevert(this.safeMath.doDiv(a, b), 'SafeMath: division by zero');
       });
     });
 
@@ -253,28 +253,28 @@ contract('SafeMath', function (accounts) {
           const a = new BN('284');
           const b = new BN('5678');
 
-          expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
+          expect(await this.safeMath.doMod(a, b)).to.be.bignumber.equal(a.mod(b));
         });
 
         it('when the dividend is equal to the divisor', async function () {
           const a = new BN('5678');
           const b = new BN('5678');
 
-          expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
+          expect(await this.safeMath.doMod(a, b)).to.be.bignumber.equal(a.mod(b));
         });
 
         it('when the dividend is larger than the divisor', async function () {
           const a = new BN('7000');
           const b = new BN('5678');
 
-          expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
+          expect(await this.safeMath.doMod(a, b)).to.be.bignumber.equal(a.mod(b));
         });
 
         it('when the dividend is a multiple of the divisor', async function () {
           const a = new BN('17034'); // 17034 == 5678 * 3
           const b = new BN('5678');
 
-          expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
+          expect(await this.safeMath.doMod(a, b)).to.be.bignumber.equal(a.mod(b));
         });
       });
 
@@ -282,7 +282,7 @@ contract('SafeMath', function (accounts) {
         const a = new BN('5678');
         const b = new BN('0');
 
-        await expectRevert(this.safeMath.mod(a, b), 'SafeMath: modulo by zero');
+        await expectRevert(this.safeMath.doMod(a, b), 'SafeMath: modulo by zero');
       });
     });
   });


### PR DESCRIPTION
We were getting these warnings:

```
contracts/mocks/SafeMathMock.sol:32:5: Warning: Variable is shadowed in inline assembly by an instruction of the same name
    function sub(uint256 a, uint256 b) public pure returns (uint256) {
    ^ (Relevant source part starts here and spans across multiple lines).
```