### PR TITLE
Refactor consecutive transfer hooks

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -287,7 +287,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         require(to != address(0), "ERC721: mint to the zero address");
         require(!_exists(tokenId), "ERC721: token already minted");
 
-        _beforeTokenTransfer(address(0), to, tokenId);
+        _beforeTokenTransfer(address(0), to, tokenId, tokenId);
 
         // Check that tokenId was not minted by `_beforeTokenTransfer` hook
         require(!_exists(tokenId), "ERC721: token already minted");
@@ -304,7 +304,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
 
         emit Transfer(address(0), to, tokenId);
 
-        _afterTokenTransfer(address(0), to, tokenId);
+        _afterTokenTransfer(address(0), to, tokenId, tokenId);
     }
 
     /**
@@ -321,7 +321,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     function _burn(uint256 tokenId) internal virtual {
         address owner = ERC721.ownerOf(tokenId);
 
-        _beforeTokenTransfer(owner, address(0), tokenId);
+        _beforeTokenTransfer(owner, address(0), tokenId, tokenId);
 
         // Update ownership in case tokenId was transferred by `_beforeTokenTransfer` hook
         owner = ERC721.ownerOf(tokenId);
@@ -338,7 +338,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
 
         emit Transfer(owner, address(0), tokenId);
 
-        _afterTokenTransfer(owner, address(0), tokenId);
+        _afterTokenTransfer(owner, address(0), tokenId, tokenId);
     }
 
     /**
@@ -360,7 +360,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
         require(to != address(0), "ERC721: transfer to the zero address");
 
-        _beforeTokenTransfer(from, to, tokenId);
+        _beforeTokenTransfer(from, to, tokenId, tokenId);
 
         // Check that tokenId was not transferred by `_beforeTokenTransfer` hook
         require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
@@ -381,7 +381,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
 
         emit Transfer(from, to, tokenId);
 
-        _afterTokenTransfer(from, to, tokenId);
+        _afterTokenTransfer(from, to, tokenId, tokenId);
     }
 
     /**
@@ -467,8 +467,19 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint256 tokenId
-    ) internal virtual {}
+        uint256 firstTokenId,
+        uint256 lastTokenId
+    ) internal virtual {
+        if (lastTokenId > firstTokenId) {
+            uint size = lastTokenId - firstTokenId + 1;
+            if (from != address(0)) {
+                _balances[from] -= size;
+            }
+            if (to != address(0)) {
+                _balances[to] += size;
+            }
+        }
+    }
 
     /**
      * @dev Hook that is called after any (single) transfer of tokens. This includes minting and burning.
@@ -484,37 +495,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     function _afterTokenTransfer(
         address from,
         address to,
-        uint256 tokenId
-    ) internal virtual {}
-
-    /**
-     * @dev Hook that is called before "consecutive token transfers" as defined in ERC2309 and implemented in
-     * {ERC721Consecutive}.
-     * Calling conditions are similar to {_beforeTokenTransfer}.
-     */
-    function _beforeConsecutiveTokenTransfer(
-        address from,
-        address to,
-        uint256, /*first*/
-        uint96 size
-    ) internal virtual {
-        if (from != address(0)) {
-            _balances[from] -= size;
-        }
-        if (to != address(0)) {
-            _balances[to] += size;
-        }
-    }
-
-    /**
-     * @dev Hook that is called after "consecutive token transfers" as defined in ERC2309 and implemented in
-     * {ERC721Consecutive}.
-     * Calling conditions are similar to {_afterTokenTransfer}.
-     */
-    function _afterConsecutiveTokenTransfer(
-        address, /*from*/
-        address, /*to*/
-        uint256, /*first*/
-        uint96 /*size*/
+        uint256 firstTokenId,
+        uint256 lastTokenId
     ) internal virtual {}
 }

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -71,9 +71,16 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint256 tokenId
+        uint256 firstTokenId,
+        uint256 lastTokenId
     ) internal virtual override {
-        super._beforeTokenTransfer(from, to, tokenId);
+        super._beforeTokenTransfer(from, to, firstTokenId, lastTokenId);
+
+        if (lastTokenId != firstTokenId) {
+            revert("ERC721Enumerable: consecutive transfers not supported");
+        }
+
+        uint256 tokenId = firstTokenId;
 
         if (from == address(0)) {
             _addTokenToAllTokensEnumeration(tokenId);
@@ -84,34 +91,6 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
             _removeTokenFromAllTokensEnumeration(tokenId);
         } else if (to != from) {
             _addTokenToOwnerEnumeration(to, tokenId);
-        }
-    }
-
-    /**
-     * @dev Hook that is called before any batch token transfer. For now this is limited
-     * to batch minting by the {ERC721Consecutive} extension.
-     *
-     * Calling conditions:
-     *
-     * - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be
-     * transferred to `to`.
-     * - When `from` is zero, `tokenId` will be minted for `to`.
-     * - When `to` is zero, ``from``'s `tokenId` will be burned.
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
-     *
-     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
-     */
-    function _beforeConsecutiveTokenTransfer(
-        address,
-        address,
-        uint256,
-        uint96 size
-    ) internal virtual override {
-        // We revert because enumerability is not supported with consecutive batch minting.
-        // This conditional is only needed to silence spurious warnings about unreachable code.
-        if (size > 0) {
-            revert("ERC721Enumerable: consecutive transfers not supported");
         }
     }
 

--- a/contracts/token/ERC721/extensions/ERC721Pausable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Pausable.sol
@@ -24,20 +24,10 @@ abstract contract ERC721Pausable is ERC721, Pausable {
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint256 tokenId
+        uint256 firstTokenId,
+        uint256 lastTokenId
     ) internal virtual override {
-        super._beforeTokenTransfer(from, to, tokenId);
-
-        require(!paused(), "ERC721Pausable: token transfer while paused");
-    }
-
-    function _beforeConsecutiveTokenTransfer(
-        address from,
-        address to,
-        uint256 first,
-        uint96 size
-    ) internal virtual override {
-        super._beforeConsecutiveTokenTransfer(from, to, first, size);
+        super._beforeTokenTransfer(from, to, firstTokenId, lastTokenId);
 
         require(!paused(), "ERC721Pausable: token transfer while paused");
     }

--- a/contracts/token/ERC721/extensions/ERC721Votes.sol
+++ b/contracts/token/ERC721/extensions/ERC721Votes.sol
@@ -24,25 +24,12 @@ abstract contract ERC721Votes is ERC721, Votes {
     function _afterTokenTransfer(
         address from,
         address to,
-        uint256 tokenId
+        uint256 firstTokenId,
+        uint256 lastTokenId
     ) internal virtual override {
-        _transferVotingUnits(from, to, 1);
-        super._afterTokenTransfer(from, to, tokenId);
-    }
-
-    /**
-     * @dev Adjusts votes when a batch of tokens is transferred.
-     *
-     * Emits a {IVotes-DelegateVotesChanged} event.
-     */
-    function _afterConsecutiveTokenTransfer(
-        address from,
-        address to,
-        uint256 first,
-        uint96 size
-    ) internal virtual override {
+        uint256 size = lastTokenId - firstTokenId + 1;
         _transferVotingUnits(from, to, size);
-        super._afterConsecutiveTokenTransfer(from, to, first, size);
+        super._afterTokenTransfer(from, to, firstTokenId, lastTokenId);
     }
 
     /**

--- a/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol
@@ -124,15 +124,6 @@ contract ERC721PresetMinterPauserAutoId is
         super._beforeTokenTransfer(from, to, tokenId);
     }
 
-    function _beforeConsecutiveTokenTransfer(
-        address from,
-        address to,
-        uint256 first,
-        uint96 size
-    ) internal virtual override(ERC721, ERC721Enumerable, ERC721Pausable) {
-        super._beforeConsecutiveTokenTransfer(from, to, first, size);
-    }
-
     /**
      * @dev See {IERC165-supportsInterface}.
      */


### PR DESCRIPTION
In #3739 we realized that the introduction of ERC721Consecutive results in a breaking change, not because the behavior of a contract changes, but because it may stop compiling due to new required disambiguating overrides. An example is the combination of ERC721+ERC721Pausable, or ERC721+ERC721Enumerable, even though these combinations don't involve ERC721Consecutive the user still has to write a disambiguating override for `_beforeConsecutiveTokenTransfer`.

This understandably results in confusion. This is a proposal for an alternative way to design the hooks, which gives in to the breaking change but with an arguably less disruptive result. The idea is to reuse `_beforeTokenTransfer` but add a new argument, so that the signature becomes `_beforeTokenTransfer(address from, address to, uint firstTokenId, uint lastTokenId)`. Thus, the same hook is reused for simple and consecutive token transfers. A user that updates the dependency to 4.8 "simply" has to add the new `lastTokenId` argument to get their contract to compile, and as long as they don't use ERC721Consecutive they can ignore that argument.

This PR is incomplete but I wanted to get the idea out since this is blocking the release of 4.8. I personally think this is an important thing to consider. The effect of having consecutive-related overrides in a contract that doesn't use ERC721Consecutive is not nice at all, and I think it just shows that the design needs to be improved.