### PR TITLE
Optimize Math.max and SignedMath.max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
  * `Arrays`: Add `unsafeAccess` functions that allow reading and writing to an element in a storage array bypassing Solidity's "out-of-bounds" check. ([#3589](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3589))
  * `Strings`: optimize `toString`. ([#3573](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3573))
  * `Ownable2Step`: extension of `Ownable` that makes the ownership transfers a two step process. ([#3620](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3620))
+ * `Math` and `SignedMath`: optimize function `max` by using `>` instead of `>=`. ([#3679](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3679))
 
 ### Breaking changes
 

--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -17,7 +17,7 @@ library Math {
      * @dev Returns the largest of two numbers.
      */
     function max(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a >= b ? a : b;
+        return a > b ? a : b;
     }
 
     /**

--- a/contracts/utils/math/SignedMath.sol
+++ b/contracts/utils/math/SignedMath.sol
@@ -11,7 +11,7 @@ library SignedMath {
      * @dev Returns the largest of two signed numbers.
      */
     function max(int256 a, int256 b) internal pure returns (int256) {
-        return a >= b ? a : b;
+        return a > b ? a : b;
     }
 
     /**


### PR DESCRIPTION
In Solidity, there is no single op-code for `<=` or `>=` expressions. Solidity compiler executes the LT/GT (less than/greater than) op-code and afterwards it executes an ISZERO op-code to check if the result of the previous comparison (LT/ GT) is zero and validate it or not. So the use of `<` and `>` are cheaper than `<=` and `>=`.  Below is current version of max function:

```solidity
    function max(uint256 a, uint256 b) internal pure returns (uint256) {
        return a >= b ? a : b;
    }
```

The above code works as below steps:

```solidity
    function max(uint256 a, uint256 b) internal pure returns (uint256) {
        if (a > b) {
            return a;
        } else if (a == b) {
            return a;
        } else {
            return b;
        }
    }
```

If we use the new version:

```solidity
    function max(uint256 a, uint256 b) internal pure returns (uint256) {
        return a > b ? a : b;
    }
```

Then the function will works as below steps:
```solidity
    function max(uint256 a, uint256 b) internal pure returns (uint256) {
        if (a > b) {
            return a;
        } else {
            return b;
        }
    }
```

So the step of check `a == b` is omitted.