### PR TITLE
Duplicate IERC721Reciever to ERC721TokenReciever

### DIFF
--- a/contracts/token/ERC721/ERC721TokenReceiver.sol
+++ b/contracts/token/ERC721/ERC721TokenReceiver.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (token/ERC721/ERC721TokenReceiver.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC721 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers
+ * from ERC721 asset contracts.
+ */
+interface ERC721TokenReceiver {
+    /**
+     * @dev Whenever an {IERC721} `tokenId` token is transferred to this contract via {IERC721-safeTransferFrom}
+     * by `operator` from `from`, this function is called.
+     *
+     * It must return its Solidity selector to confirm the token transfer.
+     * If any other value is returned or the interface is not implemented by the recipient, the transfer will be reverted.
+     *
+     * The selector can be obtained in Solidity with `ERC721TokenReceiver.onERC721Received.selector`.
+     */
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external returns (bytes4);
+}


### PR DESCRIPTION
Fixes #3262
Duplicates the IERC721Reciever to ERC721TokenReciever and creates a separate file. This is to conform to the EIP-721 standard.
