### PR TITLE
Implmenting a view function for viewing the values of an EnumerableSet

### DIFF
--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -130,6 +130,13 @@ library EnumerableSet {
         return set._values[index];
     }
 
+    /**
+     * @dev Returns the token values owned by an owner. O(1).
+     */
+    function _view(Set storage set) private view returns (bytes32[] memory) {
+        return set._values;
+    }
+
     // Bytes32Set
 
     struct Bytes32Set {
@@ -290,5 +297,12 @@ library EnumerableSet {
      */
     function at(UintSet storage set, uint256 index) internal view returns (uint256) {
         return uint256(_at(set._inner, index));
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function getValues(UintSet storage set) internal view returns (bytes32[] memory) {
+        return _view(set._inner);
     }
 }


### PR DESCRIPTION
We are using ERC721 contracts from version [v3.4.0](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v3.4.0), which was integrated with the enumerability of tokens. So we were thinking of implementing a view function for returning an array of token indexes of the holder that would be useful in retrieving each holder's collectibles, by using then the `tokenURI()` function to retrieve the token link _i.e ipfs link_. 

So we implemented this function in the ERC721 contract: 

```solidity
    // Mapping from holder address to their (enumerable) set of owned tokens
    mapping (address => EnumerableSet.UintSet) private _holderTokens;
    
   /**
     * @dev Returning an array of the token indexes of the holder.
     */
    function holderBalance(address owner) public view virtual returns (bytes32[] memory) {
        return _holderTokens[owner].getValues();
    }

```

By using the help of `getValues()` view function that we added in the `EnumerableSet` liberary, as follows: 

- First implementing a private view function for viewing Set `_values`: 
```solidity
   /**
     * @dev Returns the token values owned by an owner. O(1).
     */
    function _view(Set storage set) private view returns (bytes32[] memory) {
        return set._values;
    }

```
- Then, implementing an internal view function for the UintSet as follows: 

```solidity
  /**
     * @dev Returns the number of values on the set. O(1).
     */
    function getValues(UintSet storage set) internal view returns (bytes32[] memory) {
        return _view(set._inner);
    }

```  
So, I think this might be a useful general feature, although I know that the enumerability of tokens has been removed in [v4.0.0](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v4.0.0)

Thanks so much!

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [x] Changelog entry
