### PR TITLE
 Optimize votes lookups for recent checkpoints 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  * `Address`: optimize `functionCall` functions by checking contract size only if there is no returned data. ([#3469](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3469))
  * `GovernorCompatibilityBravo`: remove unused `using` statements. ([#3506](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3506))
  * `ERC20`: optimize `_transfer`, `_mint` and `_burn` by using `unchecked` arithmetic when possible. ([#3513](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3513))
+ * `ERC20Votes`, `ERC721Votes`: optimize `getPastVotes` for looking up recent checkpoints. ([#3673](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3673))
  * `ERC20FlashMint`: add an internal `_flashFee` function for overriding. ([#3551](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3551))
  * `ERC4626`: use the same `decimals()` as the underlying asset by default (if available). ([#3639](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3639))
  * `ERC4626`: add internal `_initialConvertToShares` and `_initialConvertToAssets` functions to customize empty vaults behavior. ([#3639](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3639))

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -56,7 +56,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
      * - `blockNumber` must have been already mined
      */
     function getPastVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
-        return _delegateCheckpoints[account].getAtBlock(blockNumber);
+        return _delegateCheckpoints[account].getAtRecentBlock(blockNumber, _recencyThreshold());
     }
 
     /**
@@ -72,7 +72,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
      */
     function getPastTotalSupply(uint256 blockNumber) public view virtual override returns (uint256) {
         require(blockNumber < block.number, "Votes: block not yet mined");
-        return _totalCheckpoints.getAtBlock(blockNumber);
+        return _totalCheckpoints.getAtRecentBlock(blockNumber, _recencyThreshold());
     }
 
     /**
@@ -202,6 +202,14 @@ abstract contract Votes is IVotes, Context, EIP712 {
     // solhint-disable-next-line func-name-mixedcase
     function DOMAIN_SEPARATOR() external view returns (bytes32) {
         return _domainSeparatorV4();
+    }
+
+    /**
+     * @dev A parameter used in {getPastVotes} that determines how many of the last checkpoints get an optimized path.
+     * Defaults to 32.
+     */
+    function _recencyThreshold() internal view virtual returns (uint256) {
+        return 32;
     }
 
     /**

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -56,7 +56,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
      * - `blockNumber` must have been already mined
      */
     function getPastVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
-        return _delegateCheckpoints[account].getAtRecentBlock(blockNumber, _recencyThreshold());
+        return _delegateCheckpoints[account].getAtProbablyRecentBlock(blockNumber, _recencyThreshold());
     }
 
     /**
@@ -72,7 +72,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
      */
     function getPastTotalSupply(uint256 blockNumber) public view virtual override returns (uint256) {
         require(blockNumber < block.number, "Votes: block not yet mined");
-        return _totalCheckpoints.getAtRecentBlock(blockNumber, _recencyThreshold());
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber, _recencyThreshold());
     }
 
     /**

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -56,7 +56,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
      * - `blockNumber` must have been already mined
      */
     function getPastVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
-        return _delegateCheckpoints[account].getAtProbablyRecentBlock(blockNumber, _recencyThreshold());
+        return _delegateCheckpoints[account].getAtProbablyRecentBlock(blockNumber);
     }
 
     /**
@@ -72,7 +72,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
      */
     function getPastTotalSupply(uint256 blockNumber) public view virtual override returns (uint256) {
         require(blockNumber < block.number, "Votes: block not yet mined");
-        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber, _recencyThreshold());
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber);
     }
 
     /**
@@ -202,14 +202,6 @@ abstract contract Votes is IVotes, Context, EIP712 {
     // solhint-disable-next-line func-name-mixedcase
     function DOMAIN_SEPARATOR() external view returns (bytes32) {
         return _domainSeparatorV4();
-    }
-
-    /**
-     * @dev A parameter used in {getPastVotes} that determines how many of the last checkpoints get an optimized path.
-     * Defaults to 32.
-     */
-    function _recencyThreshold() internal view virtual returns (uint256) {
-        return 32;
     }
 
     /**

--- a/contracts/mocks/CheckpointsMock.sol
+++ b/contracts/mocks/CheckpointsMock.sol
@@ -22,8 +22,8 @@ contract CheckpointsMock {
         return _totalCheckpoints.getAtBlock(blockNumber);
     }
 
-    function getAtRecentBlock(uint256 blockNumber) public view returns (uint256) {
-        return _totalCheckpoints.getAtRecentBlock(blockNumber, 32);
+    function getAtProbablyRecentBlock(uint256 blockNumber) public view returns (uint256) {
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber, 32);
     }
 
     function length() public view returns (uint256) {

--- a/contracts/mocks/CheckpointsMock.sol
+++ b/contracts/mocks/CheckpointsMock.sol
@@ -23,7 +23,7 @@ contract CheckpointsMock {
     }
 
     function getAtRecentBlock(uint256 blockNumber) public view returns (uint256) {
-        return _totalCheckpoints.getAtRecentBlock(blockNumber);
+        return _totalCheckpoints.getAtRecentBlock(blockNumber, 32);
     }
 
     function length() public view returns (uint256) {

--- a/contracts/mocks/CheckpointsMock.sol
+++ b/contracts/mocks/CheckpointsMock.sol
@@ -23,7 +23,7 @@ contract CheckpointsMock {
     }
 
     function getAtProbablyRecentBlock(uint256 blockNumber) public view returns (uint256) {
-        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber, 32);
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber);
     }
 
     function length() public view returns (uint256) {

--- a/contracts/mocks/CheckpointsMock.sol
+++ b/contracts/mocks/CheckpointsMock.sol
@@ -52,10 +52,6 @@ contract Checkpoints224Mock {
         return _totalCheckpoints.upperLookup(key);
     }
 
-    function upperLookupRecent(uint32 key) public view returns (uint224) {
-        return _totalCheckpoints.upperLookupRecent(key);
-    }
-
     function length() public view returns (uint256) {
         return _totalCheckpoints._checkpoints.length;
     }
@@ -80,10 +76,6 @@ contract Checkpoints160Mock {
 
     function upperLookup(uint96 key) public view returns (uint160) {
         return _totalCheckpoints.upperLookup(key);
-    }
-
-    function upperLookupRecent(uint96 key) public view returns (uint224) {
-        return _totalCheckpoints.upperLookupRecent(key);
     }
 
     function length() public view returns (uint256) {

--- a/contracts/token/ERC20/extensions/ERC20Votes.sol
+++ b/contracts/token/ERC20/extensions/ERC20Votes.sol
@@ -75,7 +75,7 @@ abstract contract ERC20Votes is IVotes, ERC20Permit {
      */
     function getPastVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
         require(blockNumber < block.number, "ERC20Votes: block not yet mined");
-        return _checkpointsLookup(_checkpoints[account], blockNumber);
+        return _checkpointsLookup(_checkpoints[account], blockNumber, _recencyThreshold());
     }
 
     /**
@@ -88,7 +88,7 @@ abstract contract ERC20Votes is IVotes, ERC20Permit {
      */
     function getPastTotalSupply(uint256 blockNumber) public view virtual override returns (uint256) {
         require(blockNumber < block.number, "ERC20Votes: block not yet mined");
-        return _checkpointsLookup(_totalSupplyCheckpoints, blockNumber);
+        return _checkpointsLookup(_totalSupplyCheckpoints, blockNumber, _recencyThreshold());
     }
 
     /**

--- a/contracts/token/ERC20/extensions/ERC20Votes.sol
+++ b/contracts/token/ERC20/extensions/ERC20Votes.sol
@@ -113,14 +113,11 @@ abstract contract ERC20Votes is IVotes, ERC20Permit {
         uint256 high = length;
 
         if (length > 5) {
-            uint256 recentThreshold = Math.sqrt(length);
-            if (recentThreshold < length) {
-                uint256 mid = length - recentThreshold;
-                if (_unsafeAccess(ckpts, mid).fromBlock > blockNumber) {
-                    high = mid;
-                } else {
-                    low = mid + 1;
-                }
+            uint256 mid = length - Math.sqrt(length);
+            if (_unsafeAccess(ckpts, mid).fromBlock > blockNumber) {
+                high = mid;
+            } else {
+                low = mid + 1;
             }
         }
 

--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -66,7 +66,7 @@ library Checkpoints {
         uint256 low = 0;
         uint256 high = length;
 
-        if (recencyThreshold < length) {
+        if (0 < recencyThreshold && recencyThreshold < length) {
             uint256 mid = length - recencyThreshold;
             if (key < _unsafeAccess(self._checkpoints, mid)._blockNumber) {
                 high = mid;

--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -63,14 +63,11 @@ library Checkpoints {
         uint256 high = length;
 
         if (length > 5) {
-            uint256 recentThreshold = Math.sqrt(length);
-            if (recentThreshold < length) {
-                uint256 mid = length - recentThreshold;
-                if (key < _unsafeAccess(self._checkpoints, mid)._blockNumber) {
-                    high = mid;
-                } else {
-                    low = mid + 1;
-                }
+            uint256 mid = length - Math.sqrt(length);
+            if (key < _unsafeAccess(self._checkpoints, mid)._blockNumber) {
+                high = mid;
+            } else {
+                low = mid + 1;
             }
         }
 

--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -53,7 +53,7 @@ library Checkpoints {
      * checkpoint is probably "recent", i.e. is among the last few checkpoints (at most `recencyThreshold`), in which
      * case the search gas cost has an upper bound independent of the total number of checkpoints.
      */
-    function getAtRecentBlock(
+    function getAtProbablyRecentBlock(
         History storage self,
         uint256 blockNumber,
         uint256 recencyThreshold

--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -226,25 +226,6 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the most recent checkpoint with key lower or equal than the search key (similarly to
-     * {upperLookup}), optimized for the case when the search key is known to be recent.
-     */
-    function upperLookupRecent(Trace224 storage self, uint32 key) internal view returns (uint224) {
-        uint256 length = self._checkpoints.length;
-        uint256 offset = 1;
-
-        while (offset <= length && _unsafeAccess(self._checkpoints, length - offset)._key > key) {
-            offset <<= 1;
-        }
-
-        uint256 low = offset < length ? length - offset : 0;
-        uint256 high = length - (offset >> 1);
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
-
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
-    }
-
-    /**
      * @dev Pushes a (`key`, `value`) pair into an ordered list of checkpoints, either by inserting a new checkpoint,
      * or by updating the last one.
      */
@@ -377,25 +358,6 @@ library Checkpoints {
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 length = self._checkpoints.length;
         uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, length);
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
-    }
-
-    /**
-     * @dev Returns the value in the most recent checkpoint with key lower or equal than the search key (similarly to
-     * {upperLookup}), optimized for the case when the search key is known to be recent.
-     */
-    function upperLookupRecent(Trace160 storage self, uint96 key) internal view returns (uint160) {
-        uint256 length = self._checkpoints.length;
-        uint256 offset = 1;
-
-        while (offset <= length && _unsafeAccess(self._checkpoints, length - offset)._key > key) {
-            offset <<= 1;
-        }
-
-        uint256 low = offset < length ? length - offset : 0;
-        uint256 high = length - (offset >> 1);
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
-
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -109,7 +109,7 @@ function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 
     uint256 low = 0;
     uint256 high = length;
 
-    if (recencyThreshold < length) {
+    if (0 < recencyThreshold && recencyThreshold < length) {
         uint256 mid = length - recencyThreshold;
         if (key < _unsafeAccess(self.${opts.checkpointFieldName}, mid)._blockNumber) {
             high = mid;

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -99,7 +99,7 @@ function getAtBlock(${opts.historyTypeName} storage self, uint256 blockNumber) i
  * before it is returned, or zero otherwise. Similarly to {upperLookup} but optimized for the case when the search
  * key is known to be recent.
  */
-function getAtRecentBlock(${opts.historyTypeName} storage self, uint256 blockNumber) internal view returns (uint256) {
+function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 blockNumber) internal view returns (uint256) {
     require(blockNumber < block.number, "Checkpoints: block not yet mined");
     uint32 key = SafeCast.toUint32(blockNumber);
 

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -70,25 +70,6 @@ function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
     uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, length);
     return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
 }
-
-/**
- * @dev Returns the value in the most recent checkpoint with key lower or equal than the search key (similarly to
- * {upperLookup}), optimized for the case when the search key is known to be recent.
- */
-function upperLookupRecent(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
-    uint256 length = self.${opts.checkpointFieldName}.length;
-    uint256 offset = 1;
-
-    while (offset <= length && _unsafeAccess(self.${opts.checkpointFieldName}, length - offset).${opts.keyFieldName} > key) {
-        offset <<= 1;
-    }
-
-    uint256 low = offset < length ? length - offset : 0;
-    uint256 high = length - (offset >> 1);
-    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
-
-    return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
-}
 `;
 
 const legacyOperations = opts => `\

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -110,14 +110,11 @@ function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 
     uint256 high = length;
 
     if (length > 5) {
-        uint256 recentThreshold = Math.sqrt(length);
-        if (recentThreshold < length) {
-            uint256 mid = length - recentThreshold;
-            if (key < _unsafeAccess(self.${opts.checkpointFieldName}, mid)._blockNumber) {
-                high = mid;
-            } else {
-                low = mid + 1;
-            }
+        uint256 mid = length - Math.sqrt(length);
+        if (key < _unsafeAccess(self.${opts.checkpointFieldName}, mid)._blockNumber) {
+            high = mid;
+        } else {
+            low = mid + 1;
         }
     }
 

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -96,22 +96,28 @@ function getAtBlock(${opts.historyTypeName} storage self, uint256 blockNumber) i
 
 /**
  * @dev Returns the value at a given block number. If a checkpoint is not available at that block, the closest one
- * before it is returned, or zero otherwise. Similarly to {upperLookup} but optimized for the case when the search
- * key is known to be recent.
+ * before it is returned, or zero otherwise. Similar to {upperLookup} but optimized for the case when the searched
+ * checkpoint is probably "recent", i.e. is among the last few checkpoints (at most \`recencyThreshold\`), in which
+ * case the search gas cost has an upper bound independent of the total number of checkpoints.
  */
-function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 blockNumber) internal view returns (uint256) {
+function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 blockNumber, uint256 recencyThreshold) internal view returns (uint256) {
     require(blockNumber < block.number, "Checkpoints: block not yet mined");
     uint32 key = SafeCast.toUint32(blockNumber);
 
     uint256 length = self.${opts.checkpointFieldName}.length;
-    uint256 offset = 1;
 
-    while (offset <= length && _unsafeAccess(self.${opts.checkpointFieldName}, length - offset).${opts.keyFieldName} > key) {
-        offset <<= 1;
+    uint256 low = 0;
+    uint256 high = length;
+
+    if (recencyThreshold < length) {
+        uint256 mid = length - recencyThreshold;
+        if (key < _unsafeAccess(self.${opts.checkpointFieldName}, mid)._blockNumber) {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
     }
 
-    uint256 low = offset < length ? length - offset : 0;
-    uint256 high = length - (offset >> 1);
     uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 
     return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -97,10 +97,10 @@ function getAtBlock(${opts.historyTypeName} storage self, uint256 blockNumber) i
 /**
  * @dev Returns the value at a given block number. If a checkpoint is not available at that block, the closest one
  * before it is returned, or zero otherwise. Similar to {upperLookup} but optimized for the case when the searched
- * checkpoint is probably "recent", i.e. is among the last few checkpoints (at most \`recencyThreshold\`), in which
- * case the search gas cost has an upper bound independent of the total number of checkpoints.
+ * checkpoint is probably "recent", defined as being among the last sqrt(N) checkpoints where N is the number of
+ * checkpoints.
  */
-function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 blockNumber, uint256 recencyThreshold) internal view returns (uint256) {
+function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 blockNumber) internal view returns (uint256) {
     require(blockNumber < block.number, "Checkpoints: block not yet mined");
     uint32 key = SafeCast.toUint32(blockNumber);
 
@@ -109,12 +109,15 @@ function getAtProbablyRecentBlock(${opts.historyTypeName} storage self, uint256 
     uint256 low = 0;
     uint256 high = length;
 
-    if (0 < recencyThreshold && recencyThreshold < length) {
-        uint256 mid = length - recencyThreshold;
-        if (key < _unsafeAccess(self.${opts.checkpointFieldName}, mid)._blockNumber) {
-            high = mid;
-        } else {
-            low = mid + 1;
+    if (length > 5) {
+        uint256 recentThreshold = Math.sqrt(length);
+        if (recentThreshold < length) {
+            uint256 mid = length - recentThreshold;
+            if (key < _unsafeAccess(self.${opts.checkpointFieldName}, mid)._blockNumber) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
         }
     }
 

--- a/scripts/generate/templates/CheckpointsMock.js
+++ b/scripts/generate/templates/CheckpointsMock.js
@@ -26,8 +26,8 @@ contract CheckpointsMock {
         return _totalCheckpoints.getAtBlock(blockNumber);
     }
 
-    function getAtRecentBlock(uint256 blockNumber) public view returns (uint256) {
-        return _totalCheckpoints.getAtRecentBlock(blockNumber);
+    function getAtProbablyRecentBlock(uint256 blockNumber) public view returns (uint256) {
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber);
     }
 
     function length() public view returns (uint256) {

--- a/scripts/generate/templates/CheckpointsMock.js
+++ b/scripts/generate/templates/CheckpointsMock.js
@@ -58,10 +58,6 @@ contract Checkpoints${length}Mock {
         return _totalCheckpoints.upperLookup(key);
     }
 
-    function upperLookupRecent(uint${256 - length} key) public view returns (uint224) {
-        return _totalCheckpoints.upperLookupRecent(key);
-    }
-
     function length() public view returns (uint256) {
         return _totalCheckpoints._checkpoints.length;
     }

--- a/scripts/generate/templates/CheckpointsMock.js
+++ b/scripts/generate/templates/CheckpointsMock.js
@@ -27,7 +27,7 @@ contract CheckpointsMock {
     }
 
     function getAtProbablyRecentBlock(uint256 blockNumber) public view returns (uint256) {
-        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber, 32);
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber);
     }
 
     function length() public view returns (uint256) {

--- a/scripts/generate/templates/CheckpointsMock.js
+++ b/scripts/generate/templates/CheckpointsMock.js
@@ -27,7 +27,7 @@ contract CheckpointsMock {
     }
 
     function getAtProbablyRecentBlock(uint256 blockNumber) public view returns (uint256) {
-        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber);
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber, 32);
     }
 
     function length() public view returns (uint256) {

--- a/test/token/ERC20/extensions/ERC20Votes.test.js
+++ b/test/token/ERC20/extensions/ERC20Votes.test.js
@@ -56,6 +56,19 @@ contract('ERC20Votes', function (accounts) {
     );
   });
 
+  it('recent checkpoints', async function () {
+    await this.token.delegate(holder, { from: holder });
+    for (let i = 0; i < 6; i++) {
+      await this.token.mint(holder, 1);
+    }
+    const block = await web3.eth.getBlockNumber();
+    expect(await this.token.numCheckpoints(holder)).to.be.bignumber.equal('6');
+    // recent
+    expect(await this.token.getPastVotes(holder, block - 1)).to.be.bignumber.equal('5');
+    // non-recent
+    expect(await this.token.getPastVotes(holder, block - 6)).to.be.bignumber.equal('0');
+  });
+
   describe('set delegation', function () {
     describe('call', function () {
       it('delegation with balance', async function () {

--- a/test/utils/Checkpoints.test.js
+++ b/test/utils/Checkpoints.test.js
@@ -22,8 +22,10 @@ contract('Checkpoints', function (accounts) {
 
       it('returns zero as past value', async function () {
         await time.advanceBlock();
-        expect(await this.checkpoint.getAtBlock(await web3.eth.getBlockNumber() - 1)).to.be.bignumber.equal('0');
-        expect(await this.checkpoint.getAtProbablyRecentBlock(await web3.eth.getBlockNumber() - 1)).to.be.bignumber.equal('0');
+        expect(await this.checkpoint.getAtBlock(await web3.eth.getBlockNumber() - 1))
+          .to.be.bignumber.equal('0');
+        expect(await this.checkpoint.getAtProbablyRecentBlock(await web3.eth.getBlockNumber() - 1))
+          .to.be.bignumber.equal('0');
       });
     });
 

--- a/test/utils/Checkpoints.test.js
+++ b/test/utils/Checkpoints.test.js
@@ -80,6 +80,18 @@ contract('Checkpoints', function (accounts) {
         expect(await this.checkpoint.length()).to.be.bignumber.equal(lengthBefore.addn(1));
         expect(await this.checkpoint.latest()).to.be.bignumber.equal('10');
       });
+
+      it('more than 5 checkpoints', async function () {
+        for (let i = 4; i <= 6; i++) {
+          await this.checkpoint.push(i);
+        }
+        expect(await this.checkpoint.length()).to.be.bignumber.equal('6');
+        const block = await web3.eth.getBlockNumber();
+        // recent
+        expect(await this.checkpoint.getAtProbablyRecentBlock(block - 1)).to.be.bignumber.equal('5');
+        // non-recent
+        expect(await this.checkpoint.getAtProbablyRecentBlock(block - 9)).to.be.bignumber.equal('0');
+      });
     });
   });
 

--- a/test/utils/Checkpoints.test.js
+++ b/test/utils/Checkpoints.test.js
@@ -95,7 +95,6 @@ contract('Checkpoints', function (accounts) {
         it('lookup returns 0', async function () {
           expect(await this.contract.lowerLookup(0)).to.be.bignumber.equal('0');
           expect(await this.contract.upperLookup(0)).to.be.bignumber.equal('0');
-          expect(await this.contract.upperLookupRecent(0)).to.be.bignumber.equal('0');
         });
       });
 
@@ -149,7 +148,6 @@ contract('Checkpoints', function (accounts) {
             const value = last(this.checkpoints.filter(x => i >= x.key))?.value || '0';
 
             expect(await this.contract.upperLookup(i)).to.be.bignumber.equal(value);
-            expect(await this.contract.upperLookupRecent(i)).to.be.bignumber.equal(value);
           }
         });
       });

--- a/test/utils/Checkpoints.test.js
+++ b/test/utils/Checkpoints.test.js
@@ -23,7 +23,7 @@ contract('Checkpoints', function (accounts) {
       it('returns zero as past value', async function () {
         await time.advanceBlock();
         expect(await this.checkpoint.getAtBlock(await web3.eth.getBlockNumber() - 1)).to.be.bignumber.equal('0');
-        expect(await this.checkpoint.getAtRecentBlock(await web3.eth.getBlockNumber() - 1)).to.be.bignumber.equal('0');
+        expect(await this.checkpoint.getAtProbablyRecentBlock(await web3.eth.getBlockNumber() - 1)).to.be.bignumber.equal('0');
       });
     });
 
@@ -41,7 +41,7 @@ contract('Checkpoints', function (accounts) {
         expect(await this.checkpoint.latest()).to.be.bignumber.equal('3');
       });
 
-      for (const fn of [ 'getAtBlock(uint256)', 'getAtRecentBlock(uint256)' ]) {
+      for (const fn of [ 'getAtBlock(uint256)', 'getAtProbablyRecentBlock(uint256)' ]) {
         describe(`lookup: ${fn}`, function () {
           it('returns past values', async function () {
             expect(await this.checkpoint.methods[fn](this.tx1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');


### PR DESCRIPTION
This PR optimizes `getPastVotes` so that for recent checkpoints it has lower gas cost than the worst case.

The worst case runs in O(log n) time, but delegates can have large numbers of checkpoints: a quick search led us to find one with 8500 checkpoints, which adds around 43k gas to a vote.

In the context of governance, since there is a voting period, `getPastVotes` will be invoked with a relatively recent block which will be near the end of the checkpoints array.

We modify `getPastVotes` so that it first checks to see if the sought checkpoint is a recent checkpoint, if so does a binary search among those, and otherwise does a binary search on the rest of the array. We define the recent checkpoints as the last sqrt(n), where n is the number of checkpoints. Thus, the best case cost of `getPastVotes` is half that of the worst case, though it remains logarithmic. 

![](https://user-images.githubusercontent.com/481465/188224225-a6e1507a-1f0b-4c30-8367-bdef1c7e00c5.png)


---

Some other changes bundled here:
- Changed ERC20Votes to use unsafe array accesses to save on bounds checks.
- Renamed `getAtRecentBlock` to `getAtProbablyRecentBlock`, to indicate that the function works even for non-recent blocks.
- Removed `upperLookupRecent` for other Trace/Checkpoints types, since we won't be using it and if the keys are not block numbers or timestamps it is not clear that they are worth it.