### PR TITLE
EnumerableSet: Skip SSTORE On Last Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * `IERC20Metadata`: add a new extended interface that includes the optional `name()`, `symbol()` and `decimals()` functions. ([#2561](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2561))
  * `ERC777`: make reception acquirement optional in `_mint`. ([#2552](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2552))
  * `ERC20Permit`: add a `_useNonce` to enable further usage of ERC712 signatures. ([#2565](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2565))
+ * Enumerables: Improve gas cost of removal in `EnumerableSet` and `EnumerableMap`.
 
 ## Unreleased
 

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -81,15 +81,14 @@ library EnumerableSet {
             uint256 toDeleteIndex = valueIndex - 1;
             uint256 lastIndex = set._values.length - 1;
 
-            // When the value to delete is the last one, the swap operation is unnecessary. However, since this occurs
-            // so rarely, we still do the swap anyway to avoid the gas cost of adding an 'if' statement.
+            if (lastIndex != toDeleteIndex) {
+                bytes32 lastvalue = set._values[lastIndex];
 
-            bytes32 lastvalue = set._values[lastIndex];
-
-            // Move the last value to the index where the value to delete is
-            set._values[toDeleteIndex] = lastvalue;
-            // Update the index for the moved value
-            set._indexes[lastvalue] = valueIndex; // Replace lastvalue's index to valueIndex
+                // Move the last value to the index where the value to delete is
+                set._values[toDeleteIndex] = lastvalue;
+                // Update the index for the moved value
+                set._indexes[lastvalue] = valueIndex; // Replace lastvalue's index to valueIndex
+            }
 
             // Delete the slot where the moved value was stored
             set._values.pop();


### PR DESCRIPTION

#### Changes
Reverses a bad tradeoff in the design of EnumerableSet.
Now even more efficient to remove from the end.
The JUMPI is >23 (DUPx, DUPx, PUSHx, EQ, JUMPI, JUMPDEST).
The redundant SSTOREs after EIP-2929 is >3256 = 2x(SSTORE_SLOAD_WARM, SLOAD_WARM, 5xDUPx, JUMPI, LT).
So there would need to be at least 142 items for skipping this check to be optimal, on average.
Of course solidity is less optimal than that but we can estimate with future compiler improvements.
But there is the pattern of removing all items to consider: it is not necessarily true that the items will be removed randomly.
In fact, one [major use](https://github.com/airswap/airswap-protocols/blob/7a6ca7aa1d22e4c335b17e54a506d634fd177a6d/source/registry/contracts/Registry.sol#L70) of the EnumerableSet is to track and remove all items in a mapping.
I believe the prior cost analysis missed solidity's boundary checks and supposed random removal.
Reviewers @nventuro