### PR TITLE
Reduce ERC20 allowance before triggering transfer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Preset contracts are now deprecated in favor of [Contracts Wizard](https://wizard.openzeppelin.com). ([#2986](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2986))
  * `Governor`: add a relay function to help recover assets sent to a governor that is not its own executor (e.g. when using a timelock). ([#2926](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2926))
  * `GovernorExtendedVoting`: add new module to ensure a minimum voting duration is available after the quorum is reached. ([#2973](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2973))
+ * `ERC20`: reduce allowance before triggering transfer.
 
 ## 4.4.0 (2021-11-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
 ## Unreleased
- * `GovernorExtendedVoting`: add new module to ensure a minimum voting duration is available after the quorum is reached. ([#2973](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2973))
-
-## Unreleased
 
 * `GovernorTimelockControl`: improve the `state()` function to have it reflect cases where a proposal has been canceled directly on the timelock. ([#2977](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2977))
 * `Math`: add a `abs(int256)` method that returns the unsigned absolute value of a signed value. ([#2984](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2984))
 * Preset contracts are now deprecated in favor of [Contracts Wizard](https://wizard.openzeppelin.com). ([#2986](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2986))
  * `Governor`: add a relay function to help recover assets sent to a governor that is not its own executor (e.g. when using a timelock). ([#2926](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2926))
+ * `GovernorExtendedVoting`: add new module to ensure a minimum voting duration is available after the quorum is reached. ([#2973](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2973))
 
 ## 4.4.0 (2021-11-25)
 

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -152,13 +152,13 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         address recipient,
         uint256 amount
     ) public virtual override returns (bool) {
-        _transfer(sender, recipient, amount);
-
         uint256 currentAllowance = _allowances[sender][_msgSender()];
         require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
         unchecked {
             _approve(sender, _msgSender(), currentAllowance - amount);
         }
+
+        _transfer(sender, recipient, amount);
 
         return true;
     }

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -287,11 +287,11 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         _callTokensToSend(spender, holder, recipient, amount, "", "");
 
-        _move(spender, holder, recipient, amount, "", "");
-
         uint256 currentAllowance = _allowances[holder][spender];
         require(currentAllowance >= amount, "ERC777: transfer amount exceeds allowance");
         _approve(holder, spender, currentAllowance - amount);
+
+        _move(spender, holder, recipient, amount, "", "");
 
         _callTokensReceived(spender, holder, recipient, amount, "", "", false);
 

--- a/docs/modules/ROOT/pages/erc20-supply.adoc
+++ b/docs/modules/ROOT/pages/erc20-supply.adoc
@@ -4,7 +4,7 @@ In this guide you will learn how to create an ERC20 token with a custom supply m
 
 The standard interface implemented by tokens built on Ethereum is called ERC20, and Contracts includes a widely used implementation of it: the aptly named xref:api:token/ERC20.adoc[`ERC20`] contract. This contract, like the standard itself, is quite simple and bare-bones. In fact, if you try to deploy an instance of `ERC20` as-is it will be quite literally useless... it will have no supply! What use is a token with no supply?
 
-The way that supply is created is not defined in the ERC20 document. Every token is free to experiment with their own mechanisms, ranging from the most decentralized to the most centralized, from the most naive to the most researched, and more.
+The way that supply is created is not defined in the ERC20 document. Every token is free to experiment with its own mechanisms, ranging from the most decentralized to the most centralized, from the most naive to the most researched, and more.
 
 [[fixed-supply]]
 == Fixed Supply

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -63,23 +63,19 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
             });
 
             it('emits a transfer event', async function () {
-              const { logs } = await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
-
-              expectEvent.inLogs(logs, 'Transfer', {
-                from: tokenOwner,
-                to: to,
-                value: amount,
-              });
+              expectEvent(
+                await this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
+                'Transfer',
+                { from: tokenOwner, to: to, value: amount },
+              );
             });
 
             it('emits an approval event', async function () {
-              const { logs } = await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
-
-              expectEvent.inLogs(logs, 'Approval', {
-                owner: tokenOwner,
-                spender: spender,
-                value: await this.token.allowance(tokenOwner, spender),
-              });
+              expectEvent(
+                await this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
+                'Approval',
+                { owner: tokenOwner, spender: spender, value: await this.token.allowance(tokenOwner, spender) },
+              );
             });
           });
 
@@ -158,7 +154,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
       it('reverts', async function () {
         await expectRevert(
           this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-          `from the zero address`,
+          `${errorPrefix}: approve from the zero address`,
         );
       });
     });
@@ -197,13 +193,11 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
       });
 
       it('emits a transfer event', async function () {
-        const { logs } = await transfer.call(this, from, to, amount);
-
-        expectEvent.inLogs(logs, 'Transfer', {
-          from,
-          to,
-          value: amount,
-        });
+        expectEvent(
+          await transfer.call(this, from, to, amount),
+          'Transfer',
+          { from, to, value: amount },
+        );
       });
     });
 
@@ -219,13 +213,11 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
       });
 
       it('emits a transfer event', async function () {
-        const { logs } = await transfer.call(this, from, to, amount);
-
-        expectEvent.inLogs(logs, 'Transfer', {
-          from,
-          to,
-          value: amount,
-        });
+        expectEvent(
+          await transfer.call(this, from, to, amount),
+          'Transfer',
+          { from, to, value: amount },
+        );
       });
     });
   });
@@ -245,13 +237,11 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
       const amount = supply;
 
       it('emits an approval event', async function () {
-        const { logs } = await approve.call(this, owner, spender, amount);
-
-        expectEvent.inLogs(logs, 'Approval', {
-          owner: owner,
-          spender: spender,
-          value: amount,
-        });
+        expectEvent(
+          await approve.call(this, owner, spender, amount),
+          'Approval',
+          { owner: owner, spender: spender, value: amount },
+        );
       });
 
       describe('when there was no approved amount before', function () {
@@ -279,13 +269,11 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
       const amount = supply.addn(1);
 
       it('emits an approval event', async function () {
-        const { logs } = await approve.call(this, owner, spender, amount);
-
-        expectEvent.inLogs(logs, 'Approval', {
-          owner: owner,
-          spender: spender,
-          value: amount,
-        });
+        expectEvent(
+          await approve.call(this, owner, spender, amount),
+          'Approval',
+          { owner: owner, spender: spender, value: amount },
+        );
       });
 
       describe('when there was no approved amount before', function () {

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -158,7 +158,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
       it('reverts', async function () {
         await expectRevert(
           this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-          `${errorPrefix}: approve from the zero address`,
+          `from the zero address`,
         );
       });
     });

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -154,7 +154,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
       it('reverts', async function () {
         await expectRevert(
           this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-          `${errorPrefix}: approve from the zero address`,
+          'from the zero address',
         );
       });
     });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -63,17 +63,15 @@ contract('ERC20', function (accounts) {
           const approvedAmount = amount;
 
           beforeEach(async function () {
-            ({ logs: this.logs } = await this.token.approve(spender, approvedAmount, { from: initialHolder }));
+            await this.token.approve(spender, approvedAmount, { from: initialHolder });
           });
 
           it('emits an approval event', async function () {
-            const { logs } = await this.token.decreaseAllowance(spender, approvedAmount, { from: initialHolder });
-
-            expectEvent.inLogs(logs, 'Approval', {
-              owner: initialHolder,
-              spender: spender,
-              value: new BN(0),
-            });
+            expectEvent(
+              await this.token.decreaseAllowance(spender, approvedAmount, { from: initialHolder }),
+              'Approval',
+              { owner: initialHolder, spender: spender, value: new BN(0) },
+            );
           });
 
           it('decreases the spender allowance subtracting the requested amount', async function () {
@@ -129,13 +127,11 @@ contract('ERC20', function (accounts) {
 
       describe('when the sender has enough balance', function () {
         it('emits an approval event', async function () {
-          const { logs } = await this.token.increaseAllowance(spender, amount, { from: initialHolder });
-
-          expectEvent.inLogs(logs, 'Approval', {
-            owner: initialHolder,
-            spender: spender,
-            value: amount,
-          });
+          expectEvent(
+            await this.token.increaseAllowance(spender, amount, { from: initialHolder }),
+            'Approval',
+            { owner: initialHolder, spender: spender, value: amount },
+          );
         });
 
         describe('when there was no approved amount before', function () {
@@ -163,13 +159,11 @@ contract('ERC20', function (accounts) {
         const amount = initialSupply.addn(1);
 
         it('emits an approval event', async function () {
-          const { logs } = await this.token.increaseAllowance(spender, amount, { from: initialHolder });
-
-          expectEvent.inLogs(logs, 'Approval', {
-            owner: initialHolder,
-            spender: spender,
-            value: amount,
-          });
+          expectEvent(
+            await this.token.increaseAllowance(spender, amount, { from: initialHolder }),
+            'Approval',
+            { owner: initialHolder, spender: spender, value: amount },
+          );
         });
 
         describe('when there was no approved amount before', function () {
@@ -215,8 +209,7 @@ contract('ERC20', function (accounts) {
 
     describe('for a non zero account', function () {
       beforeEach('minting', async function () {
-        const { logs } = await this.token.mint(recipient, amount);
-        this.logs = logs;
+        this.receipt = await this.token.mint(recipient, amount);
       });
 
       it('increments totalSupply', async function () {
@@ -229,10 +222,11 @@ contract('ERC20', function (accounts) {
       });
 
       it('emits Transfer event', async function () {
-        const event = expectEvent.inLogs(this.logs, 'Transfer', {
-          from: ZERO_ADDRESS,
-          to: recipient,
-        });
+        const event = expectEvent(
+          this.receipt,
+          'Transfer',
+          { from: ZERO_ADDRESS, to: recipient },
+        );
 
         expect(event.args.value).to.be.bignumber.equal(amount);
       });
@@ -255,8 +249,7 @@ contract('ERC20', function (accounts) {
       const describeBurn = function (description, amount) {
         describe(description, function () {
           beforeEach('burning', async function () {
-            const { logs } = await this.token.burn(initialHolder, amount);
-            this.logs = logs;
+            this.receipt = await this.token.burn(initialHolder, amount);
           });
 
           it('decrements totalSupply', async function () {
@@ -270,10 +263,11 @@ contract('ERC20', function (accounts) {
           });
 
           it('emits Transfer event', async function () {
-            const event = expectEvent.inLogs(this.logs, 'Transfer', {
-              from: initialHolder,
-              to: ZERO_ADDRESS,
-            });
+            const event = expectEvent(
+              this.receipt,
+              'Transfer',
+              { from: initialHolder, to: ZERO_ADDRESS },
+            );
 
             expect(event.args.value).to.be.bignumber.equal(amount);
           });


### PR DESCRIPTION
This has been pointed out many times and even though it is not an issue, I think it's better to change the order to follow the general rule of failing early.