### PR TITLE
Disable npm audit when installing deps in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
         path: '**/node_modules'
         key: npm-v3-${{ hashFiles('**/package-lock.json') }}
     - name: Install dependencies
-      run: npm ci --prefer-offline
+      run: npm ci --prefer-offline --no-audit
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
       env:


### PR DESCRIPTION
This makes it faster to install dependencies.