### PR TITLE
Update blurb on GovernorVotes compatibility

### DIFF
--- a/contracts/governance/README.adoc
+++ b/contracts/governance/README.adoc
@@ -20,7 +20,7 @@ For a written walkthrough, check out our guide on xref:ROOT:governance.adoc[How 
 
 Votes modules determine the source of voting power, and sometimes quorum number.
 
-* {GovernorVotes}: Extracts voting weight from an {ERC20Votes} token.
+* {GovernorVotes}: Extracts voting weight from an {ERC20Votes}, or since v4.5 an {ERC721Votes} token.
 
 * {GovernorVotesComp}: Extracts voting weight from a COMP-like or {ERC20VotesComp} token.
 


### PR DESCRIPTION
Since v4.5, GovernorVotes supports ERC721Votes tokens- this is detailed in the ERC721Votes API documentation but not in the Governor documentation, which is where developers like myself land first.

The result is confusion about whether or not OZ Governor contracts can support ERC721 in addition to ERC20. Developers may come to the Governor documentation, assume only ERC20Votes is supported, and then decide to look elsewhere for ERC721 governance (this happened to me)

Updating the blurb as shown fixes this

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
