### PR TITLE
Remove unnecessary `Address` library import in `SignatureChecker`

### DIFF
--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -4,7 +4,6 @@
 pragma solidity ^0.8.0;
 
 import "./ECDSA.sol";
-import "../Address.sol";
 import "../../interfaces/IERC1271.sol";
 
 /**


### PR DESCRIPTION
Since it's a small refactor, no `CHANGELOG` entry is added.
