### PR TITLE
updated docs for governor votes, 0 is against not for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
- * `IGovernor`: Corrected documentation for what vote support stands for. 0 is against and 1 is for. 
+
  * `Ownable`: add an internal `_transferOwnership(address)`. ([#2568](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/#2568))
  * `AccessControl`: add internal `_grantRole(bytes32,address)` and `_revokeRole(bytes32,address)`. ([#2568](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/#2568))
  * `AccessControl`: mark `_setupRole(bytes32,address)` as deprecated in favor of `_grantRole(bytes32,address)`. ([#2568](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/#2568))
@@ -308,11 +308,11 @@ For example, a contract using `GSNBouncerSignature` would have to be changed in 
 
 Refer to the table below to adjust your inheritance list.
 
-| 2.4.0-beta                          | 2.4.0                   |
-| ----------------------------------- | ----------------------- |
-| `GSNRecipient, GSNBouncerSignature` | `GSNRecipientSignature` |
-| `GSNRecipient, GSNBouncerERC20Fee`  | `GSNRecipientERC20Fee`  |
-| `GSNBouncerBase`                    | `GSNRecipient`          |
+| 2.4.0-beta                         | 2.4.0                        |
+| ---------------------------------- | ---------------------------- |
+| `GSNRecipient, GSNBouncerSignature`| `GSNRecipientSignature`      |
+| `GSNRecipient, GSNBouncerERC20Fee` | `GSNRecipientERC20Fee`       |
+| `GSNBouncerBase`                   | `GSNRecipient`               |
 
 ## 2.3.0 (2019-05-27)
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

The docs were outdated. Took me a few hours to find out what was going wrong. In both the compound and oz versions of counting votes, 0 is against, but in the docs, it said 0 was for. 

Examples:
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/56d4063e928d963a96e376f2dc71831cfecf5214/contracts/governance/IGovernor.sol#L76

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/56d4063e928d963a96e376f2dc71831cfecf5214/contracts/governance/compatibility/GovernorCompatibilityBravo.sol#L31

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x ] Tests
- [x ] Documentation
- [x ] Changelog entry
