### PR TITLE
 Remove the storage associated with decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Now targeting the 0.8.x line of Solidity compilers. For 0.6.x (resp 0.7.x) support, use version 3.4.0 (resp 3.4.0-solc-0.7) of OpenZeppelin.
 * `Context`: making `_msgData` return `bytes calldata` instead of `bytes memory` ([#2492](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2492))
-* `ERC20`: Removing the `_setDecimals` functions and the storage slot associated to decimals. ([#2502](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2502))
+* `ERC20`: Removed the `_setDecimals` function and the storage slot associated to decimals. ([#2502](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2502))
 
 ## 3.4.0 (2021-02-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Now targeting the 0.8.x line of Solidity compilers. For 0.6.x (resp 0.7.x) support, use version 3.4.0 (resp 3.4.0-solc-0.7) of OpenZeppelin.
 * `Context`: making `_msgData` return `bytes calldata` instead of `bytes memory` ([#2492](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2492))
-* `ERC20`: Removing the `_setDecimals` functions and the storage slot associated to decimals. ([#2495](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2495))
+* `ERC20`: Removing the `_setDecimals` functions and the storage slot associated to decimals. ([#2502](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2502))
 
 ## 3.4.0 (2021-02-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Now targeting the 0.8.x line of Solidity compilers. For 0.6.x (resp 0.7.x) support, use version 3.4.0 (resp 3.4.0-solc-0.7) of OpenZeppelin.
 * `Context`: making `_msgData` return `bytes calldata` instead of `bytes memory` ([#2492](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2492))
+* `ERC20`: Removing the `_setDecimals` functions and the storage slot associated to decimals. ([#2495](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2495))
 
 ## 3.4.0 (2021-02-02)
 

--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -5,7 +5,13 @@ pragma solidity ^0.8.0;
 import "../token/ERC20/ERC20.sol";
 
 contract ERC20DecimalsMock is ERC20 {
-    constructor (string memory name, string memory symbol, uint8 decimals) ERC20(name, symbol) {
-        _setupDecimals(decimals);
+    uint8 immutable private _decimals;
+
+    constructor (string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
     }
 }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -42,7 +42,7 @@ contract ERC20 is Context, IERC20 {
     /**
      * @dev Sets the values for {name} and {symbol}
      *
-     * The defaut value of {decimals} is 18, to select a different value for
+     * The defaut value of {decimals} is 18. To select a different value for
      * {decimals} you should overload it.
      *
      * All three of these values are immutable: they can only be set once during

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -38,13 +38,12 @@ contract ERC20 is Context, IERC20 {
 
     string private _name;
     string private _symbol;
-    uint8 private _decimals;
 
     /**
-     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
-     * a default value of 18.
+     * @dev Sets the values for {name} and {symbol}
      *
-     * To select a different value for {decimals}, use {_setupDecimals}.
+     * The defaut value of {decimals} is 18, to select a different value for
+     * {decimals} you should overload it.
      *
      * All three of these values are immutable: they can only be set once during
      * construction.
@@ -52,7 +51,6 @@ contract ERC20 is Context, IERC20 {
     constructor (string memory name_, string memory symbol_) {
         _name = name_;
         _symbol = symbol_;
-        _decimals = 18;
     }
 
     /**
@@ -76,15 +74,15 @@ contract ERC20 is Context, IERC20 {
      * be displayed to a user as `5,05` (`505 / 10 ** 2`).
      *
      * Tokens usually opt for a value of 18, imitating the relationship between
-     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
-     * called.
+     * Ether and Wei. This is the value {ERC20} uses, unless this function is
+     * overloaded;
      *
      * NOTE: This information is only used for _display_ purposes: it in
      * no way affects any of the arithmetic of the contract, including
      * {IERC20-balanceOf} and {IERC20-transfer}.
      */
     function decimals() public view virtual returns (uint8) {
-        return _decimals;
+        return 18;
     }
 
     /**
@@ -281,17 +279,6 @@ contract ERC20 is Context, IERC20 {
 
         _allowances[owner][spender] = amount;
         emit Approval(owner, spender, amount);
-    }
-
-    /**
-     * @dev Sets {decimals} to a value other than the default one of 18.
-     *
-     * WARNING: This function should only be called from the constructor. Most
-     * applications that interact with token contracts will not expect
-     * {decimals} to ever change, and may work incorrectly if it does.
-     */
-    function _setupDecimals(uint8 decimals_) internal virtual {
-        _decimals = decimals_;
     }
 
     /**

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -40,7 +40,7 @@ contract ERC20 is Context, IERC20 {
     string private _symbol;
 
     /**
-     * @dev Sets the values for {name} and {symbol}
+     * @dev Sets the values for {name} and {symbol}.
      *
      * The defaut value of {decimals} is 18. To select a different value for
      * {decimals} you should overload it.


### PR DESCRIPTION
Reduces the gas cost of deploying an ERC20 (avoid an sstore), and the gas cost of reading decimal count (avoid an ssload).
Changing decimals should be done by overriding the decimal function, as shown in the mocks.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [x] Changelog entry
