### PR TITLE
EnumerableSet: Clear

### DIFF
--- a/contracts/mocks/EnumerableSetMock.sol
+++ b/contracts/mocks/EnumerableSetMock.sol
@@ -26,6 +26,10 @@ contract EnumerableBytes32SetMock {
         emit OperationResult(result);
     }
 
+    function clear() public {
+        _set.clear();
+    }
+
     function length() public view returns (uint256) {
         return _set.length();
     }
@@ -57,6 +61,10 @@ contract EnumerableAddressSetMock {
         emit OperationResult(result);
     }
 
+    function clear() public {
+        _set.clear();
+    }
+
     function length() public view returns (uint256) {
         return _set.length();
     }
@@ -86,6 +94,10 @@ contract EnumerableUintSetMock {
     function remove(uint256 value) public {
         bool result = _set.remove(value);
         emit OperationResult(result);
+    }
+
+    function clear() public {
+        _set.clear();
     }
 
     function length() public view returns (uint256) {

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -206,6 +206,12 @@ library EnumerableSet {
         return _at(set._inner, index);
     }
 
+    /**
+     * @dev Removes all elements from the set. O(n).
+     *
+     * Note that this can run out of gas for large sets.
+     * First use `remove` to reduce the size of a large set in this case.
+     */
     function clear(Bytes32Set storage set) internal {
         return _clear(set._inner);
     }

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -66,7 +66,7 @@ library EnumerableSet {
     function _clear(Set storage set) private {
         uint256 last = set._values.length;
         while (last --> 0) {
-            delete set.indexes[set._values[last]];
+            delete set._indexes[set._values[last]];
         }
         set._values.length = 0;
     }

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -63,6 +63,12 @@ library EnumerableSet {
         }
     }
 
+    /**
+     * @dev Removes all elements from the set. O(n).
+     *
+     * Note that this can run out of gas for large sets.
+     * First use `remove` to reduce the size of a large set in this case.
+     */
     function _clear(Set storage set) private {
         uint256 last = set._values.length;
         unchecked {
@@ -70,7 +76,11 @@ library EnumerableSet {
                 delete set._indexes[set._values[last]];
             }
         }
-        delete set._values;
+        // Only set the _values.length to zero
+        // No need to clear _values from state: they will be overridden on push
+        assembly {
+            sstore(set.slot, 0)
+        }
     }
 
     /**

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -254,6 +254,12 @@ library EnumerableSet {
         return address(uint160(uint256(_at(set._inner, index))));
     }
 
+    /**
+     * @dev Removes all elements from the set. O(n).
+     *
+     * Note that this can run out of gas for large sets.
+     * First use `remove` to reduce the size of a large set in this case.
+     */
     function clear(AddressSet storage set) internal {
         return _clear(set._inner);
     }
@@ -312,6 +318,12 @@ library EnumerableSet {
         return uint256(_at(set._inner, index));
     }
 
+    /**
+     * @dev Removes all elements from the set. O(n).
+     *
+     * Note that this can run out of gas for large sets.
+     * First use `remove` to reduce the size of a large set in this case.
+     */
     function clear(UintSet storage set) internal {
         return _clear(set._inner);
     }

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -63,6 +63,14 @@ library EnumerableSet {
         }
     }
 
+    function _clear(Set storage set) private {
+        uint256 last = set._values.length;
+        while (last --> 0) {
+            delete set.indexes[_set._values[last]];
+        }
+        set._values.length = 0;
+    }
+
     /**
      * @dev Removes a value from a set. O(1).
      *
@@ -186,6 +194,10 @@ library EnumerableSet {
         return _at(set._inner, index);
     }
 
+    function clear(Bytes32Set storage set) internal {
+        return _clear(set._inner);
+    }
+
     // AddressSet
 
     struct AddressSet {
@@ -240,6 +252,9 @@ library EnumerableSet {
         return address(uint160(uint256(_at(set._inner, index))));
     }
 
+    function clear(AddressSet storage set) internal {
+        return _clear(set._inner);
+    }
 
     // UintSet
 
@@ -293,5 +308,9 @@ library EnumerableSet {
     */
     function at(UintSet storage set, uint256 index) internal view returns (uint256) {
         return uint256(_at(set._inner, index));
+    }
+
+    function clear(UintSet storage set) internal {
+        return _clear(set._inner);
     }
 }

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -66,7 +66,7 @@ library EnumerableSet {
     function _clear(Set storage set) private {
         uint256 last = set._values.length;
         while (last --> 0) {
-            delete set.indexes[_set._values[last]];
+            delete set.indexes[set._values[last]];
         }
         set._values.length = 0;
     }

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -68,7 +68,7 @@ library EnumerableSet {
         while (last --> 0) {
             delete set._indexes[set._values[last]];
         }
-        set._values.length = 0;
+        delete set._values;
     }
 
     /**

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -65,8 +65,10 @@ library EnumerableSet {
 
     function _clear(Set storage set) private {
         uint256 last = set._values.length;
-        while (last --> 0) {
-            delete set._indexes[set._values[last]];
+        unchecked {
+            while (last --> 0) {
+                delete set._indexes[set._values[last]];
+            }
         }
         delete set._values;
     }

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -115,6 +115,21 @@ function shouldBehaveLikeSet (valueA, valueB, valueC) {
       expect(await this.set.contains(valueB)).to.equal(false);
     });
   });
+
+  describe('clear', function() {
+    it('sets length to 0', async function () {
+      await this.set.add(valueA)
+      await this.set.clear()
+      expect(await this.set.length()).to.be.bignumber.equal('0');
+    })
+    it('removes all items', async function () {
+      await this.set.add(valueA)
+      await this.set.add(valueB)
+      await this.set.clear()
+      expect(await this.set.contains(valueA)).to.equal(false);
+      expect(await this.set.contains(valueB)).to.equal(false);
+    })
+  });
 }
 
 module.exports = {

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -118,14 +118,15 @@ function shouldBehaveLikeSet (valueA, valueB, valueC) {
 
   describe('clear', function() {
     it('sets length to 0', async function () {
-      await this.set.add(valueA)
-      await this.set.clear()
+      await this.set.add(valueA);
+      await this.set.clear();
       expect(await this.set.length()).to.be.bignumber.equal('0');
     })
+
     it('removes all items', async function () {
-      await this.set.add(valueA)
-      await this.set.add(valueB)
-      await this.set.clear()
+      await this.set.add(valueA);
+      await this.set.add(valueB);
+      await this.set.clear();
       expect(await this.set.contains(valueA)).to.equal(false);
       expect(await this.set.contains(valueB)).to.equal(false);
     })

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -116,12 +116,12 @@ function shouldBehaveLikeSet (valueA, valueB, valueC) {
     });
   });
 
-  describe('clear', function() {
+  describe('clear', function () {
     it('sets length to 0', async function () {
       await this.set.add(valueA);
       await this.set.clear();
       expect(await this.set.length()).to.be.bignumber.equal('0');
-    })
+    });
 
     it('removes all items', async function () {
       await this.set.add(valueA);
@@ -129,7 +129,7 @@ function shouldBehaveLikeSet (valueA, valueB, valueC) {
       await this.set.clear();
       expect(await this.set.contains(valueA)).to.equal(false);
       expect(await this.set.contains(valueB)).to.equal(false);
-    })
+    });
   });
 }
 


### PR DESCRIPTION

#### Changes
It should be cheaper to remove all items.
It won't always be possible to do this because of the block gas limit, but when it is this should be much cheaper than sequential removal.
Reviewers @nventuro