### PR TITLE
Documentation Nit: Remove Misleading Documentation in ERC721Burnable

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721Burnable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Burnable.sol
@@ -8,7 +8,7 @@ import "../../../utils/Context.sol";
 
 /**
  * @title ERC721 Burnable Token
- * @dev ERC721 Token that can be irreversibly burned (destroyed).
+ * @dev ERC721 Token that can be burned (destroyed).
  */
 abstract contract ERC721Burnable is Context, ERC721 {
     /**


### PR DESCRIPTION
Fixes
ERC721's `_burn` implementation does not irrevocably burn the token. Contracts that inherit from ERC721/ERC721 Burnable and expose a public burn function are able to re-mint burned tokens through the _`mint` function unless overridden/modified by the deployer/implementor.

This PR is literally a nit, but removes the "irrevocably" word from the description. The motivation of this PR was confusion by newer devs directly cloning OZ's implementations. 

#### PR Checklist
- [ ] Tests
- [x] Documentation
- [ ] Changelog entry
