### PR TITLE
Optimize Clones assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  * `VestingWallet`: remove unused library `Math.sol`. ([#3605](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3605))
  * `ECDSA`: Remove redundant check on the `v` value. ([#3591](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3591))
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
+ * `Clones`: optimize assembly to use the scratch space instead of the free memory. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
  * `VestingWallet`: remove unused library `Math.sol`. ([#3605](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3605))
  * `ECDSA`: Remove redundant check on the `v` value. ([#3591](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3591))
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
- * `Clones`: optimize the assembly to use the scratch space instead of the free memory. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
+ * `Clones`: optimize the assembly to use the scratch space during deployments. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
  * `VestingWallet`: remove unused library `Math.sol`. ([#3605](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3605))
  * `ECDSA`: Remove redundant check on the `v` value. ([#3591](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3591))
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
- * `Clones`: optimize assembly to use the scratch space instead of the free memory. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
+ * `Clones`: optimize the assembly to use the scratch space instead of the free memory. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
  * `VestingWallet`: remove unused library `Math.sol`. ([#3605](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3605))
  * `ECDSA`: Remove redundant check on the `v` value. ([#3591](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3591))
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
- * `Clones`: optimize the assembly to use the scratch space during deployments. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
+ * `Clones`: optimized the assembly to use only the scratch space during deployments, and optimized `predictDeterministicAddress` to use lesser operations. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
 
 ### Deprecations
 

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -27,9 +27,9 @@ library Clones {
         assembly {
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
+            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
+            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create(0, 0x09, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");
@@ -47,9 +47,9 @@ library Clones {
         assembly {
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
+            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
+            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)
         }
         require(instance != address(0), "ERC1167: create2 failed");

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -25,11 +25,12 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-             // Packs the size 3 bytes of `implementation` with the bytecode before the address. 
-            mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.             
-             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3)) 
-            instance := create(0, 0x00, 0x37)
+            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
+            // of the `implementation` address with the bytecode before the address.
+            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
+            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
+            instance := create(0, 0x09, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");
     }

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -66,20 +66,13 @@ library Clones {
         /// @solidity memory-safe-assembly
         assembly {
             let ptr := mload(0x40)
-
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
-            mstore(ptr, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(add(ptr, 0x20), or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
-
-            // Compute and store the bytecode hash.
-            mstore(add(ptr, 0x40), keccak256(add(ptr, 0x09), 0x37))
-            mstore(ptr, deployer)
-            mstore8(add(ptr, 0x0b), 0xff) // Store the prefix at the byte before `deployer`.
-            mstore(add(ptr, 0x20), salt)
-
-            predicted := keccak256(add(ptr, 0x0b), 0x55)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, implementation))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
+            mstore(add(ptr, 0x38), shl(0x60, deployer))
+            mstore(add(ptr, 0x4c), salt)
+            mstore(add(ptr, 0x6c), keccak256(ptr, 0x37))
+            predicted := keccak256(add(ptr, 0x37), 0x55)
         }
     }
 

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -25,12 +25,11 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
-            instance := create(0, 0x09, 0x37)
+             // Packs the size 3 bytes of `implementation` with the bytecode before the address. 
+            mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
+             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.             
+             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3)) 
+            instance := create(0, 0x00, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");
     }

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -66,13 +66,13 @@ library Clones {
         /// @solidity memory-safe-assembly
         assembly {
             let ptr := mload(0x40)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(ptr, 0x14), shl(0x60, implementation))
-            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
-            mstore(add(ptr, 0x38), shl(0x60, deployer))
-            mstore(add(ptr, 0x4c), salt)
-            mstore(add(ptr, 0x6c), keccak256(ptr, 0x37))
-            predicted := keccak256(add(ptr, 0x37), 0x55)
+            mstore(add(ptr, 0x38), deployer)
+            mstore(add(ptr, 0x24), 0x5af43d82803e903d91602b57fd5bf3ff)
+            mstore(add(ptr, 0x14), implementation)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73)
+            mstore(add(ptr, 0x58), salt)
+            mstore(add(ptr, 0x78), keccak256(add(ptr, 0x0c), 0x37))
+            predicted := keccak256(add(ptr, 0x43), 0x55)
         }
     }
 

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -25,10 +25,10 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-             // Packs the size 3 bytes of `implementation` with the bytecode before the address. 
+            // Packs the size 3 bytes of `implementation` with the bytecode before the address.
             mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.             
-             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3)) 
+            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create(0, 0x00, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");
@@ -44,9 +44,8 @@ library Clones {
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
+            // Packs the size 3 bytes of `implementation` with the bytecode before the address.
+            mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -25,10 +25,10 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Packs the size 3 bytes of `implementation` with the bytecode before the address.
+             // Packs the size 3 bytes of `implementation` with the bytecode before the address. 
             mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
+             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.             
+             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3)) 
             instance := create(0, 0x00, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");
@@ -44,8 +44,9 @@ library Clones {
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Packs the size 3 bytes of `implementation` with the bytecode before the address.
-            mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
+            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
+            // of the `implementation` address with the bytecode before the address.
+            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -27,7 +27,7 @@ library Clones {
         assembly {
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
+            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create(0, 0x09, 0x37)
@@ -47,7 +47,7 @@ library Clones {
         assembly {
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(0xe8, shl(0x60, implementation))))
+            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -65,25 +65,21 @@ library Clones {
     ) internal pure returns (address predicted) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cache the free memory pointer for restoring later.
-            let freeMemoryPointer := mload(0x40)
+            let ptr := mload(0x40)
 
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
+            mstore(ptr, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
+            mstore(add(ptr, 0x20), or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
 
             // Compute and store the bytecode hash.
-            mstore(0x40, keccak256(0x09, 0x37))
-            mstore(0x00, deployer)
-            mstore8(0x0b, 0xff) // Store the prefix at the byte before `deployer`.
-            mstore(0x20, salt)
+            mstore(add(ptr, 0x40), keccak256(add(ptr, 0x09), 0x37))
+            mstore(ptr, deployer)
+            mstore8(add(ptr, 0x0b), 0xff) // Store the prefix at the byte before `deployer`.
+            mstore(add(ptr, 0x20), salt)
 
-            predicted := keccak256(0x0b, 0x55)
-
-            // Restore the free memory pointer.
-            mstore(0x40, freeMemoryPointer)
+            predicted := keccak256(add(ptr, 0x0b), 0x55)
         }
     }
 

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -25,8 +25,11 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
+            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
+            // of the `implementation` address with the bytecode before the address.
             mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
-            mstore(0x20, or(0x5af43d82803e903d91602b57fd5bf3, shl(120, implementation)))
+            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create(0, 0x09, 0x37)
         }
         require(instance != address(0), "ERC1167: create failed");
@@ -42,8 +45,11 @@ library Clones {
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
+            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
+            // of the `implementation` address with the bytecode before the address.
             mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
-            mstore(0x20, or(0x5af43d82803e903d91602b57fd5bf3, shl(120, implementation)))
+            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)
         }
         require(instance != address(0), "ERC1167: create2 failed");
@@ -62,14 +68,16 @@ library Clones {
             // Cache the free memory pointer for restoring later.
             let freeMemoryPointer := mload(0x40)
 
+            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
+            // of the `implementation` address with the bytecode before the address.
             mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
-            mstore(0x20, or(0x5af43d82803e903d91602b57fd5bf3, shl(120, implementation)))
+            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(120, implementation), 0x5af43d82803e903d91602b57fd5bf3))
 
-            // Compute and Store the bytecode hash.
+            // Compute and store the bytecode hash.
             mstore(0x40, keccak256(0x09, 0x37))
             mstore(0x00, deployer)
-            // Store the prefix.
-            mstore8(0x0b, 0xff)
+            mstore8(0x0b, 0xff) // Store the prefix at the byte before `deployer`.
             mstore(0x20, salt)
 
             predicted := keccak256(0x0b, 0x55)

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -64,14 +64,14 @@ library Clones {
 
             mstore(0x00, or(0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000, shr(232, shl(96, implementation))))
             mstore(0x20, or(0x5af43d82803e903d91602b57fd5bf3, shl(120, implementation)))
-            
+
             // Compute and Store the bytecode hash.
             mstore(0x40, keccak256(0x09, 0x37))
             mstore(0x00, deployer)
             // Store the prefix.
             mstore8(0x0b, 0xff)
             mstore(0x20, salt)
-            
+
             predicted := keccak256(0x0b, 0x55)
 
             // Restore the free memory pointer.


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Changes:

- Deployments use the scratch space.
- Optimize `predictDeterministicAddress` to use lesser operations, while maintaining the same memory expansion costs.

Gas Before:
```
·------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                    Solc version: 0.8.13                    ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
·····························································|···························|·············|······························
|  Methods                                                                                                                           │
···············|·············································|·············|·············|·············|···············|··············
|  Contract    ·  Method                                     ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···············|·············································|·············|·············|·············|···············|··············
|  ClonesMock  ·  clone(address,bytes)                       ·      90724  ·      97783  ·      93136  ·           12  ·          -  │
···············|·············································|·············|·············|·············|···············|··············
|  ClonesMock  ·  cloneDeterministic(address,bytes32,bytes)  ·      65269  ·      98378  ·      89662  ·           14  ·          -  │
···············|·············································|·············|·············|·············|···············|··············
|  Deployments                                               ·                                         ·  % of limit   ·             │
·····························································|·············|·············|·············|···············|··············
|  ClonesMock                                                ·          -  ·          -  ·     435385  ·        4.4 %  ·          -  │
·····························································|·············|·············|·············|···············|··············
|  DummyImplementation                                       ·          -  ·          -  ·     398946  ·          4 %  ·          -  │
·------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

Gas After:
```
·------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                    Solc version: 0.8.13                    ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
·····························································|···························|·············|······························
|  Methods                                                                                                                           │
···············|·············································|·············|·············|·············|···············|··············
|  Contract    ·  Method                                     ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···············|·············································|·············|·············|·············|···············|··············
|  ClonesMock  ·  clone(address,bytes)                       ·      90707  ·      97766  ·      93119  ·           12  ·          -  │
···············|·············································|·············|·············|·············|···············|··············
|  ClonesMock  ·  cloneDeterministic(address,bytes32,bytes)  ·      65237  ·      98361  ·      89645  ·           14  ·          -  │
···············|·············································|·············|·············|·············|···············|··············
|  Deployments                                               ·                                         ·  % of limit   ·             │
·····························································|·············|·············|·············|···············|··············
|  ClonesMock                                                ·          -  ·          -  ·     432690  ·        4.3 %  ·          -  │
·····························································|·············|·············|·············|···············|··············
|  DummyImplementation                                       ·          -  ·          -  ·     398946  ·          4 %  ·          -  │
·------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry
