### PR TITLE
Remove all underbar prefix for function parameters

### DIFF
--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -19,12 +19,12 @@ contract DummyImplementation {
         value = 100;
     }
 
-    function initializeNonPayableWithValue(uint256 _value) public {
-        value = _value;
+    function initializeNonPayableWithValue(uint256 value_) public {
+        value = value_;
     }
 
-    function initializePayableWithValue(uint256 _value) public payable {
-        value = _value;
+    function initializePayableWithValue(uint256 value_) public payable {
+        value = value_;
     }
 
     function initialize(

--- a/contracts/mocks/ERC721URIStorageMock.sol
+++ b/contracts/mocks/ERC721URIStorageMock.sol
@@ -25,8 +25,8 @@ contract ERC721URIStorageMock is ERC721URIStorage {
         return _baseURI();
     }
 
-    function setTokenURI(uint256 tokenId, string memory _tokenURI) public {
-        _setTokenURI(tokenId, _tokenURI);
+    function setTokenURI(uint256 tokenId, string memory tokenURI_) public {
+        _setTokenURI(tokenId, tokenURI_);
     }
 
     function exists(uint256 tokenId) public view returns (bool) {

--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -20,12 +20,12 @@ contract InitializableMock is Initializable {
         initialize();
     }
 
-    function initializeWithX(uint256 _x) public payable initializer {
-        x = _x;
+    function initializeWithX(uint256 x_) public payable initializer {
+        x = x_;
     }
 
-    function nonInitializable(uint256 _x) public payable {
-        x = _x;
+    function nonInitializable(uint256 x_) public payable {
+        x = x_;
     }
 
     function fail() public pure {

--- a/contracts/mocks/MultipleInheritanceInitializableMocks.sol
+++ b/contracts/mocks/MultipleInheritanceInitializableMocks.sol
@@ -56,9 +56,9 @@ contract SampleGramps is Initializable, SampleHuman {
 contract SampleFather is Initializable, SampleGramps {
     uint256 public father;
 
-    function initialize(string memory _gramps, uint256 _father) public initializer {
-        SampleGramps.initialize(_gramps);
-        father = _father;
+    function initialize(string memory gramps, uint256 father_) public initializer {
+        SampleGramps.initialize(gramps);
+        father = father_;
     }
 }
 

--- a/contracts/mocks/RegressionImplementation.sol
+++ b/contracts/mocks/RegressionImplementation.sol
@@ -9,8 +9,8 @@ contract Implementation1 is Initializable {
 
     function initialize() public initializer {}
 
-    function setValue(uint256 _number) public {
-        _value = _number;
+    function setValue(uint256 number) public {
+        _value = number;
     }
 }
 
@@ -19,8 +19,8 @@ contract Implementation2 is Initializable {
 
     function initialize() public initializer {}
 
-    function setValue(uint256 _number) public {
-        _value = _number;
+    function setValue(uint256 number) public {
+        _value = number;
     }
 
     function getValue() public view returns (uint256) {
@@ -33,12 +33,12 @@ contract Implementation3 is Initializable {
 
     function initialize() public initializer {}
 
-    function setValue(uint256 _number) public {
-        _value = _number;
+    function setValue(uint256 number) public {
+        _value = number;
     }
 
-    function getValue(uint256 _number) public view returns (uint256) {
-        return _value + _number;
+    function getValue(uint256 number) public view returns (uint256) {
+        return _value + number;
     }
 }
 
@@ -47,8 +47,8 @@ contract Implementation4 is Initializable {
 
     function initialize() public initializer {}
 
-    function setValue(uint256 _number) public {
-        _value = _number;
+    function setValue(uint256 number) public {
+        _value = number;
     }
 
     function getValue() public view returns (uint256) {

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -111,7 +111,7 @@ interface IERC721 is IERC165 {
      *
      * Emits an {ApprovalForAll} event.
      */
-    function setApprovalForAll(address operator, bool _approved) external;
+    function setApprovalForAll(address operator, bool approved) external;
 
     /**
      * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.

--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -41,9 +41,9 @@ abstract contract ERC721URIStorage is ERC721 {
      *
      * - `tokenId` must exist.
      */
-    function _setTokenURI(uint256 tokenId, string memory _tokenURI) internal virtual {
+    function _setTokenURI(uint256 tokenId, string memory tokenURI) internal virtual {
         require(_exists(tokenId), "ERC721URIStorage: URI set of nonexistent token");
-        _tokenURIs[tokenId] = _tokenURI;
+        _tokenURIs[tokenId] = tokenURI;
     }
 
     /**

--- a/contracts/utils/introspection/IERC1820Registry.sol
+++ b/contracts/utils/introspection/IERC1820Registry.sol
@@ -74,7 +74,7 @@ interface IERC1820Registry {
      *
      * `account` being the zero address is an alias for the caller's address.
      */
-    function getInterfaceImplementer(address account, bytes32 _interfaceHash) external view returns (address);
+    function getInterfaceImplementer(address account, bytes32 interfaceHash) external view returns (address);
 
     /**
      * @dev Returns the interface hash for an `interfaceName`, as defined in the


### PR DESCRIPTION
Underbar prefix in variables names has a reserved meaning: private variables.

This is important because switching private to non-private is a big deal and that will require you to touch every part of code that references.

---

This PR removes all use of underbar prefix from function parameters.

If a some mangling is required (i.e. because that name is already in use elsewhere), prefer to use an underbar suffix. This is currently how ERC721 is implemented here and it looks fine.

---

Related thread to recommend this rule for everybody is at https://github.com/protofire/solhint/issues/300