### PR TITLE
Replace excodesize assembly with address.code.length 

### DIFF
--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -25,15 +25,11 @@ library Address {
      * ====
      */
     function isContract(address account) internal view returns (bool) {
-        // This method relies on extcodesize, which returns 0 for contracts in
-        // construction, since the code is only stored at the end of the
-        // constructor execution.
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
 
-        uint256 size;
-        assembly {
-            size := extcodesize(account)
-        }
-        return size > 0;
+        return account.code.length > 0;
     }
 
     /**


### PR DESCRIPTION
According to https://github.com/ethereum/solidity/releases/tag/v0.8.1:

> #### Compiler Features:
> - Code Generator: Reduce the cost of \<address\>.code.length by using extcodesize directly.

Kudos to this tweet: https://twitter.com/transmissions11/status/1470943473335341059

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
