### PR TITLE
Use private variable instead of immutable to allow calls to _msgSender in constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+ * `ERC2771Context`: use private variable from storage to store the forwarder address. Fixes issues where `_msgSender()` was not callable from constructors. ([#2754](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2754))
+
 ## 4.2.0 (2021-06-30)
 
  * `ERC20Votes`: add a new extension of the `ERC20` token with support for voting snapshots and delegation. ([#2632](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2632))

--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -8,7 +8,7 @@ import "../utils/Context.sol";
  * @dev Context variant with ERC2771 support.
  */
 abstract contract ERC2771Context is Context {
-    address immutable _trustedForwarder;
+    address private _trustedForwarder;
 
     constructor(address trustedForwarder) {
         _trustedForwarder = trustedForwarder;


### PR DESCRIPTION
Immutable _trustedForwarder causes issues when _msgSender() is called in constructors

Fixes #2739

#### PR Checklist

- [x] Tests
- [x] Changelog entry
