### PR TITLE
Remove inaccurate comment from `_flashFee` function

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20FlashMint.sol
+++ b/contracts/token/ERC20/extensions/ERC20FlashMint.sol
@@ -42,7 +42,7 @@ abstract contract ERC20FlashMint is ERC20, IERC3156FlashLender {
     }
 
     /**
-     * @dev Returns the fee applied when doing flash loans. This function calls the {flashFee} function which returns the fee applied when doing flash loans.
+     * @dev Returns the fee applied when doing flash loans.
      * @param token The token to be flash loaned.
      * @param amount The amount of tokens to be loaned.
      * @return The fees applied to the corresponding flash loan.

--- a/contracts/token/ERC20/extensions/ERC20FlashMint.sol
+++ b/contracts/token/ERC20/extensions/ERC20FlashMint.sol
@@ -29,9 +29,9 @@ abstract contract ERC20FlashMint is ERC20, IERC3156FlashLender {
     }
 
     /**
-     * @dev Returns the fee applied when doing flash loans. By default this
-     * implementation has 0 fees. This function can be overloaded to make
-     * the flash loan mechanism deflationary.
+     * @dev Returns the fee applied when doing flash loans. This function calls
+     * the {_flashFee} function which returns the fee applied when doing flash 
+     * loans.
      * @param token The token to be flash loaned.
      * @param amount The amount of tokens to be loaned.
      * @return The fees applied to the corresponding flash loan.
@@ -42,7 +42,9 @@ abstract contract ERC20FlashMint is ERC20, IERC3156FlashLender {
     }
 
     /**
-     * @dev Returns the fee applied when doing flash loans.
+     * @dev Returns the fee applied when doing flash loans. By default this
+     * implementation has 0 fees. This function can be overloaded to make
+     * the flash loan mechanism deflationary.
      * @param token The token to be flash loaned.
      * @param amount The amount of tokens to be loaned.
      * @return The fees applied to the corresponding flash loan.

--- a/contracts/token/ERC20/extensions/ERC20FlashMint.sol
+++ b/contracts/token/ERC20/extensions/ERC20FlashMint.sol
@@ -30,7 +30,7 @@ abstract contract ERC20FlashMint is ERC20, IERC3156FlashLender {
 
     /**
      * @dev Returns the fee applied when doing flash loans. This function calls
-     * the {_flashFee} function which returns the fee applied when doing flash 
+     * the {_flashFee} function which returns the fee applied when doing flash
      * loans.
      * @param token The token to be flash loaned.
      * @param amount The amount of tokens to be loaned.


### PR DESCRIPTION
Docstrings for the `_flashFee` function say that the function calls `flashFee`, but that's not the case. I'm removing that.