### PR TITLE
Improve Initializable docstrings

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -73,7 +73,11 @@ abstract contract Initializable {
 
     /**
      * @dev A modifier that defines a protected initializer function that can be invoked at most once. In its scope,
-     * `onlyInitializing` functions can be used to initialize parent contracts. Equivalent to `reinitializer(1)`.
+     * `onlyInitializing` functions can be used to initialize parent contracts.
+     * 
+     * WARNING: Not equivalent to `reinitializer(1)`. Functions marked with `initializer` can be nested in the context of a constructor.
+     * 
+     * Emits an {Initialized} event.
      */
     modifier initializer() {
         bool isTopLevelCall = !_initializing;
@@ -97,12 +101,18 @@ abstract contract Initializable {
      * contract hasn't been initialized to a greater version before. In its scope, `onlyInitializing` functions can be
      * used to initialize parent contracts.
      *
-     * `initializer` is equivalent to `reinitializer(1)`, so a reinitializer may be used after the original
-     * initialization step. This is essential to configure modules that are added through upgrades and that require
-     * initialization.
+     * A reinitializer may be used after the original initialization step. This is essential to configure modules that
+     * are added through upgrades and that require initialization.
      *
      * Note that versions can jump in increments greater than 1; this implies that if multiple reinitializers coexist in
      * a contract, executing them in the right order is up to the developer or operator.
+     * 
+     * WARNING: Not equivalent to `initializer`. Functions marked with `reinitializer` cannot be nested.
+     * If one is invoked in the context of another, execution will revert.
+     * 
+     * WARNING: setting the version to 255 will prevent any future reinitialization.
+     * 
+     * Emits an {Initialized} event.
      */
     modifier reinitializer(uint8 version) {
         require(!_initializing && _initialized < version, "Initializable: contract is already initialized");
@@ -127,6 +137,8 @@ abstract contract Initializable {
      * Calling this in the constructor of a contract will prevent that contract from being initialized or reinitialized
      * to any version. It is recommended to use this to lock implementation contracts that are designed to be called
      * through proxies.
+     * 
+     * Emits an {Initialized} event the first time it is successfully executed.
      */
     function _disableInitializers() internal virtual {
         require(!_initializing, "Initializable: contract is initializing");

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -74,10 +74,10 @@ abstract contract Initializable {
     /**
      * @dev A modifier that defines a protected initializer function that can be invoked at most once. In its scope,
      * `onlyInitializing` functions can be used to initialize parent contracts.
-     * 
+     *
      * Similar to `reinitializer(1)`, except that functions marked with `initializer` can be nested in the context of a
      * constructor.
-     * 
+     *
      * Emits an {Initialized} event.
      */
     modifier initializer() {
@@ -104,15 +104,15 @@ abstract contract Initializable {
      *
      * A reinitializer may be used after the original initialization step. This is essential to configure modules that
      * are added through upgrades and that require initialization.
-     * 
+     *
      * When `version` is 1, this modifier is similar to `initializer`, except that functions marked with `reinitializer`
      * cannot be nested. If one is invoked in the context of another, execution will revert.
      *
      * Note that versions can jump in increments greater than 1; this implies that if multiple reinitializers coexist in
      * a contract, executing them in the right order is up to the developer or operator.
-     * 
+     *
      * WARNING: setting the version to 255 will prevent any future reinitialization.
-     * 
+     *
      * Emits an {Initialized} event.
      */
     modifier reinitializer(uint8 version) {
@@ -138,7 +138,7 @@ abstract contract Initializable {
      * Calling this in the constructor of a contract will prevent that contract from being initialized or reinitialized
      * to any version. It is recommended to use this to lock implementation contracts that are designed to be called
      * through proxies.
-     * 
+     *
      * Emits an {Initialized} event the first time it is successfully executed.
      */
     function _disableInitializers() internal virtual {

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -75,7 +75,8 @@ abstract contract Initializable {
      * @dev A modifier that defines a protected initializer function that can be invoked at most once. In its scope,
      * `onlyInitializing` functions can be used to initialize parent contracts.
      * 
-     * Similar to `reinitializer(1)`, except that functions marked with `initializer` can be nested in the context of a constructor.
+     * Similar to `reinitializer(1)`, except that functions marked with `initializer` can be nested in the context of a
+     * constructor.
      * 
      * Emits an {Initialized} event.
      */

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -75,7 +75,7 @@ abstract contract Initializable {
      * @dev A modifier that defines a protected initializer function that can be invoked at most once. In its scope,
      * `onlyInitializing` functions can be used to initialize parent contracts.
      * 
-     * WARNING: Not equivalent to `reinitializer(1)`. Functions marked with `initializer` can be nested in the context of a constructor.
+     * Similar to `reinitializer(1)`, except that functions marked with `initializer` can be nested in the context of a constructor.
      * 
      * Emits an {Initialized} event.
      */
@@ -103,12 +103,12 @@ abstract contract Initializable {
      *
      * A reinitializer may be used after the original initialization step. This is essential to configure modules that
      * are added through upgrades and that require initialization.
+     * 
+     * It's similar to `initializer`, except that functions marked with `reinitializer` cannot be nested.
+     * If one is invoked in the context of another, execution will revert.
      *
      * Note that versions can jump in increments greater than 1; this implies that if multiple reinitializers coexist in
      * a contract, executing them in the right order is up to the developer or operator.
-     * 
-     * WARNING: Not equivalent to `initializer`. Functions marked with `reinitializer` cannot be nested.
-     * If one is invoked in the context of another, execution will revert.
      * 
      * WARNING: setting the version to 255 will prevent any future reinitialization.
      * 

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -105,8 +105,8 @@ abstract contract Initializable {
      * A reinitializer may be used after the original initialization step. This is essential to configure modules that
      * are added through upgrades and that require initialization.
      * 
-     * It's similar to `initializer`, except that functions marked with `reinitializer` cannot be nested.
-     * If one is invoked in the context of another, execution will revert.
+     * When `version` is 1, this modifier is similar to `initializer`, except that functions marked with `reinitializer`
+     * cannot be nested. If one is invoked in the context of another, execution will revert.
      *
      * Note that versions can jump in increments greater than 1; this implies that if multiple reinitializers coexist in
      * a contract, executing them in the right order is up to the developer or operator.


### PR DESCRIPTION
Updating the docstrings of the `Initializable` contract so they better reflect the actual behavior of the code.

Changes include:

1. Warning that `reinitializer(1)` is not equivalent to `initializer`. Because one allows nesting while the other doesn't. I noticed this was even mentioned in #3450, so I guess you're already aware of the difference, and the docs were just outdated.
2. Warning that `reinitializer(255)` will prevent further reinitializations.
3. Mentioning that these functions emit events.

There's one additional thing I wanted to raise, that I noticed while writing (2) but I did not mention in the docs. At first sight, it may seem that a function that executes `reinitializer(255)` would behave the same as calling `_disableInitializers`, in terms of disabling further reinitialization. However, `_disableInitializers` explicitly requires that the contract is _not_ initializing. While `reinitializer(255)` first checks the same, then it would continue execution into initializing mode. So it feels like a subtle inconsistency, but I'm not sure to what extent it could actually be problematic, or even worth highlighting in the docs.

