### PR TITLE
Fix ERC721 usage example

### DIFF
--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -16,11 +16,10 @@ Here's what a contract for tokenized items might look like:
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 
-contract GameItem is ERC721, ERC721URIStorage {
+contract GameItem is ERC721URIStorage {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3068 <!-- Fill in with issue number -->

Suggest simply removing the ERC721 import and leaving only ERC721URIStorage.

Another way is to add the overrides for `_burn()` and `tokenURI()` required by Solidity, but I think that would be too much code for a basic tutorial.
<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
