### PR TITLE
Improve docs wording on constructors and proxies

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 
 /**
  * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
- * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * behind a proxy. Since proxied contracts do not make use of a constructor, it's common to move constructor logic to an
  * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
  * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
  *


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/445 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

> _Since **a proxied contract can't have a constructor**, it's common to move constructor logic to an
> external initializer function, usually called initialize._

As outlined in the issue, proxied contract(s) retain their natural ability to utilize a constructor.
The current formulation negates this language level constant, namely, that all contracts can have a constructor.
  
**Replaced with:**

>  Since **proxied contracts do not make use of a constructor**, it's common to move constructor logic to an
>  external initializer function, usually called `initialize`.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
