### PR TITLE
Fix flaky timestamp tests 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
-      GAS: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up environment

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,6 @@ jobs:
     env:
       FORCE_COLOR: 1
       NODE_OPTIONS: --max_old_space_size=4096
-      GAS: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up environment

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       FORCE_COLOR: 1
       NODE_OPTIONS: --max_old_space_size=4096
+      GAS: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up environment

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - uses: actions/checkout@v3
       - name: Set up environment

--- a/test/helpers/governance.js
+++ b/test/helpers/governance.js
@@ -115,19 +115,22 @@ class GovernorHelper {
       : this.governor.castVote(...concatOpts([proposal.id, vote.support], opts));
   }
 
-  waitForSnapshot(offset = 0) {
+  async waitForSnapshot(offset = 0) {
     const proposal = this.currentProposal;
-    return this.governor.proposalSnapshot(proposal.id).then(timepoint => forward[this.mode](timepoint.addn(offset)));
+    const timepoint = await this.governor.proposalSnapshot(proposal.id);
+    return forward[this.mode](timepoint.addn(offset));
   }
 
-  waitForDeadline(offset = 0) {
+  async waitForDeadline(offset = 0) {
     const proposal = this.currentProposal;
-    return this.governor.proposalDeadline(proposal.id).then(timepoint => forward[this.mode](timepoint.addn(offset)));
+    const timepoint = await this.governor.proposalDeadline(proposal.id);
+    return forward[this.mode](timepoint.addn(offset));
   }
 
-  waitForEta(offset = 0) {
+  async waitForEta(offset = 0) {
     const proposal = this.currentProposal;
-    return this.governor.proposalEta(proposal.id).then(timestamp => forward.timestamp(timestamp.addn(offset)));
+    const timestamp = await this.governor.proposalEta(proposal.id);
+    return forward.timestamp(timestamp.addn(offset));
   }
 
   /**

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -1,16 +1,16 @@
-const helpers = require('@nomicfoundation/hardhat-network-helpers');
+const { time } = require('@openzeppelin/test-helpers');
 
 module.exports = {
   clock: {
-    blocknumber: () => helpers.time.latestBlock(),
-    timestamp: () => helpers.time.latest(),
+    blocknumber: () => web3.eth.getBlock('latest').then(block => block.number),
+    timestamp: () => web3.eth.getBlock('latest').then(block => block.timestamp),
   },
   clockFromReceipt: {
     blocknumber: receipt => Promise.resolve(receipt.blockNumber),
     timestamp: receipt => web3.eth.getBlock(receipt.blockNumber).then(block => block.timestamp),
   },
   forward: {
-    blocknumber: helpers.mineUpTo,
-    timestamp: helpers.time.increaseTo,
+    blocknumber: time.advanceBlockTo,
+    timestamp: time.increaseTo,
   },
 };

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -1,16 +1,16 @@
-const { time } = require('@openzeppelin/test-helpers');
+const helpers = require('@nomicfoundation/hardhat-network-helpers');
 
 module.exports = {
   clock: {
-    blocknumber: () => web3.eth.getBlock('latest').then(block => block.number),
-    timestamp: () => web3.eth.getBlock('latest').then(block => block.timestamp),
+    blocknumber: () => helpers.latestBlock(),
+    timestamp: () => helpers.time.latest(),
   },
   clockFromReceipt: {
     blocknumber: receipt => Promise.resolve(receipt.blockNumber),
     timestamp: receipt => web3.eth.getBlock(receipt.blockNumber).then(block => block.timestamp),
   },
   forward: {
-    blocknumber: time.advanceBlockTo,
-    timestamp: time.increaseTo,
+    blocknumber: helpers.mineUpTo,
+    timestamp: helpers.time.increaseTo,
   },
 };

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -1,17 +1,17 @@
-const { time } = require('@openzeppelin/test-helpers');
+const { time: { advanceBlockTo } } = require('@openzeppelin/test-helpers');
 const helpers = require('@nomicfoundation/hardhat-network-helpers');
 
 module.exports = {
   clock: {
-    blocknumber: () => web3.eth.getBlock('latest').then(block => block.number),
-    timestamp: () => web3.eth.getBlock('latest').then(block => block.timestamp),
+    blocknumber: () => helpers.time.latestBlock(),
+    timestamp: () => helpers.time.latest(),
   },
   clockFromReceipt: {
     blocknumber: receipt => Promise.resolve(receipt.blockNumber),
     timestamp: receipt => web3.eth.getBlock(receipt.blockNumber).then(block => block.timestamp),
   },
   forward: {
-    blocknumber: helpers.mineUpTo,
-    timestamp: time.increaseTo,
+    blocknumber: advanceBlockTo,
+    timestamp: helpers.time.increaseTo,
   },
 };

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -2,7 +2,7 @@ const helpers = require('@nomicfoundation/hardhat-network-helpers');
 
 module.exports = {
   clock: {
-    blocknumber: () => helpers.latestBlock(),
+    blocknumber: () => helpers.time.latestBlock(),
     timestamp: () => helpers.time.latest(),
   },
   clockFromReceipt: {

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -1,4 +1,5 @@
 const { time } = require('@openzeppelin/test-helpers');
+const helpers = require('@nomicfoundation/hardhat-network-helpers');
 
 module.exports = {
   clock: {
@@ -10,7 +11,7 @@ module.exports = {
     timestamp: receipt => web3.eth.getBlock(receipt.blockNumber).then(block => block.timestamp),
   },
   forward: {
-    blocknumber: time.advanceBlockTo,
+    blocknumber: helpers.mineUpTo,
     timestamp: time.increaseTo,
   },
 };

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -1,4 +1,4 @@
-const { time: { advanceBlockTo } } = require('@openzeppelin/test-helpers');
+const ozHelpers = require('@openzeppelin/test-helpers');
 const helpers = require('@nomicfoundation/hardhat-network-helpers');
 
 module.exports = {
@@ -11,7 +11,7 @@ module.exports = {
     timestamp: receipt => web3.eth.getBlock(receipt.blockNumber).then(block => block.timestamp),
   },
   forward: {
-    blocknumber: advanceBlockTo,
+    blocknumber: ozHelpers.time.advanceBlockTo,
     timestamp: helpers.time.increaseTo,
   },
 };


### PR DESCRIPTION
They are due to an how OpenZeppelin Test Helpers implements `time.increaseTo`. We should prefer Hardhat's own network helpers (eventually we should migrate the rest of the test suite).

I also included a small refactor of `.then` in the Governor helper.

Fixes #4045