### PR TITLE
Adding 1155Compatible

### DIFF
--- a/contracts/mocks/ERC1155CompatibleMock.sol
+++ b/contracts/mocks/ERC1155CompatibleMock.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../token/ERC1155/extensions/ERC1155Compatible.sol";
+
+contract ERC1155CompatibleMock is ERC1155Compatible {
+    constructor(
+        string memory name,
+        string memory symbol,
+        string memory uri
+    ) ERC1155Compatible(name, symbol, uri) {}
+
+    function mint(
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    ) public {
+        _mint(to, id, value, data);
+    }
+}

--- a/contracts/token/ERC1155/extensions/ERC1155Compatible.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Compatible.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.6.0) (token/ERC1155/extensions/ERC1155URIStorage.sol)
+
+pragma solidity ^0.8.0;
+
+import "../../../utils/Strings.sol";
+import "../ERC1155.sol";
+
+/**
+ * @dev ERC1155 token compatible with blockchain explorers, wallets, and marketplaces.
+ *
+ */
+abstract contract ERC1155Compatible is ERC1155 {
+    using Strings for uint256;
+
+    // Token name
+    string private _name;
+
+    // Token symbol
+    string private _symbol;
+
+    // Optional base URI
+    string private _baseURI = "";
+
+    /**
+     * @dev Create a Compatible ERC1155
+     */
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        string memory baseURI_
+    ) ERC1155(baseURI_) {
+        _name = name_;
+        _symbol = symbol_;
+        _baseURI = baseURI_;
+    }
+
+    /**
+     * @dev Return the name of the token.
+     */
+    function name() public view virtual returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Return the symbol of the token.
+     */
+    function symbol() public view virtual returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC1155MetadataURI-uri}.
+     *
+     * Return a compatible metadata URI, unique for each token.
+     */
+    function uri(uint256 tokenId) public view virtual override returns (string memory) {
+        string memory baseURI = _baseURI;
+
+        // If token URI is set, concatenate base URI and tokenURI (via abi.encodePacked).
+        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+    }
+
+    /**
+     * @dev Sets `baseURI` as the `_baseURI` for all tokens
+     */
+    function _setBaseURI(string memory baseURI) internal virtual {
+        _baseURI = baseURI;
+    }
+}

--- a/test/token/ERC1155/extensions/ERC1155Compatibile.test.js
+++ b/test/token/ERC1155/extensions/ERC1155Compatibile.test.js
@@ -1,0 +1,40 @@
+const { BN } = require('@openzeppelin/test-helpers');
+
+const { expect } = require('chai');
+
+const ERC1155Compatible = artifacts.require('ERC1155CompatibleMock');
+
+contract('ERC1155Compatible', function (accounts) {
+  const [holder, operator] = accounts;
+
+  const name = 'Test Token';
+  const symbol = 'TEST';
+  const uri = 'https://token.com/';
+
+  beforeEach(async function () {
+    this.token = await ERC1155Compatible.new(name, symbol, uri);
+  });
+
+  context('when creating the token', function () {
+    const firstTokenId = new BN('1');
+    const firstTokenAmount = new BN('1000');
+
+    beforeEach(async function () {
+      await this.token.setApprovalForAll(operator, true, { from: holder });
+      await this.token.mint(holder, firstTokenId, firstTokenAmount, '0x');
+    });
+
+    it('correctly reports name and symbol', async function () {
+      const _name = await this.token.name();
+      const _symbol = await this.token.symbol();
+
+      expect(_name).to.equal(name);
+      expect(_symbol).to.equal(symbol);
+    });
+
+    it('correctly generates URI for a token', async function () {
+      const _uri = await this.token.uri(firstTokenId);
+      expect(_uri).to.equal(uri + firstTokenId.toString());
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3571 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR Introduces ERC1155Compatible, which introduces `name`, `symbol`, and a functional `uri(token)` method.  Blockchain explorers and wallets will show the name and symbol, and opensea and other NFT exchanges which recognize 1155s can leverage the uri function and work out-of-the-box.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [✅ ] Tests
- [ ] Documentation
- [ ] Changelog entry
