### PR TITLE
Fix grammar typo in doc

### DIFF
--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -7,7 +7,7 @@ This set of interfaces, contracts, and utilities are all related to the https://
 
 TIP: For an overview of ERC20 tokens and a walk through on how to create a token contract read our xref:ROOT:erc20.adoc[ERC20 guide].
 
-There a few core contracts that implement the behavior specified in the EIP:
+There are a few core contracts that implement the behavior specified in the EIP:
 
 * {IERC20}: the interface all ERC20 implementations should conform to.
 * {IERC20Metadata}: the extended ERC20 interface including the <<ERC20-name,`name`>>, <<ERC20-symbol,`symbol`>> and <<ERC20-decimals,`decimals`>> functions.


### PR DESCRIPTION
Add missing verb "are".


#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
