### PR TITLE
Merkle multiProof: support degenerate cases

### DIFF
--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -105,7 +105,7 @@ library MerkleProof {
             hashes[i] = _hashPair(a, b);
         }
 
-        return hashes[totalHashes - 1];
+        return totalHashes > 0 ? hashes[totalHashes - 1] : leafsLen > 0 ? leafs[0] : proofs[0];
     }
 
     function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {

--- a/test/utils/cryptography/MerkleProof.test.js
+++ b/test/utils/cryptography/MerkleProof.test.js
@@ -127,5 +127,17 @@ contract('MerkleProof', function (accounts) {
         'reverted with panic code 0x32',
       );
     });
+
+    it('works for tree containing a single leaf', async function () {
+      const leaves = ['a'].map(keccak256).sort(Buffer.compare);
+      const merkleTree = new MerkleTree(leaves, keccak256, { sort: true });
+
+      const root = merkleTree.getRoot();
+      const proofLeaves = ['a'].map(keccak256).sort(Buffer.compare);
+      const proof = merkleTree.getMultiProof(proofLeaves);
+      const proofFlags = merkleTree.getProofFlags(proofLeaves, proof);
+
+      expect(await this.merkleProof.multiProofVerify(root, proofLeaves, proof, proofFlags)).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
Fixes #3441

When proofFlags has length 0, the hashes array is empty. For that to be valid, we must have `leafs.length + proofs.length == 1`. This implies one of the following:

- `leafs.length == 1` and `proofs.length == 0`. In that case we are facing a merkle tree with a single leaf, that is also the root of the tree. In that case, we return `leafs[0]`

- `leafs.length == 0` and `proofs.length == 1`. In that case, we are trying to prove that nothing is part of the tree. In that case, the proof is trivial, and only contains the root of the tree. Basically, we can prove that any tree includes `[]` as a subset of its leaves.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
