### PR TITLE
FlashLoanGuard modifier

### DIFF
--- a/contracts/mocks/FlashLoanAttack.sol
+++ b/contracts/mocks/FlashLoanAttack.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "./FlashLoanMock.sol";
+
+contract FlashLoanAttack is FlashLoanGuard {
+    function increaseSafe(address addr) public {
+        FlashLoanMock(addr).increaseSafe();
+        FlashLoanMock(addr).increaseSafe();
+        FlashLoanMock(addr).increaseSafe();
+    }
+
+    function increaseUnsafe(address addr) public {
+        FlashLoanMock(addr).increaseUnsafe();
+        FlashLoanMock(addr).increaseUnsafe();
+        FlashLoanMock(addr).increaseUnsafe();
+    }
+}

--- a/contracts/mocks/FlashLoanMock.sol
+++ b/contracts/mocks/FlashLoanMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../security/FlashLoanGuard.sol";
+
+contract FlashLoanMock is FlashLoanGuard {
+    uint256 public counter;
+
+    constructor() {
+        counter = 0;
+    }
+
+    function increaseSafe() public flashLoanGuard {
+        counter += 1;
+    }
+
+    function increaseUnsafe() public {
+        counter += 1;
+    }
+}

--- a/contracts/security/FlashLoanGuard.sol
+++ b/contracts/security/FlashLoanGuard.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (security/FlashLoanGuard.sol)
+/**
+ * @dev Contract module that helps prevent critial actions from
+ * happening in the same block, which may result in flash loan attacks.
+ * Inheriting from `FlashLoanGuard` will make the {flasLoanGuard} modifier
+ * available, which can be applied to functions to make sure they can only happen
+ * in subsequent blocks, preventing flash loan attacks.
+ *
+ * https://blog.openzeppelin.com/flash-loans-and-the-advent-of-episodic-finance/
+ */
+
+pragma solidity ^0.8.0;
+
+abstract contract FlashLoanGuard {
+    uint256 _lastActionTimestamp;
+
+    /**
+     * @dev Initializes the contract with lastActionTimestamp set to
+     * deploymeny yime
+     */
+    constructor() {
+        _lastActionTimestamp = block.timestamp;
+    }
+
+    /** @dev Guards against subsequent `flashLoanGuard`
+     * actions from happening in the same block
+     */
+    modifier flashLoanGuard() {
+        require(block.timestamp - _lastActionTimestamp > 0, "FlashLoanGuard: too many calls in same block");
+        _lastActionTimestamp = block.timestamp;
+        _;
+    }
+}

--- a/contracts/security/README.adoc
+++ b/contracts/security/README.adoc
@@ -7,6 +7,7 @@ These contracts aim to cover common security practices.
 
 * {PullPayment}: A pattern that can be used to avoid reentrancy attacks.
 * {ReentrancyGuard}: A modifier that can prevent reentrancy during certain functions.
+* {FlashLoanGuard}: A modifier that can prevents subsequent critical actions whithin the same block.
 * {Pausable}: A common emergency response mechanism that can pause functionality while a remediation is pending.
 
 TIP: For an overview on reentrancy and the possible mechanisms to prevent it, read our article https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
@@ -16,5 +17,7 @@ TIP: For an overview on reentrancy and the possible mechanisms to prevent it, re
 {{PullPayment}}
 
 {{ReentrancyGuard}}
+
+{{FlashLoanGuard}}
 
 {{Pausable}}

--- a/test/security/FlashLoanGuard.test.js
+++ b/test/security/FlashLoanGuard.test.js
@@ -11,17 +11,17 @@ contract('FlashLoanGuard', function (accounts) {
     expect(await this.flashLoanMock.counter()).to.be.bignumber.equal('0');
   });
 
-  it("allow unguarded function to increase ctr", async function() {
+  it('allow unguarded function to increase ctr', async function () {
     const attacker = await FlashLoanAttack.new();
     await attacker.increaseUnsafe(this.flashLoanMock.address);
     expect(await this.flashLoanMock.counter()).to.be.bignumber.equal('3');
-  })
+  });
 
-  it("prevent guarded function to increase ctr", async function() {
+  it('prevent guarded function to increase ctr', async function () {
     const attacker = await FlashLoanAttack.new();
     await expectRevert(
       attacker.increaseSafe(this.flashLoanMock.address),
-      'FlashLoanGuard: too many calls in same block'
+      'FlashLoanGuard: too many calls in same block',
     );
-  })
+  });
 });

--- a/test/security/FlashLoanGuard.test.js
+++ b/test/security/FlashLoanGuard.test.js
@@ -1,0 +1,27 @@
+const { expectRevert } = require('@openzeppelin/test-helpers');
+
+const { expect } = require('chai');
+
+const FlashLoanMock = artifacts.require('FlashLoanMock');
+const FlashLoanAttack = artifacts.require('FlashLoanAttack');
+
+contract('FlashLoanGuard', function (accounts) {
+  beforeEach(async function () {
+    this.flashLoanMock = await FlashLoanMock.new();
+    expect(await this.flashLoanMock.counter()).to.be.bignumber.equal('0');
+  });
+
+  it("allow unguarded function to increase ctr", async function() {
+    const attacker = await FlashLoanAttack.new();
+    await attacker.increaseUnsafe(this.flashLoanMock.address);
+    expect(await this.flashLoanMock.counter()).to.be.bignumber.equal('3');
+  })
+
+  it("prevent guarded function to increase ctr", async function() {
+    const attacker = await FlashLoanAttack.new();
+    await expectRevert(
+      attacker.increaseSafe(this.flashLoanMock.address),
+      'FlashLoanGuard: too many calls in same block'
+    );
+  })
+});


### PR DESCRIPTION
With the [recent BEAN flash loan attack](https://cryptobriefing.com/beanstalk-hacker-steals-76m-flash-loan-exploit/) it became clear that this year-old vulnerability is still present in complex contracts, and while the prevention is trivial, widespread usage of "flash loan guards" is lacking. This PR serves to allow complex contracts to protect their critical functionality from being called within the same block multiple times, in the same syntactic way as ReentrancyGuard.