### PR TITLE
[5.0.0 Breaking change] Using user defined value type for timers

### DIFF
--- a/contracts/mocks/TimersBlockNumberImpl.sol
+++ b/contracts/mocks/TimersBlockNumberImpl.sol
@@ -5,20 +5,21 @@ pragma solidity ^0.8.0;
 import "../utils/Timers.sol";
 
 contract TimersBlockNumberImpl {
+    using Timers for uint64;
     using Timers for Timers.BlockNumber;
 
     Timers.BlockNumber private _timer;
 
     function getDeadline() public view returns (uint64) {
-        return _timer.getDeadline();
+        return _timer.toUint64();
     }
 
     function setDeadline(uint64 timestamp) public {
-        _timer.setDeadline(timestamp);
+        _timer = timestamp.toBlockNumber();
     }
 
     function reset() public {
-        _timer.reset();
+        _timer = uint64(0).toBlockNumber();
     }
 
     function isUnset() public view returns (bool) {

--- a/contracts/mocks/TimersTimestampImpl.sol
+++ b/contracts/mocks/TimersTimestampImpl.sol
@@ -5,20 +5,21 @@ pragma solidity ^0.8.0;
 import "../utils/Timers.sol";
 
 contract TimersTimestampImpl {
+    using Timers for uint64;
     using Timers for Timers.Timestamp;
 
     Timers.Timestamp private _timer;
 
     function getDeadline() public view returns (uint64) {
-        return _timer.getDeadline();
+        return _timer.toUint64();
     }
 
     function setDeadline(uint64 timestamp) public {
-        _timer.setDeadline(timestamp);
+        _timer = timestamp.toTimestamp();
     }
 
     function reset() public {
-        _timer.reset();
+        _timer = uint64(0).toTimestamp();
     }
 
     function isUnset() public view returns (bool) {

--- a/contracts/utils/Timers.sol
+++ b/contracts/utils/Timers.sol
@@ -7,8 +7,50 @@ pragma solidity ^0.8.8;
  * @dev Tooling for timepoints, timers and delays
  */
 library Timers {
+    enum Type { TIMESTAMP, BLOCKNUMBER }
+
+    type Timer is uint64;
+
+    function toTimer(uint64 timer, Type typeSelector) internal pure returns (Timer) {
+        require(timer >> 63 == 0, 'Timer only support 63 bits values');
+        return Timer.wrap(uint8(typeSelector) << 63 | timer);
+    }
+
+    function getType(Timer timer) internal pure returns (Type) {
+        return Type(Timer.unwrap(timer) >> 63);
+    }
+
+    function getValue(Timer timer) internal pure returns (uint64) {
+        return Timer.unwrap(timer) & (type(uint64).max >> 1);
+    }
+
+    function isUnset(Timer timer) internal pure returns (bool) {
+        return getValue(timer) == 0;
+    }
+
+    function isStarted(Timer timer) internal pure returns (bool) {
+        return getValue(timer) > 0;
+    }
+
+    function isPending(Timer timer) internal view returns (bool) {
+        return getType(timer) == Type.TIMESTAMP
+            ? getValue(timer) > block.timestamp
+            : getValue(timer) > block.number;
+    }
+
+    function isExpired(Timer timer) internal view returns (bool) {
+        return isStarted(timer) && !isPending(timer);
+    }
+
+    function unset() internal pure returns (Timer) {
+        return Timer.wrap(0);
+    }
+
+    function never() internal pure returns (Timer) {
+        return Timer.wrap(type(uint64).max);
+    }
+
     type Timestamp is uint64;
-    type BlockNumber is uint64;
 
     function toTimestamp(uint64 timer) internal pure returns (Timestamp) {
         return Timestamp.wrap(timer);
@@ -33,6 +75,8 @@ library Timers {
     function isExpired(Timestamp timer) internal view returns (bool) {
         return isStarted(timer) && Timestamp.unwrap(timer) <= block.timestamp;
     }
+
+    type BlockNumber is uint64;
 
     function toBlockNumber(uint64 timer) internal pure returns (BlockNumber) {
         return BlockNumber.wrap(timer);

--- a/contracts/utils/Timers.sol
+++ b/contracts/utils/Timers.sol
@@ -1,73 +1,60 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.3.2 (utils/Timers.sol)
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 
 /**
  * @dev Tooling for timepoints, timers and delays
  */
 library Timers {
-    struct Timestamp {
-        uint64 _deadline;
+    type Timestamp is uint64;
+    type BlockNumber is uint64;
+
+    function toTimestamp(uint64 timer) internal pure returns (Timestamp) {
+        return Timestamp.wrap(timer);
     }
 
-    function getDeadline(Timestamp memory timer) internal pure returns (uint64) {
-        return timer._deadline;
+    function toUint64(Timestamp timer) internal pure returns (uint64) {
+        return Timestamp.unwrap(timer);
     }
 
-    function setDeadline(Timestamp storage timer, uint64 timestamp) internal {
-        timer._deadline = timestamp;
+    function isUnset(Timestamp timer) internal pure returns (bool) {
+        return Timestamp.unwrap(timer) == 0;
     }
 
-    function reset(Timestamp storage timer) internal {
-        timer._deadline = 0;
+    function isStarted(Timestamp timer) internal pure returns (bool) {
+        return Timestamp.unwrap(timer) > 0;
     }
 
-    function isUnset(Timestamp memory timer) internal pure returns (bool) {
-        return timer._deadline == 0;
+    function isPending(Timestamp timer) internal view returns (bool) {
+        return Timestamp.unwrap(timer) > block.timestamp;
     }
 
-    function isStarted(Timestamp memory timer) internal pure returns (bool) {
-        return timer._deadline > 0;
+    function isExpired(Timestamp timer) internal view returns (bool) {
+        return isStarted(timer) && Timestamp.unwrap(timer) <= block.timestamp;
     }
 
-    function isPending(Timestamp memory timer) internal view returns (bool) {
-        return timer._deadline > block.timestamp;
+    function toBlockNumber(uint64 timer) internal pure returns (BlockNumber) {
+        return BlockNumber.wrap(timer);
     }
 
-    function isExpired(Timestamp memory timer) internal view returns (bool) {
-        return isStarted(timer) && timer._deadline <= block.timestamp;
+    function toUint64(BlockNumber timer) internal pure returns (uint64) {
+        return BlockNumber.unwrap(timer);
     }
 
-    struct BlockNumber {
-        uint64 _deadline;
+    function isUnset(BlockNumber timer) internal pure returns (bool) {
+        return BlockNumber.unwrap(timer) == 0;
     }
 
-    function getDeadline(BlockNumber memory timer) internal pure returns (uint64) {
-        return timer._deadline;
+    function isStarted(BlockNumber timer) internal pure returns (bool) {
+        return BlockNumber.unwrap(timer) > 0;
     }
 
-    function setDeadline(BlockNumber storage timer, uint64 timestamp) internal {
-        timer._deadline = timestamp;
+    function isPending(BlockNumber timer) internal view returns (bool) {
+        return BlockNumber.unwrap(timer) > block.number;
     }
 
-    function reset(BlockNumber storage timer) internal {
-        timer._deadline = 0;
-    }
-
-    function isUnset(BlockNumber memory timer) internal pure returns (bool) {
-        return timer._deadline == 0;
-    }
-
-    function isStarted(BlockNumber memory timer) internal pure returns (bool) {
-        return timer._deadline > 0;
-    }
-
-    function isPending(BlockNumber memory timer) internal view returns (bool) {
-        return timer._deadline > block.number;
-    }
-
-    function isExpired(BlockNumber memory timer) internal view returns (bool) {
-        return isStarted(timer) && timer._deadline <= block.number;
+    function isExpired(BlockNumber timer) internal view returns (bool) {
+        return isStarted(timer) && BlockNumber.unwrap(timer) <= block.number;
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,7 +3,7 @@
 // - COVERAGE:          enable coverage report
 // - ENABLE_GAS_REPORT: enable gas report
 // - COMPILE_MODE:      production modes enables optimizations (default: development)
-// - COMPILE_VERSION:   compiler version (default: 0.8.3)
+// - COMPILE_VERSION:   compiler version (default: 0.8.9)
 // - COINMARKETCAP:     coinmarkercat api key for USD value in gas report
 
 const fs = require('fs');
@@ -33,7 +33,7 @@ const argv = require('yargs/yargs')()
     compiler: {
       alias: 'compileVersion',
       type: 'string',
-      default: '0.8.3',
+      default: '0.8.9',
     },
     coinmarketcap: {
       alias: 'coinmarketcapApiKey',


### PR DESCRIPTION
The structures used in the timers library prevent storage packing (in particular, this affects Governor's Proposals).

This has to effect that makes it a breaking change:

- Storage incompatibility (data is now packed) in the Governor contract.
- New timers being "value type", makes it impossible to write "setDeadline" and "reset" methods.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
