### PR TITLE
Reserve unchecked for when guarded by explicit require

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -267,8 +267,8 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
         unchecked {
             _balances[account] = accountBalance - amount;
-            _totalSupply -= amount;
         }
+        _totalSupply -= amount;
 
         emit Transfer(account, address(0), amount);
     }

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -421,8 +421,8 @@ contract ERC777 is Context, IERC777, IERC20 {
         require(fromBalance >= amount, "ERC777: burn amount exceeds balance");
         unchecked {
             _balances[from] = fromBalance - amount;
-            _totalSupply -= amount;
         }
+        _totalSupply -= amount;
 
         emit Burned(operator, from, amount, data, operatorData);
         emit Transfer(from, address(0), amount);


### PR DESCRIPTION
#2669 introduced `unchecked` blocks for operations that are guaranteed not to overflow. Some of the operations wrapped un `unchecked` only guarantee this through indirect invariants, and we should continue to use checked arithmetic for those. This PR reverts #2669 in those cases, leaving `unchecked` only for the cases when there is an explicit require that guarantees they won't overflow.