### PR TITLE
Erc20.sol "decimals" variable description left in comments from prev versions #3155

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -45,9 +45,6 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
     /**
      * @dev Sets the values for {name} and {symbol}.
      *
-     * The default value of {decimals} is 18. To select a different value for
-     * {decimals} you should overload it.
-     *
      * All two of these values are immutable: they can only be set once during
      * construction.
      */

--- a/contracts/token/ERC721/utils/ERC721Holder.sol
+++ b/contracts/token/ERC721/utils/ERC721Holder.sol
@@ -22,7 +22,7 @@ contract ERC721Holder is IERC721Receiver {
         address,
         uint256,
         bytes memory
-    ) public virtual override returns (bytes4) {
+    ) external virtual override returns (bytes4) {
         return this.onERC721Received.selector;
     }
 }


### PR DESCRIPTION
Fixes ##3155
Removed the default decimals comment from the constructor to avoid confusion.