### PR TITLE
Created the Withdrawable abstract contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
  * `MerkleProof`: add `multiProofVerify` to prove multiple values are part of a Merkle tree. ([#3276](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3276))
  * `ERC721`, `ERC1155`: simplified revert reasons. ([#3254](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3254))
  * `ERC721`: removed redundant require statement. ([#3434](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3434))
- * `Withdrawable`: add new `Withdrawable` abstract contract.
+ * `Withdrawable`: add new `Withdrawable` abstract contract. ([#3440](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3440))
 
 ## 4.6.0 (2022-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  * `MerkleProof`: add `multiProofVerify` to prove multiple values are part of a Merkle tree. ([#3276](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3276))
  * `ERC721`, `ERC1155`: simplified revert reasons. ([#3254](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3254))
  * `ERC721`: removed redundant require statement. ([#3434](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3434))
+ * `Withdrawable`: add new `Withdrawable` abstract contract.
 
 ## 4.6.0 (2022-04-26)
 

--- a/contracts/finance/README.adoc
+++ b/contracts/finance/README.adoc
@@ -13,8 +13,13 @@ This directory includes primitives for financial systems:
   be given to this contract, which will release the token to the beneficiary following a given, customizable, vesting
   schedule.
 
+- {Withdrawable} allows the owner of the contract to withdraw Ether or Tokens from te contract. Any ERC20 token can be 
+  used to withdraw funds from the contract.
+
 == Contracts
 
 {{PaymentSplitter}}
 
 {{VestingWallet}}
+
+{{Withdrawable}}

--- a/contracts/finance/Withdrawable.sol
+++ b/contracts/finance/Withdrawable.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.6.0) (finance/Withdrawable.sol)
+pragma solidity ^0.8.4;
+
+import "../access/Ownable.sol";
+import "../token/ERC20/IERC20.sol";
+
+abstract contract Withdrawable is Ownable {
+
+    event WithdrawalCompleted(uint256 amount);
+    event TokenWithdrawalCompleted(address tokenAddress, uint256 amount);
+
+    function withdraw(uint256 amount) public payable onlyOwner {
+        require(amount > 0, "Withdrawable: Invalid amount");
+        require(address(this).balance >= amount, "Withdrawable: Insuficient balance");
+        payable(msg.sender).transfer(address(this).balance);
+        emit WithdrawalCompleted(amount);
+    }
+
+    function withdrawTokens(address tokenAddress, uint256 amount) public payable onlyOwner {
+        require(amount > 0, "Withdrawable: Invalid amount");
+        IERC20 token = IERC20(tokenAddress);
+        require(token.balanceOf(address(this)) >= amount, "Withdrawable: Insuficient balance");
+        token.transfer(msg.sender, amount);
+        emit TokenWithdrawalCompleted(address(token), amount);
+    }
+}

--- a/contracts/finance/Withdrawable.sol
+++ b/contracts/finance/Withdrawable.sol
@@ -12,7 +12,7 @@ abstract contract Withdrawable is Ownable {
     function withdraw(uint256 amount) public payable onlyOwner {
         require(amount > 0, "Withdrawable: Invalid amount");
         require(address(this).balance >= amount, "Withdrawable: Insuficient balance");
-        payable(msg.sender).transfer(address(this).balance);
+        payable(msg.sender).transfer(amount);
         emit WithdrawalCompleted(amount);
     }
 

--- a/contracts/finance/Withdrawable.sol
+++ b/contracts/finance/Withdrawable.sol
@@ -5,18 +5,34 @@ pragma solidity ^0.8.4;
 import "../access/Ownable.sol";
 import "../token/ERC20/IERC20.sol";
 
+/**
+ * @title Withdrawable
+ * @dev This contract handles the withdrawal of Ether and ERC20 tokens by the contract owner.
+ *
+ * Any ERC20 token can be used to withdraw funds from the contract.
+ */
 abstract contract Withdrawable is Ownable {
     event WithdrawalCompleted(uint256 amount);
     event TokenWithdrawalCompleted(address tokenAddress, uint256 amount);
 
+    /**
+     * @dev Withdraw Ether from the contract by the owner.
+     *
+     * Emits a {WithdrawalCompleted} event.
+     */
     function withdraw(uint256 amount) public payable onlyOwner {
         require(amount > 0, "Withdrawable: Invalid amount");
         require(address(this).balance >= amount, "Withdrawable: Insuficient balance");
         (bool success, ) = msg.sender.call{value: amount}("");
-        require(success, "Transfer failed.");
+        require(success, "Withdrawable: Transfer failed.");
         emit WithdrawalCompleted(amount);
     }
 
+    /**
+     * @dev Withdraw an ERC20 Token from the contract by the owner.
+     *
+     * Emits a {TokenWithdrawalCompleted} event.
+     */
     function withdrawTokens(address tokenAddress, uint256 amount) public payable onlyOwner {
         require(amount > 0, "Withdrawable: Invalid amount");
         IERC20 token = IERC20(tokenAddress);

--- a/contracts/finance/Withdrawable.sol
+++ b/contracts/finance/Withdrawable.sol
@@ -6,7 +6,6 @@ import "../access/Ownable.sol";
 import "../token/ERC20/IERC20.sol";
 
 abstract contract Withdrawable is Ownable {
-
     event WithdrawalCompleted(uint256 amount);
     event TokenWithdrawalCompleted(address tokenAddress, uint256 amount);
 

--- a/contracts/finance/Withdrawable.sol
+++ b/contracts/finance/Withdrawable.sol
@@ -12,7 +12,8 @@ abstract contract Withdrawable is Ownable {
     function withdraw(uint256 amount) public payable onlyOwner {
         require(amount > 0, "Withdrawable: Invalid amount");
         require(address(this).balance >= amount, "Withdrawable: Insuficient balance");
-        payable(msg.sender).transfer(amount);
+        (bool success, ) = msg.sender.call{value: amount}("");
+        require(success, "Transfer failed.");
         emit WithdrawalCompleted(amount);
     }
 

--- a/contracts/mocks/WithdrawableMock.sol
+++ b/contracts/mocks/WithdrawableMock.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../access/Ownable.sol";
+import "../finance/Withdrawable.sol";
+
+contract WithdrawableMock is Ownable, Withdrawable {
+
+    event Received(address, uint);
+    
+    receive() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+}

--- a/contracts/mocks/WithdrawableMock.sol
+++ b/contracts/mocks/WithdrawableMock.sol
@@ -6,9 +6,8 @@ import "../access/Ownable.sol";
 import "../finance/Withdrawable.sol";
 
 contract WithdrawableMock is Ownable, Withdrawable {
+    event Received(address, uint256);
 
-    event Received(address, uint);
-    
     receive() external payable {
         emit Received(msg.sender, msg.value);
     }

--- a/test/finance/Withdrawable.test.js
+++ b/test/finance/Withdrawable.test.js
@@ -1,0 +1,92 @@
+const { balance, ether, expectEvent, send, expectRevert } = require('@openzeppelin/test-helpers');
+
+const { expect } = require('chai');
+
+const Withdrawable = artifacts.require('WithdrawableMock');
+const Token = artifacts.require('ERC20Mock');
+
+contract('Withdrawable', function (accounts) {
+  const [ owner ] = accounts;
+
+  const zero = ether('0');
+  const amount = ether('1');
+  const biggerAmount = ether('10');
+  const ownerFunds = ether('100');
+
+  beforeEach(async function () {
+    this.contract = await Withdrawable.new(owner);
+    this.token = await Token.new('MyToken', 'MT', owner, ownerFunds);
+  });
+
+  context('Ether', function () {
+    it('should throw an error when the amount is invalid', async function () {
+      await expectRevert(
+        this.contract.withdraw(zero),
+        'Withdrawable: Invalid amount',
+      );
+    });
+
+    it('should throw an error when there is no balance', async function () {
+      await expectRevert(
+        this.contract.withdraw(amount),
+        'Withdrawable: Insuficient balance',
+      );
+    });
+
+    it('should throw an error when the balance is lower then the desired amount', async function () {
+      await send.ether(owner, this.contract.address, amount);
+      await expectRevert(
+        this.contract.withdraw(biggerAmount),
+        'Withdrawable: Insuficient balance',
+      );
+    });
+
+    it('should withdraw the amount from the contract', async function () {
+      await send.ether(owner, this.contract.address, amount);
+      const initialBalance = await balance.current(this.contract.address);
+
+      const receipt = await this.contract.withdraw(amount);
+      expectEvent(receipt, 'WithdrawalCompleted');
+
+      const finalBalance = await balance.current(this.contract.address);
+      expect(initialBalance).to.be.bignumber.greaterThan(finalBalance);
+      expect(finalBalance).to.be.bignumber.equal(zero);
+    });
+  });
+
+  context('Tokens', function () {
+    it('should throw an error when the amount is invalid', async function () {
+      await expectRevert(
+        this.contract.withdrawTokens(this.token.address, zero),
+        'Withdrawable: Invalid amount',
+      );
+    });
+
+    it('should throw an error when there is no balance', async function () {
+      await expectRevert(
+        this.contract.withdrawTokens(this.token.address, amount),
+        'Withdrawable: Insuficient balance',
+      );
+    });
+
+    it('should throw an error when the balance is lower then the desired amount', async function () {
+      await this.token.transferInternal(owner, this.contract.address, amount);
+      await expectRevert(
+        this.contract.withdrawTokens(this.token.address, biggerAmount),
+        'Withdrawable: Insuficient balance',
+      );
+    });
+
+    it('should withdraw the amount from the contract', async function () {
+      await this.token.transferInternal(owner, this.contract.address, amount);
+      const initialBalance = await this.token.balanceOf(this.contract.address);
+
+      const receipt = await this.contract.withdrawTokens(this.token.address, amount);
+      expectEvent(receipt, 'TokenWithdrawalCompleted');
+
+      const finalBalance = await this.token.balanceOf(this.contract.address);
+      expect(initialBalance).to.be.bignumber.greaterThan(finalBalance);
+      expect(finalBalance).to.be.bignumber.equal(zero);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3439

Created the Withdrawable abstract contract in order to make it easy for the owner of a contract to withdraw Ether or ERC20 tokens.


#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog entry
