### PR TITLE
update comment for _beforeTokenTransfer

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -64,8 +64,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      * transferred to `to`.
      * - When `from` is zero, `tokenId` will be minted for `to`.
      * - When `to` is zero, ``from``'s `tokenId` will be burned.
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
+     * - `from` and 'to' cannot be the zero address at the same time.
      *
      * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->
This commit makes the comment clearer for ERC721Enumerable._beforeTokenTransfer() by combing its calling condition items 4) and 5) into one condition: `from` and 'to' cannot be the zero address at the same time.