### PR TITLE
Use @inheritdoc instead of See

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -71,9 +71,6 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
         _;
     }
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IAccessControl).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/access/AccessControlCrossChain.sol
+++ b/contracts/access/AccessControlCrossChain.sol
@@ -25,9 +25,6 @@ import "../crosschain/CrossChainEnabled.sol";
 abstract contract AccessControlCrossChain is AccessControl, CrossChainEnabled {
     bytes32 public constant CROSSCHAIN_ALIAS = keccak256("CROSSCHAIN_ALIAS");
 
-    /**
-     * @dev See {AccessControl-_checkRole}.
-     */
     function _checkRole(bytes32 role) internal view virtual override {
         if (_isCrossChain()) {
             _checkRole(_crossChainRoleAlias(role), _crossChainSender());

--- a/contracts/access/AccessControlEnumerable.sol
+++ b/contracts/access/AccessControlEnumerable.sol
@@ -15,9 +15,6 @@ abstract contract AccessControlEnumerable is IAccessControlEnumerable, AccessCon
 
     mapping(bytes32 => EnumerableSet.AddressSet) private _roleMembers;
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IAccessControlEnumerable).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/crosschain/arbitrum/CrossChainEnabledArbitrumL1.sol
+++ b/contracts/crosschain/arbitrum/CrossChainEnabledArbitrumL1.sol
@@ -28,16 +28,10 @@ abstract contract CrossChainEnabledArbitrumL1 is CrossChainEnabled {
         _bridge = bridge;
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_isCrossChain}
-     */
     function _isCrossChain() internal view virtual override returns (bool) {
         return LibArbitrumL1.isCrossChain(_bridge);
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_crossChainSender}
-     */
     function _crossChainSender() internal view virtual override onlyCrossChain returns (address) {
         return LibArbitrumL1.crossChainSender(_bridge);
     }

--- a/contracts/crosschain/arbitrum/CrossChainEnabledArbitrumL2.sol
+++ b/contracts/crosschain/arbitrum/CrossChainEnabledArbitrumL2.sol
@@ -19,16 +19,10 @@ import "./LibArbitrumL2.sol";
  * _Available since v4.6._
  */
 abstract contract CrossChainEnabledArbitrumL2 is CrossChainEnabled {
-    /**
-     * @dev see {CrossChainEnabled-_isCrossChain}
-     */
     function _isCrossChain() internal view virtual override returns (bool) {
         return LibArbitrumL2.isCrossChain(LibArbitrumL2.ARBSYS);
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_crossChainSender}
-     */
     function _crossChainSender() internal view virtual override onlyCrossChain returns (address) {
         return LibArbitrumL2.crossChainSender(LibArbitrumL2.ARBSYS);
     }

--- a/contracts/crosschain/optimism/CrossChainEnabledOptimism.sol
+++ b/contracts/crosschain/optimism/CrossChainEnabledOptimism.sol
@@ -25,16 +25,10 @@ abstract contract CrossChainEnabledOptimism is CrossChainEnabled {
         _messenger = messenger;
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_isCrossChain}
-     */
     function _isCrossChain() internal view virtual override returns (bool) {
         return LibOptimism.isCrossChain(_messenger);
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_crossChainSender}
-     */
     function _crossChainSender() internal view virtual override onlyCrossChain returns (address) {
         return LibOptimism.crossChainSender(_messenger);
     }

--- a/contracts/crosschain/polygon/CrossChainEnabledPolygonChild.sol
+++ b/contracts/crosschain/polygon/CrossChainEnabledPolygonChild.sol
@@ -33,16 +33,10 @@ abstract contract CrossChainEnabledPolygonChild is IFxMessageProcessor, CrossCha
         _fxChild = fxChild;
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_isCrossChain}
-     */
     function _isCrossChain() internal view virtual override returns (bool) {
         return msg.sender == _fxChild;
     }
 
-    /**
-     * @dev see {CrossChainEnabled-_crossChainSender}
-     */
     function _crossChainSender() internal view virtual override onlyCrossChain returns (address) {
         return _sender;
     }

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -86,9 +86,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         require(_executor() == address(this));
     }
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
         // In addition to the current interfaceId, also support previous version of the interfaceId that did not
         // include the castVoteWithReasonAndParams() function as standard
@@ -104,14 +101,14 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-name}.
+     * @inheritdoc IGovernor 
      */
     function name() public view virtual override returns (string memory) {
         return _name;
     }
 
     /**
-     * @dev See {IGovernor-version}.
+     * @inheritdoc IGovernor 
      */
     function version() public view virtual override returns (string memory) {
         return "1";
@@ -140,7 +137,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-state}.
+     * @inheritdoc IGovernor 
      */
     function state(uint256 proposalId) public view virtual override returns (ProposalState) {
         ProposalCore storage proposal = _proposals[proposalId];
@@ -177,14 +174,14 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-proposalSnapshot}.
+     * @inheritdoc IGovernor 
      */
     function proposalSnapshot(uint256 proposalId) public view virtual override returns (uint256) {
         return _proposals[proposalId].voteStart.getDeadline();
     }
 
     /**
-     * @dev See {IGovernor-proposalDeadline}.
+     * @inheritdoc IGovernor 
      */
     function proposalDeadline(uint256 proposalId) public view virtual override returns (uint256) {
         return _proposals[proposalId].voteEnd.getDeadline();
@@ -240,7 +237,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-propose}.
+     * @inheritdoc IGovernor 
      */
     function propose(
         address[] memory targets,
@@ -284,7 +281,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-execute}.
+     * @inheritdoc IGovernor 
      */
     function execute(
         address[] memory targets,
@@ -390,14 +387,14 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-getVotes}.
+     * @inheritdoc IGovernor 
      */
     function getVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
         return _getVotes(account, blockNumber, _defaultParams());
     }
 
     /**
-     * @dev See {IGovernor-getVotesWithParams}.
+     * @inheritdoc IGovernor 
      */
     function getVotesWithParams(
         address account,
@@ -408,7 +405,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-castVote}.
+     * @inheritdoc IGovernor 
      */
     function castVote(uint256 proposalId, uint8 support) public virtual override returns (uint256) {
         address voter = _msgSender();
@@ -416,7 +413,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-castVoteWithReason}.
+     * @inheritdoc IGovernor 
      */
     function castVoteWithReason(
         uint256 proposalId,
@@ -428,7 +425,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-castVoteWithReasonAndParams}.
+     * @inheritdoc IGovernor 
      */
     function castVoteWithReasonAndParams(
         uint256 proposalId,
@@ -441,7 +438,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-castVoteBySig}.
+     * @inheritdoc IGovernor 
      */
     function castVoteBySig(
         uint256 proposalId,
@@ -460,7 +457,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IGovernor-castVoteWithReasonAndParamsBySig}.
+     * @inheritdoc IGovernor 
      */
     function castVoteWithReasonAndParamsBySig(
         uint256 proposalId,
@@ -557,7 +554,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC721Receiver-onERC721Received}.
+     * @inheritdoc IERC721Receiver 
      */
     function onERC721Received(
         address,
@@ -569,7 +566,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC1155Receiver-onERC1155Received}.
+     * @inheritdoc IERC1155Receiver 
      */
     function onERC1155Received(
         address,
@@ -582,7 +579,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
+     * @inheritdoc IERC1155Receiver 
      */
     function onERC1155BatchReceived(
         address,

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -100,16 +100,10 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
             super.supportsInterface(interfaceId);
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function name() public view virtual override returns (string memory) {
         return _name;
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function version() public view virtual override returns (string memory) {
         return "1";
     }
@@ -136,9 +130,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return uint256(keccak256(abi.encode(targets, values, calldatas, descriptionHash)));
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function state(uint256 proposalId) public view virtual override returns (ProposalState) {
         ProposalCore storage proposal = _proposals[proposalId];
 
@@ -173,16 +164,10 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         }
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function proposalSnapshot(uint256 proposalId) public view virtual override returns (uint256) {
         return _proposals[proposalId].voteStart.getDeadline();
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function proposalDeadline(uint256 proposalId) public view virtual override returns (uint256) {
         return _proposals[proposalId].voteEnd.getDeadline();
     }
@@ -236,9 +221,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return "";
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function propose(
         address[] memory targets,
         uint256[] memory values,
@@ -280,9 +262,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return proposalId;
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function execute(
         address[] memory targets,
         uint256[] memory values,
@@ -386,16 +365,10 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return proposalId;
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function getVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
         return _getVotes(account, blockNumber, _defaultParams());
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function getVotesWithParams(
         address account,
         uint256 blockNumber,
@@ -404,17 +377,11 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return _getVotes(account, blockNumber, params);
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function castVote(uint256 proposalId, uint8 support) public virtual override returns (uint256) {
         address voter = _msgSender();
         return _castVote(proposalId, voter, support, "");
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function castVoteWithReason(
         uint256 proposalId,
         uint8 support,
@@ -424,9 +391,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return _castVote(proposalId, voter, support, reason);
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function castVoteWithReasonAndParams(
         uint256 proposalId,
         uint8 support,
@@ -437,9 +401,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return _castVote(proposalId, voter, support, reason, params);
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function castVoteBySig(
         uint256 proposalId,
         uint8 support,
@@ -456,9 +417,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return _castVote(proposalId, voter, support, "");
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function castVoteWithReasonAndParamsBySig(
         uint256 proposalId,
         uint8 support,
@@ -553,9 +511,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return address(this);
     }
 
-    /**
-     * @inheritdoc IERC721Receiver 
-     */
     function onERC721Received(
         address,
         address,
@@ -565,9 +520,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return this.onERC721Received.selector;
     }
 
-    /**
-     * @inheritdoc IERC1155Receiver 
-     */
     function onERC1155Received(
         address,
         address,
@@ -578,9 +530,6 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         return this.onERC1155Received.selector;
     }
 
-    /**
-     * @inheritdoc IERC1155Receiver 
-     */
     function onERC1155BatchReceived(
         address,
         address,

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -120,9 +120,6 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
      */
     receive() external payable {}
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, AccessControl) returns (bool) {
         return interfaceId == type(IERC1155Receiver).interfaceId || super.supportsInterface(interfaceId);
     }
@@ -377,9 +374,6 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         _minDelay = newDelay;
     }
 
-    /**
-     * @dev See {IERC721Receiver-onERC721Received}.
-     */
     function onERC721Received(
         address,
         address,
@@ -389,9 +383,6 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         return this.onERC721Received.selector;
     }
 
-    /**
-     * @dev See {IERC1155Receiver-onERC1155Received}.
-     */
     function onERC1155Received(
         address,
         address,
@@ -402,9 +393,6 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
         return this.onERC1155Received.selector;
     }
 
-    /**
-     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
-     */
     function onERC1155BatchReceived(
         address,
         address,

--- a/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
@@ -50,9 +50,6 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     // ============================================== Proposal lifecycle ==============================================
-    /**
-     * @inheritdoc IGovernor 
-     */
     function propose(
         address[] memory targets,
         uint256[] memory values,
@@ -63,9 +60,6 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
         return super.propose(targets, values, calldatas, description);
     }
 
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
     function propose(
         address[] memory targets,
         uint256[] memory values,
@@ -77,9 +71,6 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
         return propose(targets, values, _encodeCalldata(signatures, calldatas), description);
     }
 
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
     function queue(uint256 proposalId) public virtual override {
         ProposalDetails storage details = _proposalDetails[proposalId];
         queue(
@@ -90,9 +81,6 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
         );
     }
 
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
     function execute(uint256 proposalId) public payable virtual override {
         ProposalDetails storage details = _proposalDetails[proposalId];
         execute(
@@ -164,9 +152,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     // ==================================================== Views =====================================================
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
+
     function proposals(uint256 proposalId)
         public
         view
@@ -201,9 +187,6 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
         executed = status == ProposalState.Executed;
     }
 
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
     function getActions(uint256 proposalId)
         public
         view
@@ -220,24 +203,16 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
         return (details.targets, details.values, details.signatures, details.calldatas);
     }
 
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
     function getReceipt(uint256 proposalId, address voter) public view virtual override returns (Receipt memory) {
         return _proposalDetails[proposalId].receipts[voter];
     }
 
-    /**
-     * @inheritdoc IGovernorCompatibilityBravo 
-     */
     function quorumVotes() public view virtual override returns (uint256) {
         return quorum(block.number - 1);
     }
 
     // ==================================================== Voting ====================================================
-    /**
-     * @inheritdoc IGovernor 
-     */
+
     function hasVoted(uint256 proposalId, address account) public view virtual override returns (bool) {
         return _proposalDetails[proposalId].receipts[account].hasVoted;
     }

--- a/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
@@ -51,7 +51,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
 
     // ============================================== Proposal lifecycle ==============================================
     /**
-     * @dev See {IGovernor-propose}.
+     * @inheritdoc IGovernor 
      */
     function propose(
         address[] memory targets,
@@ -64,7 +64,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     /**
-     * @dev See {IGovernorCompatibilityBravo-propose}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function propose(
         address[] memory targets,
@@ -78,7 +78,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     /**
-     * @dev See {IGovernorCompatibilityBravo-queue}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function queue(uint256 proposalId) public virtual override {
         ProposalDetails storage details = _proposalDetails[proposalId];
@@ -91,7 +91,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     /**
-     * @dev See {IGovernorCompatibilityBravo-execute}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function execute(uint256 proposalId) public payable virtual override {
         ProposalDetails storage details = _proposalDetails[proposalId];
@@ -165,7 +165,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
 
     // ==================================================== Views =====================================================
     /**
-     * @dev See {IGovernorCompatibilityBravo-proposals}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function proposals(uint256 proposalId)
         public
@@ -202,7 +202,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     /**
-     * @dev See {IGovernorCompatibilityBravo-getActions}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function getActions(uint256 proposalId)
         public
@@ -221,14 +221,14 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     }
 
     /**
-     * @dev See {IGovernorCompatibilityBravo-getReceipt}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function getReceipt(uint256 proposalId, address voter) public view virtual override returns (Receipt memory) {
         return _proposalDetails[proposalId].receipts[voter];
     }
 
     /**
-     * @dev See {IGovernorCompatibilityBravo-quorumVotes}.
+     * @inheritdoc IGovernorCompatibilityBravo 
      */
     function quorumVotes() public view virtual override returns (uint256) {
         return quorum(block.number - 1);
@@ -236,7 +236,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
 
     // ==================================================== Voting ====================================================
     /**
-     * @dev See {IGovernor-hasVoted}.
+     * @inheritdoc IGovernor 
      */
     function hasVoted(uint256 proposalId, address account) public view virtual override returns (bool) {
         return _proposalDetails[proposalId].receipts[account].hasVoted;

--- a/contracts/governance/extensions/GovernorCountingSimple.sol
+++ b/contracts/governance/extensions/GovernorCountingSimple.sol
@@ -30,7 +30,7 @@ abstract contract GovernorCountingSimple is Governor {
     mapping(uint256 => ProposalVote) private _proposalVotes;
 
     /**
-     * @dev See {IGovernor-COUNTING_MODE}.
+     * @inheritdoc IGovernor 
      */
     // solhint-disable-next-line func-name-mixedcase
     function COUNTING_MODE() public pure virtual override returns (string memory) {
@@ -38,7 +38,7 @@ abstract contract GovernorCountingSimple is Governor {
     }
 
     /**
-     * @dev See {IGovernor-hasVoted}.
+     * @inheritdoc IGovernor 
      */
     function hasVoted(uint256 proposalId, address account) public view virtual override returns (bool) {
         return _proposalVotes[proposalId].hasVoted[account];
@@ -62,7 +62,7 @@ abstract contract GovernorCountingSimple is Governor {
     }
 
     /**
-     * @dev See {Governor-_quorumReached}.
+     * @inheritdoc Governor 
      */
     function _quorumReached(uint256 proposalId) internal view virtual override returns (bool) {
         ProposalVote storage proposalvote = _proposalVotes[proposalId];

--- a/contracts/governance/extensions/GovernorCountingSimple.sol
+++ b/contracts/governance/extensions/GovernorCountingSimple.sol
@@ -29,17 +29,11 @@ abstract contract GovernorCountingSimple is Governor {
 
     mapping(uint256 => ProposalVote) private _proposalVotes;
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     // solhint-disable-next-line func-name-mixedcase
     function COUNTING_MODE() public pure virtual override returns (string memory) {
         return "support=bravo&quorum=for,abstain";
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function hasVoted(uint256 proposalId, address account) public view virtual override returns (bool) {
         return _proposalVotes[proposalId].hasVoted[account];
     }
@@ -61,9 +55,6 @@ abstract contract GovernorCountingSimple is Governor {
         return (proposalvote.againstVotes, proposalvote.forVotes, proposalvote.abstainVotes);
     }
 
-    /**
-     * @inheritdoc Governor 
-     */
     function _quorumReached(uint256 proposalId) internal view virtual override returns (bool) {
         ProposalVote storage proposalvote = _proposalVotes[proposalId];
 

--- a/contracts/governance/extensions/GovernorSettings.sol
+++ b/contracts/governance/extensions/GovernorSettings.sol
@@ -33,21 +33,21 @@ abstract contract GovernorSettings is Governor {
     }
 
     /**
-     * @dev See {IGovernor-votingDelay}.
+     * @inheritdoc IGovernor 
      */
     function votingDelay() public view virtual override returns (uint256) {
         return _votingDelay;
     }
 
     /**
-     * @dev See {IGovernor-votingPeriod}.
+     * @inheritdoc IGovernor 
      */
     function votingPeriod() public view virtual override returns (uint256) {
         return _votingPeriod;
     }
 
     /**
-     * @dev See {Governor-proposalThreshold}.
+     * @inheritdoc Governor 
      */
     function proposalThreshold() public view virtual override returns (uint256) {
         return _proposalThreshold;

--- a/contracts/governance/extensions/GovernorSettings.sol
+++ b/contracts/governance/extensions/GovernorSettings.sol
@@ -32,23 +32,14 @@ abstract contract GovernorSettings is Governor {
         _setProposalThreshold(initialProposalThreshold);
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function votingDelay() public view virtual override returns (uint256) {
         return _votingDelay;
     }
 
-    /**
-     * @inheritdoc IGovernor 
-     */
     function votingPeriod() public view virtual override returns (uint256) {
         return _votingPeriod;
     }
 
-    /**
-     * @inheritdoc Governor 
-     */
     function proposalThreshold() public view virtual override returns (uint256) {
         return _proposalThreshold;
     }

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -45,7 +45,7 @@ abstract contract GovernorTimelockCompound is IGovernorTimelock, Governor {
     }
 
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @inheritdoc IERC165 
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, Governor) returns (bool) {
         return interfaceId == type(IGovernorTimelock).interfaceId || super.supportsInterface(interfaceId);

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -44,9 +44,6 @@ abstract contract GovernorTimelockCompound is IGovernorTimelock, Governor {
         _updateTimelock(timelockAddress);
     }
 
-    /**
-     * @inheritdoc IERC165 
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, Governor) returns (bool) {
         return interfaceId == type(IGovernorTimelock).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/governance/extensions/GovernorTimelockControl.sol
+++ b/contracts/governance/extensions/GovernorTimelockControl.sol
@@ -39,9 +39,6 @@ abstract contract GovernorTimelockControl is IGovernorTimelock, Governor {
         _updateTimelock(timelockAddress);
     }
 
-    /**
-     * @inheritdoc IERC165 
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, Governor) returns (bool) {
         return interfaceId == type(IGovernorTimelock).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/governance/extensions/GovernorTimelockControl.sol
+++ b/contracts/governance/extensions/GovernorTimelockControl.sol
@@ -40,7 +40,7 @@ abstract contract GovernorTimelockControl is IGovernorTimelock, Governor {
     }
 
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @inheritdoc IERC165 
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, Governor) returns (bool) {
         return interfaceId == type(IGovernorTimelock).interfaceId || super.supportsInterface(interfaceId);

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -36,9 +36,6 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         _setURI(uri_);
     }
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
         return
             interfaceId == type(IERC1155).interfaceId ||
@@ -98,21 +95,21 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     }
 
     /**
-     * @dev See {IERC1155-setApprovalForAll}.
+     * @inheritdoc IERC1155 
      */
     function setApprovalForAll(address operator, bool approved) public virtual override {
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
-     * @dev See {IERC1155-isApprovedForAll}.
+     * @inheritdoc IERC1155 
      */
     function isApprovedForAll(address account, address operator) public view virtual override returns (bool) {
         return _operatorApprovals[account][operator];
     }
 
     /**
-     * @dev See {IERC1155-safeTransferFrom}.
+     * @inheritdoc IERC1155 
      */
     function safeTransferFrom(
         address from,
@@ -129,7 +126,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     }
 
     /**
-     * @dev See {IERC1155-safeBatchTransferFrom}.
+     * @inheritdoc IERC1155 
      */
     function safeBatchTransferFrom(
         address from,

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -94,23 +94,14 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         return batchBalances;
     }
 
-    /**
-     * @inheritdoc IERC1155 
-     */
     function setApprovalForAll(address operator, bool approved) public virtual override {
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
-    /**
-     * @inheritdoc IERC1155 
-     */
     function isApprovedForAll(address account, address operator) public view virtual override returns (bool) {
         return _operatorApprovals[account][operator];
     }
 
-    /**
-     * @inheritdoc IERC1155 
-     */
     function safeTransferFrom(
         address from,
         address to,
@@ -125,9 +116,6 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         _safeTransferFrom(from, to, id, amount, data);
     }
 
-    /**
-     * @inheritdoc IERC1155 
-     */
     function safeBatchTransferFrom(
         address from,
         address to,

--- a/contracts/token/ERC1155/extensions/ERC1155Supply.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Supply.sol
@@ -31,7 +31,7 @@ abstract contract ERC1155Supply is ERC1155 {
     }
 
     /**
-     * @dev See {ERC1155-_beforeTokenTransfer}.
+     * @inheritdoc ERC1155 
      */
     function _beforeTokenTransfer(
         address operator,

--- a/contracts/token/ERC1155/extensions/ERC1155Supply.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Supply.sol
@@ -30,9 +30,6 @@ abstract contract ERC1155Supply is ERC1155 {
         return ERC1155Supply.totalSupply(id) > 0;
     }
 
-    /**
-     * @inheritdoc ERC1155 
-     */
     function _beforeTokenTransfer(
         address operator,
         address from,

--- a/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
+++ b/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
@@ -103,7 +103,7 @@ contract ERC1155PresetMinterPauser is Context, AccessControlEnumerable, ERC1155B
     }
 
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @inheritdoc IERC165 
      */
     function supportsInterface(bytes4 interfaceId)
         public

--- a/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
+++ b/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
@@ -102,9 +102,6 @@ contract ERC1155PresetMinterPauser is Context, AccessControlEnumerable, ERC1155B
         _unpause();
     }
 
-    /**
-     * @inheritdoc IERC165 
-     */
     function supportsInterface(bytes4 interfaceId)
         public
         view

--- a/contracts/token/ERC1155/utils/ERC1155Receiver.sol
+++ b/contracts/token/ERC1155/utils/ERC1155Receiver.sol
@@ -10,9 +10,6 @@ import "../../../utils/introspection/ERC165.sol";
  * @dev _Available since v3.1._
  */
 abstract contract ERC1155Receiver is ERC165, IERC1155Receiver {
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
         return interfaceId == type(IERC1155Receiver).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -88,16 +88,10 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         return 18;
     }
 
-    /**
-     * @dev See {IERC20-totalSupply}.
-     */
     function totalSupply() public view virtual override returns (uint256) {
         return _totalSupply;
     }
 
-    /**
-     * @dev See {IERC20-balanceOf}.
-     */
     function balanceOf(address account) public view virtual override returns (uint256) {
         return _balances[account];
     }
@@ -116,9 +110,6 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         return true;
     }
 
-    /**
-     * @dev See {IERC20-allowance}.
-     */
     function allowance(address owner, address spender) public view virtual override returns (uint256) {
         return _allowances[owner][spender];
     }

--- a/contracts/token/ERC20/extensions/ERC20Capped.sol
+++ b/contracts/token/ERC20/extensions/ERC20Capped.sol
@@ -27,9 +27,6 @@ abstract contract ERC20Capped is ERC20 {
         return _cap;
     }
 
-    /**
-     * @dev See {ERC20-_mint}.
-     */
     function _mint(address account, uint256 amount) internal virtual override {
         require(ERC20.totalSupply() + amount <= cap(), "ERC20Capped: cap exceeded");
         super._mint(account, amount);

--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -22,9 +22,6 @@ abstract contract ERC20Wrapper is ERC20 {
         underlying = underlyingToken;
     }
 
-    /**
-     * @dev See {ERC20-decimals}.
-     */
     function decimals() public view virtual override returns (uint8) {
         try IERC20Metadata(address(underlying)).decimals() returns (uint8 value) {
             return value;

--- a/contracts/token/ERC20/extensions/draft-ERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/draft-ERC20Permit.sol
@@ -43,9 +43,6 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712 {
      */
     constructor(string memory name) EIP712(name, "1") {}
 
-    /**
-     * @dev See {IERC20Permit-permit}.
-     */
     function permit(
         address owner,
         address spender,
@@ -67,16 +64,10 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712 {
         _approve(owner, spender, value);
     }
 
-    /**
-     * @dev See {IERC20Permit-nonces}.
-     */
     function nonces(address owner) public view virtual override returns (uint256) {
         return _nonces[owner].current();
     }
 
-    /**
-     * @dev See {IERC20Permit-DOMAIN_SEPARATOR}.
-     */
     // solhint-disable-next-line func-name-mixedcase
     function DOMAIN_SEPARATOR() external view override returns (bytes32) {
         return _domainSeparatorV4();

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -46,9 +46,6 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         _symbol = symbol_;
     }
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
         return
             interfaceId == type(IERC721).interfaceId ||
@@ -56,40 +53,25 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
             super.supportsInterface(interfaceId);
     }
 
-    /**
-     * @dev See {IERC721-balanceOf}.
-     */
     function balanceOf(address owner) public view virtual override returns (uint256) {
         require(owner != address(0), "ERC721: address zero is not a valid owner");
         return _balances[owner];
     }
 
-    /**
-     * @dev See {IERC721-ownerOf}.
-     */
     function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         address owner = _owners[tokenId];
         require(owner != address(0), "ERC721: invalid token ID");
         return owner;
     }
 
-    /**
-     * @dev See {IERC721Metadata-name}.
-     */
     function name() public view virtual override returns (string memory) {
         return _name;
     }
 
-    /**
-     * @dev See {IERC721Metadata-symbol}.
-     */
     function symbol() public view virtual override returns (string memory) {
         return _symbol;
     }
 
-    /**
-     * @dev See {IERC721Metadata-tokenURI}.
-     */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         _requireMinted(tokenId);
 
@@ -106,9 +88,6 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         return "";
     }
 
-    /**
-     * @dev See {IERC721-approve}.
-     */
     function approve(address to, uint256 tokenId) public virtual override {
         address owner = ERC721.ownerOf(tokenId);
         require(to != owner, "ERC721: approval to current owner");
@@ -121,32 +100,20 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         _approve(to, tokenId);
     }
 
-    /**
-     * @dev See {IERC721-getApproved}.
-     */
     function getApproved(uint256 tokenId) public view virtual override returns (address) {
         _requireMinted(tokenId);
 
         return _tokenApprovals[tokenId];
     }
 
-    /**
-     * @dev See {IERC721-setApprovalForAll}.
-     */
     function setApprovalForAll(address operator, bool approved) public virtual override {
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
-    /**
-     * @dev See {IERC721-isApprovedForAll}.
-     */
     function isApprovedForAll(address owner, address operator) public view virtual override returns (bool) {
         return _operatorApprovals[owner][operator];
     }
 
-    /**
-     * @dev See {IERC721-transferFrom}.
-     */
     function transferFrom(
         address from,
         address to,
@@ -158,9 +125,6 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         _transfer(from, to, tokenId);
     }
 
-    /**
-     * @dev See {IERC721-safeTransferFrom}.
-     */
     function safeTransferFrom(
         address from,
         address to,
@@ -169,9 +133,6 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         safeTransferFrom(from, to, tokenId, "");
     }
 
-    /**
-     * @dev See {IERC721-safeTransferFrom}.
-     */
     function safeTransferFrom(
         address from,
         address to,

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -24,31 +24,19 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     // Mapping from token id to position in the allTokens array
     mapping(uint256 => uint256) private _allTokensIndex;
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721) returns (bool) {
         return interfaceId == type(IERC721Enumerable).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    /**
-     * @dev See {IERC721Enumerable-tokenOfOwnerByIndex}.
-     */
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
         require(index < ERC721.balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
         return _ownedTokens[owner][index];
     }
 
-    /**
-     * @dev See {IERC721Enumerable-totalSupply}.
-     */
     function totalSupply() public view virtual override returns (uint256) {
         return _allTokens.length;
     }
 
-    /**
-     * @dev See {IERC721Enumerable-tokenByIndex}.
-     */
     function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
         require(index < ERC721Enumerable.totalSupply(), "ERC721Enumerable: global index out of bounds");
         return _allTokens[index];

--- a/contracts/token/ERC721/extensions/ERC721Royalty.sol
+++ b/contracts/token/ERC721/extensions/ERC721Royalty.sol
@@ -22,7 +22,7 @@ import "../../../utils/introspection/ERC165.sol";
  */
 abstract contract ERC721Royalty is ERC2981, ERC721 {
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @inheritdoc IERC165 
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC2981) returns (bool) {
         return super.supportsInterface(interfaceId);

--- a/contracts/token/ERC721/extensions/ERC721Royalty.sol
+++ b/contracts/token/ERC721/extensions/ERC721Royalty.sol
@@ -21,9 +21,6 @@ import "../../../utils/introspection/ERC165.sol";
  * _Available since v4.5._
  */
 abstract contract ERC721Royalty is ERC2981, ERC721 {
-    /**
-     * @inheritdoc IERC165 
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC2981) returns (bool) {
         return super.supportsInterface(interfaceId);
     }

--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -14,9 +14,6 @@ abstract contract ERC721URIStorage is ERC721 {
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
 
-    /**
-     * @inheritdoc IERC721Metadata 
-     */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         _requireMinted(tokenId);
 

--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -15,7 +15,7 @@ abstract contract ERC721URIStorage is ERC721 {
     mapping(uint256 => string) private _tokenURIs;
 
     /**
-     * @dev See {IERC721Metadata-tokenURI}.
+     * @inheritdoc IERC721Metadata 
      */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         _requireMinted(tokenId);

--- a/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol
@@ -124,9 +124,6 @@ contract ERC721PresetMinterPauserAutoId is
         super._beforeTokenTransfer(from, to, tokenId);
     }
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId)
         public
         view

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -75,16 +75,10 @@ contract ERC777 is Context, IERC777, IERC20 {
         _ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC20Token"), address(this));
     }
 
-    /**
-     * @dev See {IERC777-name}.
-     */
     function name() public view virtual override returns (string memory) {
         return _name;
     }
 
-    /**
-     * @dev See {IERC777-symbol}.
-     */
     function symbol() public view virtual override returns (string memory) {
         return _symbol;
     }
@@ -108,9 +102,6 @@ contract ERC777 is Context, IERC777, IERC20 {
         return 1;
     }
 
-    /**
-     * @dev See {IERC777-totalSupply}.
-     */
     function totalSupply() public view virtual override(IERC20, IERC777) returns (uint256) {
         return _totalSupply;
     }
@@ -157,9 +148,6 @@ contract ERC777 is Context, IERC777, IERC20 {
         _burn(_msgSender(), amount, data, "");
     }
 
-    /**
-     * @dev See {IERC777-isOperatorFor}.
-     */
     function isOperatorFor(address operator, address tokenHolder) public view virtual override returns (bool) {
         return
             operator == tokenHolder ||
@@ -167,9 +155,6 @@ contract ERC777 is Context, IERC777, IERC20 {
             _operators[tokenHolder][operator];
     }
 
-    /**
-     * @dev See {IERC777-authorizeOperator}.
-     */
     function authorizeOperator(address operator) public virtual override {
         require(_msgSender() != operator, "ERC777: authorizing self as operator");
 
@@ -182,9 +167,6 @@ contract ERC777 is Context, IERC777, IERC20 {
         emit AuthorizedOperator(operator, _msgSender());
     }
 
-    /**
-     * @dev See {IERC777-revokeOperator}.
-     */
     function revokeOperator(address operator) public virtual override {
         require(operator != _msgSender(), "ERC777: revoking self as operator");
 
@@ -197,9 +179,6 @@ contract ERC777 is Context, IERC777, IERC20 {
         emit RevokedOperator(operator, _msgSender());
     }
 
-    /**
-     * @dev See {IERC777-defaultOperators}.
-     */
     function defaultOperators() public view virtual override returns (address[] memory) {
         return _defaultOperatorsArray;
     }

--- a/contracts/token/common/ERC2981.sol
+++ b/contracts/token/common/ERC2981.sol
@@ -30,9 +30,6 @@ abstract contract ERC2981 is IERC2981, ERC165 {
     RoyaltyInfo private _defaultRoyaltyInfo;
     mapping(uint256 => RoyaltyInfo) private _tokenRoyaltyInfo;
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
         return interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/token/common/ERC2981.sol
+++ b/contracts/token/common/ERC2981.sol
@@ -34,9 +34,6 @@ abstract contract ERC2981 is IERC2981, ERC165 {
         return interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    /**
-     * @inheritdoc IERC2981
-     */
     function royaltyInfo(uint256 _tokenId, uint256 _salePrice) public view virtual override returns (address, uint256) {
         RoyaltyInfo memory royalty = _tokenRoyaltyInfo[_tokenId];
 

--- a/contracts/utils/introspection/ERC165.sol
+++ b/contracts/utils/introspection/ERC165.sol
@@ -20,9 +20,6 @@ import "./IERC165.sol";
  * Alternatively, {ERC165Storage} provides an easier to use but more expensive implementation.
  */
 abstract contract ERC165 is IERC165 {
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IERC165).interfaceId;
     }

--- a/contracts/utils/introspection/ERC165Storage.sol
+++ b/contracts/utils/introspection/ERC165Storage.sol
@@ -17,9 +17,6 @@ abstract contract ERC165Storage is ERC165 {
      */
     mapping(bytes4 => bool) private _supportedInterfaces;
 
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return super.supportsInterface(interfaceId) || _supportedInterfaces[interfaceId];
     }

--- a/contracts/utils/introspection/ERC1820Implementer.sol
+++ b/contracts/utils/introspection/ERC1820Implementer.sol
@@ -18,9 +18,6 @@ contract ERC1820Implementer is IERC1820Implementer {
 
     mapping(bytes32 => mapping(address => bool)) private _supportedInterfaces;
 
-    /**
-     * @dev See {IERC1820Implementer-canImplementInterfaceForAddress}.
-     */
     function canImplementInterfaceForAddress(bytes32 interfaceHash, address account)
         public
         view


### PR DESCRIPTION
Fixes #3502

Remove comments of type `@dev See {CONTRACT-METHOD}` that do not add more context.
Solc will inherit the comment by default.

#### PR Checklist
- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
