### PR TITLE
Search the whole checkpoint trace if offset overflows during initial exponential search.

### DIFF
--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -237,7 +237,7 @@ library Checkpoints {
             offset <<= 1;
         }
 
-        uint256 low = offset < length ? length - offset : 0;
+        uint256 low = 0 < offset && offset < length ? length - offset : 0;
         uint256 high = length - (offset >> 1);
         uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
 
@@ -392,7 +392,7 @@ library Checkpoints {
             offset <<= 1;
         }
 
-        uint256 low = offset < length ? length - offset : 0;
+        uint256 low = 0 < offset && offset < length ? length - offset : 0;
         uint256 high = length - (offset >> 1);
         uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
 

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -83,7 +83,7 @@ function upperLookupRecent(${opts.historyTypeName} storage self, ${opts.keyTypeN
         offset <<= 1;
     }
 
-    uint256 low = offset < length ? length - offset : 0;
+    uint256 low = 0 < offset && offset < length ? length - offset : 0;
     uint256 high = length - (offset >> 1);
     uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 


### PR DESCRIPTION
This should not be needed in realistic cases, because for this offset to overflow, the length would have to be > 2**255, which is not possible to happen with checkpoints being pushed one at a time.

This check has a minor gas cost because it can be performed outside of the loop.

If `offset` overflows, its value will be 0. The `unsafeAccess` will then lookup the array at position `length` which is a not yet set checkpoint. This should be 0, so the key condition will exist the loop. At that point `offset = 0` is characteristic of the overflow, and in that case rather than doing `low = length` we should do `low = 0`. This will cause the binary search to run on the whole Trace, from `low = 0` to `high = length`.

Not that in that case, we are doing a binary search on an array that takes more than 50% of the total storage space. It is very likely that there is some storage collision, which is a really bad situation to be in. Still, we do our best to try and glue things together.

Note: this is a minor fix to an unreleased feature, no need for a changelog entry IMO 