### PR TITLE
ERC721 transfer should not emit Approval event

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -338,9 +338,10 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         _beforeTokenTransfer(from, to, tokenId);
 
         // Clear approvals from the previous owner
-        _approve(address(0), tokenId);
+        delete _tokenApprovals[tokenId];
 
-        _balances[from] -= 1;
+
+    _balances[from] -= 1;
         _balances[to] += 1;
         _owners[tokenId] = to;
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -341,7 +341,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         delete _tokenApprovals[tokenId];
 
 
-    _balances[from] -= 1;
+        _balances[from] -= 1;
         _balances[to] += 1;
         _owners[tokenId] = to;
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -96,10 +96,6 @@ function shouldBehaveLikeERC721 (errorPrefix, owner, newOwner, approved, another
           expect(await this.token.getApproved(tokenId)).to.be.equal(ZERO_ADDRESS);
         });
 
-        it('emits an Approval event', async function () {
-          expectEvent(receipt, 'Approval', { owner, approved: ZERO_ADDRESS, tokenId: tokenId });
-        });
-
         it('adjusts owners balances', async function () {
           expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('1');
         });
@@ -695,10 +691,6 @@ function shouldBehaveLikeERC721 (errorPrefix, owner, newOwner, approved, another
 
         it('emits a Transfer event', function () {
           expectEvent(this.receipt, 'Transfer', { from: owner, to: ZERO_ADDRESS, tokenId: firstTokenId });
-        });
-
-        it('emits an Approval event', function () {
-          expectEvent(this.receipt, 'Approval', { owner, approved: ZERO_ADDRESS, tokenId: firstTokenId });
         });
 
         it('deletes the token', async function () {


### PR DESCRIPTION
As per the ERC721 standard, the Approval event should not be emitted on token transfer. It is implicit in the emitted Transfer event.

```
    /// @dev This emits when the approved address for an NFT is changed or
    ///  reaffirmed. The zero address indicates there is no approved address.
    ///  When a Transfer event emits, this also indicates that the approved
    ///  address for that NFT (if any) is reset to none.
    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
 ```