### PR TITLE
typo: remove duplicate word

### DIFF
--- a/docs/modules/ROOT/pages/erc20.adoc
+++ b/docs/modules/ROOT/pages/erc20.adoc
@@ -70,7 +70,7 @@ function decimals() public view virtual override returns (uint8) {
 }
 ```
 
-So if you want to send `5` tokens using a token contract with 18 decimals, the the method to call will actually be:
+So if you want to send `5` tokens using a token contract with 18 decimals, the method to call will actually be:
 
 ```solidity
 transfer(recipient, 5 * 10^18);


### PR DESCRIPTION
Typo fix: remove duplicate word "the" in ERC20 guide.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
