### PR TITLE
Add MultiPaymentSplitter, an ERC20 compatible payment splitter

### DIFF
--- a/contracts/finance/MultiPaymentSplitter.sol
+++ b/contracts/finance/MultiPaymentSplitter.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../token/ERC20/utils/SafeERC20.sol";
+import "../utils/structs/Distribution.sol";
+import "./PaymentSplitter.sol";
+
+/**
+ * @title MultiPaymentSplitter
+ * @dev This contract allows to split Ether and ERC20 payments among a group of accounts. Asset senders do not need to
+ * be aware that the splitting in this way, since it is handled transparently by the contract.
+ *
+ * The split can be in equal parts or in any other arbitrary proportion. The way this is specified is by assigning each
+ * account to a number of shares. Of all the Ether that this contract receives, each account will then be able to claim
+ * an amount proportional to the percentage of total shares they were assigned.
+ *
+ * `PaymentSplitter` follows a _pull payment_ model. This means that payments are not automatically forwarded to the
+ * accounts but kept in this contract, and the actual transfer is triggered as a separate step by calling the {release}
+ * function.
+ */
+contract MultiPaymentSplitter is PaymentSplitter {
+    using Distribution for Distribution.AddressToUintWithTotal;
+
+    event ERC20PaymentReleased(IERC20 indexed asset, address indexed to, uint256 amount);
+
+    mapping(IERC20 => Distribution.AddressToUintWithTotal) private _released;
+
+    /**
+     * @dev Creates an instance of `PaymentSplitter` where each account in `payees` is assigned the number of shares at
+     * the matching position in the `shares` array.
+     *
+     * All addresses in `payees` must be non-zero. Both arrays must have the same non-zero length, and there must be no
+     * duplicates in `payees`.
+     */
+    constructor(address[] memory payees, uint256[] memory shares_) payable
+    PaymentSplitter(payees, shares_)
+    {}
+
+    /**
+     * @dev Getter for the amount of `asset` tokens already released to a payee.
+     */
+    function released(IERC20 asset, address account) public view returns (uint256) {
+        return _released[asset].getValue(account);
+    }
+
+    /**
+     * @dev Getter for the total amount of `asset` tokens already released.
+     */
+    function totalReleased(IERC20 asset) public view returns (uint256) {
+        return _released[asset].getTotal();
+    }
+
+    /**
+     * @dev Triggers an ERC20 transfer to `account` of the amount of `asset` tokens they are owed, according to their
+     * percentage of the total shares and their previous withdrawals.
+     */
+    function release(IERC20 asset, address payable account) public virtual {
+        require(shares(account) > 0, "PaymentSplitter: account has no shares");
+
+        uint256 totalReceived = asset.balanceOf(address(this)) + totalReleased(asset);
+        uint256 payment = (totalReceived * shares(account)) / totalShares() - _released[asset].getValue(account);
+
+        _released[asset].add(account, payment);
+
+        SafeERC20.safeTransfer(IERC20(asset), account, payment);
+        emit ERC20PaymentReleased(asset, account, payment);
+    }
+}

--- a/contracts/utils/structs/Distribution.sol
+++ b/contracts/utils/structs/Distribution.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+library Distribution {
+    struct AddressToUintWithTotal {
+        mapping(address => uint256) _values;
+        uint256 _total;
+    }
+
+    function getValue(AddressToUintWithTotal storage store, address account) internal view returns (uint256) {
+        return store._values[account];
+    }
+
+    function getTotal(AddressToUintWithTotal storage store) internal view returns (uint256) {
+        return store._total;
+    }
+
+    function add(
+        AddressToUintWithTotal storage store,
+        address account,
+        uint256 value
+    ) internal {
+        store._values[account] += value;
+        store._total += value;
+    }
+
+    function sub(
+        AddressToUintWithTotal storage store,
+        address account,
+        uint256 value
+    ) internal {
+        store._values[account] -= value;
+        store._total -= value;
+    }
+
+    function move(
+        AddressToUintWithTotal storage store,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        store._values[from] -= value;
+        store._values[to] += value;
+    }
+
+    struct AddressToIntWithTotal {
+        mapping(address => int256) _values;
+        int256 _total;
+    }
+
+    function getValue(AddressToIntWithTotal storage store, address account) internal view returns (int256) {
+        return store._values[account];
+    }
+
+    function getTotal(AddressToIntWithTotal storage store) internal view returns (int256) {
+        return store._total;
+    }
+
+    function add(
+        AddressToIntWithTotal storage store,
+        address account,
+        int256 value
+    ) internal {
+        store._values[account] += value;
+        store._total += value;
+    }
+
+    function sub(
+        AddressToIntWithTotal storage store,
+        address account,
+        int256 value
+    ) internal {
+        store._values[account] -= value;
+        store._total -= value;
+    }
+
+    function move(
+        AddressToIntWithTotal storage store,
+        address from,
+        address to,
+        int256 value
+    ) internal {
+        store._values[from] -= value;
+        store._values[to] += value;
+    }
+}


### PR DESCRIPTION
This PR proposes a new `MultiPaymentSplitter` that inherits and extends the existing payment splitter storage pattern and ABI to add support for ERC20 tokens.

New functions and events include:

| PaymentSplitter (Eth) | MultiPaymentSplitter (ERC20) |
| - | - |
| `totalReleased() public view returns (uint256)` | `totalReleased(IERC20 asset) public view returns (uint256)` |
| `released(address account) public view returns (uint256)` | `released(IERC20 asset, address account) public view returns (uint256)` |
| `release(address payable account) public` | `release(IERC20 asset, address payable account) public` |

Note that both interfaces are independent, and that Eth cannot be released through the ERC20 specific interface. 

Fixes #2701, #2762, #2853

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
