### PR TITLE
Improve the calculation speed of function ceilDiv in library Math

### DIFF
--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -38,7 +38,7 @@ library Math {
      */
     function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
         // (a + b - 1) / b can overflow on addition, so we distribute.
-        return a / b + (a % b == 0 ? 0 : 1);
+        return (a > 0) ? ((a - 1) / b + 1): 0;
     }
 
     /**


### PR DESCRIPTION
`(a > 0) ? ((a - 1) / b + 1) : 0` should be faster than `a / b + (a % b == 0 ? 0 : 1)` because of not use `a % b`