### PR TITLE
Simplification of ERC777's transfer & transferFrom by using _send

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -162,9 +162,9 @@ contract ERC777 is Context, IERC777, IERC20 {
      */
     function isOperatorFor(address operator, address tokenHolder) public view virtual override returns (bool) {
         return
-        operator == tokenHolder ||
-        (_defaultOperators[operator] && !_revokedDefaultOperators[tokenHolder][operator]) ||
-        _operators[tokenHolder][operator];
+            operator == tokenHolder ||
+            (_defaultOperators[operator] && !_revokedDefaultOperators[tokenHolder][operator]) ||
+            _operators[tokenHolder][operator];
     }
 
     /**

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -277,8 +277,6 @@ contract ERC777 is Context, IERC777, IERC20 {
         address recipient,
         uint256 amount
     ) public virtual override returns (bool) {
-        _send(holder, recipient, amount, "", "", false);
-
         address spender = _msgSender();
         uint256 currentAllowance = _allowances[holder][spender];
         if (currentAllowance != type(uint256).max) {
@@ -287,6 +285,8 @@ contract ERC777 is Context, IERC777, IERC20 {
                 _approve(holder, spender, currentAllowance - amount);
             }
         }
+
+        _send(holder, recipient, amount, "", "", false);
 
         return true;
     }
@@ -375,8 +375,8 @@ contract ERC777 is Context, IERC777, IERC20 {
         bytes memory operatorData,
         bool requireReceptionAck
     ) internal virtual {
-        require(from != address(0), "ERC777: send from the zero address");
-        require(to != address(0), "ERC777: send to the zero address");
+        require(from != address(0), "ERC777: transfer from the zero address");
+        require(to != address(0), "ERC777: transfer to the zero address");
 
         address operator = _msgSender();
 

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -432,9 +432,9 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         uint256 fromBalance = _balances[from];
         require(fromBalance >= amount, "ERC777: transfer amount exceeds balance");
-    unchecked {
-        _balances[from] = fromBalance - amount;
-    }
+        unchecked {
+            _balances[from] = fromBalance - amount;
+        }
         _balances[to] += amount;
 
         emit Sent(operator, from, to, amount, userData, operatorData);

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -411,9 +411,9 @@ contract ERC777 is Context, IERC777, IERC20 {
         // Update state variables
         uint256 fromBalance = _balances[from];
         require(fromBalance >= amount, "ERC777: burn amount exceeds balance");
-    unchecked {
-        _balances[from] = fromBalance - amount;
-    }
+        unchecked {
+            _balances[from] = fromBalance - amount;
+        }
         _totalSupply -= amount;
 
         emit Burned(operator, from, amount, data, operatorData);


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->

Reuse of the internal `_send` method for the `transfer` and `transferFrom` methods, which allows one method for all, meaning it can be nicely override by a parent class.

There was issues with adding custom logic to the _move function. However this may allow for the cleanest approach to doing this.

Please let me know if this looks ok, if so, will continue with tests, documentation and a changelog entry

<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
