### PR TITLE
Add Tally link on docs

### DIFF
--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -28,7 +28,7 @@ When using a timelock with your Governor contract, you can use either OpenZeppel
 
 === Tally
 
-Tally is a full-fledged application for user owned on-chain governance. It comprises a voting dashboard, proposal creation wizard, real time research and analysis, and educational content.
+https://www.withtally.com[Tally] is a full-fledged application for user owned on-chain governance. It comprises a voting dashboard, proposal creation wizard, real time research and analysis, and educational content.
 
 For all of these options, the Governor will be compatible with Tally: users will be able to create proposals, visualize voting power and advocates, navigate proposals, and cast votes. For proposal creation in particular, projects can also use Defender Admin as an alternative interface.
 


### PR DESCRIPTION
Tally is simply namedropped but heavily referenced in the following sections, a link to the right site can be very useful given the large amount of companies and projects with 'tally' in their name.