### PR TITLE
gas optimize Checkpoints.sol

### DIFF
--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -51,7 +51,7 @@ library Checkpoints {
 
         uint256 len = self._checkpoints.length;
 
-        uint256 low = 0;
+        uint256 low;
         uint256 high = len;
 
         if (len > 5) {
@@ -139,7 +139,7 @@ library Checkpoints {
     ) private returns (uint224, uint224) {
         uint256 pos = self.length;
 
-        if (pos > 0) {
+        if (pos >= 1) {
             // Copying to memory is important here.
             Checkpoint memory last = _unsafeAccess(self, pos - 1);
 
@@ -300,7 +300,7 @@ library Checkpoints {
     ) private returns (uint224, uint224) {
         uint256 pos = self.length;
 
-        if (pos > 0) {
+        if (pos >= 1) {
             // Copying to memory is important here.
             Checkpoint224 memory last = _unsafeAccess(self, pos - 1);
 
@@ -465,7 +465,7 @@ library Checkpoints {
     ) private returns (uint160, uint160) {
         uint256 pos = self.length;
 
-        if (pos > 0) {
+        if (pos >= 1) {
             // Copying to memory is important here.
             Checkpoint160 memory last = _unsafeAccess(self, pos - 1);
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Fixes #???? Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


<!-- #### PR Checklist -->

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

### No need to explicitly initialize variables with default values

If a variable is not set/initialized, it is assumed to have the default value (0 for uint, false for bool, address(0) for address…). Explicitly initializing it with its default value is an anti-pattern and wastes gas. As an example: `for (uint256 i = 0; i < numIterations; ++i) {` should be replaced with: `for (uint256 i; i < numIterations; ++i) {`
Lines: 
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/Checkpoints.sol#L54

### `>=` is cheaper than `>` in if with optimizer disabled

`>=` is cheaper than `>` [in require](https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#-is-cheaper-than-). And it's also cheaper sometimes to use `>=` than `>` with the optimizer disabled. With optimizer enabled they have the same amount of gas used (checked only 0.8.17).

```Solidity
    // 0.8.17 | optimizer off
    uint256 public gas;

    event log(uint256 time);

    function checkStrict() external {
        gas = gasleft();
        if (999999999999999999 > 0) {
            emit log(block.timestamp);
        } // gas 23329
        gas -= gasleft();
    }

    function checkNonStrict() external {
        gas = gasleft();
        if (999999999999999999 >= 1) {
            emit log(block.timestamp);
        } // gas 23326
        gas -= gasleft();
    }
 ```

I changed > 0 to >= 1 where possible.

- [ ] Tests
- [ ] Documentation
- [x] Changelog entry
