### PR TITLE
draft-EIP-712 - optimization in hashedVersion

### DIFF
--- a/contracts/utils/cryptography/draft-EIP712.sol
+++ b/contracts/utils/cryptography/draft-EIP712.sol
@@ -52,7 +52,7 @@ abstract contract EIP712 {
      */
     constructor(string memory name, string memory version) {
         bytes32 hashedName = keccak256(bytes(name));
-        bytes32 hashedVersion = keccak256(version);
+        bytes32 hashedVersion = keccak256("version");
         bytes32 typeHash = keccak256(
             "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
         );

--- a/contracts/utils/cryptography/draft-EIP712.sol
+++ b/contracts/utils/cryptography/draft-EIP712.sol
@@ -52,7 +52,7 @@ abstract contract EIP712 {
      */
     constructor(string memory name, string memory version) {
         bytes32 hashedName = keccak256(bytes(name));
-        bytes32 hashedVersion = keccak256(bytes(version));
+        bytes32 hashedVersion = keccak256(version);
         bytes32 typeHash = keccak256(
             "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
         );


### PR DESCRIPTION
remove bytes wrapper on version in deriving hashedVersion.

We can save some gas by removing bytes wrapper.

- [x] Tests
- [x] Documentation
- [x] Changelog entry
