### PR TITLE
Allow Governor + CompoundTimelock to manage native tokens (eth) in and out of the timelock contract.

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -56,6 +56,13 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor {
     }
 
     /**
+     * @dev Function to receive ETH that will be handled by the governor (disabled if executor is a third party contract)
+     */
+    receive() external payable virtual {
+        require(_executor() == address(this));
+    }
+
+    /**
      * @dev See {IERC165-supportsInterface}.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -177,8 +177,9 @@ abstract contract GovernorTimelockCompound is IGovernorTimelock, Governor {
     ) internal virtual override {
         uint256 eta = proposalEta(proposalId);
         require(eta > 0, "GovernorTimelockCompound: proposal not yet queued");
+        Address.sendValue(payable(_timelock), msg.value);
         for (uint256 i = 0; i < targets.length; ++i) {
-            _timelock.executeTransaction{value: i == 0 ? msg.value : 0}(targets[i], values[i], "", calldatas[i], eta);
+            _timelock.executeTransaction(targets[i], values[i], "", calldatas[i], eta);
         }
     }
 

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -178,7 +178,7 @@ abstract contract GovernorTimelockCompound is IGovernorTimelock, Governor {
         uint256 eta = proposalEta(proposalId);
         require(eta > 0, "GovernorTimelockCompound: proposal not yet queued");
         for (uint256 i = 0; i < targets.length; ++i) {
-            _timelock.executeTransaction{value: values[i]}(targets[i], values[i], "", calldatas[i], eta);
+            _timelock.executeTransaction{value: i == 0 ? msg.value : 0}(targets[i], values[i], "", calldatas[i], eta);
         }
     }
 

--- a/contracts/mocks/GovernorCompMock.sol
+++ b/contracts/mocks/GovernorCompMock.sol
@@ -20,8 +20,6 @@ contract GovernorCompMock is Governor, GovernorVotesComp, GovernorCountingSimple
         _votingPeriod = votingPeriod_;
     }
 
-    receive() external payable {}
-
     function votingDelay() public view override returns (uint256) {
         return _votingDelay;
     }

--- a/contracts/mocks/GovernorMock.sol
+++ b/contracts/mocks/GovernorMock.sol
@@ -21,8 +21,6 @@ contract GovernorMock is Governor, GovernorVotesQuorumFraction, GovernorCounting
         _votingPeriod = votingPeriod_;
     }
 
-    receive() external payable {}
-
     function votingDelay() public view override returns (uint256) {
         return _votingDelay;
     }


### PR DESCRIPTION
[In GovernorBravo (and Alpha), the execute function must send the value attached to the proposal to the timelock](https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorBravoDelegate.sol#L146)

This means two things:

- The executor must give away all the Eth needed to run the proposal
- Any Eth present on the timelock cannot be moved away from it (such proposal would require the executor to provide an equal amount, resulting in a null result from the timelock point of view).

This means that governor + compound timelock cannot be used to manage big funds in Eth.

This PR moves away from compound behavior to enable such usecases.

Note: this issue does NOT affect OZ Governor + TimelockController combo



