### PR TITLE
fix race condition in approve function

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -134,8 +134,8 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
      * - `spender` cannot be the zero address.
      */
     function approve(address spender, uint256 amount) public virtual override returns (bool) {
-        address owner = _msgSender();
-        _approve(owner, spender, amount);
+        require(_allowances[_msgSender()][spender] <= 0, "use increase/decrease allowance to update");
+        _approve(_msgSender(), spender, amount);
         return true;
     }
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

#fix   ---- >  
line number 136 :
function approve(address spender, uint256 amount) public virtual override returns (bool) {
        require(_allowances[_msgSender()][spender] <= 0, "use increase/decrease allowance to update");  // make condition here
        _approve(_msgSender(), spender, amount);
        return true;
    }


// The standard ERC20 implementation contains a widely-known racing condition in its approve function, wherein a spender is able to witness the token owner broadcast a transaction altering their approval and quickly sign and broadcast a transaction using transferFrom to move the current approved amount from the owner’s balance to the spender. If the spender’s transaction is validated before the owner’s, the spender will be able to get both approval amounts of both transactions.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
