### PR TITLE
Docs update - updated docs for setting decimals

### DIFF
--- a/docs/modules/ROOT/pages/erc20.adoc
+++ b/docs/modules/ROOT/pages/erc20.adoc
@@ -62,7 +62,13 @@ It is important to understand that `decimals` is _only used for display purposes
 
 You'll probably want to use a `decimals` value of `18`, just like Ether and most ERC20 token contracts in use, unless you have a very special reason not to. When minting tokens or transferring them around, you will be actually sending the number `num GLD * 10^decimals`.
 
-NOTE: By default, `ERC20` uses a value of `18` for `decimals`. To use a different value, you will need to call xref:api:token/ERC20.adoc#ERC20-_setupDecimals-uint8-[_setupDecimals] in your constructor.
+NOTE: By default, `ERC20` uses a value of `18` for `decimals`. To use a different value, you will need to override the `decimals()` function in your contract.
+
+```solidity
+function decimals() public view virtual override returns (uint8) {
+  return 16;
+}
+```
 
 So if you want to send `5` tokens using a token contract with 18 decimals, the the method to call will actually be:
 

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -35,6 +35,15 @@ contract('ERC20', function (accounts) {
     expect(await this.token.decimals()).to.be.bignumber.equal('18');
   });
 
+  describe('set decimals', function () {
+    const decimals = new BN(6);
+
+    it('can set decimals during construction', async function () {
+      const token = await ERC20DecimalsMock.new(name, symbol, decimals);
+      expect(await token.decimals()).to.be.bignumber.equal(decimals);
+    });
+  });
+
   shouldBehaveLikeERC20('ERC20', initialSupply, initialHolder, recipient, anotherAccount);
 
   describe('decrease allowance', function () {

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -35,15 +35,6 @@ contract('ERC20', function (accounts) {
     expect(await this.token.decimals()).to.be.bignumber.equal('18');
   });
 
-  describe('_setupDecimals', function () {
-    const decimals = new BN(6);
-
-    it('can set decimals during construction', async function () {
-      const token = await ERC20DecimalsMock.new(name, symbol, decimals);
-      expect(await token.decimals()).to.be.bignumber.equal(decimals);
-    });
-  });
-
   shouldBehaveLikeERC20('ERC20', initialSupply, initialHolder, recipient, anotherAccount);
 
   describe('decrease allowance', function () {


### PR DESCRIPTION
Fixes #????

Fixes documentation around setting decimals. Somewhat related to #2613, #2615

Changelog: 

1. Updated docs to reference how to set decimals using `decimals()` method.
2. Removed deprecated `_setDecimals` test.