### PR TITLE
Address: explain dangers of isContract

### DIFF
--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -15,6 +15,12 @@ library Address {
      * It is unsafe to assume that an address for which this function returns
      * false is an externally-owned account (EOA) and not a contract.
      *
+     * **You cannot rely on `isContract` to protect against flash loan attacks!**
+     * Using `isContract` to intentionally prevent calls from contracts should be avoided, as it:
+     * 1) breaks composability
+     * 2) breaks support for smart wallets like Gnosis Safe where every user is a contract
+     * 3) can be circumvented by calling from a contract constructor
+     *
      * Among others, `isContract` will return false for the following
      * types of addresses:
      *


### PR DESCRIPTION
This explains in detail why `isContract` should be avoided a security check.

I've been seeing  more and more teams in crypto implement checks that depend on `isContract` to guard against flash loan attacks, reentrancies, among other things

Obviously this breaks composability and completely breaks support for smart wallets like Gnosis Safe, Argent, Ambire and others.

I believe the direct way in this is written is necessary, because figuring out that you should NOT do this from the current disclaimer requires some thought. Seeing that this is becoming a pattern (pppular projects like Anyswap do this and say it protects them from flashloans), I think stating it directly is the best way to go. 