### PR TITLE
Add memory safe assembly annotations 

### DIFF
--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -24,6 +24,7 @@ abstract contract ERC2771Context is Context {
     function _msgSender() internal view virtual override returns (address sender) {
         if (isTrustedForwarder(msg.sender)) {
             // The assembly code is more direct than the Solidity version using `abi.decode`.
+            /// @solidity memory-safe-assembly
             assembly {
                 sender := shr(96, calldataload(sub(calldatasize(), 20)))
             }

--- a/contracts/metatx/MinimalForwarder.sol
+++ b/contracts/metatx/MinimalForwarder.sol
@@ -57,6 +57,7 @@ contract MinimalForwarder is EIP712 {
             // We explicitly trigger invalid opcode to consume all gas and bubble-up the effects, since
             // neither revert or assert consume all gas since Solidity 0.8.0
             // https://docs.soliditylang.org/en/v0.8.0/control-structures.html#panic-via-assert-and-error-via-require
+            /// @solidity memory-safe-assembly
             assembly {
                 invalid()
             }

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -73,14 +73,12 @@ contract SafeMathMock {
 
     function addMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        /// @solidity memory-safe-assembly
         assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.add(1, 1);
         }
-        /// @solidity memory-safe-assembly
         assembly {
             mem := sub(mload(0x40), mem)
         }
@@ -88,14 +86,12 @@ contract SafeMathMock {
 
     function subMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        /// @solidity memory-safe-assembly
         assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.sub(1, 1);
         }
-        /// @solidity memory-safe-assembly
         assembly {
             mem := sub(mload(0x40), mem)
         }
@@ -103,14 +99,12 @@ contract SafeMathMock {
 
     function mulMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        /// @solidity memory-safe-assembly
         assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.mul(1, 1);
         }
-        /// @solidity memory-safe-assembly
         assembly {
             mem := sub(mload(0x40), mem)
         }
@@ -118,14 +112,12 @@ contract SafeMathMock {
 
     function divMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        /// @solidity memory-safe-assembly
         assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.div(1, 1);
         }
-        /// @solidity memory-safe-assembly
         assembly {
             mem := sub(mload(0x40), mem)
         }
@@ -133,14 +125,12 @@ contract SafeMathMock {
 
     function modMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        /// @solidity memory-safe-assembly
         assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.mod(1, 1);
         }
-        /// @solidity memory-safe-assembly
         assembly {
             mem := sub(mload(0x40), mem)
         }

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -73,65 +73,75 @@ contract SafeMathMock {
 
     function addMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.add(1, 1);
         }
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function subMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.sub(1, 1);
         }
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function mulMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.mul(1, 1);
         }
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function divMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.div(1, 1);
         }
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function modMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.mod(1, 1);
         }
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             mem := sub(mload(0x40), mem)
         }
     }

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -73,65 +73,65 @@ contract SafeMathMock {
 
     function addMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly {
+        assembly ("memory-safe") {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.add(1, 1);
         }
-        assembly {
+        assembly ("memory-safe") {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function subMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly {
+        assembly ("memory-safe") {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.sub(1, 1);
         }
-        assembly {
+        assembly ("memory-safe") {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function mulMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly {
+        assembly ("memory-safe") {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.mul(1, 1);
         }
-        assembly {
+        assembly ("memory-safe") {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function divMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly {
+        assembly ("memory-safe") {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.div(1, 1);
         }
-        assembly {
+        assembly ("memory-safe") {
             mem := sub(mload(0x40), mem)
         }
     }
 
     function modMemoryCheck() public pure returns (uint256 mem) {
         uint256 length = 32;
-        assembly {
+        assembly ("memory-safe") {
             mem := mload(0x40)
         }
         for (uint256 i = 0; i < length; ++i) {
             SafeMath.mod(1, 1);
         }
-        assembly {
+        assembly ("memory-safe") {
             mem := sub(mload(0x40), mem)
         }
     }

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -23,6 +23,7 @@ library Clones {
      * This function uses the create opcode, which should never revert.
      */
     function clone(address implementation) internal returns (address instance) {
+        /// @solidity memory-safe-assembly
         assembly {
             let ptr := mload(0x40)
             mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
@@ -41,6 +42,7 @@ library Clones {
      * the clones cannot be deployed twice at the same address.
      */
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
+        /// @solidity memory-safe-assembly
         assembly {
             let ptr := mload(0x40)
             mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)
@@ -59,6 +61,7 @@ library Clones {
         bytes32 salt,
         address deployer
     ) internal pure returns (address predicted) {
+        /// @solidity memory-safe-assembly
         assembly {
             let ptr := mload(0x40)
             mstore(ptr, 0x602d8060093d393df3363d3d373d3d3d363d7300000000000000000000000000)

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -398,6 +398,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
                 if (reason.length == 0) {
                     revert("ERC721: transfer to non ERC721Receiver implementer");
                 } else {
+                    /// @solidity memory-safe-assembly
                     assembly {
                         revert(add(32, reason), mload(reason))
                     }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -209,7 +209,7 @@ library Address {
             // Look for revert reason and bubble it up if present
             if (returndata.length > 0) {
                 // The easiest way to bubble the revert reason is using memory via assembly
-
+                /// @solidity memory-safe-assembly
                 assembly {
                     let returndata_size := mload(returndata)
                     revert(add(32, returndata), returndata_size)

--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -35,6 +35,7 @@ library Base64 {
         // - `4 *`              -> 4 characters for each chunk
         string memory result = new string(4 * ((data.length + 2) / 3));
 
+        /// @solidity memory-safe-assembly
         assembly {
             // Prepare the lookup table (skip the first "length" byte)
             let tablePtr := add(table, 1)

--- a/contracts/utils/StorageSlot.sol
+++ b/contracts/utils/StorageSlot.sol
@@ -50,6 +50,7 @@ library StorageSlot {
      * @dev Returns an `AddressSlot` with member `value` located at `slot`.
      */
     function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        /// @solidity memory-safe-assembly
         assembly {
             r.slot := slot
         }
@@ -59,6 +60,7 @@ library StorageSlot {
      * @dev Returns an `BooleanSlot` with member `value` located at `slot`.
      */
     function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {
+        /// @solidity memory-safe-assembly
         assembly {
             r.slot := slot
         }
@@ -68,6 +70,7 @@ library StorageSlot {
      * @dev Returns an `Bytes32Slot` with member `value` located at `slot`.
      */
     function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {
+        /// @solidity memory-safe-assembly
         assembly {
             r.slot := slot
         }
@@ -77,6 +80,7 @@ library StorageSlot {
      * @dev Returns an `Uint256Slot` with member `value` located at `slot`.
      */
     function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {
+        /// @solidity memory-safe-assembly
         assembly {
             r.slot := slot
         }

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -275,6 +275,7 @@ library EnumerableSet {
         bytes32[] memory store = _values(set._inner);
         address[] memory result;
 
+        /// @solidity memory-safe-assembly
         assembly {
             result := store
         }
@@ -348,6 +349,7 @@ library EnumerableSet {
         bytes32[] memory store = _values(set._inner);
         uint256[] memory result;
 
+        /// @solidity memory-safe-assembly
         assembly {
             result := store
         }


### PR DESCRIPTION
Part of #3336

Adds memory safe annotations for blocks of inline assembly in the following files:
- Address.sol
- Base64.sol
- Clones.sol
- EnumerableSet.sol
- ERC721.sol
- ERC2771Context.sol
- MinimalForwarder.sol
- StorageSlot.sol
- ~SafeMathMock.sol~

As discussed [here](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3336#issuecomment-1101568318), I am happy to add more files into this PR before merging, but I wanted to open this now to gather feedback.

This is also my first contribution to this repository, so please let me know if I have made any errors.🙏 



#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [X] Tests
- [ ] Documentation
- [ ] Changelog entry
