### PR TITLE
#890: Add ECDSA#toEthSignedMessage for bytes type

### DIFF
--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -6,6 +6,7 @@ import "../utils/cryptography/ECDSA.sol";
 
 contract ECDSAMock {
     using ECDSA for bytes32;
+    using ECDSA for bytes;
 
     function recover(bytes32 hash, bytes memory signature) public pure returns (address) {
         return hash.recover(signature);
@@ -32,5 +33,9 @@ contract ECDSAMock {
 
     function toEthSignedMessageHash(bytes32 hash) public pure returns (bytes32) {
         return hash.toEthSignedMessageHash();
+    }
+
+    function toEthSignedMessage(bytes memory s) public pure returns (bytes32) {
+        return s.toEthSignedMessage();
     }
 }

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.0;
 
+import "../Strings.sol";
+
 /**
  * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
  *
@@ -202,6 +204,18 @@ library ECDSA {
         // 32 is the length in bytes of hash,
         // enforced by the type signature above
         return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+
+    /**
+     * @dev Returns an Ethereum Signed Message, created from `s`. This
+     * produces hash corresponding to the one signed with the
+     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]
+     * JSON-RPC method as part of EIP-191.
+     *
+     * See {recover}.
+     */
+    function toEthSignedMessage(bytes memory s) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", Strings.toString(s.length), s));
     }
 
     /**

--- a/test/utils/cryptography/ECDSA.test.js
+++ b/test/utils/cryptography/ECDSA.test.js
@@ -200,5 +200,9 @@ contract('ECDSA', function (accounts) {
     it('prefixes hashes correctly', async function () {
       expect(await this.ecdsa.toEthSignedMessageHash(TEST_MESSAGE)).to.equal(toEthSignedMessageHash(TEST_MESSAGE));
     });
+
+    it('prefixes byte strings correctly', async function () {
+      expect(await this.ecdsa.toEthSignedMessage(TEST_MESSAGE)).to.equal(toEthSignedMessageHash(TEST_MESSAGE));
+    });
   });
 });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #890 <!-- Fill in with issue number -->
Issue [link](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/890)

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
The PR adds a function toEthSignedMessage(bytes) to the ECDSA contract, that works for any length of a bytes array.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
