### PR TITLE
Document Address.isContract for zero-byte contracts

### DIFF
--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -22,6 +22,7 @@ library Address {
      *  - a contract in construction
      *  - an address where a contract will be created
      *  - an address where a contract lived, but was destroyed
+     *  - an address of a contract with zero-length bytecode
      * ====
      *
      * [IMPORTANT]


### PR DESCRIPTION
Fixes #3507 (kind of)

Adds an explicitly warning for `Address.isContract` about returning `false` for zero-byte contracts.


#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
