### PR TITLE
Normalize return variable names in IERC721Enumerable

### DIFF
--- a/contracts/token/ERC721/extensions/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/IERC721Enumerable.sol
@@ -19,11 +19,11 @@ interface IERC721Enumerable is IERC721 {
      * @dev Returns a token ID owned by `owner` at a given `index` of its token list.
      * Use along with {balanceOf} to enumerate all of ``owner``'s tokens.
      */
-    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256 tokenId);
+    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256);
 
     /**
      * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
      * Use along with {totalSupply} to enumerate all tokens.
      */
-    function tokenByIndex(uint256 index) external view returns (uint256 tokenId);
+    function tokenByIndex(uint256 index) external view returns (uint256);
 }

--- a/contracts/token/ERC721/extensions/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/IERC721Enumerable.sol
@@ -25,5 +25,5 @@ interface IERC721Enumerable is IERC721 {
      * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
      * Use along with {totalSupply} to enumerate all tokens.
      */
-    function tokenByIndex(uint256 index) external view returns (uint256);
+    function tokenByIndex(uint256 index) external view returns (uint256 tokenId);
 }


### PR DESCRIPTION
For consistency across all functions. This PR does not add a variable name for `totalSupply()` nor to the return variable of the implemented contracts.