### PR TITLE
Remove unnecessary virtual

### DIFF
--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -15,7 +15,7 @@ contract ERC20DecimalsMock is ERC20 {
         _decimals = decimals_;
     }
 
-    function decimals() public view virtual override returns (uint8) {
+    function decimals() public view override returns (uint8) {
         return _decimals;
     }
 


### PR DESCRIPTION
Because this contract is not intended to be subclassed
