### PR TITLE
Remove double sload when doing math checks in tokens

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -137,8 +137,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
 
         _beforeTokenTransfer(operator, from, to, _asSingletonArray(id), _asSingletonArray(amount), data);
 
-        require(_balances[id][from] >= amount, "ERC1155: insufficient balance for transfer");
-        _balances[id][from] -= amount;
+        uint256 balance_ = _balances[id][from];
+        require(balance_ >= amount, "ERC1155: insufficient balance for transfer");
+        _balances[id][from] = balance_ - amount;
         _balances[id][to] += amount;
 
         emit TransferSingle(operator, from, to, id, amount);
@@ -175,8 +176,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 
-            require(_balances[id][from] >= amount, "ERC1155: insufficient balance for transfer");
-            _balances[id][from] -= amount;
+            uint256 balance_ = _balances[id][from];
+            require(balance_ >= amount, "ERC1155: insufficient balance for transfer");
+            _balances[id][from] = balance_ - amount;
             _balances[id][to] += amount;
         }
 
@@ -273,8 +275,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
 
         _beforeTokenTransfer(operator, account, address(0), _asSingletonArray(id), _asSingletonArray(amount), "");
 
-        require(_balances[id][account] >= amount, "ERC1155: burn amount exceeds balance");
-        _balances[id][account] -= amount;
+        uint256 balance_ = _balances[id][account];
+        require(balance_ >= amount, "ERC1155: burn amount exceeds balance");
+        _balances[id][account] = balance_ - amount;
 
         emit TransferSingle(operator, account, address(0), id, amount);
     }
@@ -298,8 +301,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 
-            require(_balances[id][account] >= amount, "ERC1155: burn amount exceeds balance");
-            _balances[id][account] -= amount;
+            uint256 balance_ = _balances[id][account];
+            require(balance_ >= amount, "ERC1155: burn amount exceeds balance");
+            _balances[id][account] = balance_ - amount;
         }
 
         emit TransferBatch(operator, account, address(0), ids, amounts);

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -137,9 +137,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
 
         _beforeTokenTransfer(operator, from, to, _asSingletonArray(id), _asSingletonArray(amount), data);
 
-        uint256 balance_ = _balances[id][from];
-        require(balance_ >= amount, "ERC1155: insufficient balance for transfer");
-        _balances[id][from] = balance_ - amount;
+        uint256 fromBalance = _balances[id][from];
+        require(fromBalance >= amount, "ERC1155: insufficient balance for transfer");
+        _balances[id][from] = fromBalance - amount;
         _balances[id][to] += amount;
 
         emit TransferSingle(operator, from, to, id, amount);
@@ -176,9 +176,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 
-            uint256 balance_ = _balances[id][from];
-            require(balance_ >= amount, "ERC1155: insufficient balance for transfer");
-            _balances[id][from] = balance_ - amount;
+            uint256 fromBalance = _balances[id][from];
+            require(fromBalance >= amount, "ERC1155: insufficient balance for transfer");
+            _balances[id][from] = fromBalance - amount;
             _balances[id][to] += amount;
         }
 
@@ -275,9 +275,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
 
         _beforeTokenTransfer(operator, account, address(0), _asSingletonArray(id), _asSingletonArray(amount), "");
 
-        uint256 balance_ = _balances[id][account];
-        require(balance_ >= amount, "ERC1155: burn amount exceeds balance");
-        _balances[id][account] = balance_ - amount;
+        uint256 accountBalance = _balances[id][account];
+        require(accountBalance >= amount, "ERC1155: burn amount exceeds balance");
+        _balances[id][account] = accountBalance - amount;
 
         emit TransferSingle(operator, account, address(0), id, amount);
     }
@@ -301,9 +301,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 
-            uint256 balance_ = _balances[id][account];
-            require(balance_ >= amount, "ERC1155: burn amount exceeds balance");
-            _balances[id][account] = balance_ - amount;
+            uint256 accountBalance = _balances[id][account];
+            require(accountBalance >= amount, "ERC1155: burn amount exceeds balance");
+            _balances[id][account] = accountBalance - amount;
         }
 
         emit TransferBatch(operator, account, address(0), ids, amounts);

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -147,9 +147,9 @@ contract ERC20 is Context, IERC20 {
     function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
 
-        uint256 senderAllowance = _allowances[sender][_msgSender()];
-        require(senderAllowance >= amount, "ERC20: transfer amount exceeds allowance");
-        _approve(sender, _msgSender(), senderAllowance - amount);
+        uint256 currentAllowance = _allowances[sender][_msgSender()];
+        require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+        _approve(sender, _msgSender(), currentAllowance - amount);
 
         return true;
     }
@@ -186,9 +186,9 @@ contract ERC20 is Context, IERC20 {
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        uint256 spenderAllowance = _allowances[_msgSender()][spender];
-        require(spenderAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
-        _approve(_msgSender(), spender, spenderAllowance - subtractedValue);
+        uint256 currentAllowance = _allowances[_msgSender()][spender];
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        _approve(_msgSender(), spender, currentAllowance - subtractedValue);
 
         return true;
     }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -149,8 +149,9 @@ contract ERC20 is Context, IERC20 {
     function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
 
-        require(_allowances[sender][_msgSender()] >= amount, "ERC20: transfer amount exceeds allowance");
-        _approve(sender, _msgSender(), _allowances[sender][_msgSender()] - amount);
+        uint256 allowance_ = _allowances[sender][_msgSender()];
+        require(allowance_ >= amount, "ERC20: transfer amount exceeds allowance");
+        _approve(sender, _msgSender(), allowance_ - amount);
 
         return true;
     }
@@ -187,8 +188,9 @@ contract ERC20 is Context, IERC20 {
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        require(_allowances[_msgSender()][spender] >= subtractedValue, "ERC20: decreased allowance below zero");
-        _approve(_msgSender(), spender, _allowances[_msgSender()][spender] - subtractedValue);
+        uint256 allowance_ = _allowances[_msgSender()][spender];
+        require(allowance_ >= subtractedValue, "ERC20: decreased allowance below zero");
+        _approve(_msgSender(), spender, allowance_ - subtractedValue);
 
         return true;
     }
@@ -213,8 +215,9 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(sender, recipient, amount);
 
-        require(_balances[sender] >= amount, "ERC20: transfer amount exceeds balance");
-        _balances[sender] -= amount;
+        uint256 balance_ = _balances[sender];
+        require(balance_ >= amount, "ERC20: transfer amount exceeds balance");
+        _balances[sender] = balance_ - amount;
         _balances[recipient] += amount;
 
         emit Transfer(sender, recipient, amount);
@@ -255,8 +258,9 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(account, address(0), amount);
 
-        require(_balances[account] >= amount, "ERC20: burn amount exceeds balance");
-        _balances[account] -= amount;
+        uint256 balance_ = _balances[account];
+        require(balance_ >= amount, "ERC20: burn amount exceeds balance");
+        _balances[account] = balance_ - amount;
         _totalSupply -= amount;
 
         emit Transfer(account, address(0), amount);

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -149,9 +149,9 @@ contract ERC20 is Context, IERC20 {
     function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
 
-        uint256 allowance_ = _allowances[sender][_msgSender()];
-        require(allowance_ >= amount, "ERC20: transfer amount exceeds allowance");
-        _approve(sender, _msgSender(), allowance_ - amount);
+        uint256 senderAllowance = _allowances[sender][_msgSender()];
+        require(senderAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+        _approve(sender, _msgSender(), senderAllowance - amount);
 
         return true;
     }
@@ -188,9 +188,9 @@ contract ERC20 is Context, IERC20 {
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        uint256 allowance_ = _allowances[_msgSender()][spender];
-        require(allowance_ >= subtractedValue, "ERC20: decreased allowance below zero");
-        _approve(_msgSender(), spender, allowance_ - subtractedValue);
+        uint256 spenderAllowance = _allowances[_msgSender()][spender];
+        require(spenderAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        _approve(_msgSender(), spender, spenderAllowance - subtractedValue);
 
         return true;
     }
@@ -215,9 +215,9 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(sender, recipient, amount);
 
-        uint256 balance_ = _balances[sender];
-        require(balance_ >= amount, "ERC20: transfer amount exceeds balance");
-        _balances[sender] = balance_ - amount;
+        uint256 senderBalance = _balances[sender];
+        require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
+        _balances[sender] = senderBalance - amount;
         _balances[recipient] += amount;
 
         emit Transfer(sender, recipient, amount);
@@ -258,9 +258,9 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(account, address(0), amount);
 
-        uint256 balance_ = _balances[account];
-        require(balance_ >= amount, "ERC20: burn amount exceeds balance");
-        _balances[account] = balance_ - amount;
+        uint256 accountBalance = _balances[account];
+        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
+        _balances[account] = accountBalance - amount;
         _totalSupply -= amount;
 
         emit Transfer(account, address(0), amount);

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -32,9 +32,9 @@ abstract contract ERC20Burnable is Context, ERC20 {
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
-        uint256 accountAllowance = allowance(account, _msgSender());
-        require(accountAllowance >= amount, "ERC20: burn amount exceeds allowance");
-        _approve(account, _msgSender(), accountAllowance - amount);
+        uint256 currentAllowance = allowance(account, _msgSender());
+        require(currentAllowance >= amount, "ERC20: burn amount exceeds allowance");
+        _approve(account, _msgSender(), currentAllowance - amount);
         _burn(account, amount);
     }
 }

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -32,8 +32,9 @@ abstract contract ERC20Burnable is Context, ERC20 {
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
-        require(allowance(account, _msgSender()) >= amount, "ERC20: burn amount exceeds allowance");
-        _approve(account, _msgSender(), allowance(account, _msgSender()) - amount);
+        uint256 allowance_ = allowance(account, _msgSender());
+        require(allowance_ >= amount, "ERC20: burn amount exceeds allowance");
+        _approve(account, _msgSender(), allowance_ - amount);
         _burn(account, amount);
     }
 }

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -32,9 +32,9 @@ abstract contract ERC20Burnable is Context, ERC20 {
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
-        uint256 allowance_ = allowance(account, _msgSender());
-        require(allowance_ >= amount, "ERC20: burn amount exceeds allowance");
-        _approve(account, _msgSender(), allowance_ - amount);
+        uint256 accountAllowance = allowance(account, _msgSender());
+        require(accountAllowance >= amount, "ERC20: burn amount exceeds allowance");
+        _approve(account, _msgSender(), accountAllowance - amount);
         _burn(account, amount);
     }
 }

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -278,8 +278,9 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         _move(spender, holder, recipient, amount, "", "");
 
-        require(_allowances[holder][spender] >= amount, "ERC777: transfer amount exceeds allowance");
-        _approve(holder, spender, _allowances[holder][spender] - amount);
+        uint256 allowance_ = _allowances[holder][spender];
+        require(allowance_ >= amount, "ERC777: transfer amount exceeds allowance");
+        _approve(holder, spender, allowance_ - amount);
 
         _callTokensReceived(spender, holder, recipient, amount, "", "", false);
 
@@ -385,8 +386,9 @@ contract ERC777 is Context, IERC777, IERC20 {
         _beforeTokenTransfer(operator, from, address(0), amount);
 
         // Update state variables
-        require(_balances[from] >= amount, "ERC777: burn amount exceeds balance");
-        _balances[from] -= amount;
+        uint256 balance_ = _balances[from];
+        require(balance_ >= amount, "ERC777: burn amount exceeds balance");
+        _balances[from] = balance_ - amount;
         _totalSupply -= amount;
 
         emit Burned(operator, from, amount, data, operatorData);
@@ -405,8 +407,9 @@ contract ERC777 is Context, IERC777, IERC20 {
     {
         _beforeTokenTransfer(operator, from, to, amount);
 
-        require(_balances[from] >= amount, "ERC777: transfer amount exceeds balance");
-        _balances[from] -= amount;
+        uint256 balance_ = _balances[from];
+        require(balance_ >= amount, "ERC777: transfer amount exceeds balance");
+        _balances[from] = balance_ - amount;
         _balances[to] += amount;
 
         emit Sent(operator, from, to, amount, userData, operatorData);

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -278,9 +278,9 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         _move(spender, holder, recipient, amount, "", "");
 
-        uint256 allowance_ = _allowances[holder][spender];
-        require(allowance_ >= amount, "ERC777: transfer amount exceeds allowance");
-        _approve(holder, spender, allowance_ - amount);
+        uint256 currentAllowance = _allowances[holder][spender];
+        require(currentAllowance >= amount, "ERC777: transfer amount exceeds allowance");
+        _approve(holder, spender, currentAllowance - amount);
 
         _callTokensReceived(spender, holder, recipient, amount, "", "", false);
 
@@ -386,9 +386,9 @@ contract ERC777 is Context, IERC777, IERC20 {
         _beforeTokenTransfer(operator, from, address(0), amount);
 
         // Update state variables
-        uint256 balance_ = _balances[from];
-        require(balance_ >= amount, "ERC777: burn amount exceeds balance");
-        _balances[from] = balance_ - amount;
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= amount, "ERC777: burn amount exceeds balance");
+        _balances[from] = fromBalance - amount;
         _totalSupply -= amount;
 
         emit Burned(operator, from, amount, data, operatorData);
@@ -407,9 +407,9 @@ contract ERC777 is Context, IERC777, IERC20 {
     {
         _beforeTokenTransfer(operator, from, to, amount);
 
-        uint256 balance_ = _balances[from];
-        require(balance_ >= amount, "ERC777: transfer amount exceeds balance");
-        _balances[from] = balance_ - amount;
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= amount, "ERC777: transfer amount exceeds balance");
+        _balances[from] = fromBalance - amount;
         _balances[to] += amount;
 
         emit Sent(operator, from, to, amount, userData, operatorData);


### PR DESCRIPTION
The addition of revert messages back into the 0.8 branch (#2491) generated double reading of some storage slot. This PR remove the double sload, which reduces gas costs of running the affected function.

#### PR Checklist

- [x] Tests
- [ ] Changelog entry
