### PR TITLE
Correct ERC721 inheritance example

### DIFF
--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -20,7 +20,7 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 
-contract GameItem is ERC721, ERC721URIStorage {
+contract GameItem is ERC721URIStorage {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 


### PR DESCRIPTION
In the latest release tag on GitHub v4.4.2, `ERC721URIStorage` already inherits from `ERC721`. The website's example, hence, lead to a situation where the Solidity compiler threw `TypeError` as the functions available in both `ERC721URIStorage` and `ERC721` (`tokenURI` and `_burn`) required overriding. In this case, it suffices to just inherit from `ERC721URIStorage` when wanting to create a custom ERC721 contract with a customizable `tokenURI`.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

The error that Solidity compiler threw before the fix

```
TypeError: Derived contract must override function "_burn". Two or more base classes define function with same name and parameter types.
```

Same for `tokenURI`.


#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
