### PR TITLE
Deprecate presets in favor of Wizard

### DIFF
--- a/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
+++ b/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
@@ -22,6 +22,8 @@ import "../../../utils/Context.sol";
  * The account that deploys the contract will be granted the minter and pauser
  * roles, as well as the default admin role, which will let it grant both minter
  * and pauser roles to other accounts.
+ *
+ * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC1155PresetMinterPauser is Context, AccessControlEnumerable, ERC1155Burnable, ERC1155Pausable {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");

--- a/contracts/token/ERC1155/presets/README.md
+++ b/contracts/token/ERC1155/presets/README.md
@@ -1,0 +1,1 @@
+Contract presets are now deprecated in favor of [Contracts Wizard](https://wizard.openzeppelin.com/) as a more powerful alternative.

--- a/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol
+++ b/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol
@@ -15,6 +15,8 @@ import "../extensions/ERC20Burnable.sol";
  * its documentation for details.
  *
  * _Available since v3.4._
+ *
+ * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC20PresetFixedSupply is ERC20Burnable {
     /**

--- a/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol
@@ -22,6 +22,8 @@ import "../../../utils/Context.sol";
  * The account that deploys the contract will be granted the minter and pauser
  * roles, as well as the default admin role, which will let it grant both minter
  * and pauser roles to other accounts.
+ *
+ * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC20PresetMinterPauser is Context, AccessControlEnumerable, ERC20Burnable, ERC20Pausable {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");

--- a/contracts/token/ERC20/presets/README.md
+++ b/contracts/token/ERC20/presets/README.md
@@ -1,0 +1,1 @@
+Contract presets are now deprecated in favor of [Contracts Wizard](https://wizard.openzeppelin.com/) as a more powerful alternative.

--- a/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol
@@ -25,6 +25,8 @@ import "../../../utils/Counters.sol";
  * The account that deploys the contract will be granted the minter and pauser
  * roles, as well as the default admin role, which will let it grant both minter
  * and pauser roles to other accounts.
+ *
+ * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC721PresetMinterPauserAutoId is
     Context,

--- a/contracts/token/ERC721/presets/README.md
+++ b/contracts/token/ERC721/presets/README.md
@@ -1,0 +1,1 @@
+Contract presets are now deprecated in favor of [Contracts Wizard](https://wizard.openzeppelin.com/) as a more powerful alternative.


### PR DESCRIPTION
By now Contracts Wizard has proved itself as a much better alternative to the preset contracts, so I think we can deprecate them. I didn't deprecate the single ERC777 preset we have because Wizard doesn't support that ERC.