### PR TITLE
Show if event parameter is indexed in docs

### DIFF
--- a/docs/templates/helpers.js
+++ b/docs/templates/helpers.js
@@ -11,7 +11,7 @@ module.exports.names = params => params.map(p => p.name).join(', ');
 module.exports['typed-params'] = params => {
   console.log(params);
   if (params == undefined) return [];
-  return params.map(p => `${p.type}${p.indexed ? ' indexed': ''}${p.name ? ' ' + p.name : ''}`).join(', ');
+  return params.map(p => `${p.type}${p.indexed ? ' indexed' : ''}${p.name ? ' ' + p.name : ''}`).join(', ');
 };
 
 const slug = (module.exports.slug = str => {

--- a/docs/templates/helpers.js
+++ b/docs/templates/helpers.js
@@ -9,8 +9,7 @@ module.exports['readme-path'] = opts => {
 module.exports.names = params => params.map(p => p.name).join(', ');
 
 module.exports['typed-params'] = params => {
-  if (params == undefined) return [];
-  return params.map(p => `${p.type}${p.indexed ? ' indexed' : ''}${p.name ? ' ' + p.name : ''}`).join(', ');
+  return params?.map(p => `${p.type}${p.indexed ? ' indexed' : ''}${p.name ? ' ' + p.name : ''}`).join(', ');
 };
 
 const slug = (module.exports.slug = str => {

--- a/docs/templates/helpers.js
+++ b/docs/templates/helpers.js
@@ -9,7 +9,9 @@ module.exports['readme-path'] = opts => {
 module.exports.names = params => params.map(p => p.name).join(', ');
 
 module.exports['typed-params'] = params => {
-  return params.map(p => `${p.type}${p.name ? ' ' + p.name : ''}`).join(', ');
+  console.log(params);
+  if (params == undefined) return [];
+  return params.map(p => `${p.type}${p.indexed ? ' indexed': ''}${p.name ? ' ' + p.name : ''}`).join(', ');
 };
 
 const slug = (module.exports.slug = str => {

--- a/docs/templates/helpers.js
+++ b/docs/templates/helpers.js
@@ -9,7 +9,6 @@ module.exports['readme-path'] = opts => {
 module.exports.names = params => params.map(p => p.name).join(', ');
 
 module.exports['typed-params'] = params => {
-  console.log(params);
   if (params == undefined) return [];
   return params.map(p => `${p.type}${p.indexed ? ' indexed' : ''}${p.name ? ' ' + p.name : ''}`).join(', ');
 };


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes an issue in the docs repo [#311](https://github.com/OpenZeppelin/docs.openzeppelin.com/issues/311) <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
The documentation is rendered without showing if an event parameter was indexed or not. This PR modifies the existing helper to consider if indexed too.

To check how it would show run `nom run docs:watch`

Result:
![Screen Shot 2023-01-16 at 10 31 56 AM](https://user-images.githubusercontent.com/8561085/212702195-d6b05d35-6892-492d-80b0-f0bfd8f77182.png)
#### PR Checklist


<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changelog entry
