### PR TITLE
Improve clarity of error messages in functions checking token ownership

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -123,7 +123,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     ) public virtual override {
         require(
             from == _msgSender() || isApprovedForAll(from, _msgSender()),
-            "ERC1155: caller is not owner nor approved"
+            "ERC1155: transfer caller is not token owner nor approved"
         );
         _safeTransferFrom(from, to, id, amount, data);
     }
@@ -140,7 +140,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     ) public virtual override {
         require(
             from == _msgSender() || isApprovedForAll(from, _msgSender()),
-            "ERC1155: transfer caller is not owner nor approved"
+            "ERC1155: transfer caller is not token owner nor approved"
         );
         _safeBatchTransferFrom(from, to, ids, amounts, data);
     }

--- a/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
@@ -19,7 +19,7 @@ abstract contract ERC1155Burnable is ERC1155 {
     ) public virtual {
         require(
             account == _msgSender() || isApprovedForAll(account, _msgSender()),
-            "ERC1155: caller is not owner nor approved"
+            "ERC1155: caller is not token owner nor approved"
         );
 
         _burn(account, id, value);
@@ -32,7 +32,7 @@ abstract contract ERC1155Burnable is ERC1155 {
     ) public virtual {
         require(
             account == _msgSender() || isApprovedForAll(account, _msgSender()),
-            "ERC1155: caller is not owner nor approved"
+            "ERC1155: caller is not token owner nor approved"
         );
 
         _burnBatch(account, ids, values);

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -115,7 +115,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
 
         require(
             _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
-            "ERC721: approve caller is not owner nor approved for all"
+            "ERC721: approve caller is not token owner nor approved for all"
         );
 
         _approve(to, tokenId);
@@ -153,7 +153,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         uint256 tokenId
     ) public virtual override {
         //solhint-disable-next-line max-line-length
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not token owner nor approved");
 
         _transfer(from, to, tokenId);
     }
@@ -178,7 +178,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         uint256 tokenId,
         bytes memory _data
     ) public virtual override {
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not token owner nor approved");
         _safeTransfer(from, to, tokenId, _data);
     }
 

--- a/contracts/token/ERC721/extensions/ERC721Burnable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Burnable.sol
@@ -20,7 +20,7 @@ abstract contract ERC721Burnable is Context, ERC721 {
      */
     function burn(uint256 tokenId) public virtual {
         //solhint-disable-next-line max-line-length
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721Burnable: caller is not owner nor approved");
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721Burnable: caller is not token owner nor approved");
         _burn(tokenId);
     }
 }

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -293,7 +293,7 @@ function shouldBehaveLikeERC1155 ([minter, firstTokenHolder, secondTokenHolder, 
               this.token.safeTransferFrom(multiTokenHolder, recipient, firstTokenId, firstAmount, '0x', {
                 from: proxy,
               }),
-              'ERC1155: caller is not owner nor approved',
+              'ERC1155: transfer caller is not token owner nor approved',
             );
           });
         });
@@ -569,7 +569,7 @@ function shouldBehaveLikeERC1155 ([minter, firstTokenHolder, secondTokenHolder, 
                 [firstAmount, secondAmount],
                 '0x', { from: proxy },
               ),
-              'ERC1155: transfer caller is not owner nor approved',
+              'ERC1155: transfer caller is not token owner nor approved',
             );
           });
         });

--- a/test/token/ERC1155/extensions/ERC1155Burnable.test.js
+++ b/test/token/ERC1155/extensions/ERC1155Burnable.test.js
@@ -36,7 +36,7 @@ contract('ERC1155Burnable', function (accounts) {
     it('unapproved accounts cannot burn the holder\'s tokens', async function () {
       await expectRevert(
         this.token.burn(holder, tokenIds[0], amounts[0].subn(1), { from: other }),
-        'ERC1155: caller is not owner nor approved',
+        'ERC1155: caller is not token owner nor approved',
       );
     });
   });
@@ -60,7 +60,7 @@ contract('ERC1155Burnable', function (accounts) {
     it('unapproved accounts cannot burn the holder\'s tokens', async function () {
       await expectRevert(
         this.token.burnBatch(holder, tokenIds, [ amounts[0].subn(1), amounts[1].subn(2) ], { from: other }),
-        'ERC1155: caller is not owner nor approved',
+        'ERC1155: caller is not token owner nor approved',
       );
     });
   });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -192,7 +192,7 @@ function shouldBehaveLikeERC721 (errorPrefix, owner, newOwner, approved, another
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, other, tokenId, { from: other }),
-              'ERC721: transfer caller is not owner nor approved',
+              'ERC721: transfer caller is not token owner nor approved',
             );
           });
         });
@@ -509,7 +509,7 @@ function shouldBehaveLikeERC721 (errorPrefix, owner, newOwner, approved, another
       context('when the sender does not own the given token ID', function () {
         it('reverts', async function () {
           await expectRevert(this.token.approve(approved, tokenId, { from: other }),
-            'ERC721: approve caller is not owner nor approved');
+            'ERC721: approve caller is not token owner nor approved');
         });
       });
 
@@ -517,7 +517,7 @@ function shouldBehaveLikeERC721 (errorPrefix, owner, newOwner, approved, another
         it('reverts', async function () {
           await this.token.approve(approved, tokenId, { from: owner });
           await expectRevert(this.token.approve(anotherApproved, tokenId, { from: approved }),
-            'ERC721: approve caller is not owner nor approved for all');
+            'ERC721: approve caller is not token owner nor approved for all');
         });
       });
 


### PR DESCRIPTION
## Issue


<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3120  <!-- Fill in with issue number -->

As described in the issue, I have expanded the (hopefully complete set) of error messages in which the user is informed they have insufficient ownership or approval for an action on a token. The addition is essentially `not owner` -> `not token owner` to distinguish from contract ownership.

One additional change was made in an instance where an error message for transferring tokens did not begin with the term `transfer caller`, instead just `caller`. I added `transfer` for uniformity.

Tests have been updated to check against updated error messages.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changelog entry

![are-you-the-owner-cam-gigandet](https://user-images.githubusercontent.com/5721314/150128887-6d19e880-cc03-4fa9-a674-1a354693867e.gif)

