### PR TITLE
Update IERC721.sol

### DIFF
--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -108,6 +108,7 @@ interface IERC721 is IERC165 {
      *
      * - The caller must own the token or be an approved operator.
      * - `tokenId` must exist.
+     * - `to` must not be the current owner of the `tokenId`.
      *
      * Emits an {Approval} event.
      */


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- New features will be merged faster if they were first discussed and designed with the team. -->

I'm sorry, I just found a requirement in the approve() function that was necessary to be added via comment, according to the ERC721 implementation. 

IERC721.sol comment on Line 111, " `to` must not be the current owner of the `tokenId` ".
