### PR TITLE
Avoid assembly in signature V and S decomposition

### DIFF
--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -117,12 +117,8 @@ library ECDSA {
         bytes32 r,
         bytes32 vs
     ) internal pure returns (address, RecoverError) {
-        bytes32 s;
-        uint8 v;
-        assembly {
-            s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
-            v := add(shr(255, vs), 27)
-        }
+        bytes32 s = vs & 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        uint8 v = (vs >> 255) + 27;
         return tryRecover(hash, v, r, s);
     }
 

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -117,8 +117,8 @@ library ECDSA {
         bytes32 r,
         bytes32 vs
     ) internal pure returns (address, RecoverError) {
-        bytes32 s = vs & 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-        uint8 v = (vs >> 255) + 27;
+        bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+        uint8 v = uint8((uint256(vs) >> 255) + 27);
         return tryRecover(hash, v, r, s);
     }
 


### PR DESCRIPTION
Is there any specific reason why assembly was used here?

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
