### PR TITLE
Optimize Address.functionCall removing redundant isContract check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  * `PaymentSplitter`: add `releasable` getters. ([#3350](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3350))
  * `Initializable`: refactored implementation of modifiers for easier understanding. ([#3450](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3450))
  * `Proxies`: remove runtime check of ERC1967 storage slots. ([#3455](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3455))
+ * `Address`: perform `isContract` check only when the call was successful but returned no data. ([#3469](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3469))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
  * `PaymentSplitter`: add `releasable` getters. ([#3350](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3350))
  * `Initializable`: refactored implementation of modifiers for easier understanding. ([#3450](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3450))
  * `Proxies`: remove runtime check of ERC1967 storage slots. ([#3455](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3455))
- * `Address`: perform `isContract` check only when the call was successful but returned no data. ([#3469](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3469))
+ * `Address`: optimize `functionCall` functions by checking contract size only if there is no returned data. ([#3469](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3469))
 
 ### Breaking changes
 

--- a/contracts/mocks/crosschain/bridges.sol
+++ b/contracts/mocks/crosschain/bridges.sol
@@ -22,7 +22,7 @@ abstract contract BaseRelayMock {
         _currentSender = sender;
 
         (bool success, bytes memory returndata) = target.call(data);
-        Address.verifyCallResult(target, success, returndata, "low-level call reverted");
+        Address.verifyCallResultFromTarget(target, success, returndata, "low-level call reverted");
 
         _currentSender = previousSender;
     }

--- a/contracts/mocks/crosschain/bridges.sol
+++ b/contracts/mocks/crosschain/bridges.sol
@@ -22,7 +22,7 @@ abstract contract BaseRelayMock {
         _currentSender = sender;
 
         (bool success, bytes memory returndata) = target.call(data);
-        Address.verifyCallResult(success, returndata, "low-level call reverted");
+        Address.verifyCallResult(target, success, returndata, "low-level call reverted");
 
         _currentSender = previousSender;
     }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -187,10 +187,10 @@ library Address {
     }
 
     /**
-     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the
-     * revert reason using the provided one.
+     * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling 
+     * the revert reason or using the provided one) in case of unsuccessful call or if target was not a contract.
      *
-     * _Available since v4.3._
+     * _Available since v4.8._
      */
     function verifyCallResultFromTarget(
         address target,
@@ -210,6 +210,12 @@ library Address {
         }
     }
 
+    /**
+     * @dev Tool to verify that a low level call was successful, and revert if it wasn't, either by bubbling the
+     * revert reason or using the provided one.
+     *
+     * _Available since v4.3._
+     */
     function verifyCallResult(
         bool success,
         bytes memory returndata,

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -133,7 +133,7 @@ library Address {
     ) internal returns (bytes memory) {
         require(address(this).balance >= value, "Address: insufficient balance for call");
         (bool success, bytes memory returndata) = target.call{value: value}(data);
-        return verifyCallResult(target, success, returndata, errorMessage);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
     }
 
     /**
@@ -158,7 +158,7 @@ library Address {
         string memory errorMessage
     ) internal view returns (bytes memory) {
         (bool success, bytes memory returndata) = target.staticcall(data);
-        return verifyCallResult(target, success, returndata, errorMessage);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
     }
 
     /**
@@ -183,7 +183,7 @@ library Address {
         string memory errorMessage
     ) internal returns (bytes memory) {
         (bool success, bytes memory returndata) = target.delegatecall(data);
-        return verifyCallResult(target, success, returndata, errorMessage);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
     }
 
     /**
@@ -192,7 +192,7 @@ library Address {
      *
      * _Available since v4.3._
      */
-    function verifyCallResult(
+    function verifyCallResultFromTarget(
         address target,
         bool success,
         bytes memory returndata,

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -187,7 +187,7 @@ library Address {
     }
 
     /**
-     * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling 
+     * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling
      * the revert reason or using the provided one) in case of unsuccessful call or if target was not a contract.
      *
      * _Available since v4.8._

--- a/test/utils/Address.test.js
+++ b/test/utils/Address.test.js
@@ -143,7 +143,7 @@ contract('Address', function (accounts) {
         }, []);
 
         await expectRevert(
-          this.mock.functionCall(this.contractRecipient.address, abiEncodedCall, { gas: '100000' }),
+          this.mock.functionCall(this.contractRecipient.address, abiEncodedCall, { gas: '120000' }),
           'Address: low-level call failed',
         );
       });
@@ -329,7 +329,7 @@ contract('Address', function (accounts) {
       }, []);
       await expectRevert(
         this.mock.functionStaticCall(recipient, abiEncodedCall),
-        'Address: static call to non-contract',
+        'Address: call to non-contract',
       );
     });
   });
@@ -375,7 +375,7 @@ contract('Address', function (accounts) {
       }, []);
       await expectRevert(
         this.mock.functionDelegateCall(recipient, abiEncodedCall),
-        'Address: delegate call to non-contract',
+        'Address: call to non-contract',
       );
     });
   });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

In `Address.functionCall`, `Address.functionDelegateCall` and `Address.functionStaticCall` it is possible to skip target's `isContract` check in cases where call fails or returns non-empty data. This can only happen when target has some code so there is no point in redundant `isContract` check. 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry
