### PR TITLE
Add safe unary negation implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
  * `ERC721`: made `_approve` an internal function (was private).
+ * `SafeSignedMath`: added `neg` unary operator ([#2596](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2596))
 
 ## 3.4.0 (2021-02-02)
 

--- a/contracts/math/SignedSafeMath.sol
+++ b/contracts/math/SignedSafeMath.sol
@@ -89,4 +89,19 @@ library SignedSafeMath {
 
         return c;
     }
+
+    /**
+     * @dev Returns the opposite of a signed integer, reverting on overflow.
+     *
+     * Counterpart to Solidity's unary `-` operator.
+     *
+     * Requirements:
+     *
+     * - Unary negation cannot overflow.
+     */
+    function neg(int256 a) internal pure returns (int256) {
+        require(a != _INT256_MIN, "SignedSafeMath: unary negation overflow");
+
+        return -a;
+    }
 }

--- a/contracts/mocks/SignedSafeMathMock.sol
+++ b/contracts/mocks/SignedSafeMathMock.sol
@@ -20,4 +20,8 @@ contract SignedSafeMathMock {
     function add(int256 a, int256 b) public pure returns (int256) {
         return SignedSafeMath.add(a, b);
     }
+
+    function neg(int256 a) public pure returns (int256) {
+        return SignedSafeMath.neg(a);
+    }
 }

--- a/test/math/SignedSafeMath.test.js
+++ b/test/math/SignedSafeMath.test.js
@@ -149,4 +149,19 @@ contract('SignedSafeMath', function (accounts) {
       await expectRevert(this.safeMath.div(a, b), 'SignedSafeMath: division overflow');
     });
   });
+
+  describe('neg', function () {
+    it('negates correctly', async function () {
+      const a = new BN('-42');
+
+      const result = await this.safeMath.neg(a);
+      expect(result).to.be.bignumber.equal(a.neg());
+    });
+
+    it('reverts on overflow', async function () {
+      const a = new BN(MIN_INT256);
+
+      await expectRevert(this.safeMath.neg(a), 'SignedSafeMath: unary negation overflow');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #2595 

This PR adds a `neg` function for doing safe unary negation on signed integers.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog entry
