### PR TITLE
Support custom error parameters object

### DIFF
--- a/test/crosschain/CrossChainEnabled.test.js
+++ b/test/crosschain/CrossChainEnabled.test.js
@@ -27,7 +27,11 @@ function shouldBehaveLikeReceiver (sender = randomAddress()) {
   it('should restrict to cross-chain call from a invalid sender', async function () {
     await expectRevertCustomError(
       this.bridge.call(sender, this.receiver, 'crossChainOwnerRestricted()'),
-      `InvalidCrossChainSender("${sender}", "${await this.receiver.owner()}")`,
+      'InvalidCrossChainSender(address actual, address expected)',
+      {
+        actual: sender,
+        expected: await this.receiver.owner(),
+      },
     );
   });
 

--- a/test/helpers/customError.js
+++ b/test/helpers/customError.js
@@ -2,8 +2,25 @@ const { config } = require('hardhat');
 
 const optimizationsEnabled = config.solidity.compilers.some(c => c.settings.optimizer.enabled);
 
+function fail (message) {
+  throw new Error(message);
+}
+
 /** Revert handler that supports custom errors. */
-async function expectRevertCustomError (promise, reason) {
+async function expectRevertCustomError (promise, customError, params = {}) {
+  const { groups } = customError.match(/^(?<name>\w+)(\((?<args>(\w+\s+\w+)(,\s*\w+\s+\w+)*)?\))?$/) ??
+    fail(`Invalid custom error "${customError}"`);
+
+  const reason = [
+    groups.name,
+    '(',
+    groups.args?.split(',')
+      .map(p => p.split(/\s/).filter(Boolean)[1])
+      .map(arg => `"${params[arg]}"` ?? fail(`Custom error "${customError}" requires "${arg}"`))
+      .join(', ') ?? '',
+    ')',
+  ].join('');
+
   try {
     await promise;
     expect.fail('Expected promise to throw but it didn\'t');


### PR DESCRIPTION
Prepare for wider use of custom errors with parameters

#### PR Checklist

- [x] Tests
