### PR TITLE
Reduce contract size and deployment gas for onlyOwner modifier

### DIFF
--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -45,7 +45,8 @@ abstract contract Ownable is Context {
     }
 
     /**
-     * @dev Putting the requre in an internal function decreases contract size when onlyOwner modifier is used multiple times.
+     * @dev Putting the require in an internal function decreases contract size
+     * when onlyOwner modifier is used multiple times.
      */
     function _onlyOwner() internal view {
         require(owner() == _msgSender(), "Ownable: caller is not the owner");


### PR DESCRIPTION
Fixes #3222

For inheriting contracts that use the onlyOwner modifier significant gas savings for deployment can be made by not inlining the require statement in every modified function.

When you add a function modifier, the code of that function is picked up and put in the function modifier in place of the _ symbol. If the same code is inlined multiple times, it adds up in size. Internal functions, on the other hand, are not inlined but called as separate functions. This means they are very slightly more expensive in run time but save a lot of redundant bytecode in deployment.

From my testing with a sample contract this simple PR saves substantial gas per modifier call in contract size. This really adds up when for example in my contract I have 18 calls to onlyOwner!:

Savings per call at 10 Runs Optimization:
1 modifier call: 3883700-3857256 = 26,444 Gwei
2 modifier calls: 3892096-3857268 = 17,414 Gwei
5 modifier calls: 3917411-3857268 = 12,028 Gwei

Savings per call at 1000 Runs Optimization:
1 modifier call: 4311775-4258622 = 53,153 Gwei
2 modifier calls: 4329572-4258622 = 35,475 Gwei
5 modifier calls: 4382740-4258622 = 24,823 Gwei

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ N/A] Documentation
- [ ] Changelog entry
