### PR TITLE
Optimize "_isApprovedOrOwner"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  * `ReentrancyGuard`: Add a `_reentrancyGuardEntered` function to expose the guard status. ([#3714](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3714))
  * `ERC20Votes`: optimize by using unchecked arithmetic. ([#3748](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3748))
+ * `ERC721`: optimize `_isApprovedOrOwner` by not checking that `tokenId` exists twice. ([#3879](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3879))
  * `Initializable`: optimize `_disableInitializers` by using `!=` instead of `<`. ([#3787](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3787))
  * `Math`: optimize `log256` rounding check. ([#3745](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3745))
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -237,7 +237,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * - `tokenId` must exist.
      */
     function _isApprovedOrOwner(address spender, uint256 tokenId) internal view virtual returns (bool) {
-        address owner = ERC721._ownerOf(tokenId);
+        address owner = _ownerOf(tokenId);
         return (spender == owner || isApprovedForAll(owner, spender) || getApproved(tokenId) == spender);
     }
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -237,7 +237,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * - `tokenId` must exist.
      */
     function _isApprovedOrOwner(address spender, uint256 tokenId) internal view virtual returns (bool) {
-        address owner = ERC721.ownerOf(tokenId);
+        address owner = ERC721._ownerOf(tokenId);
         return (spender == owner || isApprovedForAll(owner, spender) || getApproved(tokenId) == spender);
     }
 


### PR DESCRIPTION
#### Description

There is no point in calling `ERC721.ownerOf` in the `_isApprovedOrOwner` function, because the requirement that the `tokenId` must exist is already checked in the `getApproved` function (which calls the `_requireMinted` function).

In this PR, I change the call to the internal `ERC721._ownerOf` function (with an underscore) to avoid checking twice if the owner is the zero address, saving a little gas whenever `_isApprovedOrOwner` is called.

I did not touch any of the tests, but they still pass.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog entry
