### PR TITLE
Make `Ownable2Step.acceptOwnership` virtual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  * `Strings`: add `toString` method for signed integers. ([#3773](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3773))
  * `MerkleProof`: optimize by using unchecked arithmetic. ([#3869](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3869))
  * `EnumerableMap`: add a `keys()` function that returns an array containing all the keys. ([#3920](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3920))
+ * `Ownable2Step`: make `acceptOwnership` public virtual to enable usecases that require overriding it. ([#3960](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3960))
 
 ### Deprecations
 

--- a/contracts/access/Ownable2Step.sol
+++ b/contracts/access/Ownable2Step.sol
@@ -49,7 +49,7 @@ abstract contract Ownable2Step is Ownable {
     /**
      * @dev The new owner accepts the ownership transfer.
      */
-    function acceptOwnership() external {
+    function acceptOwnership() public virtual {
         address sender = _msgSender();
         require(pendingOwner() == sender, "Ownable2Step: caller is not the new owner");
         _transferOwnership(sender);


### PR DESCRIPTION
`Ownable2Step.acceptOwnership` is currently external non virtual. This prevents overriding the function.

IMO there are usecases where overriding this function is necessary. For example:

```
    uint256 public deadline;

    function transferOwnership(address newOwner) public virtual override {
        super.transferOwnership(newOwner); // this is onlyOwner
        deadline = block.timestamp + 2 days;
    }

    function acceptOwnership() public virtual override {
        require(deadline <= block.timestamp);
        delete deadline;
        super.acceptOwnership();
    }
```

#### PR Checklist
- [x] Changelog entry
