### PR TITLE
Ignore reentrancy in`executeBatch` and update Slither config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,8 +77,6 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: crytic/slither-action@v0.2.0
-        with:
-          slither-version: 0.9.2
 
   codespell:
     if: github.repository != 'OpenZeppelin/openzeppelin-contracts-upgradeable'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,10 +76,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
-      - run: rm foundry.toml
       - uses: crytic/slither-action@v0.2.0
         with:
-          slither-version: 0.9.1
+          slither-version: 0.9.2
 
   codespell:
     if: github.repository != 'OpenZeppelin/openzeppelin-contracts-upgradeable'

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -311,6 +311,7 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
      *
      * - the caller must have the 'executor' role.
      */
+    // slither-disable-next-line reentrancy-eth
     function executeBatch(
         address[] calldata targets,
         uint256[] calldata values,

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -311,6 +311,8 @@ contract TimelockController is AccessControl, IERC721Receiver, IERC1155Receiver 
      *
      * - the caller must have the 'executor' role.
      */
+    // This function can reenter, but it doesn't pose a risk because _afterCall checks that the proposal is pending,
+    // thus any modifications to the operation during reentrancy should be caught.
     // slither-disable-next-line reentrancy-eth
     function executeBatch(
         address[] calldata targets,

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,5 @@
 {
     "detectors_to_run": "reentrancy-eth,reentrancy-no-eth,reentrancy-unlimited-gas",
-    "filter_paths": "contracts/mocks"
+    "filter_paths": "contracts/mocks",
+    "compile_force_framework": "hardhat"
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->
@frangio [indicated](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3949) this reentrancy isn't a vulnerability since the callbacks are guarded, so I've added a disable comment to `executeBatch` This result was detected in slither 0.9.2 because this [bug](https://github.com/crytic/slither/issues/1019) was fixed and now reentrancy in for loops is considered properly.  

Additionally, I've configured slither to compile with hardhat and upgraded its version in the GitHub action to 0.9.2.

ref https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3949

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
