### PR TITLE
Delay the Pending state until strictly after proposal.voteStart

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -115,7 +115,8 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor {
             return ProposalState.Executed;
         } else if (proposal.canceled) {
             return ProposalState.Canceled;
-        } else if (proposal.voteStart.isPending()) {
+        } else if (proposal.voteStart.getDeadline() >= block.number) {
+            // prevent voting until voteStart is passed, so that getVotes never tries to get value for the current block.
             return ProposalState.Pending;
         } else if (proposal.voteEnd.isPending()) {
             return ProposalState.Active;

--- a/test/governance/Governor.test.js
+++ b/test/governance/Governor.test.js
@@ -559,6 +559,10 @@ contract('Governor', function (accounts) {
 
         await time.advanceBlockTo(this.snapshot);
 
+        expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Pending);
+
+        await time.advanceBlock();
+
         expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
       });
       runGovernorWorkflow();


### PR DESCRIPTION
Delay the Pending state until strictly after proposal.voteStart to avoid issue with potential invalid implementations of the voting token

Fixes #2886

#### PR Checklist
- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
