### PR TITLE
[Discussion] ERC20 accounting library (increase library flexibility)

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -91,14 +91,14 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * @dev See {IERC20-totalSupply}.
      */
     function totalSupply() public view virtual override returns (uint256) {
-        return _data.totalSupply();
+        return _data.totalSupply(_callbacks());
     }
 
     /**
      * @dev See {IERC20-balanceOf}.
      */
     function balanceOf(address account) public view virtual override returns (uint256) {
-        return _data.balanceOf(account);
+        return _data.balanceOf(account, _callbacks());
     }
 
     /**
@@ -110,14 +110,14 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - the caller must have a balance of at least `amount`.
      */
     function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
-        return _data.transfer(_msgSender(), recipient, amount, _beforeTokenTransfer, _afterTokenTransfer);
+        return _data.transfer(_msgSender(), recipient, amount, _callbacks());
     }
 
     /**
      * @dev See {IERC20-allowance}.
      */
     function allowance(address owner, address spender) public view virtual override returns (uint256) {
-        return _data.allowance(owner, spender);
+        return _data.allowance(owner, spender, _callbacks());
     }
 
     /**
@@ -128,7 +128,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - `spender` cannot be the zero address.
      */
     function approve(address spender, uint256 amount) public virtual override returns (bool) {
-        return _data.approve(_msgSender(), spender, amount, _beforeTokenApproval, _afterTokenApproval);
+        return _data.approve(_msgSender(), spender, amount, _callbacks());
     }
 
     /**
@@ -154,10 +154,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
             sender,
             recipient,
             amount,
-            _beforeTokenTransfer,
-            _afterTokenTransfer,
-            _beforeTokenApproval,
-            _afterTokenApproval
+            _callbacks()
         );
     }
 
@@ -174,7 +171,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - `spender` cannot be the zero address.
      */
     function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
-        return _data.increaseAllowance(_msgSender(), spender, addedValue, _beforeTokenApproval, _afterTokenApproval);
+        return _data.increaseAllowance(_msgSender(), spender, addedValue, _callbacks());
     }
 
     /**
@@ -192,7 +189,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        return _data.decreaseAllowance(_msgSender(), spender, subtractedValue, _beforeTokenApproval, _afterTokenApproval);
+        return _data.decreaseAllowance(_msgSender(), spender, subtractedValue, _callbacks());
     }
 
     /**
@@ -214,7 +211,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         address recipient,
         uint256 amount
     ) internal virtual {
-        _data._transfer(sender, recipient, amount, _beforeTokenTransfer, _afterTokenTransfer);
+        _data._transfer(sender, recipient, amount, _callbacks());
     }
 
     /** @dev Creates `amount` tokens and assigns them to `account`, increasing
@@ -227,7 +224,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - `account` cannot be the zero address.
      */
     function _mint(address account, uint256 amount) internal virtual {
-        _data._mint(account, amount, _beforeTokenTransfer, _afterTokenTransfer);
+        _data._mint(account, amount, _callbacks());
     }
 
     /**
@@ -242,7 +239,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - `account` must have at least `amount` tokens.
      */
     function _burn(address account, uint256 amount) internal virtual {
-        _data._burn(account, amount, _beforeTokenTransfer, _afterTokenTransfer);
+        _data._burn(account, amount, _callbacks());
     }
 
     /**
@@ -259,7 +256,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - `spender` cannot be the zero address.
      */
     function _approve(address owner, address spender, uint256 amount) internal virtual {
-        _data._approve(owner, spender, amount, _beforeTokenApproval, _afterTokenApproval);
+        _data._approve(owner, spender, amount, _callbacks());
     }
 
     /**
@@ -304,17 +301,48 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         emit Transfer(from, to, amount);
     }
 
-    function _beforeTokenApproval(
-        address owner,
-        address spender,
-        uint256 amount
-    ) internal virtual {}
+    function _beforeTokenApproval(address owner, address spender, uint256 amount) private {}
 
-    function _afterTokenApproval(
-        address owner,
-        address spender,
-        uint256 amount
-    ) internal virtual {
+    function _afterTokenApproval(address owner, address spender, uint256 amount) private {
         emit Approval(owner, spender, amount);
+    }
+
+    function _getTotalSupply(uint256 totalSupply_) private pure returns (uint256) {
+        return totalSupply_;
+    }
+
+    function _setTotalSupply(uint256 totalSupply_) private pure returns (uint256) {
+        return totalSupply_;
+    }
+
+    function _getBalance(address /* account */, uint256 balance) private pure returns (uint256) {
+        return balance;
+    }
+
+    function _setBalance(address /* account */, uint256 balance) private pure returns (uint256) {
+        return balance;
+    }
+
+    function _getAllowance(address /* owner */, address /* spender */, uint256 amount) private pure returns (uint256) {
+        return amount;
+    }
+
+    function _setAllowance(address /* owner */, address /* spender */, uint256 amount) private pure returns (uint256) {
+        return amount;
+    }
+
+    function _callbacks() private pure returns (ERC20Accounting.Callbacks memory) {
+        return ERC20Accounting.Callbacks({
+            getTotalSupply: _getTotalSupply,
+            setTotalSupply: _setTotalSupply,
+            getBalance: _getBalance,
+            setBalance: _setBalance,
+            getAllowance: _getAllowance,
+            setAllowance: _setAllowance,
+            beforeTokenApproval: _beforeTokenApproval,
+            afterTokenApproval: _afterTokenApproval,
+            beforeTokenTransfer: _beforeTokenTransfer,
+            afterTokenTransfer: _afterTokenTransfer
+        });
     }
 }

--- a/contracts/token/ERC20/ERC20Accounting.sol
+++ b/contracts/token/ERC20/ERC20Accounting.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (token/ERC20/ERC20.sol)
+
+pragma solidity ^0.8.0;
+
+import "./IERC20.sol";
+import "./extensions/IERC20Metadata.sol";
+import "../../utils/Context.sol";
+
+library ERC20Accounting {
+    struct Data {
+        mapping(address => uint256) _balances;
+        mapping(address => mapping(address => uint256)) _allowances;
+        uint256 _totalSupply;
+    }
+
+    function totalSupply(Data storage self) internal view returns (uint256) {
+        return self._totalSupply;
+    }
+
+    function balanceOf(Data storage self, address account) internal view returns (uint256) {
+        return self._balances[account];
+    }
+
+    function transfer(
+        Data storage self,
+        address msgSender,
+        address recipient,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenTransfer,
+        function(address,address,uint256) internal _afterTokenTransfer
+    ) internal returns (bool) {
+        _transfer(self, msgSender, recipient, amount, _beforeTokenTransfer, _afterTokenTransfer);
+        return true;
+    }
+
+    function allowance(Data storage self, address owner, address spender) internal view returns (uint256) {
+        return self._allowances[owner][spender];
+    }
+
+    function approve(
+        Data storage self,
+        address msgSender,
+        address spender,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenApproval,
+        function(address,address,uint256) internal _afterTokenApproval
+    ) internal returns (bool) {
+        _approve(self, msgSender, spender, amount, _beforeTokenApproval, _afterTokenApproval);
+        return true;
+    }
+
+    function transferFrom(
+        Data storage self,
+        address msgSender,
+        address sender,
+        address recipient,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenTransfer,
+        function(address,address,uint256) internal _afterTokenTransfer,
+        function(address,address,uint256) internal _beforeTokenApproval,
+        function(address,address,uint256) internal _afterTokenApproval
+    ) internal returns (bool) {
+        _transfer(self, sender, recipient, amount, _beforeTokenTransfer, _afterTokenTransfer);
+
+        uint256 currentAllowance = self._allowances[sender][msgSender];
+        require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+        unchecked {
+            _approve(self, sender, msgSender, currentAllowance - amount, _beforeTokenApproval, _afterTokenApproval);
+        }
+
+        return true;
+    }
+
+    function increaseAllowance(
+        Data storage self,
+        address msgSender,
+        address spender,
+        uint256 addedValue,
+        function(address,address,uint256) internal _beforeTokenApproval,
+        function(address,address,uint256) internal _afterTokenApproval
+    ) internal returns (bool) {
+        _approve(self, msgSender, spender, self._allowances[msgSender][spender] + addedValue, _beforeTokenApproval, _afterTokenApproval);
+        return true;
+    }
+
+    function decreaseAllowance(
+        Data storage self,
+        address msgSender,
+        address spender,
+        uint256 subtractedValue,
+        function(address,address,uint256) internal _beforeTokenApproval,
+        function(address,address,uint256) internal _afterTokenApproval
+    ) internal returns (bool) {
+        uint256 currentAllowance = self._allowances[msgSender][spender];
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        unchecked {
+            _approve(self, msgSender, spender, currentAllowance - subtractedValue, _beforeTokenApproval, _afterTokenApproval);
+        }
+
+        return true;
+    }
+
+    function _transfer(
+        Data storage self,
+        address sender,
+        address recipient,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenTransfer,
+        function(address,address,uint256) internal _afterTokenTransfer
+    ) internal {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        uint256 senderBalance = self._balances[sender];
+        require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
+        unchecked {
+            self._balances[sender] = senderBalance - amount;
+        }
+        self._balances[recipient] += amount;
+
+        _afterTokenTransfer(sender, recipient, amount);
+    }
+
+    function _mint(
+        Data storage self,
+        address account,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenTransfer,
+        function(address,address,uint256) internal _afterTokenTransfer
+    ) internal {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        self._totalSupply += amount;
+        self._balances[account] += amount;
+
+        _afterTokenTransfer(address(0), account, amount);
+    }
+
+    function _burn(
+        Data storage self,
+        address account,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenTransfer,
+        function(address,address,uint256) internal _afterTokenTransfer
+    ) internal {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        uint256 accountBalance = self._balances[account];
+        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
+        unchecked {
+            self._balances[account] = accountBalance - amount;
+        }
+        self._totalSupply -= amount;
+
+        _afterTokenTransfer(account, address(0), amount);
+    }
+
+    function _approve(
+        Data storage self,
+        address owner,
+        address spender,
+        uint256 amount,
+        function(address,address,uint256) internal _beforeTokenApproval,
+        function(address,address,uint256) internal _afterTokenApproval
+    ) internal {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _beforeTokenApproval(owner, spender, amount);
+
+        self._allowances[owner][spender] = amount;
+
+        _afterTokenApproval(owner, spender, amount);
+    }
+}


### PR DESCRIPTION
Demo only, to demonstrate idea I came up to after this: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3003 :)

This approach would allow having multiple ERC20 accountings in a single contract if needed. Moreover, this ERC20Accounting library allows to patch `totalSupply`, `balances` and `allowances` on the flight (before and after storage) to store additional bits in the existing slots.