### PR TITLE
Add revert string to Counter decrement underflow

### DIFF
--- a/contracts/utils/Counters.sol
+++ b/contracts/utils/Counters.sol
@@ -23,10 +23,16 @@ library Counters {
     }
 
     function increment(Counter storage counter) internal {
-        counter._value += 1;
+        unchecked {
+            counter._value += 1;
+        }
     }
 
     function decrement(Counter storage counter) internal {
-        counter._value = counter._value - 1;
+        unchecked {
+            uint256 value_ = counter._value;
+            require(value_ > 0, "Counter: decrement underflow");
+            counter._value = value_ - 1;
+        }
     }
 }

--- a/test/utils/Counters.test.js
+++ b/test/utils/Counters.test.js
@@ -43,7 +43,7 @@ contract('Counters', function (accounts) {
 
       it('reverts if the current value is 0', async function () {
         await this.counter.decrement();
-        await expectRevert.unspecified(this.counter.decrement());
+        await expectRevert(this.counter.decrement(), 'Counter: decrement underflow');
       });
     });
     context('after incremented to 3', function () {


### PR DESCRIPTION
This PR adds revert message an underflow error in Counter. There used to be a default safemath revert message in 3.x which was removed during the transition to 0.8.0's built in safemath.

#### PR Checklist

- [x] Tests
- [ ] Changelog entry
