### PR TITLE
using unchecked to optimize +/- on totalsupply and balances for erc777

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -343,8 +343,10 @@ contract ERC777 is Context, IERC777, IERC20 {
 
         // Update state variables
         _totalSupply += amount;
-        _balances[account] += amount;
-
+        unchecked {
+            _balances[account] += amount;
+        }
+        
         _callTokensReceived(operator, address(0), account, amount, userData, operatorData, requireReceptionAck);
 
         emit Minted(operator, account, amount, userData, operatorData);
@@ -406,8 +408,8 @@ contract ERC777 is Context, IERC777, IERC20 {
         require(fromBalance >= amount, "ERC777: burn amount exceeds balance");
         unchecked {
             _balances[from] = fromBalance - amount;
-        }
-        _totalSupply -= amount;
+            _totalSupply -= amount;
+        }        
 
         emit Burned(operator, from, amount, data, operatorData);
         emit Transfer(from, address(0), amount);
@@ -427,9 +429,9 @@ contract ERC777 is Context, IERC777, IERC20 {
         require(fromBalance >= amount, "ERC777: transfer amount exceeds balance");
         unchecked {
             _balances[from] = fromBalance - amount;
+            _balances[to] += amount;
         }
-        _balances[to] += amount;
-
+        
         emit Sent(operator, from, to, amount, userData, operatorData);
         emit Transfer(from, to, amount);
     }

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -346,7 +346,7 @@ contract ERC777 is Context, IERC777, IERC20 {
         unchecked {
             _balances[account] += amount;
         }
-        
+
         _callTokensReceived(operator, address(0), account, amount, userData, operatorData, requireReceptionAck);
 
         emit Minted(operator, account, amount, userData, operatorData);
@@ -409,7 +409,7 @@ contract ERC777 is Context, IERC777, IERC20 {
         unchecked {
             _balances[from] = fromBalance - amount;
             _totalSupply -= amount;
-        }        
+        }
 
         emit Burned(operator, from, amount, data, operatorData);
         emit Transfer(from, address(0), amount);
@@ -431,7 +431,7 @@ contract ERC777 is Context, IERC777, IERC20 {
             _balances[from] = fromBalance - amount;
             _balances[to] += amount;
         }
-        
+
         emit Sent(operator, from, to, amount, userData, operatorData);
         emit Transfer(from, to, amount);
     }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

For ERC777, _totalSupply is the sum of all values saved in _balances. Thus, all additions on _balances[X] can be marked as unchecked, since no overflow happens on _totalSupply in function _mint(). 

Similarly, subtraction on _totalSupply can be marked as unchecked, since subtraction on _balances[from] is checked earlier. 

Similar optimizations have already been applied to ERC20. 

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
