### PR TITLE
Make upgradeTo functions public #3923

### DIFF
--- a/contracts/mocks/proxy/UUPSLegacy.sol
+++ b/contracts/mocks/proxy/UUPSLegacy.sol
@@ -44,11 +44,11 @@ contract UUPSUpgradeableLegacyMock is UUPSUpgradeableMock {
     }
 
     // hooking into the old mechanism
-    function upgradeTo(address newImplementation) external override {
+    function upgradeTo(address newImplementation) public override {
         _upgradeToAndCallSecureLegacyV1(newImplementation, bytes(""), false);
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable override {
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable override {
         _upgradeToAndCallSecureLegacyV1(newImplementation, data, false);
     }
 }


### PR DESCRIPTION
Title: Make function upgradeTo public

Description:
This PR makes the function upgradeTo(address newImplementation) public by adding the public keyword before the function keyword. This allows external contracts or users to call the function and upgrade the implementation of the contract.

Changes:

The public keyword has been added before the function keyword in the function definition of upgradeTo(address newImplementation).

Testing:
I have tested the function by calling it from an external contract and it worked as expected.

Context:
This change is needed to allow external contracts or users to upgrade the implementation of the contract.

Breaking Changes:
None, this change only makes the function public and should not affect the existing functionality of the contract.