### PR TITLE
Add `transferRole` function to `AccessRole` allowing transferring of roles from role bearers to a new accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
  * `ReentrancyGuard`: Reduce code size impact of the modifier by using internal functions. ([#3515](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3515))
  * `SafeCast`: optimize downcasting of signed integers. ([#3565](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3565))
  * `ERC20FlashMint`: add an internal `_flashFee` function for overriding. ([#3551](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3551))
- * `AccessControl`: add `transferRole` function for transferring role from a role bearer to a new account. ([#????](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/????))
+ * `AccessControl`: add `transferRole` function for transferring role from a role bearer to a new account. ([#3593](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3593))
 
 ### Compatibility Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  * `ReentrancyGuard`: Reduce code size impact of the modifier by using internal functions. ([#3515](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3515))
  * `SafeCast`: optimize downcasting of signed integers. ([#3565](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3565))
  * `ERC20FlashMint`: add an internal `_flashFee` function for overriding. ([#3551](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3551))
+ * `AccessControl`: add `transferRole` function for transferring role from a role bearer to a new account. ([#????](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/????))
 
 ### Compatibility Note
 

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -183,6 +183,35 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
     }
 
     /**
+     * @dev Transfers `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to transfer their privileges
+     * if they are switching to a new account or compromised (such as when a
+     * trusted device is misplaced), without involving the role admin.
+     *
+     * If the calling account had been granted `role`, and the recipient account
+     * had not, emits a {RoleTransferred} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have the `role` role
+     */
+    function transferRole(
+        bytes32 role,
+        address account,
+        address recipient
+    ) public virtual override {
+        require(account == _msgSender(), "AccessControl: can only transfer roles from self");
+
+        if (account != recipient && hasRole(role, account) && !hasRole(role, recipient)) {
+            _roles[role].members[account] = false;
+            _roles[role].members[recipient] = true;
+            emit RoleTransferred(role, account, recipient);
+        }
+    }
+
+    /**
      * @dev Grants `role` to `account`.
      *
      * If `account` had not been already granted `role`, emits a {RoleGranted}

--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -35,6 +35,13 @@ interface IAccessControl {
     event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
 
     /**
+     * @dev Emitted when `account` is granted `role` via a transfer.
+     *
+     * `sender` is the account that originated the contract call, a target role bearer
+     */
+    event RoleTransferred(bytes32 indexed role, address indexed account, address indexed recipient);
+
+    /**
      * @dev Returns `true` if `account` has been granted `role`.
      */
     function hasRole(bytes32 role, address account) external view returns (bool);
@@ -85,4 +92,25 @@ interface IAccessControl {
      * - the caller must be `account`.
      */
     function renounceRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Transfers `role` from the calling account to `.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to transfer their privileges
+     * if they are switching to a new account or compromised (such as when a
+     * trusted device is misplaced), without involving the role admin.
+     *
+     * If the calling account had been granted `role`, and the recipient account
+     * had not, emits a {RoleTransferred} event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account` and have the `role` role
+     */
+    function transferRole(
+        bytes32 role,
+        address account,
+        address recipient
+    ) external;
 }

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -45,6 +45,7 @@ const INTERFACES = {
     'grantRole(bytes32,address)',
     'revokeRole(bytes32,address)',
     'renounceRole(bytes32,address)',
+    'transferRole(bytes32,address,address)',
   ],
   AccessControlEnumerable: [
     'getRoleMember(bytes32,uint256)',


### PR DESCRIPTION
In this PR, I've added a new `transferRole` function to `AccessControl`, which allows role bearers to transfer their privileges to new accounts in case they are switching to a new account or compromised, without involving the role admin (which in many cases is an involved time-locked governance process).

- Similar to `renounceRole`, the `account` has to be the caller itself.
- A successful transfer from `account` to `recipient` will result in:  
  - The `role` will be granted to the `recipient.`   
  - The `role` will be revoked from `account` (the caller)
- A transfer will gracefully ignore and return if:  
  -  Both `account` and `recipient` are the same accounts.
  - `account` doesn't bear the target `role`.  
  - `recipient` already bears the target `role`.

I've tried to make the PR as idiosyncratic as possible, but of course, any feedback is highly appreciated and welcome. I've also ensured that all new and existing tests are passing and that the new code is fully covered.

P.S.,
If this PR is accepted and merged, I'd be more than happy to port it to [AccessControlUpgradeable.sol](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/access/AccessControlUpgradeable.sol) as well.