### PR TITLE
feat: short circuiting optimisation ERC721

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  * `Governor`: Add a way to parameterize votes. This can be used to implement voting systems such as fractionalized voting, ERC721 based voting, or any number of other systems. The `params` argument added to `_countVote` method, and included in the newly added `_getVotes` method, can be used by counting and voting modules respectively for such purposes.
  * `TimelockController`: Add a separate canceller role for the ability to cancel. ([#3165](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3165))
  * `draft-ERC20Permit`: replace `immutable` with `constant` for `_PERMIT_TYPEHASH` since the `keccak256` of string literals is treated specially and the hash is evaluated at compile time. ([#3196](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3196))
+ * `ERC721`: short-circuit optimisation since direct transfers are much less than proxy transfers. ([#3257](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3257))
 
 ### Breaking changes
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -232,7 +232,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     function _isApprovedOrOwner(address spender, uint256 tokenId) internal view virtual returns (bool) {
         require(_exists(tokenId), "ERC721: operator query for nonexistent token");
         address owner = ERC721.ownerOf(tokenId);
-        return (spender == owner || isApprovedForAll(owner, spender) || getApproved(tokenId) == spender);
+        return (isApprovedForAll(owner, spender) || spender == owner || getApproved(tokenId) == spender);
     }
 
     /**


### PR DESCRIPTION
This change assumes that direct transfers are much less than proxy transfers. Afaik there is no gas optimisation involved since the first check does not involve an additional `SLOAD` but in terms of logic it would make sense IMHO.

#### PR Checklist
- [ ] Tests
- [ ] Documentation
- [x] Changelog entry
