### PR TITLE
Move adds on total earlier to enable the use of unchecked

### DIFF
--- a/contracts/finance/PaymentSplitter.sol
+++ b/contracts/finance/PaymentSplitter.sol
@@ -149,6 +149,8 @@ contract PaymentSplitter is Context {
 
         require(payment != 0, "PaymentSplitter: account is not due payment");
 
+        //_totalReleased is the sum of all values in _released.
+        //if "_totalReleased += payment" does not overflow, then "_released[account] += payment" cannot overflow.
         _totalReleased += payment;
         unchecked {
             _released[account] += payment;
@@ -170,6 +172,9 @@ contract PaymentSplitter is Context {
 
         require(payment != 0, "PaymentSplitter: account is not due payment");
 
+        //_erc20TotalReleased[token] is the sum of all values in _erc20Released[token].
+        //if "_erc20TotalReleased[token] += payment" does not overflow, then "_erc20Released[token][account] += payment"
+        //cannot overflow.
         _erc20TotalReleased[token] += payment;
         unchecked {
             _erc20Released[token][account] += payment;

--- a/contracts/finance/PaymentSplitter.sol
+++ b/contracts/finance/PaymentSplitter.sol
@@ -149,8 +149,10 @@ contract PaymentSplitter is Context {
 
         require(payment != 0, "PaymentSplitter: account is not due payment");
 
-        _released[account] += payment;
         _totalReleased += payment;
+        unchecked {
+            _released[account] += payment;
+        }
 
         Address.sendValue(account, payment);
         emit PaymentReleased(account, payment);
@@ -168,8 +170,10 @@ contract PaymentSplitter is Context {
 
         require(payment != 0, "PaymentSplitter: account is not due payment");
 
-        _erc20Released[token][account] += payment;
         _erc20TotalReleased[token] += payment;
+        unchecked {
+            _erc20Released[token][account] += payment;
+        }
 
         SafeERC20.safeTransfer(token, account, payment);
         emit ERC20PaymentReleased(token, account, payment);

--- a/contracts/finance/PaymentSplitter.sol
+++ b/contracts/finance/PaymentSplitter.sol
@@ -149,8 +149,8 @@ contract PaymentSplitter is Context {
 
         require(payment != 0, "PaymentSplitter: account is not due payment");
 
-        //_totalReleased is the sum of all values in _released.
-        //if "_totalReleased += payment" does not overflow, then "_released[account] += payment" cannot overflow.
+        // _totalReleased is the sum of all values in _released.
+        // If "_totalReleased += payment" does not overflow, then "_released[account] += payment" cannot overflow.
         _totalReleased += payment;
         unchecked {
             _released[account] += payment;
@@ -172,9 +172,9 @@ contract PaymentSplitter is Context {
 
         require(payment != 0, "PaymentSplitter: account is not due payment");
 
-        //_erc20TotalReleased[token] is the sum of all values in _erc20Released[token].
-        //if "_erc20TotalReleased[token] += payment" does not overflow, then "_erc20Released[token][account] += payment"
-        //cannot overflow.
+        // _erc20TotalReleased[token] is the sum of all values in _erc20Released[token].
+        // If "_erc20TotalReleased[token] += payment" does not overflow, then "_erc20Released[token][account] += payment"
+        // cannot overflow.
         _erc20TotalReleased[token] += payment;
         unchecked {
             _erc20Released[token][account] += payment;


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

For two consecutive additions, we can put the addition on the total variable before the addition on the individual variable. After that, we can use unchecked for the second addition, because if the addition on total does not overflow, then the addition on individual variable does not overflow either. 


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
