### PR TITLE
ERC4907

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next-v*
       - release-v*
   pull_request: {}
   workflow_dispatch: {}


### PR DESCRIPTION
Support ERC4907.
It proposes an additional role (`user`) which can be granted to addresses, and a time where the role is automatically revoked (`expires`). The `user` role represents permission to "use" the NFT, but not the ability to transfer it or set users.

The owner of NFTs can set the user and expires of a NFT by call function `setUser`.

Here is a issue:
1.  Alice own  an NFT4907 with id 1.
2. Alice can set the user and expires of the NFT to anyone : `setUser(1, anyone, expires)`.
3. Alice also can cancel the right of using : `setUser(1, address(0), 0)`.

Learn more : https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4907.md