### PR TITLE
Add `solidity` language to missing code snippets

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -19,14 +19,14 @@ import "../utils/introspection/ERC165.sol";
  * in the external API and be unique. The best way to achieve this is by
  * using `public constant` hash digests:
  *
- * ```
+ * ```solidity
  * bytes32 public constant MY_ROLE = keccak256("MY_ROLE");
  * ```
  *
  * Roles can be used to represent a set of permissions. To restrict access to a
  * function call, use {hasRole}:
  *
- * ```
+ * ```solidity
  * function foo() public {
  *     require(hasRole(MY_ROLE, msg.sender));
  *     ...

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -18,12 +18,13 @@ import "../../utils/Address.sol";
  * For example:
  *
  * [.hljs-theme-light.nopadding]
- * ```
+ * ```solidity
  * contract MyToken is ERC20Upgradeable {
  *     function initialize() initializer public {
  *         __ERC20_init("MyToken", "MTK");
  *     }
  * }
+ * 
  * contract MyTokenV2 is MyToken, ERC20PermitUpgradeable {
  *     function initializeV2() reinitializer(2) public {
  *         __ERC20Permit_init("MyToken");

--- a/contracts/utils/StorageSlot.sol
+++ b/contracts/utils/StorageSlot.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.0;
  * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.
  *
  * Example usage to set ERC1967 implementation slot:
- * ```
+ * ```solidity
  * contract ERC1967 {
  *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
  *

--- a/contracts/utils/structs/DoubleEndedQueue.sol
+++ b/contracts/utils/structs/DoubleEndedQueue.sol
@@ -12,7 +12,7 @@ import "../math/SafeCast.sol";
  *
  * The struct is called `Bytes32Deque`. Other types can be cast to and from `bytes32`. This data structure can only be
  * used in storage, and not in memory.
- * ```
+ * ```solidity
  * DoubleEndedQueue.Bytes32Deque queue;
  * ```
  *

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -17,7 +17,7 @@ import "./EnumerableSet.sol";
  * (O(1)).
  * - Entries are enumerated in O(n). No guarantees are made on the ordering.
  *
- * ```
+ * ```solidity
  * contract Example {
  *     // Add the library methods
  *     using EnumerableMap for EnumerableMap.UintToAddressMap;

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -15,7 +15,7 @@ pragma solidity ^0.8.0;
  * (O(1)).
  * - Elements are enumerated in O(n). No guarantees are made on the ordering.
  *
- * ```
+ * ```solidity
  * contract Example {
  *     // Add the library methods
  *     using EnumerableSet for EnumerableSet.AddressSet;


### PR DESCRIPTION
## Description

Just fixing missing `solidity` language in code snippets across our docs