### PR TITLE
Access _allowances directly instead of via public virtual allowance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  * `ERC1155`: Add a `_afterTokenTransfer` hook for improved extensibility. ([#3166](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3166))
  * `DoubleEndedQueue`: a new data structure that supports efficient push and pop to both front and back, useful for FIFO and LIFO queues. ([#3153](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3153))
  * `Governor`: improved security of `onlyGovernance` modifier when using an external executor contract (e.g. a timelock) that can operate without necessarily going through the governance protocol. ([#3147](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3147))
+ * `ERC20`: Replace call `allowance` function during call to `transferFrom` with direct access of `_allowances` variable to prevent undeterministic behaviour caused by concrete overrides. ([#3212](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3212))
+  * `ERC777`: Replace call `allowance` function during call to `transferFrom` with direct access of `_allowances` variable to prevent undeterministic behaviour caused by concrete overrides. ([#3212](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3212))
 
 ## 4.5.0 (2022-02-09)
 

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -332,7 +332,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         address spender,
         uint256 amount
     ) internal virtual {
-        uint256 currentAllowance = allowance(owner, spender);
+        uint256 currentAllowance = _allowances[owner][spender];
         if (currentAllowance != type(uint256).max) {
             require(currentAllowance >= amount, "ERC20: insufficient allowance");
             unchecked {

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -514,7 +514,7 @@ contract ERC777 is Context, IERC777, IERC20 {
         address spender,
         uint256 amount
     ) internal virtual {
-        uint256 currentAllowance = allowance(owner, spender);
+        uint256 currentAllowance = _allowances[owner][spender];
         if (currentAllowance != type(uint256).max) {
             require(currentAllowance >= amount, "ERC777: insufficient allowance");
             unchecked {


### PR DESCRIPTION
Fixes #3211

- Replace call to `allowance` with direct access of `_allowances` variable in ERC20
- Replace call to `allowance` with direct access of `_allowances` variable in ERC777

#### PR Checklist
- [x]  Tests
- [ ]  Documentation
- [x]  Changelog entry