### PR TITLE
Remove unused using statements in GovernorCompatibilityBravo

### DIFF
--- a/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
@@ -3,7 +3,6 @@
 
 pragma solidity ^0.8.0;
 
-import "../../utils/Counters.sol";
 import "../../utils/math/SafeCast.sol";
 import "../extensions/IGovernorTimelock.sol";
 import "../Governor.sol";
@@ -20,9 +19,6 @@ import "./IGovernorCompatibilityBravo.sol";
  * _Available since v4.3._
  */
 abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorCompatibilityBravo, Governor {
-    using Counters for Counters.Counter;
-    using Timers for Timers.BlockNumber;
-
     enum VoteType {
         Against,
         For,


### PR DESCRIPTION
The two using statements in `GovernorCompatibilityBravo.sol` are not used inside the contract, and cannot affect anything upstream or downstream of them via inheritance. They should be safe to remove.

```javascript
using Counters for Counters.Counter;
using Timers for Timers.BlockNumber;
```

[Since Solidity 0.7.0](https://docs.soliditylang.org/en/latest/070-breaking-changes.html#functions-and-events) `using` statements no longer affect downstream contracts in inheritance hierarchy:

> `using A for B` only affects the contract it is mentioned in. Previously, the effect was inherited. Now, you have to repeat the `using` statement in all derived contracts that make use of the feature.

