### PR TITLE
Proposing an access module to make contract sellable: Sellable.sol an…

### DIFF
--- a/contracts/access/Sellable.sol
+++ b/contracts/access/Sellable.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+
+
+/**
+ * @dev Contract module extension of Ownable where the owner can sell the contract ownership
+ * or approve a proxy to make a sale.
+ *
+ * This module is used through inheritance. 
+ * 
+ * Ownable contract has been copied inside this contract because its critical methods cannot and should not be inherited
+ */
+abstract contract Sellable is Context {
+
+    uint256 private _ownershipSellingPrice;
+    bool private _sellingOwnershipApproved = false;
+    bool private _proxyApproved = false;
+    address private _approvedBuyer = address(0);
+    address private _approvedProxy = address(0);
+
+
+    /**
+    * @dev Above attributes and methods are a copy of Ownable contract
+    */
+
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor() {
+        _setOwner(_msgSender());
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _setOwner(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _setOwner(newOwner);
+    }
+
+    function _setOwner(address newOwner) private {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+
+
+    /**
+    * @dev end of Ownable contract copy
+    */
+
+
+
+    /**
+     * @dev Methods for approving a Buyer address to buy the contract ownership at given price
+     */
+
+    /**
+     * @dev Approve a buyer address to buy the contract ownership with given price
+     * Can only be called by the current owner
+     */
+    function approveSellingOwnership(address approvedBuyer, uint256 price) public virtual onlyOwner {
+        require(approvedBuyer != address(0), "Sellable: approved buyer is the zero address");
+        require(approvedBuyer != owner(), "Sellable: approved buyer is the current owner");
+        require(!_sellingOwnershipApproved, 'Sellable: a buyer has already been approved, call cancelSellingOwnership first to change it');
+        require(price > 0, "Sellable: price must be > 0");
+
+        _sellingOwnershipApproved = true;
+        _ownershipSellingPrice = price;
+        _approvedBuyer = approvedBuyer;
+    }
+
+    /**
+     * @dev Cancel precedent call to approveSellingOwnership
+     * Can only be called by the current owner
+     */
+    function cancelSellingOwnership() public virtual onlyOwner {
+        _sellingOwnershipApproved=false;
+        _approvedBuyer=address(0);
+    }
+
+    /**
+     * @dev Allow anyone to check if an adress is the approved buyer
+     */
+    function isApprovedBuyer(address buyer) public virtual view returns(bool){
+        return (_sellingOwnershipApproved && buyer == _approvedBuyer); 
+    } 
+
+    /**
+     * @dev Allow the approved buyer and owner to check the selling approval status
+     */
+    function isSellingOwnershipApproved() public virtual view onlyOwner returns(bool){
+        return _sellingOwnershipApproved;
+    }    
+
+    /**
+     * @dev Allow the approved buyer and owner to get the approved selling price
+     */
+    function getOwnershipSellingPrice() public virtual view returns(uint256){
+        require(_msgSender() == _approvedBuyer || _msgSender() == owner(), "Sender is not the approved buyer or owner");
+        require(_sellingOwnershipApproved, "Buying contract is not approved");
+        return _ownershipSellingPrice;
+    }
+
+    /**
+     * @dev Allow the approved buyer to buy the ownership of the contract with the approved selling price
+     * 
+     * NOTES:
+     * i) Only the selling price is transfered to the owner here, the rest of the contract's balance
+     * will stay unchanged, so the owner should first withdraw before selling.
+     * 
+     * ii) In payable methods the contract balance is updated directly when the method is called and
+     * gets msg.value added to it. So we can call payable(owner()).transfer(msg.value) here.
+     */
+    function buyOwnership() public virtual payable {
+        require(_msgSender() == _approvedBuyer, "Sender is not the approved buyer");
+        require(_sellingOwnershipApproved, "Buying contract ownership is not approved");        
+        require(msg.value == _ownershipSellingPrice, "Selling price incorrect");
+        payable(owner()).transfer(msg.value);
+        _reset();
+        _setOwner(_msgSender());
+    }
+
+
+
+    /**
+     * @dev Methods for approving a proxy address transfer the contract ownership
+     */
+
+
+    /**
+     * @dev Approve a trusted proxy to get ownership of the contract in order to make a sale
+     * as it is done for tokens with approve method
+     */
+    function approveProxy(address approvedProxy) public virtual onlyOwner {
+        require(approvedProxy != address(0), "Sellable: approved proxy is the zero address");
+        require(approvedProxy != owner(), "Sellable: approved proxy is the current owner");
+        require(!_proxyApproved, 'Sellable: a proxy has already been approved, call cancelApproveProxy first to change it');
+
+        _proxyApproved = true;
+        _approvedProxy = approvedProxy;
+    }
+
+    /**
+     * @dev Cancel precedent call to approveProxy
+     * Can only be called by the current owner
+     */
+    function cancelApproveProxy() public virtual onlyOwner {
+        _proxyApproved=false;
+        _approvedProxy=address(0);
+    }
+
+    /**
+     * @dev Allow anyone to check if an adress is the approved proxy
+     */
+    function isApprovedProxy(address proxy) public virtual view returns(bool){
+        return (_proxyApproved && proxy == _approvedProxy); 
+    }     
+
+    /**
+     * @dev Allow the owner to check the proxy approved status
+     */
+    function isProxyApproved() public virtual view onlyOwner returns(bool){
+        return _proxyApproved;
+    }     
+
+    /**
+     * @dev Allow the approved proxy to transfer the ownership of the contract 
+     * 
+     * NOTES: This should be used for selling contracts on trusted market places
+     * For private and safe sales, use the buyOwnership method
+     * 
+     * Only the proxy can use this method. If the owner wants to manually transfer the contract for free,
+     * he/she should use the transferOwnership method instead.
+     */
+    function proxyTransferOwnership(address newOwner) public virtual {
+        require(_msgSender() == _approvedProxy, "Sellable: sender is not the approved proxy");
+        require(_proxyApproved, "Sellable: transfering contract ownership to proxy is not approved");        
+        require(newOwner != address(0), "Sellable: new owner is the zero address");
+        _reset(); // reset buyer and proxy values before transfering ownership
+        _setOwner(newOwner);
+    }
+
+    function _reset() private {
+        _sellingOwnershipApproved=false;
+        _proxyApproved=false;
+        _approvedProxy=address(0);
+        _approvedBuyer=address(0);
+     }    
+
+}

--- a/contracts/mocks/SellableMock.sol
+++ b/contracts/mocks/SellableMock.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../access/Sellable.sol";
+
+contract SellableMock is Sellable {}

--- a/test/access/Sellable.test.js
+++ b/test/access/Sellable.test.js
@@ -1,0 +1,204 @@
+const { constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { ZERO_ADDRESS } = constants;
+
+const { expect } = require('chai');
+
+const Sellable = artifacts.require('SellableMock');
+
+contract("Sellable", function (accounts) {
+	const [owner, buyer, proxy, peep] = accounts;
+  	const price = 10;
+  
+  beforeEach(async function () {
+    this.sellable = await Sellable.new({from:owner});
+  });
+
+  // no need to test for the Ownable because it's a pure copy paste
+
+  describe("Getters", function () {
+
+      it("Should allow anyone to see check if an address is the approved buyer", async function () {
+        // before approval
+        assert.equal(await this.sellable.isApprovedBuyer(buyer, {from:peep}),false);
+
+        // after approval
+        await this.sellable.approveSellingOwnership(buyer, price, {from:owner});
+        assert.equal(await this.sellable.isApprovedBuyer(peep, {from:peep}),false);
+        assert.equal(await this.sellable.isApprovedBuyer(buyer, {from:peep}),true);
+      });
+
+      it("Should allow only buyer or owner to get selling price", async function () {
+        // before approval
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:peep}),
+        	"Sender is not the approved buyer or owner"
+        	);
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:buyer}),
+        	"Sender is not the approved buyer or owner"
+        	);
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:owner}),
+        	"Buying contract is not approved"
+        	);
+
+        // after approval
+        await this.sellable.approveSellingOwnership(buyer, price,{from:owner});
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:peep}),
+        	"Sender is not the approved buyer or owner"
+        	);
+        let _price = Number((await this.sellable.getOwnershipSellingPrice({from:owner})).toString() );
+        assert.equal(_price,price);
+        _price = Number((await this.sellable.getOwnershipSellingPrice({from:buyer})).toString() );
+        assert.equal(_price,price);        
+
+        // after cancelling
+        await this.sellable.cancelSellingOwnership({from:owner});
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:peep}),
+        	"Sender is not the approved buyer or owner"
+        	);
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:buyer}),
+        	"Sender is not the approved buyer or owner"
+        	);
+        await expectRevert(
+        	this.sellable.getOwnershipSellingPrice({from:owner}),
+        	"Buying contract is not approved"
+        	);
+
+      }); 
+
+      it("Should allow anyone to see check if an address is the approved proxy", async function () {
+        // before approval
+        assert.equal(await this.sellable.isApprovedProxy(proxy, {from:peep}),false);
+
+        // after approval
+        await this.sellable.approveProxy(proxy,{from:owner});
+        assert.equal(await this.sellable.isApprovedProxy(peep, {from:peep}),false);
+        assert.equal(await this.sellable.isApprovedProxy(proxy, {from:peep}),true);
+      });
+
+  });
+
+
+  describe("Selling contract", function () {
+
+      it("Should allow the owner to approve a buyer with given price", async function () {
+        // before approval
+        await expectRevert(
+        	this.sellable.buyOwnership({from:buyer, value:price}),
+        	"Sender is not the approved buyer"
+        	);
+
+        // approval
+        await expectRevert(
+        	this.sellable.approveSellingOwnership(buyer,0,{from:owner}),
+        	"Sellable: price must be > 0"
+        	);
+        await expectRevert(
+        	this.sellable.approveSellingOwnership(owner,price,{from:owner}),
+        	"Sellable: approved buyer is the current owner"
+        	);
+        await this.sellable.approveSellingOwnership(buyer, price,{from:owner});
+
+        // after approval
+        await expectRevert(
+        	this.sellable.buyOwnership({from:peep, value:price}),
+        	"Sender is not the approved buyer"
+        	);
+        await expectRevert(
+        	this.sellable.buyOwnership({from:buyer, value:price+1}),
+        	"Selling price incorrect"
+        	);
+        let balance = Number(await web3.eth.getBalance(owner));        
+        await this.sellable.buyOwnership({from:buyer, value:price});
+        assert.equal(await this.sellable.owner(),buyer); // check the new owner
+        // check that the seller has received the price        
+        let newbalance = Number(await web3.eth.getBalance(owner));
+        assert.equal(newbalance, balance+price);
+
+      });
+
+      it("Should allow the owner to cancel a selling approval", async function () {
+        // approval
+        await this.sellable.approveSellingOwnership(buyer, price,{from:owner});
+        // cancelling
+        await this.sellable.cancelSellingOwnership({from:owner});
+        // after cancelling
+        await expectRevert(
+        	this.sellable.buyOwnership({from:buyer, value:price}),
+        	"Sender is not the approved buyer"
+        	);
+      }); 
+
+      it("Should allow the owner to approve a proxy", async function () {
+        // before approval
+        await expectRevert(
+        	this.sellable.proxyTransferOwnership(buyer,{from:peep}),
+        	"Sellable: sender is not the approved proxy"
+        	);
+
+        // approval
+        await this.sellable.approveProxy(proxy,{from:owner});
+
+        // after approval
+        await expectRevert(
+        	this.sellable.proxyTransferOwnership(buyer,{from:peep}),
+        	"Sellable: sender is not the approved proxy"
+        	);
+        await this.sellable.proxyTransferOwnership(buyer,{from:proxy});
+        assert.equal(await this.sellable.owner(),buyer);
+      });
+
+      it("Should allow the owner to cancel a proxy approval", async function () {
+        // approval
+        await this.sellable.approveProxy(proxy,{from:owner});
+        // cancelling
+        await this.sellable.cancelApproveProxy({from:owner});
+        // after cancelling
+        await expectRevert(
+        	this.sellable.proxyTransferOwnership(buyer,{from:proxy}),
+        	"Sellable: sender is not the approved proxy"
+        	);
+      });
+
+      it("Should disable the proxy approval after a sale", async function () {
+        await this.sellable.approveProxy(proxy,{from:owner});
+        // sale
+        await this.sellable.approveSellingOwnership(buyer, price,{from:owner});
+        await this.sellable.buyOwnership({from:buyer, value:price});
+        // after sale
+        await expectRevert(
+        	this.sellable.proxyTransferOwnership(peep,{from:proxy}),
+        	"Sellable: sender is not the approved proxy"
+        	);
+      }); 
+
+      it("Should disable the proxy approval after a proxy transfer", async function () {
+        await this.sellable.approveProxy(proxy,{from:owner});
+        // sale
+        await this.sellable.proxyTransferOwnership(buyer,{from:proxy});
+        // after transfer
+        await expectRevert(
+        	this.sellable.proxyTransferOwnership(peep,{from:proxy}),
+        	"Sellable: sender is not the approved proxy"
+        	);
+      }); 
+
+      it("Should disable the buying approval after a proxy transfer", async function () {
+        await this.sellable.approveProxy(proxy,{from:owner});
+        await this.sellable.approveSellingOwnership(buyer, price,{from:owner});
+        // sale by proxy to peep
+        await this.sellable.proxyTransferOwnership(peep,{from:proxy});
+        // after transfer, buyer should not be able to by contract
+        await expectRevert(
+        	this.sellable.buyOwnership({from:buyer, value:price}),
+        	"Sender is not the approved buyer"
+        	);
+      }); 
+
+  });
+});
+


### PR DESCRIPTION
**Sellable:**  an extension of Ownable module to make contract ownership sellable. The module has a copy paste of Ownable inside it*, then it defines new methods to :
- allow the owner to approve a buyer with given price
- allow an approved buyer to buy the contract (the eth. will go to the owner and the ownership will transfer)
- allow the owner to approve a trusted proxy to transfer the ownership of the contract (as it is done for tokens)
- allow an approved proxy to transfer the ownership of the contract (proxy can be marketplace sale contracts)

* I copy pasted Ownable instead of inheriting from it to be able to access its private method _setOwner, but the module will behave for users as if it had inherited from it.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? None
<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [v ] Tests
- [ v] Documentation
- [ ?] Changelog entry
