### PR TITLE
✍️ IERC20: use `amount` instead of `value`

### DIFF
--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -8,18 +8,18 @@ pragma solidity ^0.8.0;
  */
 interface IERC20 {
     /**
-     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * @dev Emitted when `amount` tokens are moved from one account (`from`) to
      * another (`to`).
      *
-     * Note that `value` may be zero.
+     * Note that `amount` may be zero.
      */
-    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 amount);
 
     /**
      * @dev Emitted when the allowance of a `spender` for an `owner` is set by
-     * a call to {approve}. `value` is the new allowance.
+     * a call to {approve}. `amount` is the new allowance.
      */
-    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
 
     /**
      * @dev Returns the amount of tokens in existence.


### PR DESCRIPTION
✍️  use `amount` instead of `value` for event params to make match underlying functions

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry