### PR TITLE
[IDEA] Don't rely on _beforeConsecutiveTokenTransfer for balance tracting

### DIFF
--- a/contracts/mocks/ERC721ConsecutiveEnumerableMock.unreachable.sol
+++ b/contracts/mocks/ERC721ConsecutiveEnumerableMock.unreachable.sol
@@ -27,6 +27,10 @@ contract ERC721ConsecutiveEnumerableMock is ERC721Consecutive, ERC721Enumerable 
         return super.supportsInterface(interfaceId);
     }
 
+    function balanceOf(address account) public view virtual override(IERC721, ERC721, ERC721Consecutive) returns (uint256) {
+        return super.balanceOf(account);
+    }
+
     function _ownerOf(uint256 tokenId) internal view virtual override(ERC721, ERC721Consecutive) returns (address) {
         return super._ownerOf(tokenId);
     }

--- a/contracts/mocks/ERC721ConsecutiveMock.sol
+++ b/contracts/mocks/ERC721ConsecutiveMock.sol
@@ -52,6 +52,10 @@ contract ERC721ConsecutiveMock is ERC721Burnable, ERC721Consecutive, ERC721Pausa
         _safeMint(to, tokenId);
     }
 
+    function balanceOf(address account) public view virtual override(ERC721, ERC721Consecutive) returns (uint256) {
+        return super.balanceOf(account);
+    }
+
     function _ownerOf(uint256 tokenId) internal view virtual override(ERC721, ERC721Consecutive) returns (address) {
         return super._ownerOf(tokenId);
     }

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -493,18 +493,11 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * Calling conditions are similar to {_beforeTokenTransfer}.
      */
     function _beforeConsecutiveTokenTransfer(
-        address from,
-        address to,
+        address, /*from*/
+        address, /*to*/
         uint256, /*first*/
-        uint96 size
-    ) internal virtual {
-        if (from != address(0)) {
-            _balances[from] -= size;
-        }
-        if (to != address(0)) {
-            _balances[to] += size;
-        }
-    }
+        uint96 /*size*/
+    ) internal virtual {}
 
     /**
      * @dev Hook that is called after "consecutive token transfers" as defined in ERC2309 and implemented in


### PR DESCRIPTION
This PR
- uses a new `ERC721Concutive._batchBalances` to keep track of the tokens minted sequentially.
- don't write to `ERC721._balances` when minting batches.
- rely on the unchecked sum of both values to get the actual result.

Note: this uses the fact that `ERC721._balances` will overflow when transferring out a token that was minted in batch.

**The upside** is that we don't need to manipulate the `ERC721._balances` in the `_beforeConsecutiveTokenTransfer`. Unfortunatelly the hooks still have to be defined in `ERC721` so that ERC721Consecutive and ERC721Pausable can be binded together.

**The downside** is that we now have two memory slots. The cost of transferring should be similar in the long run, but a bit higher at first since the two slot needs to be initialized. Also, any account that got token minted and batch and then transfer them will have both slots set to non zero value (when the sum is actually zero). In addition, `balanceOf` now need 2 sload, increassing the cost by 2100 gas (plus the mapping lookup).

Is that worth it?

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
