### PR TITLE
fix small typo in erc20 docs

### DIFF
--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -22,7 +22,7 @@ Additionally there are multiple custom extensions, including:
 * {ERC20Permit}: gasless approval of tokens (standardized as ERC2612).
 * {ERC20FlashMint}: token level support for flash loans through the minting and burning of ephemeral tokens (standardized as ERC3156).
 * {ERC20Votes}: support for voting and vote delegation.
-* {ERC20VotesComp}: support for voting and vote delegation (compatible with Compound's tokenn, with uint96 restrictions).
+* {ERC20VotesComp}: support for voting and vote delegation (compatible with Compound's token, with uint96 restrictions).
 * {ERC20Wrapper}: wrapper to create an ERC20 backed by another ERC20, with deposit and withdraw methods. Useful in conjunction with {ERC20Votes}.
 
 Finally, there are some utilities to interact with ERC20 contracts in various ways.


### PR DESCRIPTION

Fixes #???? 

Fixes a small typo in the `ERC20` docs page.


#### PR Checklist

- [X] Tests
- [X] Documentation
- [X] Changelog entry
