### PR TITLE
Make upgradeTo and upgradeToAndCall functions public ( OpenZeppelin#3923 )

### DIFF
--- a/.changeset/spotty-maps-flash.md
+++ b/.changeset/spotty-maps-flash.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Make upgradeTo and upgradeToAndCall functions public in all relevant files

--- a/contracts/mocks/proxy/UUPSLegacy.sol
+++ b/contracts/mocks/proxy/UUPSLegacy.sol
@@ -44,11 +44,11 @@ contract UUPSUpgradeableLegacyMock is UUPSUpgradeableMock {
     }
 
     // hooking into the old mechanism
-    function upgradeTo(address newImplementation) external override {
+    function upgradeTo(address newImplementation) public override {
         _upgradeToAndCallSecureLegacyV1(newImplementation, bytes(""), false);
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable override {
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable override {
         _upgradeToAndCallSecureLegacyV1(newImplementation, data, false);
     }
 }

--- a/contracts/mocks/proxy/UUPSUpgradeableMock.sol
+++ b/contracts/mocks/proxy/UUPSUpgradeableMock.sol
@@ -23,11 +23,11 @@ contract UUPSUpgradeableMock is NonUpgradeableMock, UUPSUpgradeable {
 }
 
 contract UUPSUpgradeableUnsafeMock is UUPSUpgradeableMock {
-    function upgradeTo(address newImplementation) external override {
+    function upgradeTo(address newImplementation) public override {
         ERC1967Upgrade._upgradeToAndCall(newImplementation, bytes(""), false);
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable override {
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable override {
         ERC1967Upgrade._upgradeToAndCall(newImplementation, data, false);
     }
 }

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -65,7 +65,7 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
      *
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
-    function upgradeTo(address newImplementation) external virtual onlyProxy {
+    function upgradeTo(address newImplementation) public virtual onlyProxy {
         _authorizeUpgrade(newImplementation);
         _upgradeToAndCallUUPS(newImplementation, new bytes(0), false);
     }
@@ -80,7 +80,7 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
      *
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable virtual onlyProxy {
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable virtual onlyProxy {
         _authorizeUpgrade(newImplementation);
         _upgradeToAndCallUUPS(newImplementation, data, true);
     }


### PR DESCRIPTION
…lin#3923 )

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->
Fixes https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3923

The functions `upgradeTo` and `upgradeToAndCall` were having `external` visibility. I made them `public` in all related files, so that now these functions can be overriden and also be invoked via `super` keyword.

After the changes, the library is still compiling successfully

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
