### PR TITLE
Fix ERC777 link

### DIFF
--- a/contracts/token/ERC777/README.adoc
+++ b/contracts/token/ERC777/README.adoc
@@ -3,7 +3,7 @@
 [.readme-notice]
 NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc777
 
-This set of interfaces and contracts are all related to the [ERC777 token standard](https://eips.ethereum.org/EIPS/eip-777).
+This set of interfaces and contracts are all related to the https://eips.ethereum.org/EIPS/eip-777[ERC777 token standard].
 
 TIP: For an overview of ERC777 tokens and a walk through on how to create a token contract read our xref:ROOT:erc777.adoc[ERC777 guide].
 


### PR DESCRIPTION
Fixes link for ERC777 in https://docs.openzeppelin.com/contracts/4.x/api/token/erc777 to use adoc format.

- [x] Documentation