### PR TITLE
`Base64.encode`: Masking is not required for the first part of the block

### DIFF
--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -62,7 +62,7 @@ library Base64 {
                 // and finally write it in the result pointer but with a left shift
                 // of 256 (1 byte) - 8 (1 ASCII char) = 248 bits
 
-                mstore8(resultPtr, mload(add(tablePtr, and(shr(18, input), 0x3F))))
+                mstore8(resultPtr, mload(add(tablePtr, shr(18, input))))
                 resultPtr := add(resultPtr, 1) // Advance
 
                 mstore8(resultPtr, mload(add(tablePtr, and(shr(12, input), 0x3F))))


### PR DESCRIPTION
As title. Note that masking is not required for the first part of the block, as 6 bits are already extracted when the chunk is shifted to the right by 18 bits (out of 24 bits). To illustrate why, here is an example:
Example case for `c1`:

`c1` =  011100 000111 100101 110100 (6bit parts for illustration)
`c1 >> 18` = 000000 000000 000000 011100 (6bit parts for illustration)
63 (or `0x3F`) is `000000000000000000111111` in binary.
Thus, the bitwise `AND` operation is redundant in that case.