### PR TITLE
equality check for empty queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
  * `Math`: Add `log2`, `log10` and `log256`. ([#3670](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3670))
  * Arbitrum: Update the vendored arbitrum contracts to match the nitro upgrade. ([#3692](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3692))
  * `Math`: optimize `log256` rounding check. ([#3745](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3745))
+ * `DoubleEndedQueue`: optimize function `empty` by using `==` instead of `<=`. ([#3760](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3760))
 
 ### Breaking changes
 

--- a/contracts/utils/structs/DoubleEndedQueue.sol
+++ b/contracts/utils/structs/DoubleEndedQueue.sol
@@ -165,6 +165,6 @@ library DoubleEndedQueue {
      * @dev Returns true if the queue is empty.
      */
     function empty(Bytes32Deque storage deque) internal view returns (bool) {
-        return deque._end <= deque._begin;
+        return deque._end == deque._begin;
     }
 }


### PR DESCRIPTION
`_begin<=_end` is an invariant for DoubleEndedQueue, so `empty()` can just check `_end == _begin` as `_end` is never less than `_begin`.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [x] Changelog entry
