### PR TITLE
Add `ERC*Pausable` warning for public pausing mechanism

### DIFF
--- a/.changeset/new-ways-own.md
+++ b/.changeset/new-ways-own.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC*Pausable`: Add note regarding missing public pausing functionality
+`ERC20Pausable`, `ERC721Pausable`, `ERC1155Pausable`: Add note regarding missing public pausing functionality

--- a/.changeset/new-ways-own.md
+++ b/.changeset/new-ways-own.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC20Pausable`: Add a warning regarding the missing public pausing functionality
+`ERC*Pausable`: Add note regarding missing public pausing functionality

--- a/.changeset/new-ways-own.md
+++ b/.changeset/new-ways-own.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`Pausable`: Add a warning regarding the missing public pausing functionality

--- a/.changeset/new-ways-own.md
+++ b/.changeset/new-ways-own.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`Pausable`: Add a warning regarding the missing public pausing functionality
+`ERC20Pausable`: Add a warning regarding the missing public pausing functionality

--- a/contracts/token/ERC1155/extensions/ERC1155Pausable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Pausable.sol
@@ -18,7 +18,7 @@ import "../../../security/Pausable.sol";
  * {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate
  * access control, e.g. using {AccessControl} or {Ownable}. Not doing so will
  * make the contract unpausable.
- * 
+ *
  * _Available since v3.1._
  */
 abstract contract ERC1155Pausable is ERC1155, Pausable {

--- a/contracts/token/ERC1155/extensions/ERC1155Pausable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Pausable.sol
@@ -13,6 +13,12 @@ import "../../../security/Pausable.sol";
  * period, or having an emergency switch for freezing all token transfers in the
  * event of a large bug.
  *
+ * IMPORTANT: This contract does not include public pause and unpause functions. In
+ * addition to inheriting this contract, you must define both functions, invoking the
+ * {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate
+ * access control, e.g. using {AccessControl} or {Ownable}. Not doing so will
+ * make the contract unpausable.
+ * 
  * _Available since v3.1._
  */
 abstract contract ERC1155Pausable is ERC1155, Pausable {

--- a/contracts/token/ERC20/extensions/ERC20Pausable.sol
+++ b/contracts/token/ERC20/extensions/ERC20Pausable.sol
@@ -12,6 +12,11 @@ import "../../../security/Pausable.sol";
  * Useful for scenarios such as preventing trades until the end of an evaluation
  * period, or having an emergency switch for freezing all token transfers in the
  * event of a large bug.
+ *
+ * WARNING: Using it requires securely exposing both {Pausable-_pause} and
+ * {Pausable-_unpause} internal functions since {Pausable} is intended to be used
+ * through inheritance. This is done in order to allow both {AccessControl} and
+ * {Ownable} restricted pause mechanisms. Not doing so will make the contract unpausable.
  */
 abstract contract ERC20Pausable is ERC20, Pausable {
     /**

--- a/contracts/token/ERC20/extensions/ERC20Pausable.sol
+++ b/contracts/token/ERC20/extensions/ERC20Pausable.sol
@@ -13,10 +13,10 @@ import "../../../security/Pausable.sol";
  * period, or having an emergency switch for freezing all token transfers in the
  * event of a large bug.
  *
- * WARNING: Using it requires securely exposing and adding access control to both
- * {Pausable-_pause} and {Pausable-_unpause} internal functions since {Pausable} is
- * intended to be used through inheritance. This is done in order to allow both
- * {AccessControl} and {Ownable} pause restriction mechanisms. Not doing so will
+ * IMPORTANT: This contract does not include public pause and unpause functions. In
+ * addition to inheriting this contract, you must define both functions, invoking the
+ * {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate
+ * access control, e.g. using {AccessControl} or {Ownable}. Not doing so will
  * make the contract unpausable.
  */
 abstract contract ERC20Pausable is ERC20, Pausable {

--- a/contracts/token/ERC20/extensions/ERC20Pausable.sol
+++ b/contracts/token/ERC20/extensions/ERC20Pausable.sol
@@ -14,9 +14,9 @@ import "../../../security/Pausable.sol";
  * event of a large bug.
  *
  * WARNING: Using it requires securely exposing and adding access control to both
- * {Pausable-_pause} and {Pausable-_unpause} internal functions since {Pausable} is 
- * intended to be used through inheritance. This is done in order to allow both 
- * {AccessControl} and {Ownable} pause restriction mechanisms. Not doing so will 
+ * {Pausable-_pause} and {Pausable-_unpause} internal functions since {Pausable} is
+ * intended to be used through inheritance. This is done in order to allow both
+ * {AccessControl} and {Ownable} pause restriction mechanisms. Not doing so will
  * make the contract unpausable.
  */
 abstract contract ERC20Pausable is ERC20, Pausable {

--- a/contracts/token/ERC20/extensions/ERC20Pausable.sol
+++ b/contracts/token/ERC20/extensions/ERC20Pausable.sol
@@ -13,10 +13,11 @@ import "../../../security/Pausable.sol";
  * period, or having an emergency switch for freezing all token transfers in the
  * event of a large bug.
  *
- * WARNING: Using it requires securely exposing both {Pausable-_pause} and
- * {Pausable-_unpause} internal functions since {Pausable} is intended to be used
- * through inheritance. This is done in order to allow both {AccessControl} and
- * {Ownable} restricted pause mechanisms. Not doing so will make the contract unpausable.
+ * WARNING: Using it requires securely exposing and adding access control to both
+ * {Pausable-_pause} and {Pausable-_unpause} internal functions since {Pausable} is 
+ * intended to be used through inheritance. This is done in order to allow both 
+ * {AccessControl} and {Ownable} pause restriction mechanisms. Not doing so will 
+ * make the contract unpausable.
  */
 abstract contract ERC20Pausable is ERC20, Pausable {
     /**

--- a/contracts/token/ERC721/extensions/ERC721Pausable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Pausable.sol
@@ -12,6 +12,12 @@ import "../../../security/Pausable.sol";
  * Useful for scenarios such as preventing trades until the end of an evaluation
  * period, or having an emergency switch for freezing all token transfers in the
  * event of a large bug.
+ *
+ * IMPORTANT: This contract does not include public pause and unpause functions. In
+ * addition to inheriting this contract, you must define both functions, invoking the
+ * {Pausable-_pause} and {Pausable-_unpause} internal functions, with appropriate
+ * access control, e.g. using {AccessControl} or {Ownable}. Not doing so will
+ * make the contract unpausable.
  */
 abstract contract ERC721Pausable is ERC721, Pausable {
     /**


### PR DESCRIPTION
Mitigates #4006, although it doesn't solve, makes it clear that there are missing functions.
