### PR TITLE
perf(proxy): add memory safe

### DIFF
--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -20,6 +20,7 @@ abstract contract Proxy {
      * This function does not return to its internal call site, it will return directly to the external caller.
      */
     function _delegate(address implementation) internal virtual {
+        /// @solidity memory-safe-assembly
         assembly {
             // Copy msg.data. We take full control of memory in this inline assembly
             // block because it will not return to Solidity code. We overwrite the


### PR DESCRIPTION
Add `@solidity memory-safe-assembly` to `_delegate`.

I also found some assembly blocks aren't labeled `memory-safe`.
Should I add memory-safe to all assembly blocks?