### PR TITLE
Move event definition at the top of IERC20, IERC777 and IERC1820

### DIFF
--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -20,7 +20,7 @@ interface IERC20 {
      * a call to {approve}. `value` is the new allowance.
      */
     event Approval(address indexed owner, address indexed spender, uint256 value);
-    
+
     /**
      * @dev Returns the amount of tokens in existence.
      */

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -8,6 +8,20 @@ pragma solidity ^0.8.0;
  */
 interface IERC20 {
     /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    
+    /**
      * @dev Returns the amount of tokens in existence.
      */
     function totalSupply() external view returns (uint256);
@@ -65,18 +79,4 @@ interface IERC20 {
         address to,
         uint256 amount
     ) external returns (bool);
-
-    /**
-     * @dev Emitted when `value` tokens are moved from one account (`from`) to
-     * another (`to`).
-     *
-     * Note that `value` may be zero.
-     */
-    event Transfer(address indexed from, address indexed to, uint256 value);
-
-    /**
-     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
-     * a call to {approve}. `value` is the new allowance.
-     */
-    event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/token/ERC777/IERC777.sol
+++ b/contracts/token/ERC777/IERC777.sol
@@ -13,7 +13,6 @@ pragma solidity ^0.8.0;
  * {ERC1820Implementer}.
  */
 interface IERC777 {
-    
     /**
      * @dev Emitted when `amount` tokens are created by `operator` and assigned to `to`.
      *
@@ -30,7 +29,7 @@ interface IERC777 {
 
     /**
      * @dev Emitted when `operator` is made operator for `tokenHolder`
-     */    
+     */
     event AuthorizedOperator(address indexed operator, address indexed tokenHolder);
 
     /**

--- a/contracts/token/ERC777/IERC777.sol
+++ b/contracts/token/ERC777/IERC777.sol
@@ -14,12 +14,28 @@ pragma solidity ^0.8.0;
  */
 interface IERC777 {
     
+    /**
+     * @dev Emitted when `amount` tokens are created by `operator` and assigned to `to`.
+     *
+     * Note that some additional user `data` and `operatorData` can be logged in the event.
+     */
     event Minted(address indexed operator, address indexed to, uint256 amount, bytes data, bytes operatorData);
 
+    /**
+     * @dev Emitted when `operator` destroys `amount` tokens from `account`.
+     *
+     * Note that some additional user `data` and `operatorData` can be logged in the event.
+     */
     event Burned(address indexed operator, address indexed from, uint256 amount, bytes data, bytes operatorData);
 
+    /**
+     * @dev Emitted when `operator` is made operator for `tokenHolder`
+     */    
     event AuthorizedOperator(address indexed operator, address indexed tokenHolder);
 
+    /**
+     * @dev Emitted when `operator` is revoked its operator status for `tokenHolder`
+     */
     event RevokedOperator(address indexed operator, address indexed tokenHolder);
 
     /**

--- a/contracts/token/ERC777/IERC777.sol
+++ b/contracts/token/ERC777/IERC777.sol
@@ -13,6 +13,15 @@ pragma solidity ^0.8.0;
  * {ERC1820Implementer}.
  */
 interface IERC777 {
+    
+    event Minted(address indexed operator, address indexed to, uint256 amount, bytes data, bytes operatorData);
+
+    event Burned(address indexed operator, address indexed from, uint256 amount, bytes data, bytes operatorData);
+
+    event AuthorizedOperator(address indexed operator, address indexed tokenHolder);
+
+    event RevokedOperator(address indexed operator, address indexed tokenHolder);
+
     /**
      * @dev Returns the name of the token.
      */
@@ -182,12 +191,4 @@ interface IERC777 {
         bytes data,
         bytes operatorData
     );
-
-    event Minted(address indexed operator, address indexed to, uint256 amount, bytes data, bytes operatorData);
-
-    event Burned(address indexed operator, address indexed from, uint256 amount, bytes data, bytes operatorData);
-
-    event AuthorizedOperator(address indexed operator, address indexed tokenHolder);
-
-    event RevokedOperator(address indexed operator, address indexed tokenHolder);
 }

--- a/contracts/utils/introspection/IERC1820Registry.sol
+++ b/contracts/utils/introspection/IERC1820Registry.sol
@@ -18,11 +18,10 @@ pragma solidity ^0.8.0;
  * For an in-depth explanation and source code analysis, see the EIP text.
  */
 interface IERC1820Registry {
-    
     event InterfaceImplementerSet(address indexed account, bytes32 indexed interfaceHash, address indexed implementer);
 
     event ManagerChanged(address indexed account, address indexed newManager);
-    
+
     /**
      * @dev Sets `newManager` as the manager for `account`. A manager of an
      * account is able to set interface implementers for it.

--- a/contracts/utils/introspection/IERC1820Registry.sol
+++ b/contracts/utils/introspection/IERC1820Registry.sol
@@ -18,6 +18,11 @@ pragma solidity ^0.8.0;
  * For an in-depth explanation and source code analysis, see the EIP text.
  */
 interface IERC1820Registry {
+    
+    event InterfaceImplementerSet(address indexed account, bytes32 indexed interfaceHash, address indexed implementer);
+
+    event ManagerChanged(address indexed account, address indexed newManager);
+    
     /**
      * @dev Sets `newManager` as the manager for `account`. A manager of an
      * account is able to set interface implementers for it.
@@ -109,8 +114,4 @@ interface IERC1820Registry {
      * @return True if `account` implements `interfaceId`, false otherwise.
      */
     function implementsERC165InterfaceNoCache(address account, bytes4 interfaceId) external view returns (bool);
-
-    event InterfaceImplementerSet(address indexed account, bytes32 indexed interfaceHash, address indexed implementer);
-
-    event ManagerChanged(address indexed account, address indexed newManager);
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
Move event definitions at the top of the interface contracts for `IERC20`, `IERC777` and `IERC1820` + add one short sentence to document and explain the event, using Natspec comment and `@dev` tag.

<!-- Include any context necessary for understanding the PR's purpose. -->
This is to follow the Style guide provided by the Solidity docs, under the section **["Style Guide > Order of Layout"](https://docs.soliditylang.org/en/v0.8.12/style-guide.html#order-of-layout)**

> Layout contract elements in the following order:
> 
> 1. Pragma statements
> 2. Import statements
> 3. Interfaces
> 4. Libraries
> 5. Contracts
> 
> Inside each contract, library or interface, use the following order:
> 
> 1. Type declarations
> 2. State variables
> 3. Events
> 4. Modifiers
> 5. Functions

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry **(Not Applicable)**
