### PR TITLE
Restore previous behavior of initializer during construction

### DIFF
--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -60,6 +60,18 @@ contract ConstructorInitializableMock is Initializable {
     }
 }
 
+contract ChildConstructorInitializableMock is ConstructorInitializableMock {
+    bool public childInitializerRan;
+
+    constructor() initializer {
+        childInitialize();
+    }
+
+    function childInitialize() public initializer {
+        childInitializerRan = true;
+    }
+}
+
 contract ReinitializerMock is Initializable {
     uint256 public counter;
 

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -141,7 +141,7 @@ abstract contract Initializable {
             );
             return false;
         } else {
-            require(_initialized < version, "Initializable: contract is already initialized");
+            require(_initialized < version || (version == 1 && !Address.isContract(address(this))), "Initializable: contract is already initialized");
             _initialized = version;
             return true;
         }

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -139,8 +139,9 @@ abstract contract Initializable {
         uint8 currentVersion = _initialized; // cache sload
 
         require(
-            (isTopLevelCall && version > currentVersion) || // not nested with increasing version or
-                (!Address.isContract(address(this)) && version == 1), // contract being constructed
+            // not nested with increasing version or
+            // contract being constructed and initializing version 1
+            (isTopLevelCall && version > currentVersion) || (!Address.isContract(address(this)) && version == 1),
             "Initializable: contract is already initialized"
         );
 

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -139,9 +139,8 @@ abstract contract Initializable {
         uint8 currentVersion = _initialized; // cache sload
 
         require(
-            // not nested with increasing version or
-            // contract being constructed and initializing version 1
-            (isTopLevelCall && version > currentVersion) || (!Address.isContract(address(this)) && version == 1),
+            (isTopLevelCall && version > currentVersion) || // not nested with increasing version or
+                (!Address.isContract(address(this)) && (version == 1 || version == type(uint8).max)), // contract being constructed
             "Initializable: contract is already initialized"
         );
 

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -134,19 +134,21 @@ abstract contract Initializable {
         // If the contract is initializing we ignore whether _initialized is set in order to support multiple
         // inheritance patterns, but we only do this in the context of a constructor, and for the lowest level
         // of initializers, because in other contexts the contract may have been reentered.
-        if (_initializing) {
-            require(
-                version == 1 && !Address.isContract(address(this)),
-                "Initializable: contract is already initialized"
-            );
-            return false;
-        } else {
-            require(
-                _initialized < version || (version == 1 && !Address.isContract(address(this))),
-                "Initializable: contract is already initialized"
-            );
+
+        bool isTopLevelCall = !_initializing; // cache sload
+        uint8 currentVersion = _initialized; // cache sload
+
+        require(
+            (isTopLevelCall && version > currentVersion) || // not nested with increasing version or
+                (!isTopLevelCall && version == currentVersion) || // nested with same version or
+                (!Address.isContract(address(this)) && version == 1), // contract being constructed
+            "Initializable: contract is already initialized"
+        );
+
+        if (isTopLevelCall) {
             _initialized = version;
-            return true;
         }
+
+        return isTopLevelCall;
     }
 }

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -140,7 +140,6 @@ abstract contract Initializable {
 
         require(
             (isTopLevelCall && version > currentVersion) || // not nested with increasing version or
-                (!isTopLevelCall && version == currentVersion) || // nested with same version or
                 (!Address.isContract(address(this)) && version == 1), // contract being constructed
             "Initializable: contract is already initialized"
         );

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -141,7 +141,10 @@ abstract contract Initializable {
             );
             return false;
         } else {
-            require(_initialized < version || (version == 1 && !Address.isContract(address(this))), "Initializable: contract is already initialized");
+            require(
+                _initialized < version || (version == 1 && !Address.isContract(address(this))),
+                "Initializable: contract is already initialized"
+            );
             _initialized = version;
             return true;
         }

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -34,7 +34,7 @@ contract('Initializable', function (accounts) {
     });
 
     describe('nested under an initializer', function () {
-      it('initializer modifier can be nested', async function () {
+      it('initializer modifier reverts', async function () {
         await expectRevert(this.contract.initializerNested(), 'Initializable: contract is already initialized');
       });
 

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -85,13 +85,9 @@ contract('Initializable', function (accounts) {
       expect(await this.contract.counter()).to.be.bignumber.equal('2');
     });
 
-    it('can nest reinitializers with same version', async function () {
+    it('cannot nest reinitializers', async function () {
       expect(await this.contract.counter()).to.be.bignumber.equal('0');
       await expectRevert(this.contract.nestedReinitialize(2, 2), 'Initializable: contract is already initialized');
-    });
-
-    it('cannot nest reinitializers with different versions', async function () {
-      expect(await this.contract.counter()).to.be.bignumber.equal('0');
       await expectRevert(this.contract.nestedReinitialize(2, 3), 'Initializable: contract is already initialized');
       await expectRevert(this.contract.nestedReinitialize(3, 2), 'Initializable: contract is already initialized');
     });

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -34,8 +34,8 @@ contract('Initializable', function (accounts) {
     });
 
     describe('nested under an initializer', function () {
-      it('initializer modifier reverts', async function () {
-        await expectRevert(this.contract.initializerNested(), 'Initializable: contract is already initialized');
+      it('initializer modifier can be nested', async function () {
+        await this.contract.initializerNested();
       });
 
       it('onlyInitializing modifier succeeds', async function () {
@@ -85,7 +85,13 @@ contract('Initializable', function (accounts) {
       expect(await this.contract.counter()).to.be.bignumber.equal('2');
     });
 
-    it('cannot nest reinitializers', async function () {
+    it('can nest reinitializers with same version', async function () {
+      expect(await this.contract.counter()).to.be.bignumber.equal('0');
+      await this.contract.nestedReinitialize(2, 2);
+      expect(await this.contract.counter()).to.be.bignumber.equal('1');
+    });
+
+    it('cannot nest reinitializers with different versions', async function () {
       expect(await this.contract.counter()).to.be.bignumber.equal('0');
       await expectRevert(this.contract.nestedReinitialize(2, 3), 'Initializable: contract is already initialized');
       await expectRevert(this.contract.nestedReinitialize(3, 2), 'Initializable: contract is already initialized');

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 
 const InitializableMock = artifacts.require('InitializableMock');
 const ConstructorInitializableMock = artifacts.require('ConstructorInitializableMock');
+const ChildConstructorInitializableMock = artifacts.require('ChildConstructorInitializableMock');
 const ReinitializerMock = artifacts.require('ReinitializerMock');
 const SampleChild = artifacts.require('SampleChild');
 
@@ -51,6 +52,13 @@ contract('Initializable', function (accounts) {
   it('nested initializer can run during construction', async function () {
     const contract2 = await ConstructorInitializableMock.new();
     expect(await contract2.initializerRan()).to.equal(true);
+    expect(await contract2.onlyInitializingRan()).to.equal(true);
+  });
+
+  it('multiple constructor levels can be initializers', async function () {
+    const contract2 = await ChildConstructorInitializableMock.new();
+    expect(await contract2.initializerRan()).to.equal(true);
+    expect(await contract2.childInitializerRan()).to.equal(true);
     expect(await contract2.onlyInitializingRan()).to.equal(true);
   });
 

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -35,7 +35,7 @@ contract('Initializable', function (accounts) {
 
     describe('nested under an initializer', function () {
       it('initializer modifier can be nested', async function () {
-        await this.contract.initializerNested();
+        await expectRevert(this.contract.initializerNested(), 'Initializable: contract is already initialized');
       });
 
       it('onlyInitializing modifier succeeds', async function () {
@@ -87,8 +87,7 @@ contract('Initializable', function (accounts) {
 
     it('can nest reinitializers with same version', async function () {
       expect(await this.contract.counter()).to.be.bignumber.equal('0');
-      await this.contract.nestedReinitialize(2, 2);
-      expect(await this.contract.counter()).to.be.bignumber.equal('1');
+      await expectRevert(this.contract.nestedReinitialize(2, 2), 'Initializable: contract is already initialized');
     });
 
     it('cannot nest reinitializers with different versions', async function () {


### PR DESCRIPTION
The following code is broken with 4.x:

```
contract A is Initializable {
    constructor() initializer { /* ... */ }
    /* ... */
}

contract B is A {
    constructor() initializer { /* ... */ }
    /* ... */
}
```

When B's constructor enters the `initializer` modifier, A's construction is already over. We are:
- not initializing
- version already set to 1.

This falls into the `else` part of `_setInitializedVersion`, which requires the next version to be greater than the previous one.

---

This would work, but requires the dev to affect version numbers that match the linearisation ...
```
contract B is A {
    constructor() reinitializer(2) { /* ... */ }
    /* ... */
}
```

---

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
