### PR TITLE
Update tests for RFC 2606

### DIFF
--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -12,7 +12,7 @@ const Error = [ 'None', 'RevertWithMessage', 'RevertWithoutMessage', 'Panic' ]
 const firstTokenId = new BN('5042');
 const secondTokenId = new BN('79217');
 const nonExistentTokenId = new BN('13');
-const baseURI = 'https://api.com/v1/';
+const baseURI = 'https://api.example.com/v1/';
 
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
@@ -929,7 +929,7 @@ function shouldBehaveLikeERC721Metadata (errorPrefix, name, symbol, owner) {
 
         it('token URI can be changed by changing the base URI', async function () {
           await this.token.setBaseURI(baseURI);
-          const newBaseURI = 'https://api.com/v2/';
+          const newBaseURI = 'https://api.example.com/v2/';
           await this.token.setBaseURI(newBaseURI);
           expect(await this.token.tokenURI(firstTokenId)).to.be.equal(newBaseURI + firstTokenId.toString());
         });

--- a/test/token/ERC721/extensions/ERC721URIStorage.test.js
+++ b/test/token/ERC721/extensions/ERC721URIStorage.test.js
@@ -22,7 +22,7 @@ contract('ERC721URIStorage', function (accounts) {
       await this.token.mint(owner, firstTokenId);
     });
 
-    const baseURI = 'https://api.com/v1/';
+    const baseURI = 'https://api.example.com/v1/';
     const sampleUri = 'mock://mytoken';
 
     it('it is empty by default', async function () {
@@ -62,7 +62,7 @@ contract('ERC721URIStorage', function (accounts) {
       await this.token.setBaseURI(baseURI);
       await this.token.setTokenURI(firstTokenId, sampleUri);
 
-      const newBaseURI = 'https://api.com/v2/';
+      const newBaseURI = 'https://api.example.com/v2/';
       await this.token.setBaseURI(newBaseURI);
       expect(await this.token.tokenURI(firstTokenId)).to.be.equal(newBaseURI + sampleUri);
     });


### PR DESCRIPTION
RFC 2606 gives us domains we can use as an example. Let's use those rather than recommending some specific unrelated company.