### PR TITLE
Keep track of historical quorum values

### DIFF
--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -97,7 +97,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
         // make sure we keep track of the old numerator (applicable to upgrade only)
         if (_quorumNumeratorHistory._checkpoints.length == 0) {
             _quorumNumeratorHistory._checkpoints.push(
-                Checkpoint({ _blockNumber: 0, _value: oldQuorumNumerator })
+                Checkpoints({ _blockNumber: 0, _value: oldQuorumNumerator })
             );
         }
 

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -101,7 +101,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
             );
         }
 
-        // set new quorum for upcomming proposals
+        // Set new quorum for future proposals
         _quorumNumeratorHistory.push(newQuorumNumerator);
 
         emit QuorumNumeratorUpdated(oldQuorumNumerator, newQuorumNumerator);

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -93,6 +93,15 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
         );
 
         uint256 oldQuorumNumerator = quorumNumerator();
+
+        // make sure we keep track of the old numerator (applicable to upgrade only)
+        if (_quorumNumeratorHistory._checkpoints.length == 0) {
+            _quorumNumeratorHistory._checkpoints.push(
+                Checkpoint({ _blockNumber: 0, _value: oldQuorumNumerator })
+            );
+        }
+
+        // set new quorum for upcomming proposals
         _quorumNumeratorHistory.push(newQuorumNumerator);
 
         emit QuorumNumeratorUpdated(oldQuorumNumerator, newQuorumNumerator);

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -36,18 +36,17 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
      * @dev Returns the current quorum numerator. See {quorumDenominator}.
      */
     function quorumNumerator() public view virtual returns (uint256) {
-        return _quorumNumeratorHistory._checkpoints.length == 0
-            ? _quorumNumerator
-            : _quorumNumeratorHistory.latest();
+        return _quorumNumeratorHistory._checkpoints.length == 0 ? _quorumNumerator : _quorumNumeratorHistory.latest();
     }
 
     /**
      * @dev Returns the quorum numerator at a specific block number. See {quorumDenominator}.
      */
     function quorumNumerator(uint256 blockNumber) public view virtual returns (uint256) {
-        return _quorumNumeratorHistory._checkpoints.length == 0
-            ? _quorumNumerator
-            : _quorumNumeratorHistory.getAtBlock(blockNumber);
+        return
+            _quorumNumeratorHistory._checkpoints.length == 0
+                ? _quorumNumerator
+                : _quorumNumeratorHistory.getAtBlock(blockNumber);
     }
 
     /**

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -35,7 +35,16 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
      * @dev Returns the current quorum numerator. See {quorumDenominator}.
      */
     function quorumNumerator() public view virtual returns (uint256) {
-        return _quorumNumeratorHistory.latest();
+        return quorumNumerator(block.number - 1);
+    }
+
+    /**
+     * @dev Returns the quorum numerator at a specific block number. See {quorumDenominator}.
+     */
+    function quorumNumerator(uint256 blockNumber) public view virtual returns (uint256) {
+        return _quorumNumeratorHistory._checkpoints.length == 0
+            ? _quorumNumerator
+            : _quorumNumeratorHistory.getAtBlock(blockNumber);
     }
 
     /**
@@ -49,7 +58,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
      * @dev Returns the quorum for a block number, in terms of number of votes: `supply * numerator / denominator`.
      */
     function quorum(uint256 blockNumber) public view virtual override returns (uint256) {
-        return (token.getPastTotalSupply(blockNumber) * _quorumNumeratorHistory.getAtBlock(blockNumber)) / quorumDenominator();
+        return (token.getPastTotalSupply(blockNumber) * quorumNumerator(blockNumber)) / quorumDenominator();
     }
 
     /**

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 
 import "./GovernorVotes.sol";
 import "../../utils/Checkpoints.sol";
+import "../../utils/math/SafeCast.sol";
 
 /**
  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token and a quorum expressed as a
@@ -97,7 +98,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
         // make sure we keep track of the old numerator (applicable to upgrade only)
         if (_quorumNumeratorHistory._checkpoints.length == 0) {
             _quorumNumeratorHistory._checkpoints.push(
-                Checkpoints({ _blockNumber: 0, _value: oldQuorumNumerator })
+                Checkpoints.Checkpoint({_blockNumber: 0, _value: SafeCast.toUint224(oldQuorumNumerator)})
             );
         }
 

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -35,7 +35,9 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
      * @dev Returns the current quorum numerator. See {quorumDenominator}.
      */
     function quorumNumerator() public view virtual returns (uint256) {
-        return quorumNumerator(block.number - 1);
+        return _quorumNumeratorHistory._checkpoints.length == 0
+            ? _quorumNumerator
+            : _quorumNumeratorHistory.latest();
     }
 
     /**

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -90,7 +90,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
             "GovernorVotesQuorumFraction: quorumNumerator over quorumDenominator"
         );
 
-        uint256 oldQuorumNumerator = _quorumNumeratorHistory.latest();
+        uint256 oldQuorumNumerator = quorumNumerator();
         _quorumNumeratorHistory.push(newQuorumNumerator);
 
         emit QuorumNumeratorUpdated(oldQuorumNumerator, newQuorumNumerator);

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -95,8 +95,8 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
 
         uint256 oldQuorumNumerator = quorumNumerator();
 
-        // make sure we keep track of the old numerator (applicable to upgrade only)
-        if (_quorumNumeratorHistory._checkpoints.length == 0) {
+        // Make sure we keep track of the original numerator in contracts upgraded from a version without checkpoints.
+        if (oldQuorumNumerator != 0 && _quorumNumeratorHistory._checkpoints.length == 0) {
             _quorumNumeratorHistory._checkpoints.push(
                 Checkpoints.Checkpoint({_blockNumber: 0, _value: SafeCast.toUint224(oldQuorumNumerator)})
             );

--- a/test/governance/extensions/GovernorVotesQuorumFraction.test.js
+++ b/test/governance/extensions/GovernorVotesQuorumFraction.test.js
@@ -104,6 +104,13 @@ contract('GovernorVotesQuorumFraction', function (accounts) {
 
       expect(await this.mock.quorumNumerator()).to.be.bignumber.equal(newRatio);
       expect(await this.mock.quorumDenominator()).to.be.bignumber.equal('100');
+
+      // it takes one block for the new quorum to take effect
+      expect(await time.latestBlock().then(blockNumber => this.mock.quorum(blockNumber.subn(1))))
+        .to.be.bignumber.equal(tokenSupply.mul(ratio).divn(100));
+
+      await time.advanceBlock();
+
       expect(await time.latestBlock().then(blockNumber => this.mock.quorum(blockNumber.subn(1))))
         .to.be.bignumber.equal(tokenSupply.mul(newRatio).divn(100));
     });


### PR DESCRIPTION
Checkpointing quorum is necessary to avoid quorum changes making old, failed because of quorum, proposals suddenly successful.

#### PR Checklist

- [x] Tests
- [ ] Changelog entry
