### PR TITLE
Fix changeset action access to ref branch

### DIFF
--- a/.changeset/tidy-donkeys-fly.md
+++ b/.changeset/tidy-donkeys-fly.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-Fix release-cycle

--- a/.changeset/tidy-donkeys-fly.md
+++ b/.changeset/tidy-donkeys-fly.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Fix release-cycle

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -20,6 +20,8 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ignore-changeset') }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # To include github.base_ref, so changesets doesn't fail
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Check changeset

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # To include github.base_ref, so changesets doesn't fail
+          fetch-depth: 0 # Include history so Changesets finds merge-base
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Check changeset

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -20,9 +20,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ignore-changeset') }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # To include github.base_ref, so changesets doesn't fail
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Check changeset
-        run: npx changeset status --since=${{ github.base_ref }}
+        run: npx changeset status --since=origin/${{ github.base_ref }}


### PR DESCRIPTION
## Description

We only tested #3915 with local pull requests, however, the OpenZeppelin contracts repo accepts Pull Requests from forks, breaking this assumption

Example of a [successful run](https://github.com/OpenZeppelin/openzeppelin-contracts/actions/runs/3961060885/jobs/6786020972)