### PR TITLE
Fix comment in ERC721Consecutive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
  * `ReentrancyGuard`: Add a `_reentrancyGuardEntered` function to expose the guard status. ([#3714](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3714))
  * `ERC20Votes`: optimize by using unchecked arithmetic. ([#3748](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3748))
- * `ERC721Consecutive`: Fixed a comment describing event behavior during contract construction. ([#3778](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3778))
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  * `ReentrancyGuard`: Add a `_reentrancyGuardEntered` function to expose the guard status. ([#3714](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3714))
  * `ERC20Votes`: optimize by using unchecked arithmetic. ([#3748](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3748))
+ * `ERC721Consecutive`: Fixed a comment describing event behavior during contract construction. ([#3778](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3778))
 
 ## Unreleased
 

--- a/contracts/token/ERC721/extensions/ERC721Consecutive.sol
+++ b/contracts/token/ERC721/extensions/ERC721Consecutive.sol
@@ -73,7 +73,7 @@ abstract contract ERC721Consecutive is IERC2309, ERC721 {
      * - `batchSize` must not be greater than {_maxBatchSize}.
      * - The function is called in the constructor of the contract (directly or indirectly).
      *
-     * CAUTION: Does not emit a `Transfer` event. This is ERC721 compliant as long as it is done outside of the
+     * CAUTION: Does not emit a `Transfer` event. This is ERC721 compliant as long as it is done inside of the
      * constructor, which is enforced by this function.
      *
      * CAUTION: Does not invoke `onERC721Received` on the receiver.


### PR DESCRIPTION
Fixes a comment in `ERC721Consecutive.sol`.

The comment states that ERC721 does not require a Transfer event when minting outside the constructor. However, it is the other way around. ERC721 does not require it *inside* the constructor.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry
