### PR TITLE
Add helper smart contract for `CREATE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
  * `ERC20FlashMint`: Add customizable flash fee receiver. ([#3327](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3327))
  * `Strings`: add a new overloaded function `toHexString` that converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
- * `Create`: add a new helper smart contract to make easier and safer usage of the `CREATE` EVM opcode. ([#TBD]())
+ * `Create`: add a new helper smart contract to make easier and safer usage of the `CREATE` EVM opcode. ([#3411](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3411))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
  * `ERC20FlashMint`: Add customizable flash fee receiver. ([#3327](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3327))
  * `Strings`: add a new overloaded function `toHexString` that converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation. ([#3403](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403))
+ * `Create`: add a new helper smart contract to make easier and safer usage of the `CREATE` EVM opcode. ([#TBD]())
 
 ## 4.6.0 (2022-04-26)
 

--- a/contracts/mocks/CreateImpl.sol
+++ b/contracts/mocks/CreateImpl.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "../utils/Create.sol";
+import "../utils/introspection/ERC1820Implementer.sol";
+
+contract CreateImpl {
+    function deploy(
+        uint256 value,
+        bytes memory code
+    ) public {
+        Create.deploy(value, code);
+    }
+
+    function deployERC1820Implementer(uint256 value) public {
+        Create.deploy(value, type(ERC1820Implementer).creationCode);
+    }
+
+    function computeAddress(address addr, uint256 nonce) public pure returns (address) {
+        return Create.computeAddress(addr, nonce);
+    }
+
+    receive() external payable {}
+}

--- a/contracts/mocks/CreateImpl.sol
+++ b/contracts/mocks/CreateImpl.sol
@@ -6,10 +6,7 @@ import "../utils/Create.sol";
 import "../utils/introspection/ERC1820Implementer.sol";
 
 contract CreateImpl {
-    function deploy(
-        uint256 value,
-        bytes memory code
-    ) public {
+    function deploy(uint256 value, bytes memory code) public {
         Create.deploy(value, code);
     }
 

--- a/contracts/mocks/CreateImpl.sol
+++ b/contracts/mocks/CreateImpl.sol
@@ -6,12 +6,12 @@ import "../utils/Create.sol";
 import "../utils/introspection/ERC1820Implementer.sol";
 
 contract CreateImpl {
-    function deploy(uint256 value, bytes memory code) public {
-        Create.deploy(value, code);
+    function deploy(uint256 value, bytes memory code) public returns (address) {
+        return Create.deploy(value, code);
     }
 
-    function deployERC1820Implementer(uint256 value) public {
-        Create.deploy(value, type(ERC1820Implementer).creationCode);
+    function deployERC1820Implementer(uint256 value) public returns (address) {
+        return Create.deploy(value, type(ERC1820Implementer).creationCode);
     }
 
     function computeAddress(address addr, uint256 nonce) public pure returns (address) {

--- a/contracts/utils/Create.sol
+++ b/contracts/utils/Create.sol
@@ -45,7 +45,7 @@ library Create {
      * and the Ethereum Wiki (https://eth.wiki/fundamentals/rlp). For further insights also, see the
      * following issue: https://github.com/Rari-Capital/solmate/issues/207.
      *
-     * Based on the EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md) specification, 
+     * Based on the EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md) specification,
      * all contract accounts on the Ethereum mainnet are initiated with `nonce = 1`.
      * Thus, the first contract address created by another contract is calculated with a non-zero nonce.
      */

--- a/contracts/utils/Create.sol
+++ b/contracts/utils/Create.sol
@@ -64,7 +64,7 @@ library Create {
 
         /**
          * @dev In the case of `nonce > type(uint24).max`, we have the following encoding scheme:
-         * 0xda = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ proxy ++ 0x84 ++ nonce)
+         * 0xda = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ address ++ 0x84 ++ nonce)
          * 0x94 = 0x80 + 0x14 (0x14 = the length of an address, 20 bytes, in hex)
          * 0x84 = 0x80 + 0x04 (0x04 = the bytes length of the nonce, 4 bytes, in hex)
          */

--- a/contracts/utils/Create.sol
+++ b/contracts/utils/Create.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.7.0 (utils/Create.sol)
+
+pragma solidity ^0.8.4;
+
+import "./errors.sol";
+
+/**
+ * @dev Helper smart contract to make easier and safer usage of the `CREATE` EVM opcode.
+ */
+
+library Create {
+    /**
+     * @dev Deploys a contract using `CREATE`. The address where the contract
+     * will be deployed can be known computed via {computeAddress}.
+     * @param amount The value in wei to send to the new account.
+     * If `amount` is non-zero, `bytecode` must have a `payable` constructor.
+     * @param bytecode The creation bytecode.
+     *
+     * The bytecode for a contract can be obtained from Solidity with
+     * `type(contractName).creationCode`.
+     *
+     * Requirements:
+     *
+     * - `bytecode` must not be empty.
+     * - the factory must have a balance of at least `amount`.
+     * - if `amount` is non-zero, `bytecode` must have a `payable` constructor.
+     */
+    function deploy(uint256 amount, bytes memory bytecode) internal returns (address) {
+        address addr;
+        if (address(this).balance < amount) revert InsufficientBalance(address(this));
+        if (bytecode.length == 0) revert ZeroBytecodeLength(address(this));
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(amount, add(bytecode, 0x20), mload(bytecode))
+        }
+        if (addr == address(0)) revert Failed(address(this));
+        return addr;
+    }
+
+    /**
+     * @dev Returns the address where a contract will be stored if deployed via {deploy}.
+     * For the specification of the Recursive Length Prefix (RLP) encoding scheme, please
+     * refer to p. 19 of the Ethereum Yellow Paper (https://ethereum.github.io/yellowpaper/paper.pdf)
+     * and the Ethereum Wiki (https://eth.wiki/fundamentals/rlp). For further insights also, see the
+     * following issue: https://github.com/Rari-Capital/solmate/issues/207.
+     */
+    function computeAddress(address addr, uint256 nonce) internal pure returns (address) {
+        bytes memory data;
+        bytes1 len = bytes1(0x94);
+
+        if (nonce == 0x00) data = abi.encodePacked(bytes1(0xd6), len, addr, bytes1(0x80));
+        else if (nonce <= 0x7f) data = abi.encodePacked(bytes1(0xd6), len, addr, uint8(nonce));
+        else if (nonce <= type(uint8).max) data = abi.encodePacked(bytes1(0xd7), len, addr, bytes1(0x81), uint8(nonce));
+        else if (nonce <= type(uint16).max)
+            data = abi.encodePacked(bytes1(0xd8), len, addr, bytes1(0x82), uint16(nonce));
+        else if (nonce <= type(uint24).max)
+            data = abi.encodePacked(bytes1(0xd9), len, addr, bytes1(0x83), uint24(nonce));
+        else data = abi.encodePacked(bytes1(0xda), len, addr, bytes1(0x84), uint32(nonce));
+
+        return address(uint160(uint256(keccak256(data))));
+    }
+}

--- a/contracts/utils/README.adoc
+++ b/contracts/utils/README.adoc
@@ -21,7 +21,7 @@ Because Solidity does not support generic types, {EnumerableMap} and {Enumerable
 As of v3.0, {EnumerableMap} supports `uint256 -> address` (`UintToAddressMap`), and {EnumerableSet} supports `address` and `uint256` (`AddressSet` and `UintSet`).
 ====
 
-Finally, {Create2} contains all necessary utilities to safely use the https://blog.openzeppelin.com/getting-the-most-out-of-create2/[`CREATE2` EVM opcode], without having to deal with low-level assembly.
+Finally, {Create} and {Create2} contain all necessary utilities to safely use the `CREATE` and https://blog.openzeppelin.com/getting-the-most-out-of-create2/[`CREATE2`] EVM opcodes, without having to deal with low-level assembly.
 
 == Math
 
@@ -93,6 +93,8 @@ Note that, in all cases, accounts simply _declare_ their interfaces, but they ar
 {{Checkpoints}}
 
 == Libraries
+
+{{Create}}
 
 {{Create2}}
 

--- a/contracts/utils/errors.sol
+++ b/contracts/utils/errors.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.7.0 (utils/errors.sol)
+
+pragma solidity ^0.8.4;
+
+/**
+ * @dev Error that occurs when the contract creation failed.
+ * @param emitter The contract that emits the error.
+ */
+error Failed(address emitter);
+
+/**
+ * @dev Error that occurs when the factory contract has insufficient balance.
+ * @param emitter The contract that emits the error.
+ */
+error InsufficientBalance(address emitter);
+
+/**
+ * @dev Error that occurs when the bytecode length is zero.
+ * @param emitter The contract that emits the error.
+ */
+error ZeroBytecodeLength(address emitter);

--- a/test/utils/Create.test.js
+++ b/test/utils/Create.test.js
@@ -1,0 +1,139 @@
+const { balance, BN, ether, send } = require('@openzeppelin/test-helpers');
+const { expectRevertCustomError } = require('../helpers/customError');
+
+const { expect } = require('chai');
+const { Address } = require('ethereumjs-util');
+const { web3 } = require('hardhat');
+
+const CreateImpl = artifacts.require('CreateImpl');
+const ERC20Mock = artifacts.require('ERC20Mock');
+const ERC1820Implementer = artifacts.require('ERC1820Implementer');
+
+async function setNonce (address, nonce) {
+  // eslint-disable-next-line no-undef
+  await network.provider.send('hardhat_setNonce', [address, nonce]);
+}
+
+contract('Create', function (accounts) {
+  const [deployerAccount] = accounts;
+
+  const encodedParams = web3.eth.abi.encodeParameters(
+    ['string', 'string', 'address', 'uint256'],
+    ['MyToken', 'MTKN', deployerAccount, 100],
+  ).slice(2);
+
+  const constructorByteCode = `${ERC20Mock.bytecode}${encodedParams}`;
+
+  beforeEach(async function () {
+    this.factory = await CreateImpl.new();
+  });
+
+  describe('computeAddress', function () {
+    it('computes the correct contract address - case 1: nonce 0x00', async function () {
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      expect(onChainComputed).to.equal(web3.utils.toChecksumAddress(offChainComputed));
+    });
+
+    it('computes the correct contract address - case 2: nonce 0x7f', async function () {
+      setNonce(this.factory.address, '0x7f');
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      expect(onChainComputed).to.equal(web3.utils.toChecksumAddress(offChainComputed));
+    });
+
+    it('computes the correct contract address - case 3: nonce 0xff', async function () {
+      setNonce(this.factory.address, '0xff');
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      expect(onChainComputed).to.equal(web3.utils.toChecksumAddress(offChainComputed));
+    });
+
+    it('computes the correct contract address - case 4: nonce 0xffff', async function () {
+      setNonce(this.factory.address, '0xffff');
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      expect(onChainComputed).to.equal(web3.utils.toChecksumAddress(offChainComputed));
+    });
+
+    it('computes the correct contract address - case 5: nonce 0xffffff', async function () {
+      setNonce(this.factory.address, '0xffffff');
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      expect(onChainComputed).to.equal(web3.utils.toChecksumAddress(offChainComputed));
+    });
+
+    it('computes the correct contract address - case 6: nonce 0xffffffa', async function () {
+      setNonce(this.factory.address, '0xffffffa');
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      expect(onChainComputed).to.equal(web3.utils.toChecksumAddress(offChainComputed));
+    });
+  });
+
+  describe('deploy', function () {
+    it('deploys an ERC1820Implementer from inline assembly code', async function () {
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      await this.factory.deployERC1820Implementer(0);
+      expect(ERC1820Implementer.bytecode).to
+        .include((await web3.eth.getCode(offChainComputed)).slice(2));
+    });
+
+    it('deploys an ERC20Mock with correct balances', async function () {
+      const from = Address.fromString(this.factory.address);
+      const offChainComputed =
+        Address.generate(from, new BN(await web3.eth.getTransactionCount(from.toString()))).toString();
+      await this.factory.deploy(0, constructorByteCode);
+      const erc20 = await ERC20Mock.at(offChainComputed);
+      expect(await erc20.balanceOf(deployerAccount)).to.be.bignumber.equal(new BN(100));
+    });
+
+    it('deploys a contract with funds deposited in the factory', async function () {
+      const deposit = ether('2');
+      await send.ether(deployerAccount, this.factory.address, deposit);
+      expect(await balance.current(this.factory.address)).to.be.bignumber.equal(deposit);
+      const onChainComputed = await this.factory
+        .computeAddress(this.factory.address, await web3.eth.getTransactionCount(this.factory.address));
+      await this.factory.deploy(deposit, constructorByteCode);
+      expect(await balance.current(onChainComputed)).to.be.bignumber.equal(deposit);
+    });
+
+    it('fails deploying a contract with invalid constructor bytecode', async function () {
+      await expectRevertCustomError(
+        this.factory.deploy(0, 0x1), `Failed("${this.factory.address}")`,
+      );
+    });
+
+    it('fails deploying a contract if the bytecode length is zero', async function () {
+      await expectRevertCustomError(
+        this.factory.deploy(0, '0x'), `ZeroBytecodeLength("${this.factory.address}")`,
+      );
+    });
+
+    it('fails deploying a contract if factory contract does not have sufficient balance', async function () {
+      await expectRevertCustomError(
+        this.factory.deploy(1, constructorByteCode), `InsufficientBalance("${this.factory.address}")`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
I've been working over the weekend on a library that implements the `CREATE` EVM opcode and I thought that could be a useful addition to the OpenZeppelin `utils`. Let me know what you think! I'm working on the tests in the meantime.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog entry
