### PR TITLE
Adds certora spec for Ownable2Step

### DIFF
--- a/certora/harnesses/Ownable2StepHarness.sol
+++ b/certora/harnesses/Ownable2StepHarness.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.8.0;
+
+import "../munged/access/Ownable2Step.sol";
+
+contract Ownable2StepHarness is Ownable2Step {
+  function restricted() external onlyOwner {
+  }
+}

--- a/certora/scripts/passes/verifyOwnable2Step.sh
+++ b/certora/scripts/passes/verifyOwnable2Step.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+certoraRun \
+    certora/harnesses/Ownable2StepHarness.sol \
+    --verify Ownable2StepHarness:certora/specs/Ownable2Step.spec \
+    --solc solc \
+    --optimistic_loop \
+    $@

--- a/certora/specs/Ownable2Step.spec
+++ b/certora/specs/Ownable2Step.spec
@@ -1,0 +1,56 @@
+methods {
+    renounceOwnership()
+    transferOwnership(address)
+    acceptOwnership()
+    restricted()
+
+    owner() returns (address) envfree
+    pendingOwner() returns (address) envfree
+} 
+
+definition noPendingOwner() returns bool = 
+    pendingOwner() == 0;
+
+rule transferOwnershipSetsPendingOwner(env e) {
+    address newOwner;
+    address currentOwner = owner();
+
+    transferOwnership(e, newOwner);
+    
+    assert pendingOwner() == newOwner, "pending owner not set";
+    assert owner() == currentOwner, "current owner changed";
+}
+
+rule onlyCurrentOwnerCanCallOnlyOwner(method f, env e)
+    filtered { f -> 
+        f.selector == renounceOwnership().selector || 
+        f.selector == transferOwnership(address).selector ||
+        f.selector == restricted().selector
+    } {
+    address currentOwner = owner();
+
+    calldataarg args;
+    f@withrevert(e, args);
+    bool success = !lastReverted;
+    
+    assert success => e.msg.sender == currentOwner, "transfer by not owner";
+}
+
+rule onlyPendingOwnerCanAccept(env e){
+    address pending;
+    pending = pendingOwner();
+
+    acceptOwnership(e);
+
+    assert e.msg.sender == pending, "accepted by not pending owner";
+    assert noPendingOwner(), "pending owner not cleared";
+    assert owner() == pending, "owner not transferred";
+}
+
+rule renounceDoesNotRequireTwoSteps(env e) {
+    address currentOwner = owner();
+    renounceOwnership(e);
+
+    assert noPendingOwner(), "pending owner not cleared";
+    assert owner() == 0, "owner not cleared";
+}

--- a/certora/specs/Ownable2Step.spec
+++ b/certora/specs/Ownable2Step.spec
@@ -37,8 +37,7 @@ rule onlyCurrentOwnerCanCallOnlyOwner(method f, env e)
 }
 
 rule onlyPendingOwnerCanAccept(env e){
-    address pending;
-    pending = pendingOwner();
+    address pending = pendingOwner();
 
     acceptOwnership(e);
 
@@ -53,4 +52,17 @@ rule renounceDoesNotRequireTwoSteps(env e) {
 
     assert noPendingOwner(), "pending owner not cleared";
     assert owner() == 0, "owner not cleared";
+}
+
+rule onlyOwnerOrPendingOwnerCanChangeOwnership(env e, method f) {
+    address oldOwner = owner();
+    address oldPendingOwner = pendingOwner();
+    
+    calldataarg args;
+    f(e, args);
+    
+    assert (owner() != oldOwner || pendingOwner() != oldPendingOwner) 
+        => (e.msg.sender == oldOwner || e.msg.sender == oldPendingOwner);
+    
+    assert (owner() != oldOwner) => (pendingOwner() == 0);
 }


### PR DESCRIPTION
Adds a certora spec for formally verifying `Ownable2Step`. Includes the rules:
- `transferOwnershipSetsPendingOwner`
- `onlyCurrentOwnerCanCallOnlyOwner`: verifies that transfer, renounce, and user functions decorated with onlyOwner can indeed only be called by the current owner
- `onlyPendingOwnerCanAccept`
- `renounceDoesNotRequireTwoSteps`