### PR TITLE
Fix whitespace in docs

### DIFF
--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -87,4 +87,4 @@ A preset ERC721 is available, https://github.com/OpenZeppelin/openzeppelin-contr
 
 This contract is ready to deploy without having to write any Solidity code. It can be used as-is for quick prototyping and testing but is also suitable for production environments.
 
-NOTE: Contract presets are now deprecated in favor of link:https://wizard.openzeppelin.com[Contracts Wizard] as a more powerful alternative.
+NOTE: Contract presets are now deprecated in favor of https://wizard.openzeppelin.com[Contracts Wizard] as a more powerful alternative.

--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -87,4 +87,4 @@ A preset ERC721 is available, https://github.com/OpenZeppelin/openzeppelin-contr
 
 This contract is ready to deploy without having to write any Solidity code. It can be used as-is for quick prototyping and testing but is also suitable for production environments.
 
-NOTE: Contract presets are now deprecated in favor of https://wizard.openzeppelin.com[Contracts Wizard] as a more powerful alternative.
+NOTE: Contract presets are now deprecated in favor of link:https://wizard.openzeppelin.com[Contracts Wizard] as a more powerful alternative.


### PR DESCRIPTION
Fixes the link in the NOTE section.

<img width="770" alt="Screenshot 2022-11-23 at 16 39 43" src="https://user-images.githubusercontent.com/26070224/203587777-0ef6ba11-065c-4499-8b56-59f5fbddafce.png">
