### PR TITLE
Fix `ERC721._beforeTokenTransfer` docs

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -367,8 +367,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * transferred to `to`.
      * - When `from` is zero, `tokenId` will be minted for `to`.
      * - When `to` is zero, ``from``'s `tokenId` will be burned.
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
+     * - `from` and `to` are never both zero.
      *
      * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */


### PR DESCRIPTION
Fixes a regression introduced in ecf0725dd1bb (#2218). As written, the
docs are contradictory: they document what happens when `from` is zero
and what happens when `to` is zero, then go on to state that neither of
these can be zero. What's meant is what was written in a previous
version of the code: that `from` and `to` are never *both* zero.

wchargin-branch: erc721-beforetokentransfer-docs
