### PR TITLE
Fix error in documentation and typo

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -120,7 +120,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     /**
      * @dev See {IGovernor-hashProposal}.
      *
-     * The proposal id is produced by hashing the RLC encoded `targets` array, the `values` array, the `calldatas` array
+     * The proposal id is produced by hashing the ABI encoded `targets` array, the `values` array, the `calldatas` array
      * and the descriptionHash (bytes32 which itself is the keccak256 hash of the description string). This proposal id
      * can be produced from the proposal data which is part of the {ProposalCreated} event. It can even be computed in
      * advance, before the proposal is submitted.

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -141,7 +141,7 @@ abstract contract IGovernor is IERC165 {
     /**
      * @notice module:user-config
      * @dev Delay, in number of block, between the proposal is created and the vote starts. This can be increassed to
-     * leave time for users to buy voting power, of delegate it, before the voting of a proposal starts.
+     * leave time for users to buy voting power, or delegate it, before the voting of a proposal starts.
      */
     function votingDelay() public view virtual returns (uint256);
 


### PR DESCRIPTION
Hello, just minor nitpicks. RLC encoding (RLP maybe?) doesn't seem to be a thing, and abi.encode doesn't do RLP anyway
