### PR TITLE
Add ERC4626 standard property tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/erc4626-tests"]
+	path = lib/erc4626-tests
+	url = https://github.com/a16z/erc4626-tests.git

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,2 +1,3 @@
 [fuzz]
 runs = 10000
+max_test_rejects = 1000000

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,3 @@
 [fuzz]
 runs = 10000
-max_test_rejects = 1000000
+max_test_rejects = 100000

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "erc4626-tests/ERC4626.test.sol";
+
+import {ERC20Mock} from "../../../../contracts/mocks/ERC20Mock.sol";
+import {ERC4626Mock, IERC20Metadata} from "../../../../contracts/mocks/ERC4626Mock.sol";
+
+contract ERC4626StdTest is ERC4626Test {
+    function setUp() public override {
+        _underlying_ = address(new ERC20Mock("MockERC20", "MockERC20", address(this), 0));
+        _vault_ = address(new ERC4626Mock(IERC20Metadata(_underlying_), "MockERC4626", "MockERC4626"));
+        _delta_ = 0;
+        _vaultMayBeEmpty = false;
+        _unlimitedAmount = false;
+    }
+}

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.0;
 
 import "erc4626-tests/ERC4626.test.sol";
 

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -12,6 +12,6 @@ contract ERC4626StdTest is ERC4626Test {
         _vault_ = address(new ERC4626Mock(IERC20Metadata(_underlying_), "MockERC4626", "MockERC4626"));
         _delta_ = 0;
         _vaultMayBeEmpty = false;
-        _unlimitedAmount = false;
+        _unlimitedAmount = true;
     }
 }

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -8,7 +8,7 @@ import {ERC4626Mock, IERC20Metadata} from "../../../../contracts/mocks/ERC4626Mo
 
 contract ERC4626StdTest is ERC4626Test {
     function setUp() public override {
-        _underlying_ = address(new ERC20Mock("MockERC20", "MockERC20", address(0), 0));
+        _underlying_ = address(new ERC20Mock("MockERC20", "MockERC20", address(this), 0));
         _vault_ = address(new ERC4626Mock(IERC20Metadata(_underlying_), "MockERC4626", "MockERC4626"));
         _delta_ = 0;
         _vaultMayBeEmpty = false;

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -8,7 +8,7 @@ import {ERC4626Mock, IERC20Metadata} from "../../../../contracts/mocks/ERC4626Mo
 
 contract ERC4626StdTest is ERC4626Test {
     function setUp() public override {
-        _underlying_ = address(new ERC20Mock("MockERC20", "MockERC20", address(this), 0));
+        _underlying_ = address(new ERC20Mock("MockERC20", "MockERC20", address(0), 0));
         _vault_ = address(new ERC4626Mock(IERC20Metadata(_underlying_), "MockERC4626", "MockERC4626"));
         _delta_ = 0;
         _vaultMayBeEmpty = false;


### PR DESCRIPTION
This PR adds the ERC4626 property tests for standard conformance: https://github.com/a16z/erc4626-tests

The idea is to maintain a common test suite that is applicable for any ERC4626 implementations, to help detect their unintentional discrepancies, if any. More details can be found in [this post](https://a16zcrypto.com/generalized-property-tests-for-erc4626-vaults/).

Any feedback or suggestions (e.g., adding more test cases, or improving fuzzing speed, etc.) would be greatly appreciated!

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
