### PR TITLE
Modify ReentrancyGuard to reduce contract size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+ * `ReentrancyGuard`: Reduce code size impact of the modifier by using internal functions. ([#3515](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3515))
+
+## Unreleased
+
  * `TimelockController`: Migrate `_call` to `_execute` and allow inheritance and overriding similar to `Governor`. ([#3317](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3317))
  * `CrossChainEnabledPolygonChild`: replace the `require` statement with the custom error `NotCrossChainCall`. ([#3380](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3380))
  * `ERC20FlashMint`: Add customizable flash fee receiver. ([#3327](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3327))

--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -40,6 +40,20 @@ abstract contract ReentrancyGuard {
         _status = _NOT_ENTERED;
     }
 
+    function _nonReentrant() private {
+        // On the first call to nonReentrant, _notEntered will be true
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _status = _ENTERED;
+    }
+
+    function _nonReentrant2() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = _NOT_ENTERED;
+    }
+
     /**
      * @dev Prevents a contract from calling itself, directly or indirectly.
      * Calling a `nonReentrant` function from another `nonReentrant`
@@ -48,16 +62,8 @@ abstract contract ReentrancyGuard {
      * `private` function that does the actual work.
      */
     modifier nonReentrant() {
-        // On the first call to nonReentrant, _notEntered will be true
-        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
-
-        // Any calls to nonReentrant after this point will fail
-        _status = _ENTERED;
-
+        _nonReentrant();
         _;
-
-        // By storing the original value once again, a refund is triggered (see
-        // https://eips.ethereum.org/EIPS/eip-2200)
-        _status = _NOT_ENTERED;
+        _nonReentrant2();
     }
 }

--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -40,6 +40,19 @@ abstract contract ReentrancyGuard {
         _status = _NOT_ENTERED;
     }
 
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+    
     function _nonReentrantBefore() private {
         // On the first call to nonReentrant, _notEntered will be true
         require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
@@ -52,18 +65,5 @@ abstract contract ReentrancyGuard {
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
         _status = _NOT_ENTERED;
-    }
-
-    /**
-     * @dev Prevents a contract from calling itself, directly or indirectly.
-     * Calling a `nonReentrant` function from another `nonReentrant`
-     * function is not supported. It is possible to prevent this from happening
-     * by making the `nonReentrant` function external, and making it call a
-     * `private` function that does the actual work.
-     */
-    modifier nonReentrant() {
-        _nonReentrantBefore();
-        _;
-        _nonReentrantAfter();
     }
 }

--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -40,7 +40,7 @@ abstract contract ReentrancyGuard {
         _status = _NOT_ENTERED;
     }
 
-    function _nonReentrant() private {
+    function _nonReentrantBefore() private {
         // On the first call to nonReentrant, _notEntered will be true
         require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
 
@@ -48,7 +48,7 @@ abstract contract ReentrancyGuard {
         _status = _ENTERED;
     }
 
-    function _nonReentrant2() private {
+    function _nonReentrantAfter() private {
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
         _status = _NOT_ENTERED;
@@ -62,8 +62,8 @@ abstract contract ReentrancyGuard {
      * `private` function that does the actual work.
      */
     modifier nonReentrant() {
-        _nonReentrant();
+        _nonReentrantBefore();
         _;
-        _nonReentrant2();
+        _nonReentrantAfter();
     }
 }

--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -52,7 +52,7 @@ abstract contract ReentrancyGuard {
         _;
         _nonReentrantAfter();
     }
-    
+
     function _nonReentrantBefore() private {
         // On the first call to nonReentrant, _notEntered will be true
         require(_status != _ENTERED, "ReentrancyGuard: reentrant call");


### PR DESCRIPTION
Refer issue #3514 

I wrapped the code present in function `modifier` with 2 functions (private) outside & just call the function(s) inside the modifier.
