### PR TITLE
Multicall for view

### DIFF
--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -21,4 +21,15 @@ abstract contract Multicall {
         }
         return results;
     }
+    
+    /**
+     * @dev Receives and returns value of a batch of view calls on this contract.
+     */
+    function multicallview(bytes[] calldata data) external view returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+        for (uint256 i = 0; i < data.length; i++) {
+            results[i] = Address.functionDelegateCall(address(this), data[i]);
+        }
+        return results;
+    }
 }


### PR DESCRIPTION
It woulf be useful tu have a multicall that can perform view calls

Ethers 5 example;
```js
   const responses = await yourContract.multicall([
      yourContract.interface.encodeFunctionData('balanceOf', ["address aca"]),
      yourContract.interface.encodeFunctionData('totalSupply()'),
    ]);
    console.log(responses)
```

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
