### PR TITLE
Fix issue #3050

### DIFF
--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -60,7 +60,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
      */
-    function admin() external ifAdmin returns (address admin_) {
+    function admin() external view ifAdmin returns (address admin_) {
         admin_ = _getAdmin();
     }
 
@@ -73,7 +73,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function implementation() external ifAdmin returns (address implementation_) {
+    function implementation() external view ifAdmin returns (address implementation_) {
         implementation_ = _implementation();
     }
 


### PR DESCRIPTION
Fixes #3050 

Adds the view keyword in the functions admin() and implementation() so that they appear under "Read Contract" instead of "Write Contract" in etherscan, as these functions simply return addresses.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
