### PR TITLE
Use SignatureChecker.isValidSignatureNow to support ERC1271 wallets in ERC20Permit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+ * `ERC20Permit`: use `SignatureChecker.isValidSignatureNow` to support signatures by ERC1271 wallets. ([#2846](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2846))
+
 ## 4.3.1
 
  * `TimelockController`: Add additional isOperationReady check.

--- a/contracts/token/ERC20/extensions/draft-ERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/draft-ERC20Permit.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "./draft-IERC20Permit.sol";
 import "../ERC20.sol";
 import "../../../utils/cryptography/draft-EIP712.sol";
-import "../../../utils/cryptography/ECDSA.sol";
+import "../../../utils/cryptography/SignatureChecker.sol";
 import "../../../utils/Counters.sol";
 
 /**
@@ -52,8 +52,10 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712 {
 
         bytes32 hash = _hashTypedDataV4(structHash);
 
-        address signer = ECDSA.recover(hash, v, r, s);
-        require(signer == owner, "ERC20Permit: invalid signature");
+        require(
+            SignatureChecker.isValidSignatureNow(owner, hash, abi.encodePacked(r, s, v)),
+            "ERC20Permit: invalid signature"
+        );
 
         _approve(owner, spender, value);
     }


### PR DESCRIPTION
Fixes #2845

#### PR Checklist
- [x] Tests
- [x] Changelog entry
