### PR TITLE
Update and rename ReentrancyGuard.sol to MultiLevelReentrancyGuard.sol

### DIFF
--- a/contracts/security/MultiLevelReentrancyGuard.sol
+++ b/contracts/security/MultiLevelReentrancyGuard.sol
@@ -3,20 +3,15 @@
 pragma solidity ^0.8.0;
 
 /**
- * @dev Contract module that helps prevent reentrant calls to a function.
+ * @dev Contract module that helps prevent reentrant calls to functions.
  *
  * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
  * available, which can be applied to functions to make sure there are no nested
  * (reentrant) calls to them.
  *
- * Note that because there is a single `nonReentrant` guard, functions marked as
- * `nonReentrant` may not call one another. This can be worked around by making
- * those functions `private`, and then adding `external` `nonReentrant` entry
- * points to them.
+ * Note: functions marked as `nonReentrant` with same `level`
+ * may not call one another. 
  *
- * TIP: If you would like to learn more about reentrancy and alternative ways
- * to protect against it, check out our blog post
- * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
  */
 abstract contract ReentrancyGuard {
     // Booleans are more expensive than uint256 or any type that takes up a full
@@ -30,33 +25,32 @@ abstract contract ReentrancyGuard {
     // amount. Since refunds are capped to a percentage of the total
     // transaction's gas, it is best to keep them low in cases like this one, to
     // increase the likelihood of the full refund coming into effect.
-    uint256 private constant _NOT_ENTERED = 1;
-    uint256 private constant _ENTERED = 2;
-
-    uint256 private _status;
+    uint256 private constant _NOT_ENTERED = 0;
+    uint256 private constant _ENTERED = 1;
+    
+    // As uninitialized values are always 0
+    // that means each level _status will be _NOT_ENTERED by default
+    mapping(uint256 => uint256) private _status;
 
     constructor () {
-        _status = _NOT_ENTERED;
+        
     }
 
     /**
-     * @dev Prevents a contract from calling itself, directly or indirectly.
-     * Calling a `nonReentrant` function from another `nonReentrant`
-     * function is not supported. It is possible to prevent this from happening
-     * by making the `nonReentrant` function external, and make it call a
-     * `private` function that does the actual work.
+     * nonReentrant functions with same level will be prevented from executing reentrantly.
+     * nonReentrant functions with different level can be executed reentrantly.
      */
-    modifier nonReentrant() {
+    modifier nonReentrant(uint256 _level) {
         // On the first call to nonReentrant, _notEntered will be true
-        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+        require(_status[_level] != _ENTERED, "ReentrancyGuard: reentrant call");
 
-        // Any calls to nonReentrant after this point will fail
-        _status = _ENTERED;
+        // Any calls to nonReentrant with level as "_level" after this point will fail
+        _status[_level] = _ENTERED;
 
         _;
 
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
-        _status = _NOT_ENTERED;
+        _status[_level] = _NOT_ENTERED;
     }
 }


### PR DESCRIPTION
There might be multiple functions that needs to be `nonReentrant` for calls to themselves only, but using one modifier for every nonReentrant functions can pause the working of other functions when one is working. 
To solve the problem, this solution is proposed a multi level Reentrancy Guard. In this implementation, `nonReentrant` modifiers will have a parameter called `level`. This way non reentrant functions with different level can be executed concurrently & non reentrant functions that should not be working concurrently can be put in same level.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
