### PR TITLE
Add `event Initialized()` to Initializable

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -33,6 +33,12 @@ import "../../utils/Address.sol";
  * ====
  */
 abstract contract Initializable {
+
+    /**
+     * @dev Triggered when the contract has been initialized.
+     */
+    event Initialized();
+
     /**
      * @dev Indicates that the contract has been initialized.
      */
@@ -62,6 +68,7 @@ abstract contract Initializable {
 
         if (isTopLevelCall) {
             _initializing = false;
+            emit Initialized();
         }
     }
 


### PR DESCRIPTION
Copied over from https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/pull/148

Added an event for an initializable contract. To allow for easy identification of when a contract has been initialized.

Suggestion for tracking when a contract has been initialized. 

This is helpful in cases like when using `TheGraph` when we want to do some action on initialize. Such as reading the data and saving it. As some of the data may not be available on construct for example.

Could potentially use `event Initialized(address sender);` with the sender as well. However, thought it might be better to just keep it simple. 

Not sure if there are any negative side effects of this.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
