### PR TITLE
Refactor address-to-hex-string conversion in `_checkRole` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
  * `PaymentSplitter`: add `releasable` getters. ([#3350](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3350))
  * `Initializable`: refactored implementation of modifiers for easier understanding. ([#3450](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3450))
  * `Proxies`: remove runtime check of ERC1967 storage slots. ([#3455](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3455))
- * `AccessControl`: refactor address-to-hex-string conversion in `_checkRole` function. ([#3509](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3509))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  * `PaymentSplitter`: add `releasable` getters. ([#3350](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3350))
  * `Initializable`: refactored implementation of modifiers for easier understanding. ([#3450](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3450))
  * `Proxies`: remove runtime check of ERC1967 storage slots. ([#3455](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3455))
+ * `AccessControl`: refactor address-to-hex-string conversion in `_checkRole` function. ([#3509](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3509))
 
 ### Breaking changes
 

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -110,7 +110,7 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
                 string(
                     abi.encodePacked(
                         "AccessControl: account ",
-                        Strings.toHexString(uint160(account), 20),
+                        Strings.toHexString(account),
                         " is missing role ",
                         Strings.toHexString(uint256(role), 32)
                     )


### PR DESCRIPTION
Based on my merged PR https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3403 that introduces a function overloading for `toHexString`, we can make a small refactor of the `_checkRole` function in `AccessControl.sol`.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
