### PR TITLE
func name implies array return but returns address

### DIFF
--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -85,7 +85,7 @@ abstract contract Votes is IVotes, Context, EIP712 {
     /**
      * @dev Returns the delegate that `account` has chosen.
      */
-    function delegates(address account) public view virtual override returns (address) {
+    function delegatee(address account) public view virtual override returns (address) {
         return _delegation[account];
     }
 


### PR DESCRIPTION
'delegates()' implies a plural return value, ie an array of delegates (addresses) changing the function name to 'delegatee()' more closely represents its return value, and it matches the comments in lines 93 and 101  'delegation()' would also be acceptable

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
