### PR TITLE
Add Infix Notation Expression Evaluation Utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  * `VestingWallet`: add `releasable` getters. ([#3580](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3580))
  * `Create2`: optimize address computation by using assembly instead of `abi.encodePacked`. ([#3600](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3600))
  * `Clones`: optimized the assembly to use only the scratch space during deployments, and optimized `predictDeterministicAddress` to use lesser operations. ([#3640](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3640))
+ * `EvalInfix` : Add Infix Expression Evaluation Utility Library. ([#3660](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3660))
 
 ### Breaking changes
 

--- a/contracts/mocks/EvalInfixMock.sol
+++ b/contracts/mocks/EvalInfixMock.sol
@@ -5,22 +5,27 @@ pragma solidity ^0.8.0;
 import "../utils/EvalInfix.sol";
 
 contract EvalInfixMock {
-
-    function getResult() external pure returns(bool){
-        return (true || false && false);  //straight -> false , precedence -> true
+    function getResult() external pure returns (bool) {
+        return (true || (false && false)); //straight -> false , precedence -> true
     }
 
-    function checkValid(string[] memory tokens,uint noOfValues,uint noOfOperands) external view returns(bool check) {
-        try this.evaluateExp(tokens,noOfValues,noOfOperands) returns(bool){
+    function checkValid(
+        string[] memory tokens,
+        uint256 noOfValues,
+        uint256 noOfOperands
+    ) external view returns (bool check) {
+        try this.evaluateExp(tokens, noOfValues, noOfOperands) returns (bool) {
             check = true;
-        }
-        catch{
+        } catch {
             check = false;
         }
     }
 
-    function evaluateExp(string[] memory tokens,uint noOfValues,uint noOfOperands) external pure returns (bool) {
+    function evaluateExp(
+        string[] memory tokens,
+        uint256 noOfValues,
+        uint256 noOfOperands
+    ) external pure returns (bool) {
         return EvalInfix.evaluate(tokens, noOfValues, noOfOperands);
     }
-
 }

--- a/contracts/mocks/EvalInfixMock.sol
+++ b/contracts/mocks/EvalInfixMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/EvalInfix.sol";
+
+contract EvalInfixMock {
+
+    function getResult() external pure returns(bool){
+        return (true || false && false);  //straight -> false , precedence -> true
+    }
+
+    function checkValid(string[] memory tokens,uint noOfValues,uint noOfOperands) external view returns(bool check) {
+        try this.evaluateExp(tokens,noOfValues,noOfOperands) returns(bool){
+            check = true;
+        }
+        catch{
+            check = false;
+        }
+    }
+
+    function evaluateExp(string[] memory tokens,uint noOfValues,uint noOfOperands) external pure returns (bool) {
+        return EvalInfix.evaluate(tokens, noOfValues, noOfOperands);
+    }
+
+}

--- a/contracts/utils/EvalInfix.sol
+++ b/contracts/utils/EvalInfix.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 /**
  * @title EvalInfix
  * @author Namit Jain (namit.cs.rdjps@gmail.com)
- * @dev Provides method that can be used to evalute any Infix Notation Expression which
+ * @dev Provides method that can be used to evaluate any Infix Notation Expression which
  *     consist of 1 and 0 as operands .
  *     consist of a (&&) , o (||) , ( , ) as operators.
  *     precedence is also considered for LOGICAL AND (&&) and LOGICAL OR (||)

--- a/contracts/utils/EvalInfix.sol
+++ b/contracts/utils/EvalInfix.sol
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-
 /**
  * @title EvalInfix
  * @author Namit Jain (namit.cs.rdjps@gmail.com)
- * @dev Provides method that can be used to evalute any Infix Notation Expression which 
+ * @dev Provides method that can be used to evalute any Infix Notation Expression which
  *     consist of 1 and 0 as operands .
  *     consist of a (&&) , o (||) , ( , ) as operators.
  *     precedence is also considered for LOGICAL AND (&&) and LOGICAL OR (||)
  */
 library EvalInfix {
-
     /**
      * @dev Compare Two Strings
      */
@@ -22,92 +20,78 @@ library EvalInfix {
     /**
      * @dev Evaluate an Infix Expression consist of `1 -> true , 0 -> false , o -> logical OR , a -> logical AND , ( , )`.
      */
-    function evaluate(string[] memory tokens,uint noOfValues,uint noOfOperands) internal pure returns(bool) {
-        
+    function evaluate(
+        string[] memory tokens,
+        uint256 noOfValues,
+        uint256 noOfOperands
+    ) internal pure returns (bool) {
         // Stack for 1 and 0 : "values"
-        bool[] memory values = new bool[](noOfValues+1);
-        uint valuesLastIndex = 0;
-        
-        // Stack for Operators: "ops"(&& => a and || => o)
-        string[] memory ops = new string[](noOfOperands+1);
-        uint opsLastIndex = 0;
+        bool[] memory values = new bool[](noOfValues + 1);
+        uint256 valuesLastIndex = 0;
 
-        for (uint i = 0; i < tokens.length; i++)
-        {
+        // Stack for Operators: "ops"(&& => a and || => o)
+        string[] memory ops = new string[](noOfOperands + 1);
+        uint256 opsLastIndex = 0;
+
+        for (uint256 i = 0; i < tokens.length; i++) {
             // Current token is a whitespace or Null Character, skip it
-            if (compareStrings(tokens[i]," "))
-            {
+            if (compareStrings(tokens[i], " ")) {
                 continue;
             }
 
             // Current token is a 1 or 0,
             // push it to stack for values
-            if (compareStrings(tokens[i],"0"))
-            {
+            if (compareStrings(tokens[i], "0")) {
                 values[valuesLastIndex++] = false;
-            }
-            else if (compareStrings(tokens[i],"1"))
-            {
+            } else if (compareStrings(tokens[i], "1")) {
                 values[valuesLastIndex++] = true;
             }
-
             // Current token is an opening
             // brace, push it to "ops"
-            else if (compareStrings(tokens[i],"("))
-            {
+            else if (compareStrings(tokens[i], "(")) {
                 ops[opsLastIndex++] = tokens[i];
             }
-    
             // Closing brace encountered,
             // solve entire brace
-            else if (compareStrings(tokens[i],")"))
-            {
-                
-                while (!compareStrings(ops[opsLastIndex-1],"("))
-                {
-                    string memory op = ops[opsLastIndex-1];
-  
+            else if (compareStrings(tokens[i], ")")) {
+                while (!compareStrings(ops[opsLastIndex - 1], "(")) {
+                    string memory op = ops[opsLastIndex - 1];
+
                     opsLastIndex = opsLastIndex - 1;
-      
-                    bool op1 = values[valuesLastIndex-1];
-     
+
+                    bool op1 = values[valuesLastIndex - 1];
+
                     valuesLastIndex = valuesLastIndex - 1;
-      
-                    bool op2 = values[valuesLastIndex-1];
-     
+
+                    bool op2 = values[valuesLastIndex - 1];
+
                     valuesLastIndex = valuesLastIndex - 1;
-      
-                    values[valuesLastIndex++] = applyOp(op,op1,op2);
+
+                    values[valuesLastIndex++] = applyOp(op, op1, op2);
                 }
-                if(opsLastIndex > 0)
-                opsLastIndex = opsLastIndex - 1;
-
+                if (opsLastIndex > 0) opsLastIndex = opsLastIndex - 1;
             }
-
             // Current token is an operator.
-            else if (compareStrings(tokens[i],"o") || compareStrings(tokens[i],"a"))
-            {
-              
+            else if (compareStrings(tokens[i], "o") || compareStrings(tokens[i], "a")) {
                 // While top of 'ops' has same
                 // or greater precedence to current
                 // token, which is an operator.
                 // Apply operator on top of 'ops'
                 // to top two elements in values stack
-                while ((opsLastIndex) > 0 &&  hasPrecedence(tokens[i],ops[opsLastIndex-1]))
-                {
-                  string memory op = ops[opsLastIndex-1];
+                while ((opsLastIndex) > 0 && hasPrecedence(tokens[i], ops[opsLastIndex - 1])) {
+                    string memory op = ops[opsLastIndex - 1];
 
-                  opsLastIndex = opsLastIndex - 1;
-    
-                  bool op1 = values[valuesLastIndex-1];
-   
-                  valuesLastIndex = valuesLastIndex - 1;
-    
-                  bool op2 = values[valuesLastIndex-1];
-   
-                  valuesLastIndex = valuesLastIndex - 1;
-    
-                  values[++valuesLastIndex] = applyOp(op,op1,op2);
+                    opsLastIndex = opsLastIndex - 1;
+
+                    bool op1 = values[valuesLastIndex - 1];
+
+                    valuesLastIndex = valuesLastIndex - 1;
+
+                    bool op2 = values[valuesLastIndex - 1];
+
+                    valuesLastIndex = valuesLastIndex - 1;
+
+                    values[++valuesLastIndex] = applyOp(op, op1, op2);
                 }
 
                 // Push current token to "ops".
@@ -118,18 +102,17 @@ library EvalInfix {
         // Entire expression has been
         // parsed at this point, apply remaining
         // ops to remaining values
-        while (opsLastIndex > 0)
-        {
-            string memory op = ops[opsLastIndex-1];
+        while (opsLastIndex > 0) {
+            string memory op = ops[opsLastIndex - 1];
 
             opsLastIndex = opsLastIndex - 1;
-            bool op1 = values[valuesLastIndex-1];
+            bool op1 = values[valuesLastIndex - 1];
 
             valuesLastIndex = valuesLastIndex - 1;
-            bool op2 = values[valuesLastIndex-1];
+            bool op2 = values[valuesLastIndex - 1];
 
             valuesLastIndex = valuesLastIndex - 1;
-            values[++valuesLastIndex] = applyOp(op,op1,op2);
+            values[++valuesLastIndex] = applyOp(op, op1, op2);
         }
 
         require(valuesLastIndex == 1, "!!Wrong Infix Exp.");
@@ -142,18 +125,13 @@ library EvalInfix {
     /**
      * @dev Returns true if 'op2' has higher or same precedence as 'op1', otherwise returns false.
      */
-    function hasPrecedence(string memory op1,string memory op2) internal pure returns(bool)
-    {
-        if (compareStrings(op2,"(") || compareStrings(op2,")"))
-        {
+    function hasPrecedence(string memory op1, string memory op2) internal pure returns (bool) {
+        if (compareStrings(op2, "(") || compareStrings(op2, ")")) {
             return false;
         }
-        if (compareStrings(op1,"a") && compareStrings(op2,"o"))
-        {
+        if (compareStrings(op1, "a") && compareStrings(op2, "o")) {
             return false;
-        }
-        else
-        {
+        } else {
             return true;
         }
     }
@@ -161,14 +139,13 @@ library EvalInfix {
     /**
      * @dev A utility method to apply an operator 'op' on operands 'a' and 'b'. Return the result.
      */
-    function applyOp(string memory op,bool b,bool a) internal pure returns(bool)
-    {
-        if(compareStrings(op,"a"))
-        return a && b;
-        else if(compareStrings(op,"o"))
-        return a || b;
-        else
-        return false;
+    function applyOp(
+        string memory op,
+        bool b,
+        bool a
+    ) internal pure returns (bool) {
+        if (compareStrings(op, "a")) return a && b;
+        else if (compareStrings(op, "o")) return a || b;
+        else return false;
     }
-
 }

--- a/contracts/utils/EvalInfix.sol
+++ b/contracts/utils/EvalInfix.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+
+/**
+ * @title EvalInfix
+ * @author Namit Jain (namit.cs.rdjps@gmail.com)
+ * @dev Provides method that can be used to evalute any Infix Notation Expression which 
+ *     consist of 1 and 0 as operands .
+ *     consist of a (&&) , o (||) , ( , ) as operators.
+ *     precedence is also considered for LOGICAL AND (&&) and LOGICAL OR (||)
+ */
+library EvalInfix {
+
+    /**
+     * @dev Compare Two Strings
+     */
+    function compareStrings(string memory a, string memory b) internal pure returns (bool) {
+        return (keccak256(abi.encodePacked((a))) == keccak256(abi.encodePacked((b))));
+    }
+
+    /**
+     * @dev Evaluate an Infix Expression consist of `1 -> true , 0 -> false , o -> logical OR , a -> logical AND , ( , )`.
+     */
+    function evaluate(string[] memory tokens,uint noOfValues,uint noOfOperands) internal pure returns(bool) {
+        
+        // Stack for 1 and 0 : "values"
+        bool[] memory values = new bool[](noOfValues+1);
+        uint valuesLastIndex = 0;
+        
+        // Stack for Operators: "ops"(&& => a and || => o)
+        string[] memory ops = new string[](noOfOperands+1);
+        uint opsLastIndex = 0;
+
+        for (uint i = 0; i < tokens.length; i++)
+        {
+            // Current token is a whitespace or Null Character, skip it
+            if (compareStrings(tokens[i]," "))
+            {
+                continue;
+            }
+
+            // Current token is a 1 or 0,
+            // push it to stack for values
+            if (compareStrings(tokens[i],"0"))
+            {
+                values[valuesLastIndex++] = false;
+            }
+            else if (compareStrings(tokens[i],"1"))
+            {
+                values[valuesLastIndex++] = true;
+            }
+
+            // Current token is an opening
+            // brace, push it to "ops"
+            else if (compareStrings(tokens[i],"("))
+            {
+                ops[opsLastIndex++] = tokens[i];
+            }
+    
+            // Closing brace encountered,
+            // solve entire brace
+            else if (compareStrings(tokens[i],")"))
+            {
+                
+                while (!compareStrings(ops[opsLastIndex-1],"("))
+                {
+                    string memory op = ops[opsLastIndex-1];
+  
+                    opsLastIndex = opsLastIndex - 1;
+      
+                    bool op1 = values[valuesLastIndex-1];
+     
+                    valuesLastIndex = valuesLastIndex - 1;
+      
+                    bool op2 = values[valuesLastIndex-1];
+     
+                    valuesLastIndex = valuesLastIndex - 1;
+      
+                    values[valuesLastIndex++] = applyOp(op,op1,op2);
+                }
+                if(opsLastIndex > 0)
+                opsLastIndex = opsLastIndex - 1;
+
+            }
+
+            // Current token is an operator.
+            else if (compareStrings(tokens[i],"o") || compareStrings(tokens[i],"a"))
+            {
+              
+                // While top of 'ops' has same
+                // or greater precedence to current
+                // token, which is an operator.
+                // Apply operator on top of 'ops'
+                // to top two elements in values stack
+                while ((opsLastIndex) > 0 &&  hasPrecedence(tokens[i],ops[opsLastIndex-1]))
+                {
+                  string memory op = ops[opsLastIndex-1];
+
+                  opsLastIndex = opsLastIndex - 1;
+    
+                  bool op1 = values[valuesLastIndex-1];
+   
+                  valuesLastIndex = valuesLastIndex - 1;
+    
+                  bool op2 = values[valuesLastIndex-1];
+   
+                  valuesLastIndex = valuesLastIndex - 1;
+    
+                  values[++valuesLastIndex] = applyOp(op,op1,op2);
+                }
+
+                // Push current token to "ops".
+                ops[opsLastIndex++] = tokens[i];
+            }
+        }
+
+        // Entire expression has been
+        // parsed at this point, apply remaining
+        // ops to remaining values
+        while (opsLastIndex > 0)
+        {
+            string memory op = ops[opsLastIndex-1];
+
+            opsLastIndex = opsLastIndex - 1;
+            bool op1 = values[valuesLastIndex-1];
+
+            valuesLastIndex = valuesLastIndex - 1;
+            bool op2 = values[valuesLastIndex-1];
+
+            valuesLastIndex = valuesLastIndex - 1;
+            values[++valuesLastIndex] = applyOp(op,op1,op2);
+        }
+
+        require(valuesLastIndex == 1, "!!Wrong Infix Exp.");
+
+        // Top of "values" contains
+        // result, return it
+        return values[valuesLastIndex];
+    }
+
+    /**
+     * @dev Returns true if 'op2' has higher or same precedence as 'op1', otherwise returns false.
+     */
+    function hasPrecedence(string memory op1,string memory op2) internal pure returns(bool)
+    {
+        if (compareStrings(op2,"(") || compareStrings(op2,")"))
+        {
+            return false;
+        }
+        if (compareStrings(op1,"a") && compareStrings(op2,"o"))
+        {
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    /**
+     * @dev A utility method to apply an operator 'op' on operands 'a' and 'b'. Return the result.
+     */
+    function applyOp(string memory op,bool b,bool a) internal pure returns(bool)
+    {
+        if(compareStrings(op,"a"))
+        return a && b;
+        else if(compareStrings(op,"o"))
+        return a || b;
+        else
+        return false;
+    }
+
+}

--- a/test/utils/EvalInfix.test.js
+++ b/test/utils/EvalInfix.test.js
@@ -1,0 +1,59 @@
+const { expectRevert } = require('@openzeppelin/test-helpers');
+
+const EvalInfixMock = artifacts.require('EvalInfixMock');
+
+contract('EvalInfix', function () {
+  beforeEach(async function () {
+    this.EvalInfix = await EvalInfixMock.new();
+  });
+
+  describe('Evaluate Infix Expression which includes string array of `1 , 0 , o , a , ( , )`', function () {
+    it('evaluates (TRUE or FALSE) to True', async function () {
+        expect(await this.EvalInfix.evaluateExp(["1" , "o" , "0"],2,1)).to.equal(true);
+    })
+      
+    it('evaluates (TRUE and FALSE) to False', async function () {
+        expect(await this.EvalInfix.evaluateExp(["1" , "a" , "0"],2,1)).to.equal(false);
+    })
+
+    it('evaluates (TRUE or ( TRUE and FALSE ) ) to True', async function () {
+        expect(await this.EvalInfix.evaluateExp(["1" , "o" , "(" , "1" , "a" , "0" , ")"],3,4)).to.equal(true);
+    })
+
+    it('evaluates (FALSE and ( FALSE or TRUE ) ) to False', async function () {
+      expect(await this.EvalInfix.evaluateExp(["0" , "a" , "(" , "0" , "o" , "1" , ")"],3,4)).to.equal(false);
+    })
+
+    it('evaluates (FALSE and FALSE or TRUE ) to true (Precedence Considered)', async function () {
+      expect(await this.EvalInfix.evaluateExp(["0" , "a" , "0" , "o" , "1"],3,2)).to.equal(true);
+    })
+
+    it('evaluates (TRUE or FALSE and FALSE ) to true', async function () {
+      expect(await this.EvalInfix.evaluateExp(["1" , "o" , "0" , "a" , "0"],3,2)).to.equal(true);
+    })
+
+    it('evaluates (TRUE or FALSE and FALSE ) to true', async function () {
+      expect(await this.EvalInfix.getResult()).to.equal(true);
+    })
+
+    it('evaluates (FALSE and ( TRUE or FALSE )  to False', async function () {
+        expect(await this.EvalInfix.evaluateExp(["0" , "a" , "(" , "1" , "o" , "0" , ")"],3,4)).to.equal(false);
+    })
+
+  });
+
+  describe('Check Infix Expression Valid or Not ', function () {
+
+    it('Return False For expression (FALSE ( TRUE or FALSE )', async function () {
+      expect(await this.EvalInfix.checkValid(["0" , "(" , "1" , "o" , "0" , ")"],3,3)).to.equal(false);
+    })
+
+    it('Reverts For expression (FALSE ( TRUE or FALSE )', async function () {
+      await expectRevert(
+        this.EvalInfix.evaluateExp(["0" , "(" , "1" , "o" , "0" , ")"],3,3),
+        '!!Wrong Infix Exp.',
+      );
+    })
+  });
+
+});

--- a/test/utils/EvalInfix.test.js
+++ b/test/utils/EvalInfix.test.js
@@ -9,51 +9,45 @@ contract('EvalInfix', function () {
 
   describe('Evaluate Infix Expression which includes string array of `1 , 0 , o , a , ( , )`', function () {
     it('evaluates (TRUE or FALSE) to True', async function () {
-        expect(await this.EvalInfix.evaluateExp(["1" , "o" , "0"],2,1)).to.equal(true);
-    })
-      
+      expect(await this.EvalInfix.evaluateExp(['1', 'o', '0'], 2, 1)).to.equal(true);
+    });
+
     it('evaluates (TRUE and FALSE) to False', async function () {
-        expect(await this.EvalInfix.evaluateExp(["1" , "a" , "0"],2,1)).to.equal(false);
-    })
+      expect(await this.EvalInfix.evaluateExp(['1', 'a', '0'], 2, 1)).to.equal(false);
+    });
 
     it('evaluates (TRUE or ( TRUE and FALSE ) ) to True', async function () {
-        expect(await this.EvalInfix.evaluateExp(["1" , "o" , "(" , "1" , "a" , "0" , ")"],3,4)).to.equal(true);
-    })
+      expect(await this.EvalInfix.evaluateExp(['1', 'o', '(', '1', 'a', '0', ')'], 3, 4)).to.equal(true);
+    });
 
     it('evaluates (FALSE and ( FALSE or TRUE ) ) to False', async function () {
-      expect(await this.EvalInfix.evaluateExp(["0" , "a" , "(" , "0" , "o" , "1" , ")"],3,4)).to.equal(false);
-    })
+      expect(await this.EvalInfix.evaluateExp(['0', 'a', '(', '0', 'o', '1', ')'], 3, 4)).to.equal(false);
+    });
 
     it('evaluates (FALSE and FALSE or TRUE ) to true (Precedence Considered)', async function () {
-      expect(await this.EvalInfix.evaluateExp(["0" , "a" , "0" , "o" , "1"],3,2)).to.equal(true);
-    })
+      expect(await this.EvalInfix.evaluateExp(['0', 'a', '0', 'o', '1'], 3, 2)).to.equal(true);
+    });
 
     it('evaluates (TRUE or FALSE and FALSE ) to true', async function () {
-      expect(await this.EvalInfix.evaluateExp(["1" , "o" , "0" , "a" , "0"],3,2)).to.equal(true);
-    })
+      expect(await this.EvalInfix.evaluateExp(['1', 'o', '0', 'a', '0'], 3, 2)).to.equal(true);
+    });
 
     it('evaluates (TRUE or FALSE and FALSE ) to true', async function () {
       expect(await this.EvalInfix.getResult()).to.equal(true);
-    })
+    });
 
     it('evaluates (FALSE and ( TRUE or FALSE )  to False', async function () {
-        expect(await this.EvalInfix.evaluateExp(["0" , "a" , "(" , "1" , "o" , "0" , ")"],3,4)).to.equal(false);
-    })
-
+      expect(await this.EvalInfix.evaluateExp(['0', 'a', '(', '1', 'o', '0', ')'], 3, 4)).to.equal(false);
+    });
   });
 
   describe('Check Infix Expression Valid or Not ', function () {
-
     it('Return False For expression (FALSE ( TRUE or FALSE )', async function () {
-      expect(await this.EvalInfix.checkValid(["0" , "(" , "1" , "o" , "0" , ")"],3,3)).to.equal(false);
-    })
+      expect(await this.EvalInfix.checkValid(['0', '(', '1', 'o', '0', ')'], 3, 3)).to.equal(false);
+    });
 
     it('Reverts For expression (FALSE ( TRUE or FALSE )', async function () {
-      await expectRevert(
-        this.EvalInfix.evaluateExp(["0" , "(" , "1" , "o" , "0" , ")"],3,3),
-        '!!Wrong Infix Exp.',
-      );
-    })
+      await expectRevert(this.EvalInfix.evaluateExp(['0', '(', '1', 'o', '0', ')'], 3, 3), '!!Wrong Infix Exp.');
+    });
   });
-
 });


### PR DESCRIPTION
Add Infix Notation Expression Evaluation Utility.

Provides method that can be used to evalute any Infix Notation Expression which 
 *     consist of 1 and 0 as operands .
 *     consist of a (&&) , o (||) , ( , ) as operators.
 *     precedence is also considered for LOGICAL AND (&&) and LOGICAL OR (||)

This PR adds infix expression evaluation utility function. The EvalInfix library provides utility function to evaluate an Infix Expression. It is really usefull when we have to check multiple boolean conditions in the form of an infix expression
like (TRUE or (FALSE or TRUE)).
