### PR TITLE
Remove unnecessary virtual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
  * `Create2`: optimize address computation by using assembly instead of `abi.encodePacked`. ([#3600](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3600))
  * `Clones`: optimized the assembly to use only the scratch space during deployments, and optimized `predictDeterministicAddress` to use lesser operations. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
- * `Mocks`: removed unnecessary use of `virtual` where contracts are not meant to be subclassed. ([#3650](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3650))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
  * `Create2`: optimize address computation by using assembly instead of `abi.encodePacked`. ([#3600](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3600))
  * `Clones`: optimized the assembly to use only the scratch space during deployments, and optimized `predictDeterministicAddress` to use lesser operations. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
+ * `Mocks`: removed unnecessary use of `virtual` where contracts are not meant to be subclassed. ([#3650](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3650))
 
 ### Deprecations
 

--- a/contracts/mocks/AccessControlCrossChainMock.sol
+++ b/contracts/mocks/AccessControlCrossChainMock.sol
@@ -16,7 +16,7 @@ contract AccessControlCrossChainMock is AccessControlCrossChain, CrossChainEnabl
 
     function senderProtected(bytes32 roleId) public onlyRole(roleId) {}
 
-    function crossChainRoleAlias(bytes32 role) public pure virtual returns (bytes32) {
+    function crossChainRoleAlias(bytes32 role) public pure returns (bytes32) {
         return _crossChainRoleAlias(role);
     }
 }

--- a/contracts/mocks/ERC1155PausableMock.sol
+++ b/contracts/mocks/ERC1155PausableMock.sol
@@ -23,7 +23,7 @@ contract ERC1155PausableMock is ERC1155Mock, ERC1155Pausable {
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) internal virtual override(ERC1155, ERC1155Pausable) {
+    ) internal override(ERC1155, ERC1155Pausable) {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
     }
 }

--- a/contracts/mocks/ERC1155SupplyMock.sol
+++ b/contracts/mocks/ERC1155SupplyMock.sol
@@ -15,7 +15,7 @@ contract ERC1155SupplyMock is ERC1155Mock, ERC1155Supply {
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) internal virtual override(ERC1155, ERC1155Supply) {
+    ) internal override(ERC1155, ERC1155Supply) {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
     }
 }

--- a/contracts/mocks/ERC1155URIStorageMock.sol
+++ b/contracts/mocks/ERC1155URIStorageMock.sol
@@ -8,7 +8,7 @@ import "../token/ERC1155/extensions/ERC1155URIStorage.sol";
 contract ERC1155URIStorageMock is ERC1155Mock, ERC1155URIStorage {
     constructor(string memory _uri) ERC1155Mock(_uri) {}
 
-    function uri(uint256 tokenId) public view virtual override(ERC1155, ERC1155URIStorage) returns (string memory) {
+    function uri(uint256 tokenId) public view override(ERC1155, ERC1155URIStorage) returns (string memory) {
         return ERC1155URIStorage.uri(tokenId);
     }
 

--- a/contracts/mocks/ERC165/ERC165ReturnBomb.sol
+++ b/contracts/mocks/ERC165/ERC165ReturnBomb.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "../../utils/introspection/IERC165.sol";
 
 contract ERC165ReturnBombMock is IERC165 {
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == type(IERC165).interfaceId) {
             assembly {
                 mstore(0, 1)

--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -15,7 +15,7 @@ contract ERC20DecimalsMock is ERC20 {
         _decimals = decimals_;
     }
 
-    function decimals() public view virtual override returns (uint8) {
+    function decimals() public view override returns (uint8) {
         return _decimals;
     }
 

--- a/contracts/mocks/ERC2771ContextMock.sol
+++ b/contracts/mocks/ERC2771ContextMock.sol
@@ -12,11 +12,11 @@ contract ERC2771ContextMock is ContextMock, ERC2771Context {
         emit Sender(_msgSender()); // _msgSender() should be accessible during construction
     }
 
-    function _msgSender() internal view virtual override(Context, ERC2771Context) returns (address) {
+    function _msgSender() internal view override(Context, ERC2771Context) returns (address) {
         return ERC2771Context._msgSender();
     }
 
-    function _msgData() internal view virtual override(Context, ERC2771Context) returns (bytes calldata) {
+    function _msgData() internal view override(Context, ERC2771Context) returns (bytes calldata) {
         return ERC2771Context._msgData();
     }
 }

--- a/contracts/mocks/ERC721EnumerableMock.sol
+++ b/contracts/mocks/ERC721EnumerableMock.sol
@@ -13,7 +13,7 @@ contract ERC721EnumerableMock is ERC721Enumerable {
 
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
-    function _baseURI() internal view virtual override returns (string memory) {
+    function _baseURI() internal view override returns (string memory) {
         return _baseTokenURI;
     }
 

--- a/contracts/mocks/ERC721URIStorageMock.sol
+++ b/contracts/mocks/ERC721URIStorageMock.sol
@@ -13,7 +13,7 @@ contract ERC721URIStorageMock is ERC721URIStorage {
 
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
-    function _baseURI() internal view virtual override returns (string memory) {
+    function _baseURI() internal view override returns (string memory) {
         return _baseTokenURI;
     }
 

--- a/contracts/mocks/GovernorCompatibilityBravoMock.sol
+++ b/contracts/mocks/GovernorCompatibilityBravoMock.sol
@@ -30,7 +30,6 @@ contract GovernorCompatibilityBravoMock is
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        virtual
         override(IERC165, Governor, GovernorTimelockCompound)
         returns (bool)
     {
@@ -44,7 +43,6 @@ contract GovernorCompatibilityBravoMock is
     function state(uint256 proposalId)
         public
         view
-        virtual
         override(IGovernor, Governor, GovernorTimelockCompound)
         returns (ProposalState)
     {
@@ -54,7 +52,6 @@ contract GovernorCompatibilityBravoMock is
     function proposalEta(uint256 proposalId)
         public
         view
-        virtual
         override(IGovernorTimelock, GovernorTimelockCompound)
         returns (uint256)
     {
@@ -70,7 +67,7 @@ contract GovernorCompatibilityBravoMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual override(IGovernor, Governor, GovernorCompatibilityBravo) returns (uint256) {
+    ) public override(IGovernor, Governor, GovernorCompatibilityBravo) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 
@@ -79,7 +76,7 @@ contract GovernorCompatibilityBravoMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 salt
-    ) public virtual override(IGovernorTimelock, GovernorTimelockCompound) returns (uint256) {
+    ) public override(IGovernorTimelock, GovernorTimelockCompound) returns (uint256) {
         return super.queue(targets, values, calldatas, salt);
     }
 
@@ -88,7 +85,7 @@ contract GovernorCompatibilityBravoMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 salt
-    ) public payable virtual override(IGovernor, Governor) returns (uint256) {
+    ) public payable override(IGovernor, Governor) returns (uint256) {
         return super.execute(targets, values, calldatas, salt);
     }
 
@@ -98,7 +95,7 @@ contract GovernorCompatibilityBravoMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal virtual override(Governor, GovernorTimelockCompound) {
+    ) internal override(Governor, GovernorTimelockCompound) {
         super._execute(proposalId, targets, values, calldatas, descriptionHash);
     }
 
@@ -120,11 +117,11 @@ contract GovernorCompatibilityBravoMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 salt
-    ) internal virtual override(Governor, GovernorTimelockCompound) returns (uint256 proposalId) {
+    ) internal override(Governor, GovernorTimelockCompound) returns (uint256 proposalId) {
         return super._cancel(targets, values, calldatas, salt);
     }
 
-    function _executor() internal view virtual override(Governor, GovernorTimelockCompound) returns (address) {
+    function _executor() internal view override(Governor, GovernorTimelockCompound) returns (address) {
         return super._executor();
     }
 }

--- a/contracts/mocks/GovernorMock.sol
+++ b/contracts/mocks/GovernorMock.sol
@@ -44,7 +44,7 @@ contract GovernorMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual override(Governor, GovernorProposalThreshold) returns (uint256) {
+    ) public override(Governor, GovernorProposalThreshold) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 }

--- a/contracts/mocks/GovernorPreventLateQuorumMock.sol
+++ b/contracts/mocks/GovernorPreventLateQuorumMock.sol
@@ -31,21 +31,20 @@ contract GovernorPreventLateQuorumMock is
         _quorum = quorum_;
     }
 
-    function quorum(uint256) public view virtual override returns (uint256) {
+    function quorum(uint256) public view override returns (uint256) {
         return _quorum;
     }
 
     function proposalDeadline(uint256 proposalId)
         public
         view
-        virtual
         override(Governor, GovernorPreventLateQuorum)
         returns (uint256)
     {
         return super.proposalDeadline(proposalId);
     }
 
-    function proposalThreshold() public view virtual override(Governor, GovernorSettings) returns (uint256) {
+    function proposalThreshold() public view override(Governor, GovernorSettings) returns (uint256) {
         return super.proposalThreshold();
     }
 
@@ -55,7 +54,7 @@ contract GovernorPreventLateQuorumMock is
         uint8 support,
         string memory reason,
         bytes memory params
-    ) internal virtual override(Governor, GovernorPreventLateQuorum) returns (uint256) {
+    ) internal override(Governor, GovernorPreventLateQuorum) returns (uint256) {
         return super._castVote(proposalId, account, support, reason, params);
     }
 }

--- a/contracts/mocks/GovernorTimelockCompoundMock.sol
+++ b/contracts/mocks/GovernorTimelockCompoundMock.sol
@@ -31,7 +31,6 @@ contract GovernorTimelockCompoundMock is
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        virtual
         override(Governor, GovernorTimelockCompound)
         returns (bool)
     {
@@ -62,7 +61,6 @@ contract GovernorTimelockCompoundMock is
     function state(uint256 proposalId)
         public
         view
-        virtual
         override(Governor, GovernorTimelockCompound)
         returns (ProposalState)
     {
@@ -79,7 +77,7 @@ contract GovernorTimelockCompoundMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal virtual override(Governor, GovernorTimelockCompound) {
+    ) internal override(Governor, GovernorTimelockCompound) {
         super._execute(proposalId, targets, values, calldatas, descriptionHash);
     }
 
@@ -88,11 +86,11 @@ contract GovernorTimelockCompoundMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 salt
-    ) internal virtual override(Governor, GovernorTimelockCompound) returns (uint256 proposalId) {
+    ) internal override(Governor, GovernorTimelockCompound) returns (uint256 proposalId) {
         return super._cancel(targets, values, calldatas, salt);
     }
 
-    function _executor() internal view virtual override(Governor, GovernorTimelockCompound) returns (address) {
+    function _executor() internal view override(Governor, GovernorTimelockCompound) returns (address) {
         return super._executor();
     }
 }

--- a/contracts/mocks/GovernorTimelockControlMock.sol
+++ b/contracts/mocks/GovernorTimelockControlMock.sol
@@ -58,12 +58,7 @@ contract GovernorTimelockControlMock is
     /**
      * Overriding nightmare
      */
-    function state(uint256 proposalId)
-        public
-        view
-        override(Governor, GovernorTimelockControl)
-        returns (ProposalState)
-    {
+    function state(uint256 proposalId) public view override(Governor, GovernorTimelockControl) returns (ProposalState) {
         return super.state(proposalId);
     }
 

--- a/contracts/mocks/GovernorTimelockControlMock.sol
+++ b/contracts/mocks/GovernorTimelockControlMock.sol
@@ -31,7 +31,6 @@ contract GovernorTimelockControlMock is
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        virtual
         override(Governor, GovernorTimelockControl)
         returns (bool)
     {
@@ -62,7 +61,6 @@ contract GovernorTimelockControlMock is
     function state(uint256 proposalId)
         public
         view
-        virtual
         override(Governor, GovernorTimelockControl)
         returns (ProposalState)
     {
@@ -79,7 +77,7 @@ contract GovernorTimelockControlMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal virtual override(Governor, GovernorTimelockControl) {
+    ) internal override(Governor, GovernorTimelockControl) {
         super._execute(proposalId, targets, values, calldatas, descriptionHash);
     }
 
@@ -88,11 +86,11 @@ contract GovernorTimelockControlMock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal virtual override(Governor, GovernorTimelockControl) returns (uint256 proposalId) {
+    ) internal override(Governor, GovernorTimelockControl) returns (uint256 proposalId) {
         return super._cancel(targets, values, calldatas, descriptionHash);
     }
 
-    function _executor() internal view virtual override(Governor, GovernorTimelockControl) returns (address) {
+    function _executor() internal view override(Governor, GovernorTimelockControl) returns (address) {
         return super._executor();
     }
 

--- a/contracts/mocks/GovernorWithParamsMock.sol
+++ b/contracts/mocks/GovernorWithParamsMock.sol
@@ -26,7 +26,7 @@ contract GovernorWithParamsMock is GovernorVotes, GovernorCountingSimple {
         address account,
         uint256 blockNumber,
         bytes memory params
-    ) internal view virtual override(Governor, GovernorVotes) returns (uint256) {
+    ) internal view override(Governor, GovernorVotes) returns (uint256) {
         uint256 reduction = 0;
         // If the user provides parameters, we reduce the voting weight by the amount of the integer param
         if (params.length > 0) {
@@ -42,7 +42,7 @@ contract GovernorWithParamsMock is GovernorVotes, GovernorCountingSimple {
         uint8 support,
         uint256 weight,
         bytes memory params
-    ) internal virtual override(Governor, GovernorCountingSimple) {
+    ) internal override(Governor, GovernorCountingSimple) {
         if (params.length > 0) {
             (uint256 _uintParam, string memory _strParam) = abi.decode(params, (uint256, string));
             emit CountParams(_uintParam, _strParam);

--- a/contracts/mocks/MultipleInheritanceInitializableMocks.sol
+++ b/contracts/mocks/MultipleInheritanceInitializableMocks.sol
@@ -42,7 +42,7 @@ contract SampleHuman is Initializable {
 contract SampleMother is Initializable, SampleHuman {
     uint256 public mother;
 
-    function initialize(uint256 value) public virtual initializer {
+    function initialize(uint256 value) public initializer {
         __SampleMother_init(value);
     }
 
@@ -64,7 +64,7 @@ contract SampleMother is Initializable, SampleHuman {
 contract SampleGramps is Initializable, SampleHuman {
     string public gramps;
 
-    function initialize(string memory value) public virtual initializer {
+    function initialize(string memory value) public initializer {
         __SampleGramps_init(value);
     }
 

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -122,7 +122,7 @@ contract ERC20PermitNoRevertMock is
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public virtual {
+    ) public {
         super.permit(owner, spender, value, deadline, v, r, s);
     }
 
@@ -134,7 +134,7 @@ contract ERC20PermitNoRevertMock is
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public virtual override {
+    ) public override {
         try this.permitThatMayRevert(owner, spender, value, deadline, v, r, s) {
             // do nothing
         } catch {

--- a/contracts/mocks/UUPS/UUPSLegacy.sol
+++ b/contracts/mocks/UUPS/UUPSLegacy.sol
@@ -48,11 +48,11 @@ contract UUPSUpgradeableLegacyMock is UUPSUpgradeableMock {
     }
 
     // hooking into the old mechanism
-    function upgradeTo(address newImplementation) external virtual override {
+    function upgradeTo(address newImplementation) external override {
         _upgradeToAndCallSecureLegacyV1(newImplementation, bytes(""), false);
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable virtual override {
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable override {
         _upgradeToAndCallSecureLegacyV1(newImplementation, data, false);
     }
 }

--- a/contracts/mocks/UUPS/UUPSUpgradeableMock.sol
+++ b/contracts/mocks/UUPS/UUPSUpgradeableMock.sol
@@ -7,15 +7,15 @@ import "../../proxy/utils/UUPSUpgradeable.sol";
 
 contract UUPSUpgradeableMock is CountersImpl, UUPSUpgradeable {
     // Not having any checks in this function is dangerous! Do not do this outside tests!
-    function _authorizeUpgrade(address) internal virtual override {}
+    function _authorizeUpgrade(address) internal override {}
 }
 
 contract UUPSUpgradeableUnsafeMock is UUPSUpgradeableMock {
-    function upgradeTo(address newImplementation) external virtual override {
+    function upgradeTo(address newImplementation) external override {
         ERC1967Upgrade._upgradeToAndCall(newImplementation, bytes(""), false);
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable virtual override {
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable override {
         ERC1967Upgrade._upgradeToAndCall(newImplementation, data, false);
     }
 }

--- a/contracts/mocks/VotesMock.sol
+++ b/contracts/mocks/VotesMock.sol
@@ -18,7 +18,7 @@ contract VotesMock is Votes {
         return _delegate(account, newDelegation);
     }
 
-    function _getVotingUnits(address account) internal view virtual override returns (uint256) {
+    function _getVotingUnits(address account) internal view override returns (uint256) {
         return _balances[account];
     }
 


### PR DESCRIPTION
This PR removes unnecessary `virtual` in all mock contracts where those mocks are not intended to be subclassed.

This reduces unnecessary surface area of those mocks and also reduces the risk of somebody seeing those mocks and thinking they are intended to be subclassed.