### PR TITLE
Custom errors start with the address of the emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
+ * `crosschain`: refactor the custom errors, which now start with the address of the emitter. ([#TBD]())
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `crosschain`: refactor the custom errors, which now start with the address of the emitter. ([#TBD]())
+ * `crosschain`: refactor the custom error parameters, which now start with the address of the emitter. ([#TBD]())
 
 ## 4.6.0 (2022-04-26)
 

--- a/contracts/crosschain/CrossChainEnabled.sol
+++ b/contracts/crosschain/CrossChainEnabled.sol
@@ -23,7 +23,7 @@ abstract contract CrossChainEnabled {
      * cross-chain execution.
      */
     modifier onlyCrossChain() {
-        if (!_isCrossChain()) revert NotCrossChainCall();
+        if (!_isCrossChain()) revert NotCrossChainCall(address(this));
         _;
     }
 
@@ -33,7 +33,7 @@ abstract contract CrossChainEnabled {
      */
     modifier onlyCrossChainSender(address expected) {
         address actual = _crossChainSender();
-        if (expected != actual) revert InvalidCrossChainSender(actual, expected);
+        if (expected != actual) revert InvalidCrossChainSender(address(this), actual, expected);
         _;
     }
 

--- a/contracts/crosschain/amb/LibAMB.sol
+++ b/contracts/crosschain/amb/LibAMB.sol
@@ -29,7 +29,7 @@ library LibAMB {
      * function call is not the result of a cross-chain message.
      */
     function crossChainSender(address bridge) internal view returns (address) {
-        if (!isCrossChain(bridge)) revert NotCrossChainCall();
+        if (!isCrossChain(bridge)) revert NotCrossChainCall(address(this));
         return AMB_Bridge(bridge).messageSender();
     }
 }

--- a/contracts/crosschain/arbitrum/LibArbitrumL1.sol
+++ b/contracts/crosschain/arbitrum/LibArbitrumL1.sol
@@ -33,7 +33,7 @@ library LibArbitrumL1 {
      * function call is not the result of a cross-chain message.
      */
     function crossChainSender(address bridge) internal view returns (address) {
-        if (!isCrossChain(bridge)) revert NotCrossChainCall();
+        if (!isCrossChain(bridge)) revert NotCrossChainCall(address(this));
 
         address sender = ArbitrumL1_Outbox(ArbitrumL1_Bridge(bridge).activeOutbox()).l2ToL1Sender();
         require(sender != address(0), "LibArbitrumL1: system messages without sender");

--- a/contracts/crosschain/arbitrum/LibArbitrumL2.sol
+++ b/contracts/crosschain/arbitrum/LibArbitrumL2.sol
@@ -33,7 +33,7 @@ library LibArbitrumL2 {
      * function call is not the result of a cross-chain message.
      */
     function crossChainSender(address arbsys) internal view returns (address) {
-        if (!isCrossChain(arbsys)) revert NotCrossChainCall();
+        if (!isCrossChain(arbsys)) revert NotCrossChainCall(address(this));
 
         return
             ArbitrumL2_Bridge(arbsys).wasMyCallersAddressAliased()

--- a/contracts/crosschain/errors.sol
+++ b/contracts/crosschain/errors.sol
@@ -3,5 +3,18 @@
 
 pragma solidity ^0.8.4;
 
-error NotCrossChainCall();
-error InvalidCrossChainSender(address actual, address expected);
+/**
+ * @dev Error that occurs when a function call is not the result of
+ * a cross-chain message.
+ * @param emitter The contract that emits the error.
+ */
+error NotCrossChainCall(address emitter);
+
+/**
+ * @dev Error that occurs when a function call is not the result of
+ * a cross-chain execution initiated by `account`.
+ * @param emitter The contract that emits the error.
+ * @param actual The actual address that initiated the cross-chain execution.
+ * @param expected The expected address that is allowed to initiate the cross-chain execution.
+ */
+error InvalidCrossChainSender(address emitter, address actual, address expected);

--- a/contracts/crosschain/optimism/LibOptimism.sol
+++ b/contracts/crosschain/optimism/LibOptimism.sol
@@ -29,7 +29,7 @@ library LibOptimism {
      * function call is not the result of a cross-chain message.
      */
     function crossChainSender(address messenger) internal view returns (address) {
-        if (!isCrossChain(messenger)) revert NotCrossChainCall();
+        if (!isCrossChain(messenger)) revert NotCrossChainCall(address(this));
 
         return Optimism_Bridge(messenger).xDomainMessageSender();
     }

--- a/contracts/crosschain/polygon/CrossChainEnabledPolygonChild.sol
+++ b/contracts/crosschain/polygon/CrossChainEnabledPolygonChild.sol
@@ -63,7 +63,7 @@ abstract contract CrossChainEnabledPolygonChild is IFxMessageProcessor, CrossCha
         address rootMessageSender,
         bytes calldata data
     ) external override nonReentrant {
-        if (!_isCrossChain()) revert NotCrossChainCall();
+        if (!_isCrossChain()) revert NotCrossChainCall(address(this));
 
         _sender = rootMessageSender;
         Address.functionDelegateCall(address(this), data, "cross-chain execution failed");

--- a/contracts/mocks/crosschain/bridges.sol
+++ b/contracts/mocks/crosschain/bridges.sol
@@ -7,8 +7,8 @@ import "../../vendor/polygon/IFxMessageProcessor.sol";
 
 abstract contract BaseRelayMock {
     // needed to parse custom errors
-    error NotCrossChainCall();
-    error InvalidCrossChainSender(address sender, address expected);
+    error NotCrossChainCall(address emitter);
+    error InvalidCrossChainSender(address emitter, address actual, address expected);
 
     address internal _currentSender;
 

--- a/test/crosschain/CrossChainEnabled.test.js
+++ b/test/crosschain/CrossChainEnabled.test.js
@@ -15,14 +15,14 @@ function shouldBehaveLikeReceiver (sender = randomAddress()) {
   it('should reject same-chain calls', async function () {
     await expectRevertCustomError(
       this.receiver.crossChainRestricted(),
-      'NotCrossChainCall()',
+      `NotCrossChainCall("${this.receiver.address}")`,
     );
   });
 
   it('should restrict to cross-chain call from a invalid sender', async function () {
     await expectRevertCustomError(
       this.bridge.call(sender, this.receiver, 'crossChainOwnerRestricted()'),
-      `InvalidCrossChainSender("${sender}", "${await this.receiver.owner()}")`,
+      `InvalidCrossChainSender("${this.receiver.address}", "${sender}", "${await this.receiver.owner()}")`,
     );
   });
 


### PR DESCRIPTION
As previously discussed [here](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380#issuecomment-1113337746), custom errors should start with the address of the emitter.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [x] Changelog entry
