### PR TITLE
Use a customizable _execute function in TimelockController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  * `ERC2981`: make `royaltiInfo` public to allow super call in overrides. ([#3305](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3305))
+ * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
 
 ## Unreleased
 
@@ -22,7 +23,6 @@
  * `Governor`: Implement `IERC721Receiver` and `IERC1155Receiver` to improve token custody by governors. ([#3230](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3230))
  * `TimelockController`: Implement `IERC721Receiver` and `IERC1155Receiver` to improve token custody by timelocks. ([#3230](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3230))
  * `TimelockController`: Add a separate canceller role for the ability to cancel. ([#3165](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3165))
- * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `Initializable`: add a reinitializer modifier that enables the initialization of new modules, added to already initialized contracts through upgradeability. ([#3232](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3232))
  * `Initializable`: add an Initialized event that tracks initialized version numbers. ([#3294](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3294))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  * `Governor`: Implement `IERC721Receiver` and `IERC1155Receiver` to improve token custody by governors. ([#3230](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3230))
  * `TimelockController`: Implement `IERC721Receiver` and `IERC1155Receiver` to improve token custody by timelocks. ([#3230](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3230))
  * `TimelockController`: Add a separate canceller role for the ability to cancel. ([#3165](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3165))
+ * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `Initializable`: add a reinitializer modifier that enables the initialization of new modules, added to already initialized contracts through upgradeability. ([#3232](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3232))
  * `Initializable`: add an Initialized event that tracks initialized version numbers. ([#3294](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3294))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
  * `Governor`: Implement `IERC721Receiver` and `IERC1155Receiver` to improve token custody by governors. ([#3230](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3230))
  * `TimelockController`: Implement `IERC721Receiver` and `IERC1155Receiver` to improve token custody by timelocks. ([#3230](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3230))
  * `TimelockController`: Add a separate canceller role for the ability to cancel. ([#3165](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3165))
- * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
+ * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `Initializable`: add a reinitializer modifier that enables the initialization of new modules, added to already initialized contracts through upgradeability. ([#3232](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3232))
  * `Initializable`: add an Initialized event that tracks initialized version numbers. ([#3294](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3294))
 

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 import "../access/AccessControl.sol";
 import "../token/ERC721/IERC721Receiver.sol";
 import "../token/ERC1155/IERC1155Receiver.sol";
+import "../utils/Address.sol";
 
 /**
  * @dev Contract module which acts as a timelocked controller. When set as the
@@ -288,13 +289,15 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
     function execute(
         address target,
         uint256 value,
-        bytes calldata data,
+        bytes calldata payload,
         bytes32 predecessor,
         bytes32 salt
     ) public payable virtual onlyRoleOrOpenRole(EXECUTOR_ROLE) {
-        bytes32 id = hashOperation(target, value, data, predecessor, salt);
+        bytes32 id = hashOperation(target, value, payload, predecessor, salt);
+
         _beforeCall(id, predecessor);
-        _call(id, 0, target, value, data);
+        _execute(target, value, payload);
+        emit CallExecuted(id, 0, target, value, payload);
         _afterCall(id);
     }
 
@@ -318,11 +321,28 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         require(targets.length == payloads.length, "TimelockController: length mismatch");
 
         bytes32 id = hashOperationBatch(targets, values, payloads, predecessor, salt);
+
         _beforeCall(id, predecessor);
         for (uint256 i = 0; i < targets.length; ++i) {
-            _call(id, i, targets[i], values[i], payloads[i]);
+            address target = targets[i];
+            uint256 value = values[i];
+            bytes calldata payload = payloads[i];
+            _execute(target, value, payload);
+            emit CallExecuted(id, i, target, value, payload);
         }
         _afterCall(id);
+    }
+
+    /**
+     * @dev Execute an operation's call.
+     */
+    function _execute(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) internal virtual {
+        (bool success, bytes memory  returndata) = target.call{value: value}(data);
+        Address.verifyCallResult(success, returndata, "TimelockController: underlying transaction reverted");
     }
 
     /**
@@ -339,24 +359,6 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
     function _afterCall(bytes32 id) private {
         require(isOperationReady(id), "TimelockController: operation is not ready");
         _timestamps[id] = _DONE_TIMESTAMP;
-    }
-
-    /**
-     * @dev Execute an operation's call.
-     *
-     * Emits a {CallExecuted} event.
-     */
-    function _call(
-        bytes32 id,
-        uint256 index,
-        address target,
-        uint256 value,
-        bytes calldata data
-    ) internal virtual {
-        (bool success, ) = target.call{value: value}(data);
-        require(success, "TimelockController: underlying transaction reverted");
-
-        emit CallExecuted(id, index, target, value, data);
     }
 
     /**

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -341,7 +341,7 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         uint256 value,
         bytes calldata data
     ) internal virtual {
-        (bool success, bytes memory  returndata) = target.call{value: value}(data);
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
         Address.verifyCallResult(success, returndata, "TimelockController: underlying transaction reverted");
     }
 

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -341,7 +341,7 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         uint256 value,
         bytes calldata data
     ) internal virtual {
-        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        (bool success, ) = target.call{value: value}(data);
         require(success, "TimelockController: underlying transaction reverted");
     }
 

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -352,7 +352,7 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         address target,
         uint256 value,
         bytes calldata data
-    ) private {
+    ) internal virtual {
         (bool success, ) = target.call{value: value}(data);
         require(success, "TimelockController: underlying transaction reverted");
 

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -342,7 +342,7 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         bytes calldata data
     ) internal virtual {
         (bool success, bytes memory returndata) = target.call{value: value}(data);
-        Address.verifyCallResult(success, returndata, "TimelockController: underlying transaction reverted");
+        require(success, "TimelockController: underlying transaction reverted");
     }
 
     /**

--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -634,7 +634,7 @@ contract('TimelockController', function (accounts) {
             ],
             [
               this.callreceivermock.contract.methods.mockFunction().encodeABI(),
-              this.callreceivermock.contract.methods.mockFunctionThrows().encodeABI(),
+              this.callreceivermock.contract.methods.mockFunctionRevertsNoReason().encodeABI(),
               this.callreceivermock.contract.methods.mockFunction().encodeABI(),
             ],
             ZERO_BYTES32,
@@ -886,13 +886,13 @@ contract('TimelockController', function (accounts) {
       );
     });
 
-    it('call throw', async function () {
+    it('call reverting with message', async function () {
       const operation = genOperation(
         this.callreceivermock.address,
         0,
-        this.callreceivermock.contract.methods.mockFunctionThrows().encodeABI(),
+        this.callreceivermock.contract.methods.mockFunctionRevertsReason().encodeABI(),
         ZERO_BYTES32,
-        '0xe5ca79f295fc8327ee8a765fe19afb58f4a0cbc5053642bfdd7e73bc68e0fc67',
+        '0xb1b1b276fdf1a28d1e00537ea73b04d56639128b08063c1a2f70a52e38cba693',
       );
 
       await this.mock.schedule(
@@ -914,7 +914,38 @@ contract('TimelockController', function (accounts) {
           operation.salt,
           { from: executor },
         ),
-        'TimelockController: underlying transaction reverted',
+        'CallReceiverMock: reverting',
+      );
+    });
+
+    it('call throw', async function () {
+      const operation = genOperation(
+        this.callreceivermock.address,
+        0,
+        this.callreceivermock.contract.methods.mockFunctionThrows().encodeABI(),
+        ZERO_BYTES32,
+        '0xe5ca79f295fc8327ee8a765fe19afb58f4a0cbc5053642bfdd7e73bc68e0fc67',
+      );
+
+      await this.mock.schedule(
+        operation.target,
+        operation.value,
+        operation.data,
+        operation.predecessor,
+        operation.salt,
+        MINDELAY,
+        { from: proposer },
+      );
+      await time.increase(MINDELAY);
+      await expectRevert.unspecified(
+        this.mock.execute(
+          operation.target,
+          operation.value,
+          operation.data,
+          operation.predecessor,
+          operation.salt,
+          { from: executor },
+        ),
       );
     });
 
@@ -937,7 +968,7 @@ contract('TimelockController', function (accounts) {
         { from: proposer },
       );
       await time.increase(MINDELAY);
-      await expectRevert(
+      await expectRevert.outOfGas(
         this.mock.execute(
           operation.target,
           operation.value,
@@ -946,7 +977,6 @@ contract('TimelockController', function (accounts) {
           operation.salt,
           { from: executor, gas: '70000' },
         ),
-        'TimelockController: underlying transaction reverted',
       );
     });
 

--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -634,7 +634,7 @@ contract('TimelockController', function (accounts) {
             ],
             [
               this.callreceivermock.contract.methods.mockFunction().encodeABI(),
-              this.callreceivermock.contract.methods.mockFunctionRevertsNoReason().encodeABI(),
+              this.callreceivermock.contract.methods.mockFunctionThrows().encodeABI(),
               this.callreceivermock.contract.methods.mockFunction().encodeABI(),
             ],
             ZERO_BYTES32,
@@ -886,13 +886,13 @@ contract('TimelockController', function (accounts) {
       );
     });
 
-    it('call reverting with message', async function () {
+    it('call throw', async function () {
       const operation = genOperation(
         this.callreceivermock.address,
         0,
-        this.callreceivermock.contract.methods.mockFunctionRevertsReason().encodeABI(),
+        this.callreceivermock.contract.methods.mockFunctionThrows().encodeABI(),
         ZERO_BYTES32,
-        '0xb1b1b276fdf1a28d1e00537ea73b04d56639128b08063c1a2f70a52e38cba693',
+        '0xe5ca79f295fc8327ee8a765fe19afb58f4a0cbc5053642bfdd7e73bc68e0fc67',
       );
 
       await this.mock.schedule(
@@ -914,38 +914,7 @@ contract('TimelockController', function (accounts) {
           operation.salt,
           { from: executor },
         ),
-        'CallReceiverMock: reverting',
-      );
-    });
-
-    it('call throw', async function () {
-      const operation = genOperation(
-        this.callreceivermock.address,
-        0,
-        this.callreceivermock.contract.methods.mockFunctionThrows().encodeABI(),
-        ZERO_BYTES32,
-        '0xe5ca79f295fc8327ee8a765fe19afb58f4a0cbc5053642bfdd7e73bc68e0fc67',
-      );
-
-      await this.mock.schedule(
-        operation.target,
-        operation.value,
-        operation.data,
-        operation.predecessor,
-        operation.salt,
-        MINDELAY,
-        { from: proposer },
-      );
-      await time.increase(MINDELAY);
-      await expectRevert.unspecified(
-        this.mock.execute(
-          operation.target,
-          operation.value,
-          operation.data,
-          operation.predecessor,
-          operation.salt,
-          { from: executor },
-        ),
+        'TimelockController: underlying transaction reverted',
       );
     });
 
@@ -968,7 +937,7 @@ contract('TimelockController', function (accounts) {
         { from: proposer },
       );
       await time.increase(MINDELAY);
-      await expectRevert.outOfGas(
+      await expectRevert(
         this.mock.execute(
           operation.target,
           operation.value,
@@ -977,6 +946,7 @@ contract('TimelockController', function (accounts) {
           operation.salt,
           { from: executor, gas: '70000' },
         ),
+        'TimelockController: underlying transaction reverted',
       );
     });
 


### PR DESCRIPTION
Fixes #N/A

Set the `_call` method of the TimelockController to internal virtual so it can be overridden.

For context, I am looking to write a TimelockController which exclusively executes through a Gnosis Safe as a module https://github.com/gnosis/safe-contracts/blob/main/contracts/base/ModuleManager.sol#L61-L73

So the "call" would get overridden to:
```
    function _call(
        bytes32 id,
        uint256 index,
        address target,
        uint256 value,
        bytes calldata data
    ) internal override {
        safe.executeTransactionFromModule(target, value, data, Operation.CALL);

        emit CallExecuted(id, index, target, value, data);
```

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry