### PR TITLE
Fix typos in testing files

### DIFF
--- a/contracts/mocks/MultipleInheritanceInitializableMocks.sol
+++ b/contracts/mocks/MultipleInheritanceInitializableMocks.sol
@@ -16,7 +16,7 @@ import "../proxy/utils/Initializable.sol";
 //      -- Child --
 
 /**
- * Sample base intializable contract that is a human
+ * Sample base initializable contract that is a human
  */
 contract SampleHuman is Initializable {
     bool public isHuman;
@@ -37,7 +37,7 @@ contract SampleHuman is Initializable {
 }
 
 /**
- * Sample base intializable contract that defines a field mother
+ * Sample base initializable contract that defines a field mother
  */
 contract SampleMother is Initializable, SampleHuman {
     uint256 public mother;
@@ -59,7 +59,7 @@ contract SampleMother is Initializable, SampleHuman {
 }
 
 /**
- * Sample base intializable contract that defines a field gramps
+ * Sample base initializable contract that defines a field gramps
  */
 contract SampleGramps is Initializable, SampleHuman {
     string public gramps;
@@ -81,7 +81,7 @@ contract SampleGramps is Initializable, SampleHuman {
 }
 
 /**
- * Sample base intializable contract that defines a field father and extends from gramps
+ * Sample base initializable contract that defines a field father and extends from gramps
  */
 contract SampleFather is Initializable, SampleGramps {
     uint256 public father;

--- a/test/governance/Governor.test.js
+++ b/test/governance/Governor.test.js
@@ -454,7 +454,7 @@ contract('Governor', function (accounts) {
       await expectRevert(this.helper.propose(), 'Governor: empty proposal');
     });
 
-    it('missmatch #1', async function () {
+    it('mismatch #1', async function () {
       this.helper.setProposal({
         targets: [ ],
         values: [ web3.utils.toWei('0') ],
@@ -463,7 +463,7 @@ contract('Governor', function (accounts) {
       await expectRevert(this.helper.propose(), 'Governor: invalid proposal length');
     });
 
-    it('missmatch #2', async function () {
+    it('mismatch #2', async function () {
       this.helper.setProposal({
         targets: [ this.receiver.address ],
         values: [ ],
@@ -472,7 +472,7 @@ contract('Governor', function (accounts) {
       await expectRevert(this.helper.propose(), 'Governor: invalid proposal length');
     });
 
-    it('missmatch #3', async function () {
+    it('mismatch #3', async function () {
       this.helper.setProposal({
         targets: [ this.receiver.address ],
         values: [ web3.utils.toWei('0') ],

--- a/test/governance/compatibility/GovernorCompatibilityBravo.test.js
+++ b/test/governance/compatibility/GovernorCompatibilityBravo.test.js
@@ -168,7 +168,7 @@ contract('GovernorCompatibilityBravo', function (accounts) {
     );
   });
 
-  it('double voting is forbiden', async function () {
+  it('double voting is forbidden', async function () {
     await this.helper.propose({ from: proposer });
     await this.helper.waitForSnapshot();
     await this.helper.vote({ support: Enums.VoteType.For }, { from: voter1 });


### PR DESCRIPTION
Hey,

This PR will fix : 

- 4 typos in `contracts/mocks/MultipleInheritanceInitializableMocks.sol`
- 3 typos in `test/governance/Governor.test.js`
- 1 typo in `test/governance/compatibility/GovernorCompatibilityBravo.test.js`



Best! :robot: