### PR TITLE
Indirect owner checks

### DIFF
--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -38,6 +38,14 @@ abstract contract Ownable is Context {
     }
 
     /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier checkOwner(address account) {
+        _checkOwner(account);
+        _;
+    }
+
+    /**
      * @dev Returns the address of the current owner.
      */
     function owner() public view virtual returns (address) {
@@ -49,6 +57,13 @@ abstract contract Ownable is Context {
      */
     function _checkOwner() internal view virtual {
         require(owner() == _msgSender(), "Ownable: caller is not the owner");
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner(address account) internal view virtual {
+        require(owner() == account, "Ownable: account is not the owner");
     }
 
     /**


### PR DESCRIPTION
Sometimes developers need to check owner indirectly. For example, if some protocol provide it's `msg.sender` via callback argument as for example happens here: https://github.com/1inch/limit-order-protocol/blob/171c5d7bbb280d9f754404828051f2a47fb726df/contracts/interfaces/NotificationReceiver.sol#L35.

Action flow:
- User makes trade in Limit Order Protocol with interaction callback parameter
- In the middle of the swap desired contract gets notified about the swap
- It can check if this swap was originated by it's own owner by the first argument of the callback function

```solidity
function fillOrderInteraction(
    address taker,
    uint256 makingAmount,
    uint256 takingAmount,
    bytes memory interactiveData
)
    external
    onlyLimitOrderProtocol
    checkOwner(taker)
    returns(uint256 offeredTakingAmount)
{
    // ...
}
```

#### PR Checklist

To be done...

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
