### PR TITLE
Use allow-reachable delegatecall in Multicall

### DIFF
--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -13,8 +13,8 @@ import "./Address.sol";
 abstract contract Multicall {
     /**
      * @dev Receives and executes a batch of function calls on this contract.
+     * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
-    /// @custom:oz-upgrades-unsafe-allow-reachable delegatecall
     function multicall(bytes[] calldata data) external virtual returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -14,7 +14,7 @@ abstract contract Multicall {
     /**
      * @dev Receives and executes a batch of function calls on this contract.
      */
-    /// @custom:oz-upgrades-unsafe-allow delegatecall
+    /// @custom:oz-upgrades-unsafe-allow-reachable delegatecall
     function multicall(bytes[] calldata data) external virtual returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {


### PR DESCRIPTION
Related to #3961. @ericglau points out that we should be using the new `allow-reachable` annotation because `delegatecall` is indirectly invoked through `functionDelegateCall`. Also there was an existing natspec comment we can use to put the annotation.