### PR TITLE
Allow return data length >= 32 in SignatureChecker

### DIFF
--- a/.changeset/warm-masks-obey.md
+++ b/.changeset/warm-masks-obey.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-Allow return data length >= 32 in SignatureChecker
+`SignatureChecker`: Allow return data length greater than 32 from EIP-1271 signers.

--- a/.changeset/warm-masks-obey.md
+++ b/.changeset/warm-masks-obey.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Allow return data length >= 32 in SignatureChecker

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -31,7 +31,7 @@ library SignatureChecker {
             abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature)
         );
         return (success &&
-            result.length == 32 &&
+            result.length >= 32 &&
             abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector));
     }
 }


### PR DESCRIPTION
Used  >=32 instead of ==32 in SignatureChecker for return data length check

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #4035 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
