### PR TITLE
Change time parameters to uint64 for consistency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ * `GovernorSettings`: Changed the type of time variables to uint64 for consistency. Fixes #3208 . ([#3224](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3224))
  * `AccessControl`: add a virtual `_checkRole(bytes32)` function that can be overridden to alter the `onlyRole` modifier behavior. ([#3137](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3137))
  * `EnumerableMap`: add new `AddressToUintMap` map type. ([#3150](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3150))
  * `ERC1155`: Add a `_afterTokenTransfer` hook for improved extensibility. ([#3166](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3166))

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -229,7 +229,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor {
         require(proposal.voteStart.isUnset(), "Governor: proposal already exists");
 
         uint64 snapshot = block.number.toUint64() + votingDelay();
-        uint64 deadline = snapshot + votingPeriod().toUint64();
+        uint64 deadline = snapshot + votingPeriod();
 
         proposal.voteStart.setDeadline(snapshot);
         proposal.voteEnd.setDeadline(deadline);

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -228,7 +228,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor {
         ProposalCore storage proposal = _proposals[proposalId];
         require(proposal.voteStart.isUnset(), "Governor: proposal already exists");
 
-        uint64 snapshot = block.number.toUint64() + votingDelay().toUint64();
+        uint64 snapshot = block.number.toUint64() + votingDelay();
         uint64 deadline = snapshot + votingPeriod().toUint64();
 
         proposal.voteStart.setDeadline(snapshot);

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -122,7 +122,7 @@ abstract contract IGovernor is IERC165 {
      * @dev Delay, in number of block, between the proposal is created and the vote starts. This can be increassed to
      * leave time for users to buy voting power, of delegate it, before the voting of a proposal starts.
      */
-    function votingDelay() public view virtual returns (uint256);
+    function votingDelay() public view virtual returns (uint64);
 
     /**
      * @notice module:user-config
@@ -131,7 +131,7 @@ abstract contract IGovernor is IERC165 {
      * NOTE: The {votingDelay} can delay the start of the vote. This must be considered when setting the voting
      * duration compared to the voting delay.
      */
-    function votingPeriod() public view virtual returns (uint256);
+    function votingPeriod() public view virtual returns (uint64);
 
     /**
      * @notice module:user-config

--- a/contracts/governance/extensions/GovernorSettings.sol
+++ b/contracts/governance/extensions/GovernorSettings.sol
@@ -23,9 +23,9 @@ abstract contract GovernorSettings is Governor {
      * @dev Initialize the governance parameters.
      */
     constructor(
-        uint256 initialVotingDelay,
-        uint256 initialVotingPeriod,
-        uint256 initialProposalThreshold
+        uint64 initialVotingDelay,
+        uint64 initialVotingPeriod,
+        uint64 initialProposalThreshold
     ) {
         _setVotingDelay(initialVotingDelay);
         _setVotingPeriod(initialVotingPeriod);

--- a/contracts/governance/extensions/GovernorSettings.sol
+++ b/contracts/governance/extensions/GovernorSettings.sol
@@ -35,14 +35,14 @@ abstract contract GovernorSettings is Governor {
     /**
      * @dev See {IGovernor-votingDelay}.
      */
-    function votingDelay() public view virtual override returns (uint256) {
+    function votingDelay() public view virtual override returns (uint64) {
         return _votingDelay;
     }
 
     /**
      * @dev See {IGovernor-votingPeriod}.
      */
-    function votingPeriod() public view virtual override returns (uint256) {
+    function votingPeriod() public view virtual override returns (uint64) {
         return _votingPeriod;
     }
 

--- a/contracts/governance/extensions/GovernorSettings.sol
+++ b/contracts/governance/extensions/GovernorSettings.sol
@@ -11,8 +11,8 @@ import "../Governor.sol";
  * _Available since v4.4._
  */
 abstract contract GovernorSettings is Governor {
-    uint256 private _votingDelay;
-    uint256 private _votingPeriod;
+    uint64 private _votingDelay;
+    uint64 private _votingPeriod;
     uint256 private _proposalThreshold;
 
     event VotingDelaySet(uint256 oldVotingDelay, uint256 newVotingDelay);
@@ -58,7 +58,7 @@ abstract contract GovernorSettings is Governor {
      *
      * Emits a {VotingDelaySet} event.
      */
-    function setVotingDelay(uint256 newVotingDelay) public virtual onlyGovernance {
+    function setVotingDelay(uint64 newVotingDelay) public virtual onlyGovernance {
         _setVotingDelay(newVotingDelay);
     }
 
@@ -67,7 +67,7 @@ abstract contract GovernorSettings is Governor {
      *
      * Emits a {VotingPeriodSet} event.
      */
-    function setVotingPeriod(uint256 newVotingPeriod) public virtual onlyGovernance {
+    function setVotingPeriod(uint64 newVotingPeriod) public virtual onlyGovernance {
         _setVotingPeriod(newVotingPeriod);
     }
 
@@ -85,7 +85,7 @@ abstract contract GovernorSettings is Governor {
      *
      * Emits a {VotingDelaySet} event.
      */
-    function _setVotingDelay(uint256 newVotingDelay) internal virtual {
+    function _setVotingDelay(uint64 newVotingDelay) internal virtual {
         emit VotingDelaySet(_votingDelay, newVotingDelay);
         _votingDelay = newVotingDelay;
     }
@@ -95,7 +95,7 @@ abstract contract GovernorSettings is Governor {
      *
      * Emits a {VotingPeriodSet} event.
      */
-    function _setVotingPeriod(uint256 newVotingPeriod) internal virtual {
+    function _setVotingPeriod(uint64 newVotingPeriod) internal virtual {
         // voting period must be at least one block long
         require(newVotingPeriod > 0, "GovernorSettings: voting period too low");
         emit VotingPeriodSet(_votingPeriod, newVotingPeriod);

--- a/contracts/mocks/GovernorCompMock.sol
+++ b/contracts/mocks/GovernorCompMock.sol
@@ -12,11 +12,11 @@ contract GovernorCompMock is GovernorVotesComp, GovernorCountingSimple {
         return 0;
     }
 
-    function votingDelay() public pure override returns (uint256) {
+    function votingDelay() public pure override returns (uint64) {
         return 4;
     }
 
-    function votingPeriod() public pure override returns (uint256) {
+    function votingPeriod() public pure override returns (uint64) {
         return 16;
     }
 

--- a/contracts/mocks/GovernorCompatibilityBravoMock.sol
+++ b/contracts/mocks/GovernorCompatibilityBravoMock.sol
@@ -16,9 +16,9 @@ contract GovernorCompatibilityBravoMock is
     constructor(
         string memory name_,
         ERC20VotesComp token_,
-        uint256 votingDelay_,
-        uint256 votingPeriod_,
-        uint256 proposalThreshold_,
+        uint64 votingDelay_,
+        uint64 votingPeriod_,
+        uint64 proposalThreshold_,
         ICompoundTimelock timelock_
     )
         Governor(name_)

--- a/contracts/mocks/GovernorMock.sol
+++ b/contracts/mocks/GovernorMock.sol
@@ -16,8 +16,8 @@ contract GovernorMock is
     constructor(
         string memory name_,
         IVotes token_,
-        uint256 votingDelay_,
-        uint256 votingPeriod_,
+        uint64 votingDelay_,
+        uint64 votingPeriod_,
         uint256 quorumNumerator_
     )
         Governor(name_)

--- a/contracts/mocks/GovernorPreventLateQuorumMock.sol
+++ b/contracts/mocks/GovernorPreventLateQuorumMock.sol
@@ -18,8 +18,8 @@ contract GovernorPreventLateQuorumMock is
     constructor(
         string memory name_,
         IVotes token_,
-        uint256 votingDelay_,
-        uint256 votingPeriod_,
+        uint64 votingDelay_,
+        uint64 votingPeriod_,
         uint256 quorum_,
         uint64 voteExtension_
     )

--- a/contracts/mocks/GovernorTimelockCompoundMock.sol
+++ b/contracts/mocks/GovernorTimelockCompoundMock.sol
@@ -16,8 +16,8 @@ contract GovernorTimelockCompoundMock is
     constructor(
         string memory name_,
         IVotes token_,
-        uint256 votingDelay_,
-        uint256 votingPeriod_,
+        uint64 votingDelay_,
+        uint64 votingPeriod_,
         ICompoundTimelock timelock_,
         uint256 quorumNumerator_
     )

--- a/contracts/mocks/GovernorTimelockControlMock.sol
+++ b/contracts/mocks/GovernorTimelockControlMock.sol
@@ -16,8 +16,8 @@ contract GovernorTimelockControlMock is
     constructor(
         string memory name_,
         IVotes token_,
-        uint256 votingDelay_,
-        uint256 votingPeriod_,
+        uint64 votingDelay_,
+        uint64 votingPeriod_,
         TimelockController timelock_,
         uint256 quorumNumerator_
     )

--- a/contracts/mocks/GovernorVoteMock.sol
+++ b/contracts/mocks/GovernorVoteMock.sol
@@ -12,11 +12,11 @@ contract GovernorVoteMocks is GovernorVotes, GovernorCountingSimple {
         return 0;
     }
 
-    function votingDelay() public pure override returns (uint256) {
+    function votingDelay() public pure override returns (uint64) {
         return 4;
     }
 
-    function votingPeriod() public pure override returns (uint256) {
+    function votingPeriod() public pure override returns (uint64) {
         return 16;
     }
 

--- a/contracts/mocks/wizard/MyGovernor1.sol
+++ b/contracts/mocks/wizard/MyGovernor1.sol
@@ -21,11 +21,11 @@ contract MyGovernor1 is
         GovernorTimelockControl(_timelock)
     {}
 
-    function votingDelay() public pure override returns (uint256) {
+    function votingDelay() public pure override returns (uint64) {
         return 1; // 1 block
     }
 
-    function votingPeriod() public pure override returns (uint256) {
+    function votingPeriod() public pure override returns (uint64) {
         return 45818; // 1 week
     }
 

--- a/contracts/mocks/wizard/MyGovernor2.sol
+++ b/contracts/mocks/wizard/MyGovernor2.sol
@@ -23,11 +23,11 @@ contract MyGovernor2 is
         GovernorTimelockControl(_timelock)
     {}
 
-    function votingDelay() public pure override returns (uint256) {
+    function votingDelay() public pure override returns (uint64) {
         return 1; // 1 block
     }
 
-    function votingPeriod() public pure override returns (uint256) {
+    function votingPeriod() public pure override returns (uint64) {
         return 45818; // 1 week
     }
 

--- a/contracts/mocks/wizard/MyGovernor3.sol
+++ b/contracts/mocks/wizard/MyGovernor3.sol
@@ -21,11 +21,11 @@ contract MyGovernor is
         GovernorTimelockControl(_timelock)
     {}
 
-    function votingDelay() public pure override returns (uint256) {
+    function votingDelay() public pure override returns (uint64) {
         return 1; // 1 block
     }
 
-    function votingPeriod() public pure override returns (uint256) {
+    function votingPeriod() public pure override returns (uint64) {
         return 45818; // 1 week
     }
 


### PR DESCRIPTION
Governor: Inconsistent types for voting timing parameters #3208
Changed time parameters to uint64 for consistency

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3208 

Set the time parameters in GovrenorSettings.sol to match GovernorPreventLateQuorum


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry
