### PR TITLE
Optimize Ownable and Pausable modifiers' size impact

### DIFF
--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -47,7 +47,7 @@ abstract contract Ownable is Context {
     /**
      * @dev Throws if the sender is not the owner.
      */
-    function _checkOwner() internal virtual {
+    function _checkOwner() internal view virtual {
         require(owner() == _msgSender(), "Ownable: caller is not the owner");
     }
 

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -37,10 +37,17 @@ abstract contract Ownable is Context {
     }
 
     /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _onlyOwner() internal virtual {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+    }
+
+    /**
      * @dev Throws if called by any account other than the owner.
      */
     modifier onlyOwner() {
-        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _onlyOwner();
         _;
     }
 

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -30,6 +30,14 @@ abstract contract Ownable is Context {
     }
 
     /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _onlyOwner();
+        _;
+    }
+
+    /**
      * @dev Returns the address of the current owner.
      */
     function owner() public view virtual returns (address) {
@@ -41,14 +49,6 @@ abstract contract Ownable is Context {
      */
     function _onlyOwner() internal virtual {
         require(owner() == _msgSender(), "Ownable: caller is not the owner");
-    }
-
-    /**
-     * @dev Throws if called by any account other than the owner.
-     */
-    modifier onlyOwner() {
-        _onlyOwner();
-        _;
     }
 
     /**

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -33,7 +33,7 @@ abstract contract Ownable is Context {
      * @dev Throws if called by any account other than the owner.
      */
     modifier onlyOwner() {
-        _onlyOwner();
+        _checkOwner();
         _;
     }
 
@@ -47,7 +47,7 @@ abstract contract Ownable is Context {
     /**
      * @dev Throws if the sender is not the owner.
      */
-    function _onlyOwner() internal virtual {
+    function _checkOwner() internal virtual {
         require(owner() == _msgSender(), "Ownable: caller is not the owner");
     }
 

--- a/contracts/security/Pausable.sol
+++ b/contracts/security/Pausable.sol
@@ -68,14 +68,14 @@ abstract contract Pausable is Context {
     /**
      * @dev Throws if the contract is paused.
      */
-    function _requireNotPaused() internal virtual {
+    function _requireNotPaused() internal view virtual {
         require(!paused(), "Pausable: paused");
     }
 
     /**
      * @dev Throws if the contract is not paused.
      */
-    function _requirePaused() internal virtual {
+    function _requirePaused() internal view virtual {
         require(paused(), "Pausable: not paused");
     }
 

--- a/contracts/security/Pausable.sol
+++ b/contracts/security/Pausable.sol
@@ -42,6 +42,13 @@ abstract contract Pausable is Context {
     }
 
     /**
+     * @dev Throws if the contract is paused.
+     */
+    function _whenNotPaused() internal virtual {
+        require(!paused(), "Pausable: paused");
+    }
+
+    /**
      * @dev Modifier to make a function callable only when the contract is not paused.
      *
      * Requirements:
@@ -49,8 +56,15 @@ abstract contract Pausable is Context {
      * - The contract must not be paused.
      */
     modifier whenNotPaused() {
-        require(!paused(), "Pausable: paused");
+        _whenNotPaused();
         _;
+    }
+
+    /**
+     * @dev Throws if the contract is not paused.
+     */
+    function _whenPaused() internal virtual {
+        require(paused(), "Pausable: not paused");
     }
 
     /**
@@ -61,7 +75,7 @@ abstract contract Pausable is Context {
      * - The contract must be paused.
      */
     modifier whenPaused() {
-        require(paused(), "Pausable: not paused");
+        _whenPaused();
         _;
     }
 

--- a/contracts/security/Pausable.sol
+++ b/contracts/security/Pausable.sol
@@ -35,6 +35,30 @@ abstract contract Pausable is Context {
     }
 
     /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        _whenNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        _whenPaused();
+        _;
+    }
+
+    /**
      * @dev Returns true if the contract is paused, and false otherwise.
      */
     function paused() public view virtual returns (bool) {
@@ -49,34 +73,10 @@ abstract contract Pausable is Context {
     }
 
     /**
-     * @dev Modifier to make a function callable only when the contract is not paused.
-     *
-     * Requirements:
-     *
-     * - The contract must not be paused.
-     */
-    modifier whenNotPaused() {
-        _whenNotPaused();
-        _;
-    }
-
-    /**
      * @dev Throws if the contract is not paused.
      */
     function _whenPaused() internal virtual {
         require(paused(), "Pausable: not paused");
-    }
-
-    /**
-     * @dev Modifier to make a function callable only when the contract is paused.
-     *
-     * Requirements:
-     *
-     * - The contract must be paused.
-     */
-    modifier whenPaused() {
-        _whenPaused();
-        _;
     }
 
     /**

--- a/contracts/security/Pausable.sol
+++ b/contracts/security/Pausable.sol
@@ -42,7 +42,7 @@ abstract contract Pausable is Context {
      * - The contract must not be paused.
      */
     modifier whenNotPaused() {
-        _whenNotPaused();
+        _requireNotPaused();
         _;
     }
 
@@ -54,7 +54,7 @@ abstract contract Pausable is Context {
      * - The contract must be paused.
      */
     modifier whenPaused() {
-        _whenPaused();
+        _requirePaused();
         _;
     }
 
@@ -68,14 +68,14 @@ abstract contract Pausable is Context {
     /**
      * @dev Throws if the contract is paused.
      */
-    function _whenNotPaused() internal virtual {
+    function _requireNotPaused() internal virtual {
         require(!paused(), "Pausable: paused");
     }
 
     /**
      * @dev Throws if the contract is not paused.
      */
-    function _whenPaused() internal virtual {
+    function _requirePaused() internal virtual {
         require(paused(), "Pausable: not paused");
     }
 


### PR DESCRIPTION
Fixes #3222

<!-- Describe the changes introduced in this pull request. -->
#### Affects:
- `contracts/access/Ownable.sol`
- `contracts/security/Pausable.sol`

#### Changes:
- In both contracts, the modifiers require statements are moved into an internal virtual function. This reduces the size of compiled contracts that use the modifiers.
- In both contracts, the modifier definition is moved above the definitions of functions to better adhere to the solidity style guide.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
