### PR TITLE
Update ERC1155Supply.sol

### DIFF
--- a/contracts/token/ERC1155/extensions/ERC1155Supply.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Supply.sol
@@ -14,13 +14,18 @@ import "../ERC1155.sol";
  * same id are not going to be minted.
  */
 abstract contract ERC1155Supply is ERC1155 {
-    mapping(uint256 => uint256) private _totalSupply;
+    mapping(uint256 => uint256) private _totalSupplyBORN;
+    mapping(uint256 => uint256) private _totalSupplyALIVE;
 
     /**
      * @dev Total amount of tokens in with a given id.
      */
-    function totalSupply(uint256 id) public view virtual returns (uint256) {
-        return _totalSupply[id];
+    function totalSupply(uint256 id, bool isALIVE) public view virtual returns (uint256) { //Adds isALIVE parameter to avoid misunderstanding and improve usability
+        if (isALIVE == false) {
+            return _totalSupplyBORN[id];
+        } else {
+            return _totalSupplyALIVE[id];
+        }
     }
 
     /**
@@ -45,7 +50,8 @@ abstract contract ERC1155Supply is ERC1155 {
 
         if (from == address(0)) {
             for (uint256 i = 0; i < ids.length; ++i) {
-                _totalSupply[ids[i]] += amounts[i];
+                _totalSupplyBORN[ids[i]] += amounts[i];
+                _totalSupplyALIVE[ids[i]] += amounts[i];
             }
         }
 
@@ -53,10 +59,10 @@ abstract contract ERC1155Supply is ERC1155 {
             for (uint256 i = 0; i < ids.length; ++i) {
                 uint256 id = ids[i];
                 uint256 amount = amounts[i];
-                uint256 supply = _totalSupply[id];
+                uint256 supply = _totalSupplyALIVE[id];
                 require(supply >= amount, "ERC1155: burn amount exceeds totalSupply");
                 unchecked {
-                    _totalSupply[id] = supply - amount;
+                    _totalSupplyALIVE[id] = supply - amount;
                 }
             }
         }


### PR DESCRIPTION
//Adds isALIVE parameter to avoid misunderstanding and improve the usability

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
Adds isALIVE parameter to avoid misunderstanding and improve the usability.
<!-- Include any context necessary for understanding the PR's purpose. -->
When we are tracking supplies, it is important to know whether we want to include tokens that are dead or alive. Just a simple totalSupply is misleading when it is not explicitly explained as totalSupply of only the existing tokens. This new parameter provides a quick fix that allows smart contract developers to know exactly what they will get when they code.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
