### PR TITLE
Erc4907 support#3735

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+ * `ERC4907`: add implementation of the ERC4907 standard. ([#3735](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3737))
  * `TimelockController`: Added a new `admin` constructor parameter that is assigned the admin role instead of the deployer account. ([#3722](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3722))
  * `Initializable`: add internal functions `_getInitializedVersion` and `_isInitializing` ([#3598](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3598))
  * `ERC165Checker`: add `supportsERC165InterfaceUnchecked` for consulting individual interfaces without the full ERC165 protocol. ([#3339](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3339))

--- a/contracts/interfaces/IERC4907.sol
+++ b/contracts/interfaces/IERC4907.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v5.0 (interfaces/IERC4907.sol)
+
+pragma solidity ^0.8.0;
+
+import "../token/ERC4907/IERC4907.sol";

--- a/contracts/mocks/ERC4907Demo.sol
+++ b/contracts/mocks/ERC4907Demo.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0; 
+
+import "../token/ERC4907/ERC4907.sol";
+
+contract ERC4907Demo is ERC4907 {
+
+    constructor(string memory name_, string memory symbol_)
+     ERC4907(name_,symbol_)
+     {         
+     }
+
+    function mint(uint256 tokenId, address to) public {
+        _mint(to, tokenId);
+    }
+
+} 
+

--- a/contracts/mocks/ERC4907Mock.sol
+++ b/contracts/mocks/ERC4907Mock.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../token/ERC4907/ERC4907.sol";
 
-contract ERC4907Demo is ERC4907 {
+contract ERC4907Mock is ERC4907 {
 
     constructor(string memory name_, string memory symbol_)
      ERC4907(name_,symbol_)

--- a/contracts/mocks/ERC4907Mock.sol
+++ b/contracts/mocks/ERC4907Mock.sol
@@ -1,18 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0; 
+pragma solidity ^0.8.0;
 
 import "../token/ERC4907/ERC4907.sol";
 
 contract ERC4907Mock is ERC4907 {
-
-    constructor(string memory name_, string memory symbol_)
-     ERC4907(name_,symbol_)
-     {         
-     }
+    constructor(string memory name_, string memory symbol_) ERC4907(name_, symbol_) {}
 
     function mint(uint256 tokenId, address to) public {
         _mint(to, tokenId);
     }
-
-} 
-
+}

--- a/contracts/mocks/ERC4907Mock.sol
+++ b/contracts/mocks/ERC4907Mock.sol
@@ -9,4 +9,10 @@ contract ERC4907Mock is ERC4907 {
     function mint(uint256 tokenId, address to) public {
         _mint(to, tokenId);
     }
+
+    function burn(uint256 tokenId) public virtual {
+        //solhint-disable-next-line max-line-length
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner or approved");
+        _burn(tokenId);
+    }
 }

--- a/contracts/token/ERC4907/ERC4907.sol
+++ b/contracts/token/ERC4907/ERC4907.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0; 
+
+import "../ERC721/ERC721.sol";
+import "./IERC4907.sol";
+
+contract ERC4907 is ERC721, IERC4907 {
+    struct UserInfo 
+    {
+        address user;   // address of user role
+        uint64 expires; // unix timestamp, user expires
+    }
+
+    mapping (uint256  => UserInfo) internal _users;
+
+    constructor(string memory name_, string memory symbol_)
+     ERC721(name_,symbol_)
+     {         
+     }
+    
+    /// @notice set the user and expires of a NFT
+    /// @dev The zero address indicates there is no user 
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) public virtual{
+        require(_isApprovedOrOwner(msg.sender, tokenId),"ERC721: transfer caller is not owner nor approved");
+        UserInfo storage info =  _users[tokenId];
+        info.user = user;
+        info.expires = expires;
+        emit UpdateUser(tokenId,user,expires);
+    }
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId)public view virtual returns(address){
+        if( uint256(_users[tokenId].expires) >=  block.timestamp){
+            return  _users[tokenId].user; 
+        }
+        else{
+            return address(0);
+        }
+    }
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user 
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) public view virtual returns(uint256){
+        return _users[tokenId].expires;
+    }
+
+    /// @dev See {IERC165-supportsInterface}.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC4907).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override{
+        super._beforeTokenTransfer(from, to, tokenId);
+
+        if (from != to) {
+            _users[tokenId].user = address(0);
+            _users[tokenId].expires = 0;
+            emit UpdateUser(tokenId,address(0),0);
+        }
+    }
+} 
+

--- a/contracts/token/ERC4907/ERC4907.sol
+++ b/contracts/token/ERC4907/ERC4907.sol
@@ -1,54 +1,53 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0; 
+pragma solidity ^0.8.0;
 
 import "../ERC721/ERC721.sol";
 import "./IERC4907.sol";
 
 contract ERC4907 is ERC721, IERC4907 {
-    struct UserInfo 
-    {
-        address user;   // address of user role
+    struct UserInfo {
+        address user; // address of user role
         uint64 expires; // unix timestamp, user expires
     }
 
-    mapping (uint256  => UserInfo) internal _users;
+    mapping(uint256 => UserInfo) internal _users;
 
-    constructor(string memory name_, string memory symbol_)
-     ERC721(name_,symbol_)
-     {         
-     }
-    
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
+
     /// @notice set the user and expires of a NFT
-    /// @dev The zero address indicates there is no user 
+    /// @dev The zero address indicates there is no user
     /// Throws if `tokenId` is not valid NFT
     /// @param user  The new user of the NFT
     /// @param expires  UNIX timestamp, The new user could use the NFT before expires
-    function setUser(uint256 tokenId, address user, uint64 expires) public virtual{
-        require(_isApprovedOrOwner(msg.sender, tokenId),"ERC721: transfer caller is not owner nor approved");
-        UserInfo storage info =  _users[tokenId];
+    function setUser(
+        uint256 tokenId,
+        address user,
+        uint64 expires
+    ) public virtual {
+        require(_isApprovedOrOwner(msg.sender, tokenId), "ERC721: transfer caller is not owner nor approved");
+        UserInfo storage info = _users[tokenId];
         info.user = user;
         info.expires = expires;
-        emit UpdateUser(tokenId,user,expires);
+        emit UpdateUser(tokenId, user, expires);
     }
 
     /// @notice Get the user address of an NFT
     /// @dev The zero address indicates that there is no user or the user is expired
     /// @param tokenId The NFT to get the user address for
     /// @return The user address for this NFT
-    function userOf(uint256 tokenId)public view virtual returns(address){
-        if( uint256(_users[tokenId].expires) >=  block.timestamp){
-            return  _users[tokenId].user; 
-        }
-        else{
+    function userOf(uint256 tokenId) public view virtual returns (address) {
+        if (uint256(_users[tokenId].expires) >= block.timestamp) {
+            return _users[tokenId].user;
+        } else {
             return address(0);
         }
     }
 
     /// @notice Get the user expires of an NFT
-    /// @dev The zero value indicates that there is no user 
+    /// @dev The zero value indicates that there is no user
     /// @param tokenId The NFT to get the user expires for
     /// @return The user expires for this NFT
-    function userExpires(uint256 tokenId) public view virtual returns(uint256){
+    function userExpires(uint256 tokenId) public view virtual returns (uint256) {
         return _users[tokenId].expires;
     }
 
@@ -57,5 +56,9 @@ contract ERC4907 is ERC721, IERC4907 {
         return interfaceId == type(IERC4907).interfaceId || super.supportsInterface(interfaceId);
     }
 
-} 
-
+    function _burn(uint256 tokenId) internal virtual override {
+        super._burn(tokenId);
+        delete _users[tokenId];
+        emit UpdateUser(tokenId, address(0), 0);
+    }
+}

--- a/contracts/token/ERC4907/ERC4907.sol
+++ b/contracts/token/ERC4907/ERC4907.sol
@@ -57,18 +57,5 @@ contract ERC4907 is ERC721, IERC4907 {
         return interfaceId == type(IERC4907).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual override{
-        super._beforeTokenTransfer(from, to, tokenId);
-
-        if (from != to) {
-            _users[tokenId].user = address(0);
-            _users[tokenId].expires = 0;
-            emit UpdateUser(tokenId,address(0),0);
-        }
-    }
 } 
 

--- a/contracts/token/ERC4907/ERC4907.sol
+++ b/contracts/token/ERC4907/ERC4907.sol
@@ -56,6 +56,9 @@ contract ERC4907 is ERC721, IERC4907 {
         return interfaceId == type(IERC4907).interfaceId || super.supportsInterface(interfaceId);
     }
 
+    /**
+     * @dev See {ERC721-_burn}. This override additionally clears the user information for the token.
+     */
     function _burn(uint256 tokenId) internal virtual override {
         super._burn(tokenId);
         delete _users[tokenId];

--- a/contracts/token/ERC4907/IERC4907.sol
+++ b/contracts/token/ERC4907/IERC4907.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IERC4907 {
+    // Logged when the user of a token assigns a new user or updates expires
+    /// @notice Emitted when the `user` of an NFT or the `expires` of the `user` is changed
+    /// The zero address for user indicates that there is no user address
+    event UpdateUser(uint256 indexed tokenId, address indexed user, uint64 expires);
+
+    /// @notice set the user and expires of a NFT
+    /// @dev The zero address indicates there is no user 
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) external ;
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId) external view returns(address);
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user 
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) external view returns(uint256);
+}

--- a/contracts/token/ERC4907/IERC4907.sol
+++ b/contracts/token/ERC4907/IERC4907.sol
@@ -9,21 +9,25 @@ interface IERC4907 {
     event UpdateUser(uint256 indexed tokenId, address indexed user, uint64 expires);
 
     /// @notice set the user and expires of a NFT
-    /// @dev The zero address indicates there is no user 
+    /// @dev The zero address indicates there is no user
     /// Throws if `tokenId` is not valid NFT
     /// @param user  The new user of the NFT
     /// @param expires  UNIX timestamp, The new user could use the NFT before expires
-    function setUser(uint256 tokenId, address user, uint64 expires) external ;
+    function setUser(
+        uint256 tokenId,
+        address user,
+        uint64 expires
+    ) external;
 
     /// @notice Get the user address of an NFT
     /// @dev The zero address indicates that there is no user or the user is expired
     /// @param tokenId The NFT to get the user address for
     /// @return The user address for this NFT
-    function userOf(uint256 tokenId) external view returns(address);
+    function userOf(uint256 tokenId) external view returns (address);
 
     /// @notice Get the user expires of an NFT
-    /// @dev The zero value indicates that there is no user 
+    /// @dev The zero value indicates that there is no user
     /// @param tokenId The NFT to get the user expires for
     /// @return The user expires for this NFT
-    function userExpires(uint256 tokenId) external view returns(uint256);
+    function userExpires(uint256 tokenId) external view returns (uint256);
 }

--- a/test/token/ERC4907/ERC4907.behavior.js
+++ b/test/token/ERC4907/ERC4907.behavior.js
@@ -1,0 +1,123 @@
+const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+const { ZERO_ADDRESS } = constants;
+const hre = require("hardhat");
+
+const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
+
+const firstTokenId = new BN('5042');
+const secondTokenId = new BN('79217');
+const nonExistentTokenId = new BN('13');
+
+const expires_one_hour = new BN(Math.floor(new Date().getTime() / 1000) + 3600);
+const expires_one_day = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
+
+function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) {
+  shouldSupportInterfaces([
+    'ERC165',
+    'ERC721',
+    'ERC4907'
+  ]);
+
+  context('with minted tokens', function () {
+    beforeEach(async function () {
+      await this.token.mint(firstTokenId, owner);
+      await this.token.mint(secondTokenId, owner);
+      this.toUser = other; // default to other for toUser in context-dependent tests
+      await this.token.setUser(firstTokenId, this.toUser, expires_one_hour, { from: owner });
+      await this.token.setUser(secondTokenId, this.toUser, expires_one_day, { from: owner });
+    });
+
+    describe('userOf', function () {
+      context('when the given token ID was tracked by this token', function () {
+        it('returns the user of the given token ID if user not expired', async function () {
+          expect(await this.token.userOf(firstTokenId)).to.be.equal(this.toUser);
+        });
+
+        it('returns ZERO_ADDRESS if user expired', async function () {
+          await hre.network.provider.send("hardhat_mine", ["0x3d", "0x3c"]);
+          expect(await this.token.userOf(firstTokenId)).to.be.equal(ZERO_ADDRESS);
+        });
+      });
+
+      context('when the given token ID was not tracked by this token', function () {
+        const tokenId = nonExistentTokenId;
+        it('returns ZERO_ADDRESS', async function () {
+          expect(await this.token.userOf(tokenId)).to.be.equal(ZERO_ADDRESS);
+        });
+      });
+    });
+
+    describe('setUser', function () {
+      const tokenId = firstTokenId;
+      let receipt = null;
+
+      beforeEach(async function () {
+        await this.token.approve(approved, tokenId, { from: owner });
+        await this.token.setApprovalForAll(operator, true, { from: owner });
+      });
+
+      const setUserSuccessful = function () {
+        it('transfers the user of the given token ID to the given address', async function () {
+          expect(await this.token.userOf(tokenId)).to.be.equal(this.toUser);
+          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(expires_one_day);
+        });
+
+        it('owner still own the NFT', async function () {
+          expect(await this.token.ownerOf(tokenId)).to.be.equal(owner);
+        });
+
+        it('emits a UpdateUser event', async function () {
+          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: expires_one_day });
+        });
+
+      };
+
+      const shouldSetUserByOperator = function (setUserFunction) {
+        context('when called by the owner', function () {
+          beforeEach(async function () {
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day, owner));
+          });
+          setUserSuccessful();
+        });
+
+        context('when called by the approved individual', function () {
+          beforeEach(async function () {
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day, approved));
+          });
+          setUserSuccessful();
+        });
+
+        context('when called by the operator', function () {
+          beforeEach(async function () {
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day, operator));
+          });
+          setUserSuccessful();
+        });
+
+        context('when called by other', function () {
+          it('reverts', async function () {
+            await expectRevert(
+              setUserFunction.call(this, tokenId, this.toUser, expires_one_day, other),
+              'ERC721: transfer caller is not owner nor approved',
+            );
+          });
+
+        });
+
+      };
+
+      describe('via setUser', function () {
+        shouldSetUserByOperator(function (tokenId, user, expires, from) {
+          return this.token.setUser(tokenId, user, expires, { from: from });
+        });
+      });
+
+    });
+  });
+
+}
+
+module.exports = {
+  shouldBehaveLikeERC4907,
+};

--- a/test/token/ERC4907/ERC4907.behavior.js
+++ b/test/token/ERC4907/ERC4907.behavior.js
@@ -9,8 +9,8 @@ const firstTokenId = new BN('5042');
 const secondTokenId = new BN('79217');
 const nonExistentTokenId = new BN('13');
 
-const expires_one_hour = new BN(Math.floor(new Date().getTime() / 1000) + 3600);
-const expires_one_day = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
+const expires_one_hour_later = new BN(Math.floor(new Date().getTime() / 1000) + 3600);
+const expires_one_day_later = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
 
 function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) {
   shouldSupportInterfaces([
@@ -24,19 +24,19 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
       await this.token.mint(firstTokenId, owner);
       await this.token.mint(secondTokenId, owner);
       this.toUser = other; // default to other for toUser in context-dependent tests
-      await this.token.setUser(firstTokenId, this.toUser, expires_one_hour, { from: owner });
-      await this.token.setUser(secondTokenId, this.toUser, expires_one_day, { from: owner });
+      await this.token.setUser(firstTokenId, this.toUser, expires_one_day_later, { from: owner });
+      await this.token.setUser(secondTokenId, this.toUser, expires_one_hour_later, { from: owner });
     });
 
     describe('userOf', function () {
       context('when the given token ID was tracked by this token', function () {
         it('returns the user of the given token ID if user not expired', async function () {
-          expect(await this.token.userOf(firstTokenId)).to.be.equal(this.toUser);
+          expect(await this.token.userOf(secondTokenId)).to.be.equal(this.toUser);
         });
 
         it('returns ZERO_ADDRESS if user expired', async function () {
-          await hre.network.provider.send("hardhat_mine", ["0x3d", "0x3c"]);
-          expect(await this.token.userOf(firstTokenId)).to.be.equal(ZERO_ADDRESS);
+          await hre.network.provider.send("hardhat_mine", ["0x3e", "0x3c"]);
+          expect(await this.token.userOf(secondTokenId)).to.be.equal(ZERO_ADDRESS);
         });
       });
 
@@ -60,7 +60,7 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
       const setUserSuccessful = function () {
         it('transfers the user of the given token ID to the given address', async function () {
           expect(await this.token.userOf(tokenId)).to.be.equal(this.toUser);
-          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(expires_one_day);
+          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(expires_one_day_later);
         });
 
         it('owner still own the NFT', async function () {
@@ -68,7 +68,7 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
         });
 
         it('emits a UpdateUser event', async function () {
-          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: expires_one_day });
+          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: expires_one_day_later });
         });
 
       };
@@ -76,21 +76,21 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
       const shouldSetUserByOperator = function (setUserFunction) {
         context('when called by the owner', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day, owner));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, owner));
           });
           setUserSuccessful();
         });
 
         context('when called by the approved individual', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day, approved));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, approved));
           });
           setUserSuccessful();
         });
 
         context('when called by the operator', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day, operator));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, operator));
           });
           setUserSuccessful();
         });
@@ -98,7 +98,7 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
         context('when called by other', function () {
           it('reverts', async function () {
             await expectRevert(
-              setUserFunction.call(this, tokenId, this.toUser, expires_one_day, other),
+              setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, other),
               'ERC721: transfer caller is not owner nor approved',
             );
           });

--- a/test/token/ERC4907/ERC4907.behavior.js
+++ b/test/token/ERC4907/ERC4907.behavior.js
@@ -1,7 +1,7 @@
 const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
-const hre = require("hardhat");
+const hre = require('hardhat');
 
 const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
 
@@ -9,14 +9,14 @@ const firstTokenId = new BN('5042');
 const secondTokenId = new BN('79217');
 const nonExistentTokenId = new BN('13');
 
-const expires_one_hour_later = new BN(Math.floor(new Date().getTime() / 1000) + 3600);
-const expires_one_day_later = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
+const expiresOneHourLater = new BN(Math.floor(new Date().getTime() / 1000) + 3600);
+const expiresOneDayLater = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
 
-function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) {
+function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other) {
   shouldSupportInterfaces([
     'ERC165',
     'ERC721',
-    'ERC4907'
+    'ERC4907',
   ]);
 
   context('with minted tokens', function () {
@@ -24,8 +24,8 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
       await this.token.mint(firstTokenId, owner);
       await this.token.mint(secondTokenId, owner);
       this.toUser = other; // default to other for toUser in context-dependent tests
-      await this.token.setUser(firstTokenId, this.toUser, expires_one_day_later, { from: owner });
-      await this.token.setUser(secondTokenId, this.toUser, expires_one_hour_later, { from: owner });
+      await this.token.setUser(firstTokenId, this.toUser, expiresOneDayLater, { from: owner });
+      await this.token.setUser(secondTokenId, this.toUser, expiresOneHourLater, { from: owner });
     });
 
     describe('userOf', function () {
@@ -35,7 +35,7 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
         });
 
         it('returns ZERO_ADDRESS if user expired', async function () {
-          await hre.network.provider.send("hardhat_mine", ["0x3e", "0x3c"]);
+          await hre.network.provider.send('hardhat_mine', ['0x3e', '0x3c']);
           expect(await this.token.userOf(secondTokenId)).to.be.equal(ZERO_ADDRESS);
         });
       });
@@ -60,7 +60,7 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
       const setUserSuccessful = function () {
         it('transfers the user of the given token ID to the given address', async function () {
           expect(await this.token.userOf(tokenId)).to.be.equal(this.toUser);
-          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(expires_one_day_later);
+          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(expiresOneDayLater);
         });
 
         it('owner still own the NFT', async function () {
@@ -68,29 +68,28 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
         });
 
         it('emits a UpdateUser event', async function () {
-          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: expires_one_day_later });
+          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: expiresOneDayLater });
         });
-
       };
 
       const shouldSetUserByOperator = function (setUserFunction) {
         context('when called by the owner', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, owner));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, owner));
           });
           setUserSuccessful();
         });
 
         context('when called by the approved individual', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, approved));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, approved));
           });
           setUserSuccessful();
         });
 
         context('when called by the operator', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, operator));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, operator));
           });
           setUserSuccessful();
         });
@@ -98,13 +97,11 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
         context('when called by other', function () {
           it('reverts', async function () {
             await expectRevert(
-              setUserFunction.call(this, tokenId, this.toUser, expires_one_day_later, other),
+              setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, other),
               'ERC721: transfer caller is not owner nor approved',
             );
           });
-
         });
-
       };
 
       describe('via setUser', function () {
@@ -112,10 +109,8 @@ function shouldBehaveLikeERC4907(errorPrefix, owner, approved, operator, other) 
           return this.token.setUser(tokenId, user, expires, { from: from });
         });
       });
-
     });
   });
-
 }
 
 module.exports = {

--- a/test/token/ERC4907/ERC4907.behavior.js
+++ b/test/token/ERC4907/ERC4907.behavior.js
@@ -7,7 +7,7 @@ const firstTokenId = new BN('5042');
 const secondTokenId = new BN('79217');
 const nonExistentTokenId = new BN('13');
 
-const userExpiresTimestamp = new BN(Math.floor(new Date().getTime() / 1000) + 86400 * 365);
+const userExpiresTimestamp = new BN('18446744073709551615');
 
 function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other) {
   shouldSupportInterfaces([
@@ -26,9 +26,10 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
     describe('userOf', function () {
       context('when the given token ID was tracked by this token', function () {
         it('returns the user of the given token ID if user not expired', async function () {
-          await this.token.setUser(firstTokenId, this.toUser, userExpiresTimestamp, { from: owner });
           const timestamp = await latest();
-          if (userExpiresTimestamp >= timestamp) {
+          const _expires = timestamp.add(new BN('86400'));
+          await this.token.setUser(firstTokenId, this.toUser, _expires, { from: owner });
+          if (_expires.gte(timestamp)) {
             expect(await this.token.userOf(firstTokenId)).to.be.equal(this.toUser);
           } else {
             expect(await this.token.userOf(firstTokenId)).to.be.equal(ZERO_ADDRESS);
@@ -61,7 +62,7 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
       const setUserSuccessful = function () {
         it('transfers the user of the given token ID to the given address', async function () {
           const timestamp = await latest();
-          if (userExpiresTimestamp >= timestamp) {
+          if (userExpiresTimestamp.gte(timestamp)) {
             expect(await this.token.userOf(tokenId)).to.be.equal(this.toUser);
           } else {
             expect(await this.token.userOf(tokenId)).to.be.equal(ZERO_ADDRESS);

--- a/test/token/ERC4907/ERC4907.behavior.js
+++ b/test/token/ERC4907/ERC4907.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { latest } = require('@openzeppelin/test-helpers/src/time');
 const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
@@ -6,7 +7,7 @@ const firstTokenId = new BN('5042');
 const secondTokenId = new BN('79217');
 const nonExistentTokenId = new BN('13');
 
-const expiresOneDayLater = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
+const userExpiresTimestamp = new BN(Math.floor(new Date().getTime() / 1000) + 86400 * 365);
 
 function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other) {
   shouldSupportInterfaces([
@@ -20,17 +21,22 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
       await this.token.mint(firstTokenId, owner);
       await this.token.mint(secondTokenId, owner);
       this.toUser = other; // default to other for toUser in context-dependent tests
-      await this.token.setUser(firstTokenId, this.toUser, expiresOneDayLater, { from: owner });
-      await this.token.setUser(secondTokenId, this.toUser, 0, { from: owner });
     });
 
     describe('userOf', function () {
       context('when the given token ID was tracked by this token', function () {
         it('returns the user of the given token ID if user not expired', async function () {
-          expect(await this.token.userOf(firstTokenId)).to.be.equal(this.toUser);
+          await this.token.setUser(firstTokenId, this.toUser, userExpiresTimestamp, { from: owner });
+          const timestamp = await latest();
+          if (userExpiresTimestamp >= timestamp) {
+            expect(await this.token.userOf(firstTokenId)).to.be.equal(this.toUser);
+          } else {
+            expect(await this.token.userOf(firstTokenId)).to.be.equal(ZERO_ADDRESS);
+          }
         });
 
         it('returns ZERO_ADDRESS if user expired', async function () {
+          await this.token.setUser(secondTokenId, this.toUser, 0, { from: owner });
           expect(await this.token.userOf(secondTokenId)).to.be.equal(ZERO_ADDRESS);
         });
       });
@@ -54,8 +60,13 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
 
       const setUserSuccessful = function () {
         it('transfers the user of the given token ID to the given address', async function () {
-          expect(await this.token.userOf(tokenId)).to.be.equal(this.toUser);
-          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(expiresOneDayLater);
+          const timestamp = await latest();
+          if (userExpiresTimestamp >= timestamp) {
+            expect(await this.token.userOf(tokenId)).to.be.equal(this.toUser);
+          } else {
+            expect(await this.token.userOf(tokenId)).to.be.equal(ZERO_ADDRESS);
+          }
+          expect(await this.token.userExpires(tokenId)).to.be.bignumber.equal(userExpiresTimestamp);
         });
 
         it('owner still own the NFT', async function () {
@@ -63,28 +74,28 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
         });
 
         it('emits a UpdateUser event', async function () {
-          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: expiresOneDayLater });
+          expectEvent(receipt, 'UpdateUser', { tokenId: tokenId, user: this.toUser, expires: userExpiresTimestamp });
         });
       };
 
       const shouldSetUserByOperator = function (setUserFunction) {
         context('when called by the owner', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, owner));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, userExpiresTimestamp, owner));
           });
           setUserSuccessful();
         });
 
         context('when called by the approved individual', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, approved));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, userExpiresTimestamp, approved));
           });
           setUserSuccessful();
         });
 
         context('when called by the operator', function () {
           beforeEach(async function () {
-            (receipt = await setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, operator));
+            (receipt = await setUserFunction.call(this, tokenId, this.toUser, userExpiresTimestamp, operator));
           });
           setUserSuccessful();
         });
@@ -92,7 +103,7 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
         context('when called by other', function () {
           it('reverts', async function () {
             await expectRevert(
-              setUserFunction.call(this, tokenId, this.toUser, expiresOneDayLater, other),
+              setUserFunction.call(this, tokenId, this.toUser, userExpiresTimestamp, other),
               'ERC721: transfer caller is not owner nor approved',
             );
           });
@@ -102,6 +113,37 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
       describe('via setUser', function () {
         shouldSetUserByOperator(function (tokenId, user, expires, from) {
           return this.token.setUser(tokenId, user, expires, { from: from });
+        });
+      });
+    });
+
+    describe('_burn', function () {
+      const burnedId = new BN('4907');
+      let receipt = null;
+
+      const burnSuccessful = function () {
+        it('burn the given token ID to the given address', async function () {
+          expect(await this.token.userOf(burnedId)).to.be.equal(ZERO_ADDRESS);
+          expect(await this.token.userExpires(burnedId)).to.be.bignumber.equal(new BN(0));
+        });
+        it('emits a UpdateUser event', async function () {
+          expectEvent(receipt, 'UpdateUser', { tokenId: burnedId, user: ZERO_ADDRESS, expires: new BN(0) });
+        });
+      };
+
+      const shouldBurnByOperator = function (burnFunction) {
+        context('when called by the owner', function () {
+          beforeEach(async function () {
+            await this.token.mint(burnedId, owner, { from: owner });
+            (receipt = await burnFunction.call(this, burnedId, owner));
+          });
+          burnSuccessful();
+        });
+      };
+
+      describe('via burn', function () {
+        shouldBurnByOperator(function (tokenId, from) {
+          return this.token.burn(tokenId, { from: from });
         });
       });
     });

--- a/test/token/ERC4907/ERC4907.behavior.js
+++ b/test/token/ERC4907/ERC4907.behavior.js
@@ -1,15 +1,11 @@
 const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
-const hre = require('hardhat');
-
 const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
-
 const firstTokenId = new BN('5042');
 const secondTokenId = new BN('79217');
 const nonExistentTokenId = new BN('13');
 
-const expiresOneHourLater = new BN(Math.floor(new Date().getTime() / 1000) + 3600);
 const expiresOneDayLater = new BN(Math.floor(new Date().getTime() / 1000) + 86400);
 
 function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other) {
@@ -25,17 +21,16 @@ function shouldBehaveLikeERC4907 (errorPrefix, owner, approved, operator, other)
       await this.token.mint(secondTokenId, owner);
       this.toUser = other; // default to other for toUser in context-dependent tests
       await this.token.setUser(firstTokenId, this.toUser, expiresOneDayLater, { from: owner });
-      await this.token.setUser(secondTokenId, this.toUser, expiresOneHourLater, { from: owner });
+      await this.token.setUser(secondTokenId, this.toUser, 0, { from: owner });
     });
 
     describe('userOf', function () {
       context('when the given token ID was tracked by this token', function () {
         it('returns the user of the given token ID if user not expired', async function () {
-          expect(await this.token.userOf(secondTokenId)).to.be.equal(this.toUser);
+          expect(await this.token.userOf(firstTokenId)).to.be.equal(this.toUser);
         });
 
         it('returns ZERO_ADDRESS if user expired', async function () {
-          await hre.network.provider.send('hardhat_mine', ['0x3e', '0x3c']);
           expect(await this.token.userOf(secondTokenId)).to.be.equal(ZERO_ADDRESS);
         });
       });

--- a/test/token/ERC4907/ERC4907.test.js
+++ b/test/token/ERC4907/ERC4907.test.js
@@ -1,0 +1,31 @@
+const { expect } = require('chai');
+
+contract('ERC777', function (accounts) {
+    const [alice, bob, carl, ...otherAccounts] = accounts;
+    let contract;
+
+    beforeEach(async function () {
+        const ERC4907Demo = artifacts.require('ERC4907Demo');
+        contract = await ERC4907Demo.new("4907", "4907");
+    });
+
+    describe("setUser", function () {
+        it("Should set user to bob", async function () {
+            await contract.mint(1, alice);
+            let expires = Math.floor(new Date().getTime() / 1000) + 1000;
+            await contract.setUser(1, bob, BigInt(expires),{ from: alice });
+            expect(await contract.userOf(1)).equals(bob);
+            expect(await contract.ownerOf(1)).equals(alice);
+        });
+
+        it("Should set user to carl", async function () {
+            await contract.mint(1, alice);
+            let expires = Math.floor(new Date().getTime() / 1000) + 1000;
+            await contract.setUser(1, bob, BigInt(expires),{ from: alice });
+            await contract.setUser(1, carl, BigInt(expires),{ from: alice });
+            expect(await contract.userOf(1)).equals(carl);
+            expect(await contract.ownerOf(1)).equals(alice);
+        });
+
+    });
+});

--- a/test/token/ERC4907/ERC4907.test.js
+++ b/test/token/ERC4907/ERC4907.test.js
@@ -1,31 +1,17 @@
-const { expect } = require('chai');
+const {
+    shouldBehaveLikeERC4907
+} = require('./ERC4907.behavior');
 
-contract('ERC777', function (accounts) {
-    const [alice, bob, carl, ...otherAccounts] = accounts;
-    let contract;
+const ERC4907Mock = artifacts.require('ERC4907Mock');
 
+contract('ERC4907', function (accounts) {
+    const name = 'Non Fungible Token 4907';
+    const symbol = 'NFT4907';
+  
     beforeEach(async function () {
-        const ERC4907Mock = artifacts.require('ERC4907Mock');
-        contract = await ERC4907Mock.new("4907", "4907");
+      this.token = await ERC4907Mock.new(name, symbol);
     });
+  
+    shouldBehaveLikeERC4907('ERC4907', ...accounts);
+  });
 
-    describe("setUser", function () {
-        it("Should set user to bob", async function () {
-            await contract.mint(1, alice);
-            let expires = Math.floor(new Date().getTime() / 1000) + 1000;
-            await contract.setUser(1, bob, BigInt(expires),{ from: alice });
-            expect(await contract.userOf(1)).equals(bob);
-            expect(await contract.ownerOf(1)).equals(alice);
-        });
-
-        it("Should set user to carl", async function () {
-            await contract.mint(1, alice);
-            let expires = Math.floor(new Date().getTime() / 1000) + 1000;
-            await contract.setUser(1, bob, BigInt(expires),{ from: alice });
-            await contract.setUser(1, carl, BigInt(expires),{ from: alice });
-            expect(await contract.userOf(1)).equals(carl);
-            expect(await contract.ownerOf(1)).equals(alice);
-        });
-
-    });
-});

--- a/test/token/ERC4907/ERC4907.test.js
+++ b/test/token/ERC4907/ERC4907.test.js
@@ -5,8 +5,8 @@ contract('ERC777', function (accounts) {
     let contract;
 
     beforeEach(async function () {
-        const ERC4907Demo = artifacts.require('ERC4907Demo');
-        contract = await ERC4907Demo.new("4907", "4907");
+        const ERC4907Mock = artifacts.require('ERC4907Mock');
+        contract = await ERC4907Mock.new("4907", "4907");
     });
 
     describe("setUser", function () {

--- a/test/token/ERC4907/ERC4907.test.js
+++ b/test/token/ERC4907/ERC4907.test.js
@@ -1,17 +1,12 @@
 const {
-    shouldBehaveLikeERC4907
+  shouldBehaveLikeERC4907,
 } = require('./ERC4907.behavior');
-
 const ERC4907Mock = artifacts.require('ERC4907Mock');
-
 contract('ERC4907', function (accounts) {
-    const name = 'Non Fungible Token 4907';
-    const symbol = 'NFT4907';
-  
-    beforeEach(async function () {
-      this.token = await ERC4907Mock.new(name, symbol);
-    });
-  
-    shouldBehaveLikeERC4907('ERC4907', ...accounts);
+  const name = 'Non Fungible Token 4907';
+  const symbol = 'NFT4907';
+  beforeEach(async function () {
+    this.token = await ERC4907Mock.new(name, symbol);
   });
-
+  shouldBehaveLikeERC4907('ERC4907', ...accounts);
+});

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -99,6 +99,11 @@ const INTERFACES = {
   ERC2981: [
     'royaltyInfo(uint256,uint256)',
   ],
+  ERC4907: [
+    'setUser(uint256,address,uint64)',
+    'userOf(uint256)',
+    'userExpires(uint256)',
+  ],
 };
 
 const INTERFACE_IDS = {};


### PR DESCRIPTION
Fixes #3735

support [ERC4907](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4907.md)

ERC4907 is an extension of [EIP-721](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md). It proposes an additional role (user) which can be granted to addresses, and a time where the role is automatically revoked (expires). The user role represents permission to "use" the NFT, but not the ability to transfer it or set users.