### PR TITLE
Improve error for zero address in ERC721Enumerable

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -36,6 +36,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      */
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
         require(index < ERC721.balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
+        require(owner != address(0), "ERC721Enumerable: owner can't be the zero address");
         return _ownedTokens[owner][index];
     }
 

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -35,8 +35,8 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      * @dev See {IERC721Enumerable-tokenOfOwnerByIndex}.
      */
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
-        require(index < ERC721.balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
         require(owner != address(0), "ERC721Enumerable: owner can't be the zero address");
+        require(index < ERC721.balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
         return _ownedTokens[owner][index];
     }
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -759,6 +759,14 @@ function shouldBehaveLikeERC721Enumerable (errorPrefix, owner, newOwner, approve
         });
       });
 
+      describe('when the given address is the zero address', function () {
+        it('reverts', async function () {
+          await expectRevert(
+            this.token.tokenOfOwnerByIndex(ZERO_ADDRESS, 0), "ERC721Enumerable: owner can't be the zero address",
+          );
+        });
+      });
+
       describe('after transferring all tokens to another user', function () {
         beforeEach(async function () {
           await this.token.transferFrom(owner, other, firstTokenId, { from: owner });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -762,7 +762,7 @@ function shouldBehaveLikeERC721Enumerable (errorPrefix, owner, newOwner, approve
       describe('when the given address is the zero address', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(ZERO_ADDRESS, 0), "ERC721Enumerable: owner can't be the zero address",
+            this.token.tokenOfOwnerByIndex(ZERO_ADDRESS, 0), 'ERC721Enumerable: owner can\'t be the zero address',
           );
         });
       });


### PR DESCRIPTION
Fixes #3263 

Throws an error when the owner is zero address accordingly described in the [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721).
