### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
- * `AccessControl`: add a virtual `_checkRole(bytes32)` function that can be overriden to alter the the `onlyRole` modifier behavior. ([#3137](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3137))
+ * `AccessControl`: add a virtual `_checkRole(bytes32)` function that can be overriden to alter the `onlyRole` modifier behavior. ([#3137](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3137))
 
 ## Unreleased
 


### PR DESCRIPTION
Remove repeated word "the".

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
