### PR TITLE
add Hooks _afterTokenTransfer for ERC1155

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -180,6 +180,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         emit TransferSingle(operator, from, to, id, amount);
 
         _doSafeTransferAcceptanceCheck(operator, from, to, id, amount, data);
+
+        _afterTokenTransfer(operator, from, to, _asSingletonArray(id), _asSingletonArray(amount), data);
     }
 
     /**
@@ -221,6 +223,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         emit TransferBatch(operator, from, to, ids, amounts);
 
         _doSafeBatchTransferAcceptanceCheck(operator, from, to, ids, amounts, data);
+
+        _afterTokenTransfer(operator,  from, to, ids, amounts, data);
     }
 
     /**
@@ -273,6 +277,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         emit TransferSingle(operator, address(0), to, id, amount);
 
         _doSafeTransferAcceptanceCheck(operator, address(0), to, id, amount, data);
+
+        _afterTokenTransfer(operator, address(0), to, _asSingletonArray(id), _asSingletonArray(amount), data);
     }
 
     /**
@@ -304,6 +310,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         emit TransferBatch(operator, address(0), to, ids, amounts);
 
         _doSafeBatchTransferAcceptanceCheck(operator, address(0), to, ids, amounts, data);
+
+        _afterTokenTransfer(operator, address(0), to, ids, amounts, data);
     }
 
     /**
@@ -332,6 +340,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         }
 
         emit TransferSingle(operator, from, address(0), id, amount);
+
+        _afterTokenTransfer(operator, from, address(0), _asSingletonArray(id), _asSingletonArray(amount), "");
     }
 
     /**
@@ -365,6 +375,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         }
 
         emit TransferBatch(operator, from, address(0), ids, amounts);
+
+        _afterTokenTransfer(operator, from, address(0), ids, amounts, "");
     }
 
     /**
@@ -403,6 +415,35 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
      * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */
     function _beforeTokenTransfer(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal virtual {}
+    
+    /**
+     * @dev Hook that is called after any token transfer. This includes minting
+     * and burning, as well as batched variants.
+     *
+     * The same hook is called on both single and batched variants. For single
+     * transfers, the length of the `id` and `amount` arrays will be 1.
+     *
+     * Calling conditions (for each `id` and `amount` pair):
+     *
+     * - When `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * of token type `id` will be  transferred to `to`.
+     * - When `from` is zero, `amount` tokens of token type `id` will be minted
+     * for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens of token type `id`
+     * will be burned.
+     * - `from` and `to` are never both zero.
+     * - `ids` and `amounts` have the same, non-zero length.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
         address operator,
         address from,
         address to,


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## Added **Hooks of _afterTokenTransfer for ERC1155**

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Just like ERC721, add the hooks of `_afterTokenTransfer` for ERC1155.

Currently ERC1155 only have the `before` Hook, no `after` hook, hope to add this.

## Example

Source Code: https://polygonscan.com/address/0x2048c74851f2ed5c45db70ccb7898a73cfede11e#code#L1343

Merge2048 is ERC-1155, but any address can't hold the same token id.

When the `to` address receives a token, which `to` address already had the same id, it'll be merged to the next.

In this case, we need the `_afterTokenTransfer` to handle it.

