### PR TITLE
fix typos in timelock test

### DIFF
--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -201,7 +201,7 @@ contract('TimelockController', function (accounts) {
           );
         });
 
-        it('prevent non-proposer from commiting', async function () {
+        it('prevent non-proposer from committing', async function () {
           await expectRevert(
             this.mock.schedule(
               this.operation.target,
@@ -438,7 +438,7 @@ contract('TimelockController', function (accounts) {
           );
         });
 
-        it('prevent non-proposer from commiting', async function () {
+        it('prevent non-proposer from committing', async function () {
           await expectRevert(
             this.mock.scheduleBatch(
               this.operation.targets,


### PR DESCRIPTION
Super minor fix: `commiting` => `committing`.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
