### PR TITLE
Add StaticDelegateCall contract

### DIFF
--- a/.changeset/neat-jobs-think.md
+++ b/.changeset/neat-jobs-think.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`StaticDelegateCall`: Add utility contract that emulates static delegatecalls.

--- a/contracts/mocks/StaticDelegateCallMock.sol
+++ b/contracts/mocks/StaticDelegateCallMock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/StaticDelegateCall.sol";
+
+contract StaticDelegateCallImplementationMock {
+    uint256 private _x;
+
+    function process(uint256 c) external view returns (uint256) {
+        require(c < 5);
+        return _x + c;
+    }
+}
+
+contract StaticDelegateCallMock is StaticDelegateCall {
+    uint256 private _x;
+
+    address private _implementation;
+
+    constructor(uint256 x, address implementation) {
+        _x = x;
+        _implementation = implementation;
+    }
+
+    function process(uint256 c) external view returns (uint256) {
+        (bool success, bytes memory result) = _staticDelegateCall(
+            _implementation,
+            abi.encodeCall(StaticDelegateCallImplementationMock.process, (c))
+        );
+        if (!success) revert("Implementation reverted");
+        return abi.decode(result, (uint256));
+    }
+}

--- a/contracts/utils/StaticDelegateCall.sol
+++ b/contracts/utils/StaticDelegateCall.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Provides emulation of static delegatecalls for implementing view-only
+ * functions that execute another contract's code with the calling contract's
+ * context.
+ */
+abstract contract StaticDelegateCall {
+    /**
+     * @dev Perform a static delegate call to the specified `target` with
+     * calldata `data`. Returns success boolean and return data.
+     */
+    function _staticDelegateCall(address target, bytes memory data) internal view returns (bool, bytes memory) {
+        /* This staticcall always reverts, so we can ignore the success boolean */
+        (, bytes memory returndata) = address(this).staticcall(
+            abi.encodeCall(this.delegateCallAndRevert, (target, data))
+        );
+        return abi.decode(returndata, (bool, bytes));
+    }
+
+    /**
+     * @dev Simulate a delegatecall to the specified `target` with calldata
+     * `data` by reverting with the results. The resulting success boolean and
+     * return data are ABI-encoded in the revert data.
+     *
+     * Inspired by simulateAndRevert() from Gnosis' StorageSimulation contract.
+     */
+    function delegateCallAndRevert(address target, bytes memory data) external {
+        require(msg.sender == address(this), "StaticDelegateCall: caller must be self");
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        bytes memory result = abi.encode(success, returndata);
+        assembly {
+            revert(add(result, 0x20), mload(result))
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -188,3 +188,49 @@ await instance.multicall([
     instance.contract.methods.bar().encodeABI()
 ]);
 ----
+
+=== StaticDelegateCall
+
+The `StaticDelegateCall` abstract contract provides emulation of static delegatecalls for implementing view-only functions that execute another contract's code with the calling contract's context. It can be useful in implementing dynamic library support at runtime.
+
+Example:
+[source,solidity]
+----
+// contracts/DynamicGadget.sol
+// SPDX-License-Identifier: MIT
+
+interface IGadget {
+    function compute(uint256 c) external view returns (uint256);
+}
+
+contract GadgetStorage {
+    uint256 internal _x;
+}
+
+contract GadgetImplementationA is GadgetStorage, IGadget {
+    function compute(uint256 c) external view returns (uint256) {
+        return _x * c;
+    }
+}
+
+contract GadgetImplementationB is GadgetStorage, IGadget {
+    function compute(uint256 c) external view returns (uint256) {
+        return _x / c;
+    }
+}
+
+contract DynamicGadget is GadgetStorage, StaticDelegateCall {
+    address private _implementation;
+
+    ...
+
+    function compute(uint256 c) external view returns (uint256) {
+        (bool success, bytes memory result) = _staticDelegateCall(
+            _implementation,
+            abi.encodeCall(IGadget.compute, (c))
+        );
+        require(success);
+        return abi.decode(result, (uint256));
+    }
+}
+----

--- a/test/utils/StaticDelegateCall.test.js
+++ b/test/utils/StaticDelegateCall.test.js
@@ -1,0 +1,33 @@
+const { expectRevert } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+
+const StaticDelegateCallImplementationMock = artifacts.require('StaticDelegateCallImplementationMock');
+const StaticDelegateCallMock = artifacts.require('StaticDelegateCallMock');
+
+contract('StaticDelegateCall', function () {
+  beforeEach(async function () {
+    this.implementation = await StaticDelegateCallImplementationMock.new();
+    this.mock = await StaticDelegateCallMock.new('5', this.implementation.address);
+  });
+
+  describe('proxied implementation', function () {
+    it('processes input', async function () {
+      expect(await this.mock.process('2')).to.be.bignumber.equal('7');
+    });
+    it('reverts on out of bounds parameter', async function () {
+      await expectRevert(this.mock.process('10'), 'Implementation reverted');
+    });
+  });
+
+  describe('delegateCallAndRevert', function () {
+    it('reverts on invalid caller', async function () {
+      await expectRevert(
+        this.mock.delegateCallAndRevert(
+          this.implementation.address,
+          this.implementation.contract.methods.process('2').encodeABI(),
+        ),
+        'StaticDelegateCall: caller must be self',
+      );
+    });
+  });
+});


### PR DESCRIPTION
This primitive allows the creation of view-only getters to contracts that call dynamic external libraries with `delegatecall`. It is inspired by Gnosis' `StorageSimulation` ( https://github.com/gnosis/util-contracts/blob/main/contracts/storage/StorageSimulation.sol ), but this implementation prohibits disallows callers and is meant to be used internally for building view functions.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
