### PR TITLE
Optimize ERC1167 proxy creation code by 1 opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  * `ERC2981`: make `royaltiInfo` public to allow super call in overrides. ([#3305](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3305))
+ * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
 
 ## Unreleased
 

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -25,9 +25,9 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         assembly {
             let ptr := mload(0x40)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(ptr, 0x14), shl(0x60, implementation))
-            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
+            mstore(add(ptr, 0x13), shl(0x60, implementation))
+            mstore(add(ptr, 0x27), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
             instance := create(0, ptr, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -43,9 +43,9 @@ library Clones {
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         assembly {
             let ptr := mload(0x40)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(ptr, 0x14), shl(0x60, implementation))
-            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
+            mstore(add(ptr, 0x13), shl(0x60, implementation))
+            mstore(add(ptr, 0x27), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
             instance := create2(0, ptr, 0x37, salt)
         }
         require(instance != address(0), "ERC1167: create2 failed");
@@ -61,11 +61,11 @@ library Clones {
     ) internal pure returns (address predicted) {
         assembly {
             let ptr := mload(0x40)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(ptr, 0x14), shl(0x60, implementation))
-            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
-            mstore(add(ptr, 0x38), shl(0x60, deployer))
-            mstore(add(ptr, 0x4c), salt)
+            mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
+            mstore(add(ptr, 0x13), shl(0x60, implementation))
+            mstore(add(ptr, 0x27), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
+            mstore(add(ptr, 0x37), shl(0x60, deployer))
+            mstore(add(ptr, 0x4b), salt)
             mstore(add(ptr, 0x6c), keccak256(ptr, 0x37))
             predicted := keccak256(add(ptr, 0x37), 0x55)
         }

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -28,7 +28,7 @@ library Clones {
             mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
             mstore(add(ptr, 0x13), shl(0x60, implementation))
             mstore(add(ptr, 0x27), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-            instance := create(0, ptr, 0x37)
+            instance := create(0, ptr, 0x36)
         }
         require(instance != address(0), "ERC1167: create failed");
     }
@@ -46,7 +46,7 @@ library Clones {
             mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
             mstore(add(ptr, 0x13), shl(0x60, implementation))
             mstore(add(ptr, 0x27), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-            instance := create2(0, ptr, 0x37, salt)
+            instance := create2(0, ptr, 0x36, salt)
         }
         require(instance != address(0), "ERC1167: create2 failed");
     }
@@ -66,8 +66,8 @@ library Clones {
             mstore(add(ptr, 0x27), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
             mstore(add(ptr, 0x37), shl(0x60, deployer))
             mstore(add(ptr, 0x4b), salt)
-            mstore(add(ptr, 0x6c), keccak256(ptr, 0x37))
-            predicted := keccak256(add(ptr, 0x37), 0x55)
+            mstore(add(ptr, 0x6b), keccak256(ptr, 0x36))
+            predicted := keccak256(add(ptr, 0x36), 0x55)
         }
     }
 


### PR DESCRIPTION
#### Fixes: None (No issue created beforehand)

#### Description

The existing proxy creation bytecode was a total of 55 bytes:
* `3d602d80600a3d3981f3` 10 bytes, responsible for returning the remaining 45 byte [ERC1167](https://eips.ethereum.org/EIPS/eip-1167) proxy code, equivalent to the constructor in solidity
* `363d3d373d3d3d363d73????????????????????????????????????????5af43d82803e903pd91602b57fd5bf3` 45 bytes, standard ERC1167 proxy bytecode

Looking at the execution of the constructor code one notices that one value always remains, unused on the stack at the end of execution (stack after op depicted in the square brackets; left -> right, top -> bottom):
1. (0) RETURNDATASIZE [ 0, ]
2. (2) PUSH1 0x2d [ 45, 0, ]
3. (3) DUP1 [ 45, 45, 0, ]
4. (5) PUSH1 0x0a [ 10, 45, 45, 0, ]
5. (6) RETURNDATASIZE [ 0, 10, 45, 45, 0, ]
6. (7) CODECOPY [ 45, 0, ]
7. (8) DUP2 [ 0, 45, 0, ]
8. (9) RETURN [ 0, ]

By rearranging the opcodes slightly, one opcode can be removed, resulting in a smaller, 9-byte constructor `602d8060093d393df3`:
1.  (0) PUSH1 0x2d [ 45, ]
2.  (2) DUP1 [ 45, 45, ]
3.  (4) PUSH1 0x09 [ 9, 45, 45, ]
4.  (5) RETURNDATASIZE [0, 9, 45, 45, ]
5.  (6) CODECOPY [ 45, ]
6.  (7) RETURNDATASIZE [ 0, 45, ]
7.  (8) RETURN [ ]

The `proxy/Clones.sol` library's `clone`, `cloneDeterministic` and `predictDeterministicAddress` methods are then adjusted for the smaller code. The total creation bytecode is then 54 bytes instead of the current 55 bytes.

#### PR Checklist

- [X] Tests (functionality should remain unchanged, therefore tests should remain unchanged)
- [X] Documentation (functionality should remain unchanged, therefore docs should remain unchanged)
- [x] Changelog entry (unsure how to change)
