### PR TITLE
Changed ERC721Holder.sol visibility to external.

### DIFF
--- a/contracts/token/ERC721/utils/ERC721Holder.sol
+++ b/contracts/token/ERC721/utils/ERC721Holder.sol
@@ -22,7 +22,7 @@ contract ERC721Holder is IERC721Receiver {
         address,
         uint256,
         bytes memory
-    ) public virtual override returns (bytes4) {
+    ) external virtual override returns (bytes4) {
         return this.onERC721Received.selector;
     }
 }


### PR DESCRIPTION
Fixes #3266
Changes the visibility of the function to external as specified in the standard.
