### PR TITLE
Add Warning about use of delete

### DIFF
--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -35,7 +35,7 @@ import "./EnumerableSet.sol";
  * [WARNING]
  * ====
  *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
- *  See ethereum/solidity#11843 for more info
+ *  See https://github.com/ethereum/solidity/pull/11843[ethereum/solidity#11843] for more info.
  *
  *  In order to clean an EnumerableMap, you can either remove all elements one by one or create a fresh instance using an array of EnumerableMap.
  * ====

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -72,6 +72,10 @@ library EnumerableMap {
      * Returns true if the key was removed from the map, that is if it was present.
      */
     function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (bool) {
+        // WARNING!
+        // delete function should not be used. It will corrupt the data structure,
+        // clear function should be used instead.
+        // ref https://github.com/ethereum/solidity/pull/11843
         delete map._values[key];
         return map._keys.remove(key);
     }

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -31,6 +31,11 @@ import "./EnumerableSet.sol";
  * - `uint256 -> address` (`UintToAddressMap`) since v3.0.0
  * - `address -> uint256` (`AddressToUintMap`) since v4.6.0
  * - `bytes32 -> bytes32` (`Bytes32ToBytes32`) since v4.6.0
+ *
+ *    // WARNING!
+ *       // delete function should not be used. It will corrupt the data structure,
+ *       // clear function should be used instead.
+ *       // ref https://github.com/ethereum/solidity/pull/11843
  */
 library EnumerableMap {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -72,10 +77,6 @@ library EnumerableMap {
      * Returns true if the key was removed from the map, that is if it was present.
      */
     function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (bool) {
-        // WARNING!
-        // delete function should not be used. It will corrupt the data structure,
-        // clear function should be used instead.
-        // ref https://github.com/ethereum/solidity/pull/11843
         delete map._values[key];
         return map._keys.remove(key);
     }

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -32,10 +32,13 @@ import "./EnumerableSet.sol";
  * - `address -> uint256` (`AddressToUintMap`) since v4.6.0
  * - `bytes32 -> bytes32` (`Bytes32ToBytes32`) since v4.6.0
  *
- *    // WARNING!
- *       // delete function should not be used. It will corrupt the data structure,
- *       // clear function should be used instead.
- *       // ref https://github.com/ethereum/solidity/pull/11843
+ * [WARNING]
+ * ====
+ *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
+ *  See ethereum/solidity#11843 for more info
+ *
+ *  In order to clean an EnumerableMap, you can either remove all elements one by one or create a fresh instance using an array of EnumerableMap.
+ * ====
  */
 library EnumerableMap {
     using EnumerableSet for EnumerableSet.Bytes32Set;

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -27,10 +27,13 @@ pragma solidity ^0.8.0;
  * As of v3.3.0, sets of type `bytes32` (`Bytes32Set`), `address` (`AddressSet`)
  * and `uint256` (`UintSet`) are supported.
  *
- *    // WARNING!
- *       // delete function should not be used. It will corrupt the data structure,
- *       // clear function should be used instead.
- *       // ref https://github.com/ethereum/solidity/pull/11843
+ * [WARNING]
+ * ====
+ *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
+ *  See ethereum/solidity#11843 for more info
+ *
+ *  In order to clean an EnumerableSet, you can either remove all elements one by one or create a fresh instance using an array of EnumerableSet.
+ * ====
  */
 library EnumerableSet {
     // To implement this library for multiple types with as little code

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -95,6 +95,10 @@ library EnumerableSet {
             set._values.pop();
 
             // Delete the index for the deleted slot
+            // WARNING!
+            // delete function should not be used. It will corrupt the data structure,
+            // clear function should be used instead.
+            // ref https://github.com/ethereum/solidity/pull/11843
             delete set._indexes[value];
 
             return true;

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -26,6 +26,11 @@ pragma solidity ^0.8.0;
  *
  * As of v3.3.0, sets of type `bytes32` (`Bytes32Set`), `address` (`AddressSet`)
  * and `uint256` (`UintSet`) are supported.
+ *
+ *    // WARNING!
+ *       // delete function should not be used. It will corrupt the data structure,
+ *       // clear function should be used instead.
+ *       // ref https://github.com/ethereum/solidity/pull/11843
  */
 library EnumerableSet {
     // To implement this library for multiple types with as little code
@@ -95,10 +100,6 @@ library EnumerableSet {
             set._values.pop();
 
             // Delete the index for the deleted slot
-            // WARNING!
-            // delete function should not be used. It will corrupt the data structure,
-            // clear function should be used instead.
-            // ref https://github.com/ethereum/solidity/pull/11843
             delete set._indexes[value];
 
             return true;

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -30,7 +30,7 @@ pragma solidity ^0.8.0;
  * [WARNING]
  * ====
  *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
- *  See ethereum/solidity#11843 for more info
+ *  See https://github.com/ethereum/solidity/pull/11843[ethereum/solidity#11843] for more info.
  *
  *  In order to clean an EnumerableSet, you can either remove all elements one by one or create a fresh instance using an array of EnumerableSet.
  * ====


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3400 

Added Warning about delete operator on structs like EnumerableSet and EnumerableMap even though they contain a mapping that will not be cleared, and the operation will in fact corrupt the struct's data.

According to https://github.com/ethereum/solidity/pull/11843 this operation will no longer be allowed in Solidity 0.9, but in the meantime we should document that delete should not be used with these types.

as user frangio stated, i checked the info and link


#### PR Checklist

- [x] Documentation
check if this Warning is useful and apply.
Need any further warning or issue?
