### PR TITLE
Pin Slither to 0.9.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,6 +78,8 @@ jobs:
         uses: ./.github/actions/setup
       - run: rm foundry.toml
       - uses: crytic/slither-action@v0.2.0
+        with:
+          slither-version: 0.9.1
 
   codespell:
     if: github.repository != 'OpenZeppelin/openzeppelin-contracts-upgradeable'


### PR DESCRIPTION
Slither 0.9.2 was just released and it includes changes to the reentrancy detector. Unfortunately this is resulting in false positives for TimelockController. This PR pins Slither to 0.9.1 until it's fixed.

```
Reentrancy in TimelockController.executeBatch(address[],uint256[],bytes[],bytes32,bytes32) (contracts/governance/TimelockController.sol#308-329):
	External calls:
	- _execute(target,value,payload) (contracts/governance/TimelockController.sol#325)
		- (success) = target.call{value: value}(data) (contracts/governance/TimelockController.sol#335)
	State variables written after the call(s):
	- _afterCall(id) (contracts/governance/TimelockController.sol#328)
		- _timestamps[id] = _DONE_TIMESTAMP (contracts/governance/TimelockController.sol#352)
	TimelockController._timestamps (contracts/governance/TimelockController.sol#32) can be used in cross function reentrancies:
	- TimelockController._afterCall(bytes32) (contracts/governance/TimelockController.sol#350-353)
	- TimelockController._schedule(bytes32,uint256) (contracts/governance/TimelockController.sol#252-256)
	- TimelockController.cancel(bytes32) (contracts/governance/TimelockController.sol#265-270)
	- TimelockController.getTimestamp(bytes32) (contracts/governance/TimelockController.sol#159-161)
```

The cross function reentrancies are all guarded and would revert on reentrancy.