### PR TITLE
Add additional conditions when testing ERC4626 roundtrip

### DIFF
--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -16,7 +16,8 @@ contract ERC4626StdTest is ERC4626Test {
         _unlimitedAmount = true;
     }
 
-    function test_RT_mint_withdraw(ERC4626Test.Init memory init, uint shares) public override {
+    // solhint-disable-next-line func-name-mixedcase
+    function test_RT_mint_withdraw(ERC4626Test.Init memory init, uint256 shares) public override {
         // There is an edge case where we currently behave different than the property tests,
         // when all assets are lost to negative yield.
 

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "erc4626-tests/ERC4626.test.sol";
 
+import {SafeCast} from "../../../../contracts/utils/math/SafeCast.sol";
 import {ERC20Mock} from "../../../../contracts/mocks/ERC20Mock.sol";
 import {ERC4626Mock, IERC20Metadata} from "../../../../contracts/mocks/ERC4626Mock.sol";
 
@@ -13,5 +14,22 @@ contract ERC4626StdTest is ERC4626Test {
         _delta_ = 0;
         _vaultMayBeEmpty = false;
         _unlimitedAmount = true;
+    }
+
+    function test_RT_mint_withdraw(ERC4626Test.Init memory init, uint shares) public override {
+        // There is an edge case where we currently behave different than the property tests,
+        // when all assets are lost to negative yield.
+
+        // Sum all initially deposited assets.
+        int256 initAssets = 0;
+        for (uint256 i = 0; i < init.share.length; i++) {
+            vm.assume(init.share[i] <= uint256(type(int256).max - initAssets));
+            initAssets += SafeCast.toInt256(init.share[i]);
+        }
+
+        // Reject tests where the yield loses all assets from the vault.
+        vm.assume(init.yield > -initAssets);
+
+        super.test_RT_mint_withdraw(init, shares);
     }
 }


### PR DESCRIPTION
We have a flaky test in the ERC4626 property tests due to a property that is not valid in some edge cases. Namely, when the vault loses all assets (through negative yield), the round trip `mint-withdraw` is not valid as specified. For now we filter out those edge cases.