### PR TITLE
ERC20Votes: Emit DelegateVotesChanged events after the corresponding Transfer

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -234,6 +234,8 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         _balances[recipient] += amount;
 
         emit Transfer(sender, recipient, amount);
+
+        _afterTokenTransfer(sender, recipient, amount);
     }
 
     /** @dev Creates `amount` tokens and assigns them to `account`, increasing
@@ -253,6 +255,8 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         _totalSupply += amount;
         _balances[account] += amount;
         emit Transfer(address(0), account, amount);
+
+        _afterTokenTransfer(address(0), account, amount);
     }
 
     /**
@@ -279,6 +283,8 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         _totalSupply -= amount;
 
         emit Transfer(account, address(0), amount);
+
+        _afterTokenTransfer(account, address(0), amount);
     }
 
     /**
@@ -313,7 +319,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * Calling conditions:
      *
      * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
-     * will be to transferred to `to`.
+     * will be transferred to `to`.
      * - when `from` is zero, `amount` tokens will be minted for `to`.
      * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
      * - `from` and `to` are never both zero.
@@ -321,6 +327,26 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */
     function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * has been transferred to `to`.
+     * - when `from` is zero, `amount` tokens have been minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens have been burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
         address from,
         address to,
         uint256 amount

--- a/contracts/token/ERC20/extensions/ERC20Votes.sol
+++ b/contracts/token/ERC20/extensions/ERC20Votes.sol
@@ -190,11 +190,13 @@ abstract contract ERC20Votes is ERC20Permit {
      *
      * Emits a {DelegateVotesChanged} event.
      */
-    function _beforeTokenTransfer(
+    function _afterTokenTransfer(
         address from,
         address to,
         uint256 amount
     ) internal virtual override {
+        super._afterTokenTransfer(from, to, amount);
+
         _moveVotingPower(delegates(from), delegates(to), amount);
     }
 

--- a/test/token/ERC20/extensions/ERC20Votes.test.js
+++ b/test/token/ERC20/extensions/ERC20Votes.test.js
@@ -306,6 +306,9 @@ contract('ERC20Votes', function (accounts) {
       expectEvent(receipt, 'Transfer', { from: holder, to: recipient, value: '1' });
       expectEvent(receipt, 'DelegateVotesChanged', { delegate: holder, previousBalance: supply, newBalance: supply.subn(1) });
 
+      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
+
       this.holderVotes = supply.subn(1);
       this.recipientVotes = '0';
     });
@@ -316,6 +319,9 @@ contract('ERC20Votes', function (accounts) {
       const { receipt } = await this.token.transfer(recipient, 1, { from: holder });
       expectEvent(receipt, 'Transfer', { from: holder, to: recipient, value: '1' });
       expectEvent(receipt, 'DelegateVotesChanged', { delegate: recipient, previousBalance: '0', newBalance: '1' });
+
+      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
 
       this.holderVotes = '0';
       this.recipientVotes = '1';
@@ -329,6 +335,9 @@ contract('ERC20Votes', function (accounts) {
       expectEvent(receipt, 'Transfer', { from: holder, to: recipient, value: '1' });
       expectEvent(receipt, 'DelegateVotesChanged', { delegate: holder, previousBalance: supply, newBalance: supply.subn(1) });
       expectEvent(receipt, 'DelegateVotesChanged', { delegate: recipient, previousBalance: '0', newBalance: '1' });
+
+      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
 
       this.holderVotes = supply.subn(1);
       this.recipientVotes = '1';


### PR DESCRIPTION
In order to match Compound's interface, `DelegateVotesChanged` must be triggered after the transfer event has been emitted.

This is fixes using a new `_afterTokenTransfer` hook 


#### PR Checklist
- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
