### PR TITLE
Use calldata to reduce gas costs in ERC1155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  * `ERC20`: optimize `_transfer`, `_mint` and `_burn` by using `unchecked` arithmetic when possible. ([#3513](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3513))
  * `ERC721`: optimize transfers by making approval clearing implicit instead of emitting an event. ([#3481](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3481))
  * `ERC721`: optimize burn by making approval clearing implicit instead of emitting an event. ([#3538](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3538))
+ * `ERC1155`: optimize mint, transfer, and burn by using calldata. ([#3540](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3540))
 
 ### Compatibility Note
 

--- a/contracts/mocks/ERC1155BurnableMock.sol
+++ b/contracts/mocks/ERC1155BurnableMock.sol
@@ -11,7 +11,7 @@ contract ERC1155BurnableMock is ERC1155Burnable {
         address to,
         uint256 id,
         uint256 value,
-        bytes memory data
+        bytes calldata data
     ) public {
         _mint(to, id, value, data);
     }

--- a/contracts/mocks/ERC1155Mock.sol
+++ b/contracts/mocks/ERC1155Mock.sol
@@ -11,7 +11,7 @@ import "../token/ERC1155/ERC1155.sol";
 contract ERC1155Mock is ERC1155 {
     constructor(string memory uri) ERC1155(uri) {}
 
-    function setURI(string memory newuri) public {
+    function setURI(string calldata newuri) public {
         _setURI(newuri);
     }
 
@@ -19,16 +19,16 @@ contract ERC1155Mock is ERC1155 {
         address to,
         uint256 id,
         uint256 value,
-        bytes memory data
+        bytes calldata data
     ) public {
         _mint(to, id, value, data);
     }
 
     function mintBatch(
         address to,
-        uint256[] memory ids,
-        uint256[] memory values,
-        bytes memory data
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
     ) public {
         _mintBatch(to, ids, values, data);
     }
@@ -43,8 +43,8 @@ contract ERC1155Mock is ERC1155 {
 
     function burnBatch(
         address owner,
-        uint256[] memory ids,
-        uint256[] memory values
+        uint256[] calldata ids,
+        uint256[] calldata values
     ) public {
         _burnBatch(owner, ids, values);
     }

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -79,7 +79,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
      *
      * - `accounts` and `ids` must have the same length.
      */
-    function balanceOfBatch(address[] memory accounts, uint256[] memory ids)
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
         public
         view
         virtual
@@ -119,7 +119,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         address to,
         uint256 id,
         uint256 amount,
-        bytes memory data
+        bytes calldata data
     ) public virtual override {
         require(
             from == _msgSender() || isApprovedForAll(from, _msgSender()),
@@ -134,9 +134,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
     function safeBatchTransferFrom(
         address from,
         address to,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes memory data
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
     ) public virtual override {
         require(
             from == _msgSender() || isApprovedForAll(from, _msgSender()),

--- a/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
@@ -27,8 +27,8 @@ abstract contract ERC1155Burnable is ERC1155 {
 
     function burnBatch(
         address account,
-        uint256[] memory ids,
-        uint256[] memory values
+        uint256[] calldata ids,
+        uint256[] calldata values
     ) public virtual {
         require(
             account == _msgSender() || isApprovedForAll(account, _msgSender()),

--- a/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
+++ b/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.sol
@@ -53,7 +53,7 @@ contract ERC1155PresetMinterPauser is Context, AccessControlEnumerable, ERC1155B
         address to,
         uint256 id,
         uint256 amount,
-        bytes memory data
+        bytes calldata data
     ) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC1155PresetMinterPauser: must have minter role to mint");
 
@@ -65,9 +65,9 @@ contract ERC1155PresetMinterPauser is Context, AccessControlEnumerable, ERC1155B
      */
     function mintBatch(
         address to,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes memory data
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
     ) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC1155PresetMinterPauser: must have minter role to mint");
 


### PR DESCRIPTION
We can use `calldata` instead of `memory` in several places in ERC1155 (as well as the mocks/extensions). This will both save gas and also keep the implementation function signatures the same as the interface function signatures (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC1155/IERC1155.sol). The EIP itself has the input parameters as calldata: https://eips.ethereum.org/EIPS/eip-1155.

I ran the full set of ERC1155 tests (`env ENABLE_GAS_REPORT=true npx hardhat test --grep ERC1155`) and got these gas savings: https://www.diffchecker.com/0Mac8iiV.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [x] Changelog entry
