### PR TITLE
EnumerableSet: Remove Boundary Check in _at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
  * Enumerables: Improve gas cost of removal in `EnumerableSet` and `EnumerableMap`.
- * Enumerables: Improve gas cost of lookup `EnumerableSet` and `EnumerableMap`.
+ * Enumerables: Improve gas cost of lookup in `EnumerableSet` and `EnumerableMap`.
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  * Enumerables: Improve gas cost of removal in `EnumerableSet` and `EnumerableMap`.
+ * Enumerables: Improve gas cost of lookup `EnumerableSet` and `EnumerableMap`.
 
 ## Unreleased
 

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -128,7 +128,6 @@ library EnumerableSet {
     * - `index` must be strictly less than {length}.
     */
     function _at(Set storage set, uint256 index) private view returns (bytes32) {
-        require(set._values.length > index, "EnumerableSet: index out of bounds");
         return set._values[index];
     }
 

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -51,7 +51,7 @@ function shouldBehaveLikeSet (valueA, valueB, valueC) {
 
   describe('at', function () {
     it('reverts when retrieving non-existent elements', async function () {
-      await expectRevert(this.set.at(0), 'EnumerableSet: index out of bounds');
+      await expectRevert.unspecified(this.set.at(0));
     });
   });
 


### PR DESCRIPTION

#### Changes
This check is redundant because solidity does it for you without your consent, at great gas cost.
If you knew all of the things solidity does to arrays you would never use them.
But I'm not asking you to replace all of your solidity arrays.
Instead, complain to the compiler team, who doesn't trust you.
Reviewer @amxx