### PR TITLE
Enable the YUL IR pipeline when building with optimisations

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -33,7 +33,7 @@ const argv = require('yargs/yargs')()
     compiler: {
       alias: 'compileVersion',
       type: 'string',
-      default: '0.8.9',
+      default: '0.8.13',
     },
     coinmarketcap: {
       alias: 'coinmarketcapApiKey',
@@ -65,6 +65,7 @@ module.exports = {
         enabled: withOptimizations,
         runs: 200,
       },
+      viaIR: withOptimizations,
     },
   },
   networks: {


### PR DESCRIPTION
Since [0.8.13](https://github.com/ethereum/solidity/releases/tag/v0.8.13), the YUL IR pipeline is no longer experimental.

This greatly impacts the compilation time when optimization is enabled (from ~20 to ~80sec on my machine), so most tests should continue to run on the non-optimized version.