### PR TITLE
Remove unnecessary virtual

### DIFF
--- a/contracts/mocks/ERC721EnumerableMock.sol
+++ b/contracts/mocks/ERC721EnumerableMock.sol
@@ -13,7 +13,7 @@ contract ERC721EnumerableMock is ERC721Enumerable {
 
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
-    function _baseURI() internal view virtual override returns (string memory) {
+    function _baseURI() internal view override returns (string memory) {
         return _baseTokenURI;
     }
 


### PR DESCRIPTION
Because this contract is not intended to be subclassed