### PR TITLE
Fixed typos in `Math`: `sqrt` function.

### DIFF
--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -151,7 +151,7 @@ library Math {
     }
 
     /**
-     * @dev Returns the square root of a number. It the number is not a perfect square, the value is rounded down.
+     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded down.
      *
      * Inspired by Henry S. Warren, Jr.'s "Hacker's Delight" (Chapter 11).
      */
@@ -165,8 +165,8 @@ library Math {
         // `msb(a) <= a < 2*msb(a)`.
         // We also know that `k`, the position of the most significant bit, is such that `msb(a) = 2**k`.
         // This gives `2**k < a <= 2**(k+1)` → `2**(k/2) <= sqrt(a) < 2 ** (k/2+1)`.
-        // Using an algorithm similar to the msb conmputation, we are able to compute `result = 2**(k/2)` which is a
-        // good first aproximation of `sqrt(a)` with at least 1 correct bit.
+        // Using an algorithm similar to the msb computation, we are able to compute `result = 2**(k/2)` which is a
+        // good first approximation of `sqrt(a)` with at least 1 correct bit.
         uint256 result = 1;
         uint256 x = a;
         if (x >> 128 > 0) {


### PR DESCRIPTION
I was reading and found some typos.