### PR TITLE
Add a 'verifyWithIndex' function

### DIFF
--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -14,18 +14,21 @@ pragma solidity ^0.8.0;
 library MerkleProof {
     /**
      * @dev Returns true if a `leaf` can be proved to be a part of a Merkle tree
-     * defined by `root`. For this, a `proof` must be provided, containing
-     * sibling hashes on the branch from the leaf to the root of the tree. Each
-     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     * defined by `root`, along with the element's index in the tree.
+     * For this, a `proof` must be provided, containing sibling hashes on the
+     * branch from the leaf to the root of the tree. Each pair of leaves and
+     * each pair of pre-images are assumed to be sorted.
      */
-    function verify(
+    function verifyWithIndex(
         bytes32[] memory proof,
         bytes32 root,
         bytes32 leaf
-    ) internal pure returns (bool) {
+    ) internal pure returns (bool, uint256) {
         bytes32 computedHash = leaf;
+        uint256 index = 0;
 
         for (uint256 i = 0; i < proof.length; i++) {
+            index *= 2;
             bytes32 proofElement = proof[i];
 
             if (computedHash <= proofElement) {
@@ -34,10 +37,26 @@ library MerkleProof {
             } else {
                 // Hash(current element of the proof + current computed hash)
                 computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+                index += 1;
             }
         }
 
         // Check if the computed hash (root) is equal to the provided root
-        return computedHash == root;
+        return (computedHash == root, index);
     }
+
+    /**
+     * @dev Returns true if a `leaf` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     */
+    function verifyWithIndex(
+        bytes32[] memory proof,
+        bytes32 root,
+        bytes32 leaf
+    ) internal pure returns (bool) {
+      (bool valid,) = verifyWithIndex(proof, root, leaf);
+      return valid;
+    }    
 }


### PR DESCRIPTION
I was going to open an issue to discuss this, but figured it was just as quick to give an example PR for feedback.

It's trivial for the merkle proof verification function to compute and return an index when it verifies the proof. This is particularly useful for the common case of wanting to track when airdrops have been claimed using a bitmap; the returned index value can be used to specify the bit in the bitmap to set.