### PR TITLE
ERC721VotesForced - give tokens different voting weight

### DIFF
--- a/contracts/governance/utils/VotesForced.sol
+++ b/contracts/governance/utils/VotesForced.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.6.0) (governance/utils/Votes.sol)
+pragma solidity ^0.8.0;
+
+import "../../utils/Context.sol";
+import "../../utils/Counters.sol";
+import "../../utils/Checkpoints.sol";
+import "../../utils/cryptography/EIP712.sol";
+import "./IVotes.sol";
+
+/**
+ * @dev This is a base abstract contract that tracks voting units, which are a measure of voting power that can be
+ * transferred, and provides a system of vote delegation, where an account can delegate its voting units to a sort of
+ * "representative" that will pool delegated voting units from different accounts and can then use it to vote in
+ * decisions. In fact, voting units _must_ be delegated in order to count as actual votes, and an account has to
+ * delegate those votes to itself if it wishes to participate in decisions and does not have a trusted representative.
+ *
+ * This contract is often combined with a token contract such that voting units correspond to token units. For an
+ * example, see {ERC721Votes}.
+ *
+ * The full history of delegate votes is tracked on-chain so that governance protocols can consider votes as distributed
+ * at a particular block number to protect against flash loans and double voting. The opt-in delegate system makes the
+ * cost of this history tracking optional.
+ *
+ * When using this module the derived contract must implement {_getVotingUnits} (for example, make it return
+ * {ERC721-balanceOf}), and can use {_transferVotingUnits} to track a change in the distribution of those units (in the
+ * previous example, it would be included in {ERC721-_beforeTokenTransfer}).
+ *
+ * _Available since v4.5._
+ */
+abstract contract Votes is IVotes, Context, EIP712 {
+    using Checkpoints for Checkpoints.History;
+    using Counters for Counters.Counter;
+
+    bytes32 private constant _DELEGATION_TYPEHASH =
+        keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+
+    mapping(address => address) private _delegation;
+    mapping(address => Checkpoints.History) private _delegateCheckpoints;
+    Checkpoints.History private _totalCheckpoints;
+
+    mapping(address => Counters.Counter) private _nonces;
+
+    /**
+     * @dev Returns the current amount of votes that `account` has.
+     */
+    function getVotes(address account) public view virtual override returns (uint256) {
+        return _delegateCheckpoints[account].latest();
+    }
+
+    /**
+     * @dev Returns the amount of votes that `account` had at the end of a past block (`blockNumber`).
+     *
+     * Requirements:
+     *
+     * - `blockNumber` must have been already mined
+     */
+    function getPastVotes(address account, uint256 blockNumber) public view virtual override returns (uint256) {
+        return _delegateCheckpoints[account].getAtProbablyRecentBlock(blockNumber);
+    }
+
+    /**
+     * @dev Returns the total supply of votes available at the end of a past block (`blockNumber`).
+     *
+     * NOTE: This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
+     * Votes that have not been delegated are still part of total supply, even though they would not participate in a
+     * vote.
+     *
+     * Requirements:
+     *
+     * - `blockNumber` must have been already mined
+     */
+    function getPastTotalSupply(uint256 blockNumber) public view virtual override returns (uint256) {
+        require(blockNumber < block.number, "Votes: block not yet mined");
+        return _totalCheckpoints.getAtProbablyRecentBlock(blockNumber);
+    }
+
+    /**
+     * @dev Returns the current total supply of votes.
+     */
+    function _getTotalSupply() internal view virtual returns (uint256) {
+        return _totalCheckpoints.latest();
+    }
+
+    /**
+     * @dev Returns the delegate that `account` has chosen.
+     */
+    function delegates(address account) public view virtual override returns (address) {
+        return _delegation[account];
+    }
+
+    /**
+     * @dev Delegates votes from the sender to `delegatee`.
+     */
+    function delegate(address delegatee) public virtual override {
+        address account = _msgSender();
+        _delegate(account, delegatee);
+    }
+
+    /**
+     * @dev Delegates votes from signer to `delegatee`.
+     */
+    function delegateBySig(
+        address delegatee,
+        uint256 nonce,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual override {
+        require(block.timestamp <= expiry, "Votes: signature expired");
+        address signer = ECDSA.recover(
+            _hashTypedDataV4(keccak256(abi.encode(_DELEGATION_TYPEHASH, delegatee, nonce, expiry))),
+            v,
+            r,
+            s
+        );
+        require(nonce == _useNonce(signer), "Votes: invalid nonce");
+        _delegate(signer, delegatee);
+    }
+
+    /**
+     * @dev Delegate all of `account`'s voting units to `delegatee`.
+     *
+     * Emits events {IVotes-DelegateChanged} and {IVotes-DelegateVotesChanged}.
+     */
+    function _delegate(address account, address delegatee) internal virtual {
+        address oldDelegate = delegates(account);
+        _delegation[account] = delegatee;
+
+        emit DelegateChanged(account, oldDelegate, delegatee);
+        _moveDelegateVotes(oldDelegate, delegatee, _getVotingUnits(account));
+    }
+
+    /**
+     * @dev Transfers, mints, or burns voting units. To register a mint, `from` should be zero. To register a burn, `to`
+     * should be zero. Total supply of voting units will be adjusted with mints and burns.
+     */
+    function _transferVotingUnits(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {
+        if (from == address(0)) {
+            _totalCheckpoints.push(_add, amount);
+        }
+        if (to == address(0)) {
+            _totalCheckpoints.push(_subtract, amount);
+        }
+        _moveDelegateVotes(delegates(from), delegates(to), amount);
+    }
+
+    /**
+     * @dev Moves delegated votes from one delegate to another.
+     */
+    function _moveDelegateVotes(
+        address from,
+        address to,
+        uint256 amount
+    ) private {
+        if (from != to && amount > 0) {
+            if (from != address(0)) {
+                (uint256 oldValue, uint256 newValue) = _delegateCheckpoints[from].push(_subtract, amount);
+                emit DelegateVotesChanged(from, oldValue, newValue);
+            }
+            if (to != address(0)) {
+                (uint256 oldValue, uint256 newValue) = _delegateCheckpoints[to].push(_add, amount);
+                emit DelegateVotesChanged(to, oldValue, newValue);
+            }
+        }
+    }
+
+    function _add(uint256 a, uint256 b) private pure returns (uint256) {
+        return a + b;
+    }
+
+    function _subtract(uint256 a, uint256 b) private pure returns (uint256) {
+        return a - b;
+    }
+
+    /**
+     * @dev Consumes a nonce.
+     *
+     * Returns the current value and increments nonce.
+     */
+    function _useNonce(address owner) internal virtual returns (uint256 current) {
+        Counters.Counter storage nonce = _nonces[owner];
+        current = nonce.current();
+        nonce.increment();
+    }
+
+    /**
+     * @dev Returns an address nonce.
+     */
+    function nonces(address owner) public view virtual returns (uint256) {
+        return _nonces[owner].current();
+    }
+
+    /**
+     * @dev Returns the contract's {EIP712} domain separator.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    /**
+     * @dev Must return the voting units held by an account.
+     */
+    function _getVotingUnits(address) internal view virtual returns (uint256);
+}

--- a/contracts/governance/utils/VotesForced.sol
+++ b/contracts/governance/utils/VotesForced.sol
@@ -122,6 +122,7 @@ abstract contract VotesForced is IVotes, Context, EIP712 {
             s
         );
         require(nonce == _useNonce(signer), "Votes: invalid nonce");
+        require(_getVotingUnits(signer) > 0, "Votes: no units to transfer");
         _delegate(signer, delegatee);
     }
 
@@ -134,7 +135,7 @@ abstract contract VotesForced is IVotes, Context, EIP712 {
         address oldDelegate = delegates(account);
 
         //TODO: Consider to revert if the operation is pointless
-        // require(oldDelegate != delegatee, "NO_CHANGE");
+        // require(oldDelegate != delegatee, "Votes: no change");
 
         _delegation[account] = delegatee;
         emit DelegateChanged(account, oldDelegate, delegatee);

--- a/contracts/governance/utils/VotesForced.sol
+++ b/contracts/governance/utils/VotesForced.sol
@@ -132,6 +132,7 @@ abstract contract VotesForced is IVotes, Context, EIP712 {
      * Emits events {IVotes-DelegateChanged} and {IVotes-DelegateVotesChanged}.
      */
     function _delegate(address account, address delegatee) internal virtual {
+        require(address(0) != delegatee, "Votes: invalid address");
         address oldDelegate = delegates(account);
 
         //TODO: Consider to revert if the operation is pointless

--- a/contracts/mocks/ERC721VotesForcedMock.sol
+++ b/contracts/mocks/ERC721VotesForcedMock.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../token/ERC721/extensions/ERC721Votes.sol";
+
+contract ERC721VotesMock is ERC721Votes {
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) EIP712(name, "1") {}
+
+    function getTotalSupply() public view returns (uint256) {
+        return _getTotalSupply();
+    }
+
+    function mint(address account, uint256 tokenId) public {
+        _mint(account, tokenId);
+    }
+
+    function burn(uint256 tokenId) public {
+        _burn(tokenId);
+    }
+
+    function getChainId() external view returns (uint256) {
+        return block.chainid;
+    }
+}

--- a/contracts/mocks/ERC721VotesForcedMock.sol
+++ b/contracts/mocks/ERC721VotesForcedMock.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
-import "../token/ERC721/extensions/ERC721Votes.sol";
+import "../token/ERC721/extensions/draft-ERC721VotesForced.sol";
 
-contract ERC721VotesMock is ERC721Votes {
+contract ERC721VotesForcedMock is ERC721VotesForced {
     constructor(string memory name, string memory symbol) ERC721(name, symbol) EIP712(name, "1") {}
 
     function getTotalSupply() public view returns (uint256) {
@@ -22,4 +22,5 @@ contract ERC721VotesMock is ERC721Votes {
     function getChainId() external view returns (uint256) {
         return block.chainid;
     }
+
 }

--- a/contracts/token/ERC721/extensions/draft-ERC721VotesForced.sol
+++ b/contracts/token/ERC721/extensions/draft-ERC721VotesForced.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../ERC721.sol";
+import "../../../governance/utils/Votes.sol";
+
+/**
+ * @dev Extension of ERC721 to support voting and delegation as implemented by {Votes}, where each individual NFT counts
+ * as 1 vote unit.
+ *
+ * Tokens do not count as votes until they are delegated, because votes must be tracked which incurs an additional cost
+ * on every transfer. Token holders can either delegate to a trusted representative who will decide how to make use of
+ * the votes in governance decisions, or they can delegate to themselves to be their own representative.
+ *
+ * _Available since v4.5._
+ */
+abstract contract ERC721Votes is ERC721, Votes {
+    /**
+     * @dev Adjusts votes when tokens are transferred.
+     *
+     * Emits a {IVotes-DelegateVotesChanged} event.
+     */
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        _transferVotingUnits(from, to, 1);
+        super._afterTokenTransfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Adjusts votes when a batch of tokens is transferred.
+     *
+     * Emits a {IVotes-DelegateVotesChanged} event.
+     */
+    function _afterConsecutiveTokenTransfer(
+        address from,
+        address to,
+        uint256 first,
+        uint96 size
+    ) internal virtual override {
+        _transferVotingUnits(from, to, size);
+        super._afterConsecutiveTokenTransfer(from, to, first, size);
+    }
+
+    /**
+     * @dev Returns the balance of `account`.
+     */
+    function _getVotingUnits(address account) internal view virtual override returns (uint256) {
+        return balanceOf(account);
+    }
+}

--- a/test/governance/utils/VotesForced.behavior.js
+++ b/test/governance/utils/VotesForced.behavior.js
@@ -1,0 +1,344 @@
+const { constants, expectEvent, expectRevert, time } = require('@openzeppelin/test-helpers');
+
+const { MAX_UINT256, ZERO_ADDRESS } = constants;
+
+const { fromRpcSig } = require('ethereumjs-util');
+const ethSigUtil = require('eth-sig-util');
+const Wallet = require('ethereumjs-wallet').default;
+
+const { EIP712Domain, domainSeparator } = require('../../helpers/eip712');
+
+const Delegation = [
+  { name: 'delegatee', type: 'address' },
+  { name: 'nonce', type: 'uint256' },
+  { name: 'expiry', type: 'uint256' },
+];
+
+const version = '1';
+
+function shouldBehaveLikeVotes () {
+  describe('run votes workflow', function () {
+    it('initial nonce is 0', async function () {
+      expect(await this.votes.nonces(this.account1)).to.be.bignumber.equal('0');
+    });
+
+    it('domain separator', async function () {
+      expect(
+        await this.votes.DOMAIN_SEPARATOR(),
+      ).to.equal(
+        await domainSeparator(this.name, version, this.chainId, this.votes.address),
+      );
+    });
+
+    describe('delegation with signature', function () {
+      const delegator = Wallet.generate();
+      const delegatorAddress = web3.utils.toChecksumAddress(delegator.getAddressString());
+      const nonce = 0;
+
+      const buildData = (chainId, verifyingContract, name, message) => ({
+        data: {
+          primaryType: 'Delegation',
+          types: { EIP712Domain, Delegation },
+          domain: { name, version, chainId, verifyingContract },
+          message,
+        },
+      });
+
+      beforeEach(async function () {
+        await this.votes.mint(delegatorAddress, this.NFT0);
+      });
+
+      it('accept signed delegation', async function () {
+        const { v, r, s } = fromRpcSig(ethSigUtil.signTypedMessage(
+          delegator.getPrivateKey(),
+          buildData(this.chainId, this.votes.address, this.name, {
+            delegatee: delegatorAddress,
+            nonce,
+            expiry: MAX_UINT256,
+          }),
+        ));
+
+        expect(await this.votes.delegates(delegatorAddress)).to.be.equal(ZERO_ADDRESS);
+
+        const { receipt } = await this.votes.delegateBySig(delegatorAddress, nonce, MAX_UINT256, v, r, s);
+        expectEvent(receipt, 'DelegateChanged', {
+          delegator: delegatorAddress,
+          fromDelegate: ZERO_ADDRESS,
+          toDelegate: delegatorAddress,
+        });
+        expectEvent(receipt, 'DelegateVotesChanged', {
+          delegate: delegatorAddress,
+          previousBalance: '0',
+          newBalance: '1',
+        });
+
+        expect(await this.votes.delegates(delegatorAddress)).to.be.equal(delegatorAddress);
+
+        expect(await this.votes.getVotes(delegatorAddress)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastVotes(delegatorAddress, receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+        await time.advanceBlock();
+        expect(await this.votes.getPastVotes(delegatorAddress, receipt.blockNumber)).to.be.bignumber.equal('1');
+      });
+
+      it('rejects reused signature', async function () {
+        const { v, r, s } = fromRpcSig(ethSigUtil.signTypedMessage(
+          delegator.getPrivateKey(),
+          buildData(this.chainId, this.votes.address, this.name, {
+            delegatee: delegatorAddress,
+            nonce,
+            expiry: MAX_UINT256,
+          }),
+        ));
+
+        await this.votes.delegateBySig(delegatorAddress, nonce, MAX_UINT256, v, r, s);
+
+        await expectRevert(
+          this.votes.delegateBySig(delegatorAddress, nonce, MAX_UINT256, v, r, s),
+          'Votes: invalid nonce',
+        );
+      });
+
+      it('rejects bad delegatee', async function () {
+        const { v, r, s } = fromRpcSig(ethSigUtil.signTypedMessage(
+          delegator.getPrivateKey(),
+          buildData(this.chainId, this.votes.address, this.name, {
+            delegatee: delegatorAddress,
+            nonce,
+            expiry: MAX_UINT256,
+          }),
+        ));
+
+        const receipt = await this.votes.delegateBySig(this.account1Delegatee, nonce, MAX_UINT256, v, r, s);
+        const { args } = receipt.logs.find(({ event }) => event === 'DelegateChanged');
+        expect(args.delegator).to.not.be.equal(delegatorAddress);
+        expect(args.fromDelegate).to.be.equal(ZERO_ADDRESS);
+        expect(args.toDelegate).to.be.equal(this.account1Delegatee);
+      });
+
+      it('rejects bad nonce', async function () {
+        const { v, r, s } = fromRpcSig(ethSigUtil.signTypedMessage(
+          delegator.getPrivateKey(),
+          buildData(this.chainId, this.votes.address, this.name, {
+            delegatee: delegatorAddress,
+            nonce,
+            expiry: MAX_UINT256,
+          }),
+        ));
+        await expectRevert(
+          this.votes.delegateBySig(delegatorAddress, nonce + 1, MAX_UINT256, v, r, s),
+          'Votes: invalid nonce',
+        );
+      });
+
+      it('rejects expired permit', async function () {
+        const expiry = (await time.latest()) - time.duration.weeks(1);
+        const { v, r, s } = fromRpcSig(ethSigUtil.signTypedMessage(
+          delegator.getPrivateKey(),
+          buildData(this.chainId, this.votes.address, this.name, {
+            delegatee: delegatorAddress,
+            nonce,
+            expiry,
+          }),
+        ));
+
+        await expectRevert(
+          this.votes.delegateBySig(delegatorAddress, nonce, expiry, v, r, s),
+          'Votes: signature expired',
+        );
+      });
+    });
+
+    describe('set delegation', function () {
+      describe('call', function () {
+        it('delegation with tokens', async function () {
+          await this.votes.mint(this.account1, this.NFT0);
+          expect(await this.votes.delegates(this.account1)).to.be.equal(ZERO_ADDRESS);
+
+          const { receipt } = await this.votes.delegate(this.account1, { from: this.account1 });
+          expectEvent(receipt, 'DelegateChanged', {
+            delegator: this.account1,
+            fromDelegate: ZERO_ADDRESS,
+            toDelegate: this.account1,
+          });
+          expectEvent(receipt, 'DelegateVotesChanged', {
+            delegate: this.account1,
+            previousBalance: '0',
+            newBalance: '1',
+          });
+
+          expect(await this.votes.delegates(this.account1)).to.be.equal(this.account1);
+
+          expect(await this.votes.getVotes(this.account1)).to.be.bignumber.equal('1');
+          expect(await this.votes.getPastVotes(this.account1, receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+          await time.advanceBlock();
+          expect(await this.votes.getPastVotes(this.account1, receipt.blockNumber)).to.be.bignumber.equal('1');
+        });
+
+        it('delegation without tokens', async function () {
+          expect(await this.votes.delegates(this.account1)).to.be.equal(ZERO_ADDRESS);
+
+          const { receipt } = await this.votes.delegate(this.account1, { from: this.account1 });
+          expectEvent(receipt, 'DelegateChanged', {
+            delegator: this.account1,
+            fromDelegate: ZERO_ADDRESS,
+            toDelegate: this.account1,
+          });
+          expectEvent.notEmitted(receipt, 'DelegateVotesChanged');
+
+          expect(await this.votes.delegates(this.account1)).to.be.equal(this.account1);
+        });
+      });
+    });
+
+    describe('change delegation', function () {
+      beforeEach(async function () {
+        await this.votes.mint(this.account1, this.NFT0);
+        await this.votes.delegate(this.account1, { from: this.account1 });
+      });
+
+      it('call', async function () {
+        expect(await this.votes.delegates(this.account1)).to.be.equal(this.account1);
+
+        const { receipt } = await this.votes.delegate(this.account1Delegatee, { from: this.account1 });
+        expectEvent(receipt, 'DelegateChanged', {
+          delegator: this.account1,
+          fromDelegate: this.account1,
+          toDelegate: this.account1Delegatee,
+        });
+        expectEvent(receipt, 'DelegateVotesChanged', {
+          delegate: this.account1,
+          previousBalance: '1',
+          newBalance: '0',
+        });
+        expectEvent(receipt, 'DelegateVotesChanged', {
+          delegate: this.account1Delegatee,
+          previousBalance: '0',
+          newBalance: '1',
+        });
+        const prevBlock = receipt.blockNumber - 1;
+        expect(await this.votes.delegates(this.account1)).to.be.equal(this.account1Delegatee);
+
+        expect(await this.votes.getVotes(this.account1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getVotes(this.account1Delegatee)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastVotes(this.account1, receipt.blockNumber - 1)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastVotes(this.account1Delegatee, prevBlock)).to.be.bignumber.equal('0');
+        await time.advanceBlock();
+        expect(await this.votes.getPastVotes(this.account1, receipt.blockNumber)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastVotes(this.account1Delegatee, receipt.blockNumber)).to.be.bignumber.equal('1');
+      });
+    });
+
+    describe('getPastTotalSupply', function () {
+      beforeEach(async function () {
+        await this.votes.delegate(this.account1, { from: this.account1 });
+      });
+
+      it('reverts if block number >= current block', async function () {
+        await expectRevert(
+          this.votes.getPastTotalSupply(5e10),
+          'block not yet mined',
+        );
+      });
+
+      it('returns 0 if there are no checkpoints', async function () {
+        expect(await this.votes.getPastTotalSupply(0)).to.be.bignumber.equal('0');
+      });
+
+      it('returns the latest block if >= last checkpoint block', async function () {
+        const t1 = await this.votes.mint(this.account1, this.NFT0);
+        await time.advanceBlock();
+        await time.advanceBlock();
+
+        expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+      });
+
+      it('returns zero if < first checkpoint block', async function () {
+        await time.advanceBlock();
+        const t2 = await this.votes.mint(this.account1, this.NFT1);
+        await time.advanceBlock();
+        await time.advanceBlock();
+
+        expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+      });
+
+      it('generally returns the voting balance at the appropriate checkpoint', async function () {
+        const t1 = await this.votes.mint(this.account1, this.NFT1);
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t2 = await this.votes.burn(this.NFT1);
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t3 = await this.votes.mint(this.account1, this.NFT2);
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t4 = await this.votes.burn(this.NFT2);
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t5 = await this.votes.mint(this.account1, this.NFT3);
+        await time.advanceBlock();
+        await time.advanceBlock();
+
+        expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber + 1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t3.receipt.blockNumber)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastTotalSupply(t3.receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastTotalSupply(t4.receipt.blockNumber)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t4.receipt.blockNumber + 1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastTotalSupply(t5.receipt.blockNumber)).to.be.bignumber.equal('1');
+        expect(await this.votes.getPastTotalSupply(t5.receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+      });
+    });
+
+    // The following tests are a adaptation of
+    // https://github.com/compound-finance/compound-protocol/blob/master/tests/Governance/CompTest.js.
+    describe('Compound test suite', function () {
+      beforeEach(async function () {
+        await this.votes.mint(this.account1, this.NFT0);
+        await this.votes.mint(this.account1, this.NFT1);
+        await this.votes.mint(this.account1, this.NFT2);
+        await this.votes.mint(this.account1, this.NFT3);
+      });
+
+      describe('getPastVotes', function () {
+        it('reverts if block number >= current block', async function () {
+          await expectRevert(
+            this.votes.getPastVotes(this.account2, 5e10),
+            'block not yet mined',
+          );
+        });
+
+        it('returns 0 if there are no checkpoints', async function () {
+          expect(await this.votes.getPastVotes(this.account2, 0)).to.be.bignumber.equal('0');
+        });
+
+        it('returns the latest block if >= last checkpoint block', async function () {
+          const t1 = await this.votes.delegate(this.account2, { from: this.account1 });
+          await time.advanceBlock();
+          await time.advanceBlock();
+          const latest = await this.votes.getVotes(this.account2);
+          const nextBlock = t1.receipt.blockNumber + 1;
+          expect(await this.votes.getPastVotes(this.account2, t1.receipt.blockNumber)).to.be.bignumber.equal(latest);
+          expect(await this.votes.getPastVotes(this.account2, nextBlock)).to.be.bignumber.equal(latest);
+        });
+
+        it('returns zero if < first checkpoint block', async function () {
+          await time.advanceBlock();
+          const t1 = await this.votes.delegate(this.account2, { from: this.account1 });
+          await time.advanceBlock();
+          await time.advanceBlock();
+
+          expect(await this.votes.getPastVotes(this.account2, t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+        });
+      });
+    });
+  });
+}
+
+module.exports = {
+  shouldBehaveLikeVotes,
+};

--- a/test/governance/utils/VotesForced.behavior.js
+++ b/test/governance/utils/VotesForced.behavior.js
@@ -68,7 +68,7 @@ function shouldBehaveLikeVotesForced () {
         });
         expectEvent.notEmitted(receipt, 'DelegateVotesChanged');
         expect(await this.votes.delegates(delegatorAddress)).to.be.equal(delegatorAddress);
-        const NFT0power = await this.votes.powerForToken(this.NFT0);
+        const NFT0power = await this.votes.powerOfToken(this.NFT0);
         expect(await this.votes.getVotes(delegatorAddress)).to.be.bignumber.equal(NFT0power);
       });
 
@@ -144,7 +144,7 @@ function shouldBehaveLikeVotesForced () {
       describe('call', function () {
         it('delegation with tokens', async function () {
           await this.votes.mint(this.account1, this.NFT0);
-          const NFT0power = await this.votes.powerForToken(this.NFT0);
+          const NFT0power = await this.votes.powerOfToken(this.NFT0);
           const { receipt } = await this.votes.delegate(this.account1, { from: this.account1 });
           expectEvent(receipt, 'DelegateChanged', {
             delegator: this.account1,
@@ -176,7 +176,7 @@ function shouldBehaveLikeVotesForced () {
       beforeEach(async function () {
         await this.votes.mint(this.account1, this.NFT0);
         await this.votes.delegate(this.account1, { from: this.account1 });
-        this.NFT0power = await this.votes.powerForToken(this.NFT0);
+        this.NFT0power = await this.votes.powerOfToken(this.NFT0);
       });
 
       it('call', async function () {
@@ -236,7 +236,7 @@ function shouldBehaveLikeVotesForced () {
 
         expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber + 1))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT0));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT0));
       });
 
       it('returns zero if < first checkpoint block', async function () {
@@ -247,7 +247,7 @@ function shouldBehaveLikeVotesForced () {
 
         expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber + 1))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT1));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT1));
       });
 
       it('generally returns the voting balance at the appropriate checkpoint', async function () {
@@ -269,21 +269,21 @@ function shouldBehaveLikeVotesForced () {
 
         expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT1));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT1));
         expect(await this.votes.getPastTotalSupply(t1.receipt.blockNumber + 1))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT1));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT1));
         expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t2.receipt.blockNumber + 1)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t3.receipt.blockNumber))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT2));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT2));
         expect(await this.votes.getPastTotalSupply(t3.receipt.blockNumber + 1))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT2));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT2));
         expect(await this.votes.getPastTotalSupply(t4.receipt.blockNumber)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t4.receipt.blockNumber + 1)).to.be.bignumber.equal('0');
         expect(await this.votes.getPastTotalSupply(t5.receipt.blockNumber))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT3));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT3));
         expect(await this.votes.getPastTotalSupply(t5.receipt.blockNumber + 1))
-          .to.be.bignumber.equal(await this.votes.powerForToken(this.NFT3));
+          .to.be.bignumber.equal(await this.votes.powerOfToken(this.NFT3));
       });
     });
 

--- a/test/governance/utils/VotesForced.behavior.js
+++ b/test/governance/utils/VotesForced.behavior.js
@@ -100,11 +100,10 @@ function shouldBehaveLikeVotesForced () {
           }),
         ));
 
-        const tx = await this.votes.delegateBySig(this.account1Delegatee, nonce, MAX_UINT256, v, r, s);
-        const { args } = tx.logs.find(({ event }) => event === 'DelegateChanged');
-        expect(args.delegator).to.not.be.equal(delegatorAddress);
-        expect(args.fromDelegate).to.not.be.equal(delegatorAddress);
-        expect(args.toDelegate).to.be.equal(this.account1Delegatee);
+        await expectRevert(
+          this.votes.delegateBySig(this.account1Delegatee, nonce, MAX_UINT256, v, r, s),
+          'Votes: no units to transfer',
+        );
       });
 
       it('rejects bad nonce', async function () {

--- a/test/token/ERC721/extensions/ERC721VotesForced.test.js
+++ b/test/token/ERC721/extensions/ERC721VotesForced.test.js
@@ -1,0 +1,174 @@
+/* eslint-disable */
+
+const { BN, expectEvent, time } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+
+const { promisify } = require('util');
+const queue = promisify(setImmediate);
+
+const ERC721VotesMock = artifacts.require('ERC721VotesMock');
+
+const { shouldBehaveLikeVotes } = require('../../../governance/utils/Votes.behavior');
+
+contract('ERC721Votes', function (accounts) {
+  const [ account1, account2, account1Delegatee, other1, other2 ] = accounts;
+  this.name = 'My Vote';
+  const symbol = 'MTKN';
+
+  beforeEach(async function () {
+    this.votes = await ERC721VotesMock.new(name, symbol);
+
+    // We get the chain id from the contract because Ganache (used for coverage) does not return the same chain id
+    // from within the EVM as from the JSON RPC interface.
+    // See https://github.com/trufflesuite/ganache-core/issues/515
+    this.chainId = await this.votes.getChainId();
+
+    this.NFT0 = new BN('10000000000000000000000000');
+    this.NFT1 = new BN('10');
+    this.NFT2 = new BN('20');
+    this.NFT3 = new BN('30');
+  });
+
+  describe('balanceOf', function () {
+    beforeEach(async function () {
+      await this.votes.mint(account1, this.NFT0);
+      await this.votes.mint(account1, this.NFT1);
+      await this.votes.mint(account1, this.NFT2);
+      await this.votes.mint(account1, this.NFT3);
+    });
+
+    it('grants to initial account', async function () {
+      expect(await this.votes.balanceOf(account1)).to.be.bignumber.equal('4');
+    });
+  });
+
+  describe('transfers', function () {
+    beforeEach(async function () {
+      await this.votes.mint(account1, this.NFT0);
+    });
+
+    it('no delegation', async function () {
+      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
+      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
+      expectEvent.notEmitted(receipt, 'DelegateVotesChanged');
+
+      this.account1Votes = '0';
+      this.account2Votes = '0';
+    });
+
+    it('sender delegation', async function () {
+      await this.votes.delegate(account1, { from: account1 });
+
+      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
+      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
+      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account1, previousBalance: '1', newBalance: '0' });
+
+      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
+
+      this.account1Votes = '0';
+      this.account2Votes = '0';
+    });
+
+    it('receiver delegation', async function () {
+      await this.votes.delegate(account2, { from: account2 });
+
+      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
+      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
+      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account2, previousBalance: '0', newBalance: '1' });
+
+      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
+
+      this.account1Votes = '0';
+      this.account2Votes = '1';
+    });
+
+    it('full delegation', async function () {
+      await this.votes.delegate(account1, { from: account1 });
+      await this.votes.delegate(account2, { from: account2 });
+
+      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
+      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
+      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account1, previousBalance: '1', newBalance: '0'});
+      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account2, previousBalance: '0', newBalance: '1' });
+
+      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
+
+      this.account1Votes = '0';
+      this.account2Votes = '1';
+    });
+
+    it('returns the same total supply on transfers', async function () {
+      await this.votes.delegate(account1, { from: account1 });
+
+      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
+
+      await time.advanceBlock();
+      await time.advanceBlock();
+
+      expect(await this.votes.getPastTotalSupply(receipt.blockNumber - 1)).to.be.bignumber.equal('1');
+      expect(await this.votes.getPastTotalSupply(receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+
+      this.account1Votes = '0';
+      this.account2Votes = '0';
+    });
+
+    it('generally returns the voting balance at the appropriate checkpoint', async function () {
+      await this.votes.mint(account1, this.NFT1);
+      await this.votes.mint(account1, this.NFT2);
+      await this.votes.mint(account1, this.NFT3);
+
+      const total = await this.votes.balanceOf(account1);
+
+      const t1 = await this.votes.delegate(other1, { from: account1 });
+      await time.advanceBlock();
+      await time.advanceBlock();
+      const t2 = await this.votes.transferFrom(account1, other2, this.NFT0, { from: account1 });
+      await time.advanceBlock();
+      await time.advanceBlock();
+      const t3 = await this.votes.transferFrom(account1, other2, this.NFT2, { from: account1 });
+      await time.advanceBlock();
+      await time.advanceBlock();
+      const t4 = await this.votes.transferFrom(other2, account1, this.NFT2, { from: other2 });
+      await time.advanceBlock();
+      await time.advanceBlock();
+
+      expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+      expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber)).to.be.bignumber.equal(total);
+      expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber + 1)).to.be.bignumber.equal(total);
+      expect(await this.votes.getPastVotes(other1, t2.receipt.blockNumber)).to.be.bignumber.equal('3');
+      expect(await this.votes.getPastVotes(other1, t2.receipt.blockNumber + 1)).to.be.bignumber.equal('3');
+      expect(await this.votes.getPastVotes(other1, t3.receipt.blockNumber)).to.be.bignumber.equal('2');
+      expect(await this.votes.getPastVotes(other1, t3.receipt.blockNumber + 1)).to.be.bignumber.equal('2');
+      expect(await this.votes.getPastVotes(other1, t4.receipt.blockNumber)).to.be.bignumber.equal('3');
+      expect(await this.votes.getPastVotes(other1, t4.receipt.blockNumber + 1)).to.be.bignumber.equal('3');
+
+      this.account1Votes = '0';
+      this.account2Votes = '0';
+    });
+
+    afterEach(async function () {
+      expect(await this.votes.getVotes(account1)).to.be.bignumber.equal(this.account1Votes);
+      expect(await this.votes.getVotes(account2)).to.be.bignumber.equal(this.account2Votes);
+
+      // need to advance 2 blocks to see the effect of a transfer on "getPastVotes"
+      const blockNumber = await time.latestBlock();
+      await time.advanceBlock();
+      expect(await this.votes.getPastVotes(account1, blockNumber)).to.be.bignumber.equal(this.account1Votes);
+      expect(await this.votes.getPastVotes(account2, blockNumber)).to.be.bignumber.equal(this.account2Votes);
+    });
+  });
+
+  describe('Voting workflow', function () {
+    beforeEach(async function () {
+      this.account1 = account1;
+      this.account1Delegatee = account1Delegatee;
+      this.account2 = account2;
+      this.name = 'My Vote';
+    });
+
+    shouldBehaveLikeVotes();
+  });
+});

--- a/test/token/ERC721/extensions/ERC721VotesForced.test.js
+++ b/test/token/ERC721/extensions/ERC721VotesForced.test.js
@@ -6,14 +6,15 @@ const { expect } = require('chai');
 const { promisify } = require('util');
 const queue = promisify(setImmediate);
 
-const ERC721VotesMock = artifacts.require('ERC721VotesMock');
+const ERC721VotesMock = artifacts.require('ERC721VotesForcedMock');
 
-const { shouldBehaveLikeVotes } = require('../../../governance/utils/Votes.behavior');
+const { shouldBehaveLikeVotesForced } = require('../../../governance/utils/VotesForced.behavior');
 
-contract('ERC721Votes', function (accounts) {
+contract('ERC721VotesForced', function (accounts) {
   const [ account1, account2, account1Delegatee, other1, other2 ] = accounts;
   this.name = 'My Vote';
   const symbol = 'MTKN';
+  const powerCalc = (tokenId) => (tokenId * 2);
 
   beforeEach(async function () {
     this.votes = await ERC721VotesMock.new(name, symbol);
@@ -23,10 +24,16 @@ contract('ERC721Votes', function (accounts) {
     // See https://github.com/trufflesuite/ganache-core/issues/515
     this.chainId = await this.votes.getChainId();
 
-    this.NFT0 = new BN('10000000000000000000000000');
+    this.NFT0 = new BN('10000000000000');
     this.NFT1 = new BN('10');
     this.NFT2 = new BN('20');
     this.NFT3 = new BN('30');
+    this.NFT0power = powerCalc(Number(this.NFT0)).toString();
+    this.totalVotingPower = powerCalc(Number(this.NFT0))
+        + powerCalc(Number(this.NFT1))
+        + powerCalc(Number(this.NFT2))
+        + powerCalc(Number(this.NFT3));
+    
   });
 
   describe('balanceOf', function () {
@@ -40,125 +47,101 @@ contract('ERC721Votes', function (accounts) {
     it('grants to initial account', async function () {
       expect(await this.votes.balanceOf(account1)).to.be.bignumber.equal('4');
     });
+
+    it('has adjusted units by default', async function () {
+        expect(await this.votes.getVotes(account1)).to.be.bignumber.equal(this.totalVotingPower.toString());
+      });
   });
 
   describe('transfers', function () {
+    
     beforeEach(async function () {
       await this.votes.mint(account1, this.NFT0);
     });
 
-    it('no delegation', async function () {
-      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
-      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
-      expectEvent.notEmitted(receipt, 'DelegateVotesChanged');
+    it('transfer token with power', async function () {
+        const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
+        expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
+        expectEvent(receipt, 'DelegateVotesChanged', { delegate: account1, previousBalance: this.NFT0power, newBalance: '0' });
+        expectEvent(receipt, 'DelegateVotesChanged', { delegate: account2, previousBalance: '0', newBalance: this.NFT0power });
 
-      this.account1Votes = '0';
-      this.account2Votes = '0';
-    });
+        const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
+        expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
 
-    it('sender delegation', async function () {
-      await this.votes.delegate(account1, { from: account1 });
-
-      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
-      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
-      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account1, previousBalance: '1', newBalance: '0' });
-
-      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
-      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
-
-      this.account1Votes = '0';
-      this.account2Votes = '0';
-    });
-
-    it('receiver delegation', async function () {
-      await this.votes.delegate(account2, { from: account2 });
-
-      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
-      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
-      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account2, previousBalance: '0', newBalance: '1' });
-
-      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
-      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
-
-      this.account1Votes = '0';
-      this.account2Votes = '1';
-    });
-
-    it('full delegation', async function () {
-      await this.votes.delegate(account1, { from: account1 });
-      await this.votes.delegate(account2, { from: account2 });
-
-      const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
-      expectEvent(receipt, 'Transfer', { from: account1, to: account2, tokenId: this.NFT0 });
-      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account1, previousBalance: '1', newBalance: '0'});
-      expectEvent(receipt, 'DelegateVotesChanged', { delegate: account2, previousBalance: '0', newBalance: '1' });
-
-      const { logIndex: transferLogIndex } = receipt.logs.find(({ event }) => event == 'Transfer');
-      expect(receipt.logs.filter(({ event }) => event == 'DelegateVotesChanged').every(({ logIndex }) => transferLogIndex < logIndex)).to.be.equal(true);
-
-      this.account1Votes = '0';
-      this.account2Votes = '1';
+        this.account1Votes = '0';
+        this.account2Votes = this.NFT0power;
     });
 
     it('returns the same total supply on transfers', async function () {
-      await this.votes.delegate(account1, { from: account1 });
-
       const { receipt } = await this.votes.transferFrom(account1, account2, this.NFT0, { from: account1 });
 
       await time.advanceBlock();
       await time.advanceBlock();
 
-      expect(await this.votes.getPastTotalSupply(receipt.blockNumber - 1)).to.be.bignumber.equal('1');
-      expect(await this.votes.getPastTotalSupply(receipt.blockNumber + 1)).to.be.bignumber.equal('1');
+      expect(await this.votes.getPastTotalSupply(receipt.blockNumber - 1)).to.be.bignumber.equal(this.NFT0power);
+      expect(await this.votes.getPastTotalSupply(receipt.blockNumber + 1)).to.be.bignumber.equal(this.NFT0power);
 
       this.account1Votes = '0';
-      this.account2Votes = '0';
+      this.account2Votes = this.NFT0power;
     });
 
     it('generally returns the voting balance at the appropriate checkpoint', async function () {
       await this.votes.mint(account1, this.NFT1);
       await this.votes.mint(account1, this.NFT2);
       await this.votes.mint(account1, this.NFT3);
+      const NFT1power = powerCalc(Number(this.NFT1));
+      const NFT2power = powerCalc(Number(this.NFT2));
+      const NFT3power = powerCalc(Number(this.NFT3));
+    //   const totalPower = NFT1power + NFT2power + NFT3power;
 
-      const total = await this.votes.balanceOf(account1);
+    //   const total = await this.votes.balanceOf(account1);
 
-      const t1 = await this.votes.delegate(other1, { from: account1 });
-      await time.advanceBlock();
-      await time.advanceBlock();
-      const t2 = await this.votes.transferFrom(account1, other2, this.NFT0, { from: account1 });
-      await time.advanceBlock();
-      await time.advanceBlock();
-      const t3 = await this.votes.transferFrom(account1, other2, this.NFT2, { from: account1 });
-      await time.advanceBlock();
-      await time.advanceBlock();
-      const t4 = await this.votes.transferFrom(other2, account1, this.NFT2, { from: other2 });
-      await time.advanceBlock();
-      await time.advanceBlock();
+        const t1 = await this.votes.delegate(other1, { from: account1 });
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t2 = await this.votes.transferFrom(account1, other2, this.NFT0, { from: account1 });
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t3 = await this.votes.transferFrom(account1, other2, this.NFT2, { from: account1 });
+        await time.advanceBlock();
+        await time.advanceBlock();
+        const t4 = await this.votes.transferFrom(other2, account1, this.NFT2, { from: other2 });
+        await time.advanceBlock();
+        await time.advanceBlock();
 
-      expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
-      expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber)).to.be.bignumber.equal(total);
-      expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber + 1)).to.be.bignumber.equal(total);
-      expect(await this.votes.getPastVotes(other1, t2.receipt.blockNumber)).to.be.bignumber.equal('3');
-      expect(await this.votes.getPastVotes(other1, t2.receipt.blockNumber + 1)).to.be.bignumber.equal('3');
-      expect(await this.votes.getPastVotes(other1, t3.receipt.blockNumber)).to.be.bignumber.equal('2');
-      expect(await this.votes.getPastVotes(other1, t3.receipt.blockNumber + 1)).to.be.bignumber.equal('2');
-      expect(await this.votes.getPastVotes(other1, t4.receipt.blockNumber)).to.be.bignumber.equal('3');
-      expect(await this.votes.getPastVotes(other1, t4.receipt.blockNumber + 1)).to.be.bignumber.equal('3');
+        //Power of tokens 0,1,2,3
+        expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber - 1)).to.be.bignumber.equal('0');
+        expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber)).to.be.bignumber.equal(this.totalVotingPower.toString());
+        expect(await this.votes.getPastVotes(other1, t1.receipt.blockNumber + 1)).to.be.bignumber.equal(this.totalVotingPower.toString());
+
+        //Power of Tokens 1,2,3
+        let expectedPower2 = (powerCalc(Number(this.NFT1)) + powerCalc(Number(this.NFT2)) + powerCalc(Number(this.NFT3)));
+        expect(await this.votes.getPastVotes(other1, t2.receipt.blockNumber)).to.be.bignumber.equal(expectedPower2.toString());
+        expect(await this.votes.getPastVotes(other1, t2.receipt.blockNumber + 1)).to.be.bignumber.equal(expectedPower2.toString());
+
+        //Power of Tokens 1,3
+        let expectedPower3 = (powerCalc(Number(this.NFT1)) + powerCalc(Number(this.NFT3)));
+        expect(await this.votes.getPastVotes(other1, t3.receipt.blockNumber)).to.be.bignumber.equal(expectedPower3.toString());
+        expect(await this.votes.getPastVotes(other1, t3.receipt.blockNumber + 1)).to.be.bignumber.equal(expectedPower3.toString());
+
+        //Power of Tokens 1,2,3
+        expect(await this.votes.getPastVotes(other1, t4.receipt.blockNumber)).to.be.bignumber.equal(expectedPower2.toString());
+        expect(await this.votes.getPastVotes(other1, t4.receipt.blockNumber + 1)).to.be.bignumber.equal(expectedPower2.toString());
 
       this.account1Votes = '0';
       this.account2Votes = '0';
     });
 
     afterEach(async function () {
-      expect(await this.votes.getVotes(account1)).to.be.bignumber.equal(this.account1Votes);
-      expect(await this.votes.getVotes(account2)).to.be.bignumber.equal(this.account2Votes);
-
-      // need to advance 2 blocks to see the effect of a transfer on "getPastVotes"
-      const blockNumber = await time.latestBlock();
-      await time.advanceBlock();
-      expect(await this.votes.getPastVotes(account1, blockNumber)).to.be.bignumber.equal(this.account1Votes);
-      expect(await this.votes.getPastVotes(account2, blockNumber)).to.be.bignumber.equal(this.account2Votes);
+        expect(await this.votes.getVotes(account1)).to.be.bignumber.equal(this.account1Votes);
+        expect(await this.votes.getVotes(account2)).to.be.bignumber.equal(this.account2Votes);
+        // need to advance 2 blocks to see the effect of a transfer on "getPastVotes"
+        const blockNumber = await time.latestBlock();
+        await time.advanceBlock();
+        expect(await this.votes.getPastVotes(account1, blockNumber)).to.be.bignumber.equal(this.account1Votes);
+        expect(await this.votes.getPastVotes(account2, blockNumber)).to.be.bignumber.equal(this.account2Votes);
     });
+    
   });
 
   describe('Voting workflow', function () {
@@ -169,6 +152,6 @@ contract('ERC721Votes', function (accounts) {
       this.name = 'My Vote';
     });
 
-    shouldBehaveLikeVotes();
+    shouldBehaveLikeVotesForced();
   });
 });


### PR DESCRIPTION
👋

As a follow-up on a forum thread regarding the assignment of different voting power for different ERC721 tokens.
https://forum.openzeppelin.com/t/erc721-voting-power-based-on-some-property/24550/22

## Problems
- The current version of Votes has an opt-out mechanism that requires all tokens to be of equal weight (so the getBalance() function would return a current voting power)
- Since ERC1155 doesn't support a function for getting the total number of tokens per account it's incompatible with the current Votes architecture.

## Solution
Remove the opt-out  option and track all voting power movements for all accounts at all time. 
- Allowing to assign different power to different tokens
- Paves the way to ERC1155 compatibility

Drawbacks:
- Using this contract will make all token transfers more expensive.

However, in some cases, post merge, and on L2s this increase in transaction fees might be worth it.


## Description

This PR includes a new version of Votes, dubbed VotesForced, with a new integration for ERC721 that uses an arbitrary token power function to determine the voting power for each token.


#### PR Checklist

- [X] Tests
- [ ] Documentation
- [ ] Changelog entry
