### PR TITLE
Gas optimisation ERC721

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -94,7 +94,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         _requireMinted(tokenId);
 
         string memory baseURI = _baseURI();
-        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+        return bytes(baseURI).length == 0 ? "" : string(abi.encodePacked(baseURI, tokenId.toString()));
     }
 
     /**


### PR DESCRIPTION
Optimising ERC721 check length in `token URI` function
in line 97 
`bytes(baseURI).length == 0` cost less than `bytes(baseURI).length > 0`