### PR TITLE
Add ceiling division operation to the `Math.sol` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-* `ERC20Votes`: add a new extension of the `ERC20` token with support for voting snapshots and delegation. This extension is compatible with Compound's `Comp` token interface. ([#2632](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2632))
+ * `ERC20Votes`: add a new extension of the `ERC20` token with support for voting snapshots and delegation. This extension is compatible with Compound's `Comp` token interface. ([#2632](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2632))
  * Enumerables: Improve gas cost of removal in `EnumerableSet` and `EnumerableMap`.
  * Enumerables: Improve gas cost of lookup in `EnumerableSet` and `EnumerableMap`.
+ * `Math`: Add a `ceilDiv` method for performing ceiling division.
 
 ## 4.1.0 (2021-04-29)
 

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -16,4 +16,8 @@ contract MathMock {
     function average(uint256 a, uint256 b) public pure returns (uint256) {
         return Math.average(a, b);
     }
+
+    function ceilDiv(uint256 a, uint256 b) public pure returns (uint256) {
+        return Math.ceilDiv(a, b);
+    }
 }

--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -28,4 +28,15 @@ library Math {
         // (a + b) / 2 can overflow, so we distribute.
         return (a / 2) + (b / 2) + ((a % 2 + b % 2) / 2);
     }
+
+    /**
+     * @dev Returns the ceiling of the division of two numbers.
+     *
+     * This differs from standard division with `/` in that it rounds up instead
+     * of rounding down.
+     */
+    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        // (a + b - 1) / b can overflow on addition, so we distribute.
+        return a / b + (a % b == 0 ? 0 : 1);
+    }
 }

--- a/test/utils/math/Math.test.js
+++ b/test/utils/math/Math.test.js
@@ -1,6 +1,6 @@
-const { BN } = require('@openzeppelin/test-helpers');
-
+const { BN, constants } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
+const { MAX_UINT256 } = constants;
 
 const MathMock = artifacts.require('MathMock');
 
@@ -53,6 +53,31 @@ contract('Math', function (accounts) {
       const a = new BN('57417');
       const b = new BN('84346');
       expect(await this.math.average(a, b)).to.be.bignumber.equal(bnAverage(a, b));
+    });
+  });
+
+  describe('ceilDiv', function () {
+    it('does not round up on exact division', async function () {
+      const a = new BN('10');
+      const b = new BN('5');
+      expect(await this.math.ceilDiv(a, b)).to.be.bignumber.equal('2');
+    });
+
+    it('rounds up on division with remainders', async function () {
+      const a = new BN('42');
+      const b = new BN('13');
+      expect(await this.math.ceilDiv(a, b)).to.be.bignumber.equal('4');
+    });
+
+    it('does not overflow', async function () {
+      const b = new BN('2');
+      const result = new BN('1').shln(255);
+      expect(await this.math.ceilDiv(MAX_UINT256, b)).to.be.bignumber.equal(result);
+    });
+
+    it('correctly computes max uint256 divided by 1', async function () {
+      const b = new BN('1');
+      expect(await this.math.ceilDiv(MAX_UINT256, b)).to.be.bignumber.equal(MAX_UINT256);
     });
   });
 });


### PR DESCRIPTION
Fixes #2680

This PR adds a `ceilDiv` method to the `Math.sol` library. It uses the `a / b + uint(a % b != 0)` method for the reasons described in the issue.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog entry
