### PR TITLE
Add `address` to `string` conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
  * `ERC20FlashMint`: Add customizable flash fee receiver. ([#3327](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3327))
- * `Strings`: add a new function `addressToHexString` that converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Strings`: add a new overloaded function `toHexString` that converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `Strings`: add a new function `addressToHexString` that converts an `address` with fixed length of 20 bytes to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Strings`: add a new function `addressToHexString` that converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `Strings`: add a new function that converts an `address` to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Strings`: add a new function `fromAddressHex` that converts an `address` to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `Strings`: add a new function `addressToHexString` that converts an `address` to its ASCII `string` hexadecimal representation with fixed length of 20 bytes. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Strings`: add a new function `addressToHexString` that converts an `address` with fixed length of 20 bytes to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `Strings`: add a new function that converts an `address` to its ASCII `string` hexadecimal representation. ([#TBD]()) 
+ * `Strings`: add a new function that converts an `address` to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
+ * `Strings`: add a new function that converts an `address` to its ASCII `string` hexadecimal representation. ([#TBD]()) 
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `Strings`: add a new function `addressToHexString` that converts an `address` to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Strings`: add a new function `addressToHexString` that converts an `address` to its ASCII `string` hexadecimal representation with fixed length of 20 bytes. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  * `Clones`: optimize clone creation ([#3329](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3329))
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
- * `Strings`: add a new function `fromAddressHex` that converts an `address` to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Strings`: add a new function `addressToHexString` that converts an `address` to its ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
 
 ## 4.6.0 (2022-04-26)
 

--- a/contracts/mocks/StringsMock.sol
+++ b/contracts/mocks/StringsMock.sol
@@ -17,7 +17,7 @@ contract StringsMock {
         return Strings.toHexString(value, length);
     }
 
-    function fromAddressHex(address addr) public pure returns (string memory) {
-        return Strings.addressToHexString(addr);
+    function fromAddressHexFixed(address addr) public pure returns (string memory) {
+        return Strings.toHexString(addr);
     }
 }

--- a/contracts/mocks/StringsMock.sol
+++ b/contracts/mocks/StringsMock.sol
@@ -16,4 +16,8 @@ contract StringsMock {
     function fromUint256HexFixed(uint256 value, uint256 length) public pure returns (string memory) {
         return Strings.toHexString(value, length);
     }
+
+    function fromAddressHex(address addr) public pure returns (string memory) {
+        return Strings.addressToHexString(addr);
+    }
 }

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -64,4 +64,11 @@ library Strings {
         require(value == 0, "Strings: hex length insufficient");
         return string(buffer);
     }
+
+    /**
+     * @dev Converts an `address` to its ASCII `string` hexadecimal representation.
+     */
+    function addressToHexString(address addr) internal pure returns (string memory) {
+        return toHexString(uint256(uint160(addr)));
+    }
 }

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -67,7 +67,7 @@ library Strings {
     }
 
     /**
-     * @dev Converts an `address` with fixed length of 20 bytes to its ASCII `string` hexadecimal representation.
+     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation.
      */
     function addressToHexString(address addr) internal pure returns (string memory) {
         return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -69,7 +69,7 @@ library Strings {
     /**
      * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation.
      */
-    function addressToHexString(address addr) internal pure returns (string memory) {
+    function toHexString(address addr) internal pure returns (string memory) {
         return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
     }
 }

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -67,7 +67,7 @@ library Strings {
     }
 
     /**
-     * @dev Converts an `address` to its ASCII `string` hexadecimal representation with fixed length of 20 bytes.
+     * @dev Converts an `address` with fixed length of 20 bytes to its ASCII `string` hexadecimal representation.
      */
     function addressToHexString(address addr) internal pure returns (string memory) {
         return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -8,6 +8,7 @@ pragma solidity ^0.8.0;
  */
 library Strings {
     bytes16 private constant _HEX_SYMBOLS = "0123456789abcdef";
+    uint8 private constant _ADDRESS_LENGTH = 20;
 
     /**
      * @dev Converts a `uint256` to its ASCII `string` decimal representation.
@@ -66,9 +67,9 @@ library Strings {
     }
 
     /**
-     * @dev Converts an `address` to its ASCII `string` hexadecimal representation.
+     * @dev Converts an `address` to its ASCII `string` hexadecimal representation with fixed length of 20 bytes.
      */
     function addressToHexString(address addr) internal pure returns (string memory) {
-        return toHexString(uint256(uint160(addr)));
+        return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
     }
 }

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -57,7 +57,7 @@ contract('Strings', function (accounts) {
     });
   });
 
-  describe('from address - fixed 20 bytes hex format', function () {
+  describe('from address - hex format', function () {
     it('converts a random address', async function () {
       expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHex(this.strings.address)))
         .to.equal(this.strings.address.toString());

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -56,4 +56,11 @@ contract('Strings', function (accounts) {
         .to.equal(web3.utils.toHex(constants.MAX_UINT256));
     });
   });
+
+  describe('from address - hex format', function () {
+    it('converts an address', async function () {
+      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHex(this.strings.address)))
+        .to.equal(this.strings.address.toString());
+    });
+  });
 });

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -57,10 +57,14 @@ contract('Strings', function (accounts) {
     });
   });
 
-  describe('from address - hex format', function () {
-    it('converts an address', async function () {
+  describe('from address - fixed 20 bytes hex format', function () {
+    it('converts a random address', async function () {
       expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHex(this.strings.address)))
         .to.equal(this.strings.address.toString());
+    });
+    it('converts an address with leading zeros', async function () {
+      const addr = '0x0000E0Ca771e21bD00057F54A68C30D400000000';
+      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHex(addr))).to.equal(addr);
     });
   });
 });

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -59,8 +59,8 @@ contract('Strings', function (accounts) {
 
   describe('from address - fixed hex format', function () {
     it('converts a random address', async function () {
-      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHexFixed(this.strings.address)))
-        .to.equal(this.strings.address.toString());
+      const addr = '0xa9036907dccae6a1e0033479b12e837e5cf5a02f';
+      expect(await this.strings.fromAddressHexFixed(addr)).to.equal(addr);
     });
     it('converts an address with leading zeros', async function () {
       const addr = '0x0000E0Ca771e21bD00057F54A68C30D400000000';

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -57,14 +57,14 @@ contract('Strings', function (accounts) {
     });
   });
 
-  describe('from address - hex format', function () {
+  describe('from address - fixed hex format', function () {
     it('converts a random address', async function () {
-      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHex(this.strings.address)))
+      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHexFixed(this.strings.address)))
         .to.equal(this.strings.address.toString());
     });
     it('converts an address with leading zeros', async function () {
       const addr = '0x0000E0Ca771e21bD00057F54A68C30D400000000';
-      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHex(addr))).to.equal(addr);
+      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHexFixed(addr))).to.equal(addr);
     });
   });
 });

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -62,6 +62,7 @@ contract('Strings', function (accounts) {
       const addr = '0xa9036907dccae6a1e0033479b12e837e5cf5a02f';
       expect(await this.strings.fromAddressHexFixed(addr)).to.equal(addr);
     });
+
     it('converts an address with leading zeros', async function () {
       const addr = '0x0000e0ca771e21bd00057f54a68c30d400000000';
       expect(await this.strings.fromAddressHexFixed(addr)).to.equal(addr);

--- a/test/utils/Strings.test.js
+++ b/test/utils/Strings.test.js
@@ -63,8 +63,8 @@ contract('Strings', function (accounts) {
       expect(await this.strings.fromAddressHexFixed(addr)).to.equal(addr);
     });
     it('converts an address with leading zeros', async function () {
-      const addr = '0x0000E0Ca771e21bD00057F54A68C30D400000000';
-      expect(web3.utils.toChecksumAddress(await this.strings.fromAddressHexFixed(addr))).to.equal(addr);
+      const addr = '0x0000e0ca771e21bd00057f54a68c30d400000000';
+      expect(await this.strings.fromAddressHexFixed(addr)).to.equal(addr);
     });
   });
 });


### PR DESCRIPTION
This PR adds a new function to the [`Strings`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/Strings.sol) library that converts an `address` to its ASCII `string` hexadecimal representation. The main motivation is the reason that I've encountered already multiple projects that use a sophisticated `tokenURI` strategy, that concatenates multiple attributes - one of which is an `address` - into a string. An example:

```solidity
return string(abi.encodePacked(_baseTokenURI, toString(creator), "-", tokenId.toString()));
```

#### PR Checklist
- [x] Tests
- [x] Documentation => should be automatically added to [Strings](https://docs.openzeppelin.com/contracts/4.x/api/utils#Strings)
- [x] Changelog entry
