### PR TITLE
Delete tag next once latest is published

### DIFF
--- a/scripts/release/workflow/publish.sh
+++ b/scripts/release/workflow/publish.sh
@@ -14,7 +14,7 @@ delete_tag() {
 }
 
 if [ "$TAG" = tmp ]; then
-  delete_tag tmp
+  delete_tag "$TAG"
 elif ["$TAG" = latest ]; then
   delete_tag next
 fi

--- a/scripts/release/workflow/publish.sh
+++ b/scripts/release/workflow/publish.sh
@@ -8,8 +8,13 @@ echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 # Actual publish
 npm publish "$TARBALL" --tag "$TAG"
 
-if [ "$TAG" = "tmp" ]; then
-  # Remove tmp tag
+delete_tag() {
   PACKAGE_JSON_NAME="$(tar xfO "$TARBALL" package/package.json | jq -r .name)"
-  npm dist-tag rm "$PACKAGE_JSON_NAME" "$TAG"
+  npm dist-tag rm "$PACKAGE_JSON_NAME" "$1"
+}
+
+if [ "$TAG" = tmp ]; then
+  delete_tag tmp
+elif ["$TAG" = latest ]; then
+  delete_tag next
 fi


### PR DESCRIPTION
When we publish the tag `latest` on npm we can delete the existing `next` tag that corresponds to the release candidate.