### PR TITLE
Rename approved parameter in IERC721

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
  * `ERC20Votes`: optimize by using unchecked arithmetic. ([#3748](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3748))
  * `Initializable`: optimize `_disableInitializers` by using `!=` instead of `<`. ([#3787](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3787))
  * `Math`: optimize `log256` rounding check. ([#3745](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3745))
- * `ERC721`: rename `_approved` argument to `approved` in `setApprovalForAll` function in `IERC721` interface ([#3900](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3900))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  * `ERC20Votes`: optimize by using unchecked arithmetic. ([#3748](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3748))
  * `Initializable`: optimize `_disableInitializers` by using `!=` instead of `<`. ([#3787](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3787))
  * `Math`: optimize `log256` rounding check. ([#3745](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3745))
+ * `ERC721`: rename `_approved` argument to `approved` in `setApprovalForAll` function in `IERC721` interface ([#3900](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3900))
 
 ### Deprecations
 

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -125,7 +125,7 @@ interface IERC721 is IERC165 {
      *
      * Emits an {ApprovalForAll} event.
      */
-    function setApprovalForAll(address operator, bool _approved) external;
+    function setApprovalForAll(address operator, bool approved) external;
 
     /**
      * @dev Returns the account approved for `tokenId` token.


### PR DESCRIPTION
The name of the second argument of the `setApprovedForAll` is different between the interface (`IERC721`) and the implementation contract (`ERC721`).