### PR TITLE
Refactor ERC721 operator approvals to an internal function

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -135,8 +135,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     function setApprovalForAll(address operator, bool approved) public virtual override {
         require(operator != _msgSender(), "ERC721: approve to caller");
 
-        _operatorApprovals[_msgSender()][operator] = approved;
-        emit ApprovalForAll(_msgSender(), operator, approved);
+        _setOperatorApproval(_msgSender(), operator, approved);
     }
 
     /**
@@ -354,6 +353,20 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     function _approve(address to, uint256 tokenId) internal virtual {
         _tokenApprovals[tokenId] = to;
         emit Approval(ERC721.ownerOf(tokenId), to, tokenId);
+    }
+
+    /**
+     * @dev Approve or revoke approval from `operator` to operate on all tokens owned by `owner`
+     *
+     * Emits a {ApprovalForAll} event.
+     */
+    function _setOperatorApproval(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #2869 <!-- Fill in with issue number -->

This pull request introduces a very small change to the base ERC721 contract: [refactoring out setting `_operatorApprovals` into an internal virtual function.](https://github.com/Zer0dot/openzeppelin-contracts/commit/3563200076d39eb86d560d663004e3746501e31a)

This has a slight impact on gas, but comes with the benefit of allowing inheritors to set operator approvals via custom functions, allowing meta-transactions. 

Tests run as normal, no tests were added.
<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [X] Tests
- [ ] Documentation
- [ ] Changelog entry
