### PR TITLE
init erc20 token name and symbol in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
  * `Ownable2Step`: extension of `Ownable` that makes the ownership transfers a two step process. ([#3620](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3620))
  * `Math` and `SignedMath`: optimize function `max` by using `>` instead of `>=`. ([#3679](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3679))
  * `Math`: Add `log2`, `log10` and `log256`. ([#3670](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3670))
-
+ * `ERC4626`: Initialize the inherited `ERC20` token in `ERC4626` directly. ([[#3689](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3689)])
 ### Breaking changes
 
  * `ERC4626`: Conversion from shares to assets (and vice-versa) in an empty vault used to consider the possible mismatch between the underlying asset's and the vault's decimals. This initial conversion rate is now set to 1-to-1 irrespective of decimals, which are meant for usability purposes only. The vault now uses the assets decimals by default, so off-chain the numbers should appear the same. Developers overriding the vault decimals to a value that does not match the underlying asset may want to override the `_initialConvertToShares` and `_initialConvertToAssets` to replicate the previous behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
  * `Ownable2Step`: extension of `Ownable` that makes the ownership transfers a two step process. ([#3620](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3620))
  * `Math` and `SignedMath`: optimize function `max` by using `>` instead of `>=`. ([#3679](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3679))
  * `Math`: Add `log2`, `log10` and `log256`. ([#3670](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3670))
- * `ERC4626`: Initialize the inherited `ERC20` token in `ERC4626` directly. ([[#3689](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3689)])
+ * `ERC4626`: Initialize the inherited `ERC20` token in `ERC4626` directly. ([#3690](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3690))
 ### Breaking changes
 
  * `ERC4626`: Conversion from shares to assets (and vice-versa) in an empty vault used to consider the possible mismatch between the underlying asset's and the vault's decimals. This initial conversion rate is now set to 1-to-1 irrespective of decimals, which are meant for usability purposes only. The vault now uses the assets decimals by default, so off-chain the numbers should appear the same. Developers overriding the vault decimals to a value that does not match the underlying asset may want to override the `_initialConvertToShares` and `_initialConvertToAssets` to replicate the previous behavior.

--- a/contracts/mocks/ERC4626Mock.sol
+++ b/contracts/mocks/ERC4626Mock.sol
@@ -9,7 +9,7 @@ contract ERC4626Mock is ERC4626 {
         IERC20Metadata asset,
         string memory name,
         string memory symbol
-    ) ERC20(name, symbol) ERC4626(asset) {}
+    ) ERC20(name, symbol) ERC4626(asset, name, symbol) {}
 
     function mockMint(address account, uint256 amount) public {
         _mint(account, amount);

--- a/contracts/mocks/ERC4626Mock.sol
+++ b/contracts/mocks/ERC4626Mock.sol
@@ -9,7 +9,7 @@ contract ERC4626Mock is ERC4626 {
         IERC20Metadata asset,
         string memory name,
         string memory symbol
-    ) ERC20(name, symbol) ERC4626(asset, name, symbol) {}
+    ) ERC4626(asset, name, symbol) {}
 
     function mockMint(address account, uint256 amount) public {
         _mint(account, amount);

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -32,7 +32,11 @@ abstract contract ERC4626 is ERC20, IERC4626 {
     /**
      * @dev Set the underlying asset contract. This must be an ERC20-compatible contract (ERC20 or ERC777).
      */
-    constructor(IERC20 asset_, string memory name_, string memory symbol_) ERC20(name_, symbol_) {
+    constructor(
+        IERC20 asset_,
+        string memory name_,
+        string memory symbol_
+    ) ERC20(name_, symbol_) {
         uint8 decimals_;
         try IERC20Metadata(address(asset_)).decimals() returns (uint8 value) {
             decimals_ = value;

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -32,7 +32,7 @@ abstract contract ERC4626 is ERC20, IERC4626 {
     /**
      * @dev Set the underlying asset contract. This must be an ERC20-compatible contract (ERC20 or ERC777).
      */
-    constructor(IERC20 asset_) {
+    constructor(IERC20 asset_, string memory name_, string memory symbol_) ERC20(name_, symbol_) {
         uint8 decimals_;
         try IERC20Metadata(address(asset_)).decimals() returns (uint8 value) {
             decimals_ = value;


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3689  <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
Added the ERC20 initialization with name and symbol into ERC4626's constructor.
<!-- Include any context necessary for understanding the PR's purpose. -->
See issue #3689 
It would make more sense and easy to understand if the token name and symbol are initialized together with the ERC4626 directly.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry
