### PR TITLE
🥢Pausable: Don't set pause false via constructor.

### DIFF
--- a/contracts/security/Pausable.sol
+++ b/contracts/security/Pausable.sol
@@ -30,9 +30,7 @@ abstract contract Pausable is Context {
     /**
      * @dev Initializes the contract in unpaused state.
      */
-    constructor() {
-        _paused = false;
-    }
+    constructor() {}
 
     /**
      * @dev Modifier to make a function callable only when the contract is not paused.


### PR DESCRIPTION
It seems wasteful to set `_paused` to `false` in constructor as this is default value anyways.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
