### PR TITLE
Improve `release-cycle.yml` error reporting

### DIFF
--- a/scripts/release/workflow/start.sh
+++ b/scripts/release/workflow/start.sh
@@ -29,8 +29,7 @@ git add .
 git commit -m "Start release candidate"
 
 # Push branch
-git push origin "$RELEASE_BRANCH"
-if [ ! $? ]; then
-  echo "::error file=scripts/release/start.sh::Can't push "$RELEASE_BRANCH" branch. Did you forget to run this workflow from $RELEASE_BRANCH?"
-  exit 1;
+if ! git push origin "$RELEASE_BRANCH"; then
+  echo "::error file=scripts/release/start.sh::Can't push $RELEASE_BRANCH. Did you forget to run this workflow from $RELEASE_BRANCH?"
+  exit 1
 fi

--- a/scripts/release/workflow/start.sh
+++ b/scripts/release/workflow/start.sh
@@ -29,4 +29,8 @@ git add .
 git commit -m "Start release candidate"
 
 # Push branch
-git push origin "$RELEASE_BRANCH" || echo "::error file=scripts/release/start.sh::Can't push $RELEASE_BRANCH. Did you forget to run this workflow from $RELEASE_BRANCH?"
+git push origin "$RELEASE_BRANCH"
+if [ ! $? ]; then
+  echo "::error file=scripts/release/start.sh::Can't push "$RELEASE_BRANCH" branch. Did you forget to run this workflow from $RELEASE_BRANCH?"
+  exit 1;
+fi

--- a/scripts/release/workflow/start.sh
+++ b/scripts/release/workflow/start.sh
@@ -29,4 +29,4 @@ git add .
 git commit -m "Start release candidate"
 
 # Push branch
-git push origin "$RELEASE_BRANCH"
+git push origin "$RELEASE_BRANCH" || echo "::error file=scripts/release/start.sh::Can't push $RELEASE_BRANCH. Did you forget to run this workflow from $RELEASE_BRANCH?"


### PR DESCRIPTION
Fixes LIB-634

Adds an error for `master` manual dispatches on the release cycle, so it's clearer what to do next
![Captura de pantalla 2023-02-07 a la(s) 12 59 46](https://user-images.githubusercontent.com/33379285/217340852-cece23fd-378f-4c78-8077-84aec61a50e4.png)

