### PR TITLE
Remove outdated blurb

### DIFF
--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -308,7 +308,7 @@ image::tally-admin.png[Administration Panel in Tally]
 
 We will see now how to do this manually using Ethers.js.
 
-If a timelock was set up, the first step to execution is queueing. You will notice that both the queue and execute functions require passing in the entire proposal parameters, as opposed to just the proposal id. This is necessary because this data is not stored on chain, as a measure to save gas. Note that these parameters can always be found in the events emitted by the contract. The only parameter that is not sent in its entirety is the description, since this is only needed in its hashed form to compute the proposal id.
+If a timelock was set up, the first step to execution is queueing.
 
 To queue, we call the queue function:
 


### PR DESCRIPTION
In GovernorCompatibilityBravo, which is the version being used in this tutorial, the queue () and execute() function do in fact only accept a uint proposalId parameter (contrary to the deletd paragraph). This proposalId is used to pull a ProposalDetails from storage which in turn is used to populate the rest of the required parameters for a call to queue/execute.

The deleted blurb directly contradicts the Bravo code, presumably because it was updated at some point but this tutorial was not.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
