### PR TITLE
Improving comments for the _burn() function in ERC721URIStorage.

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -48,14 +48,9 @@ abstract contract ERC721URIStorage is ERC721 {
     }
 
     /**
-     * @dev Destroys `tokenId`.
-     * The approval is cleared when the token is burned.
-     *
-     * Requirements:
-     *
-     * - `tokenId` must exist.
-     *
-     * Emits a {Transfer} event.
+     * @dev See {ERC721-_burn}. This override additionally checks to see if a
+     * token-specific URI was set for the token, and if so, it deletes the token URI from
+     * the storage mapping.
      */
     function _burn(uint256 tokenId) internal virtual override {
         super._burn(tokenId);


### PR DESCRIPTION
Currently the comments for this function are really documenting what the
inherited function does in the parent contract (in other words, they are
describing what happens when 'super' is called). This commit changes the
comments to be more in line with other comments of other inherited
functions, whereby reference is made to the parent contract, but the
comments describe the local version of the function. An example of this
can be seen in ERC721Royalty.sol, where the comments reference the
parent contract, but describe the functionality of what the override is
doing. This seems like a better approach, because if the parent contract
were to every be changed, the comments would not necessarily need
amending in the descendants.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3324

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
