### PR TITLE
Add linter rule to prefer await instead of .then

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,9 @@
     "eslint:recommended",
     "prettier",
   ],
+  "plugins": [
+    "avoid-then"
+  ],
   "env": {
     "es2022": true,
     "browser": true,
@@ -16,5 +19,8 @@
     "web3": "readonly",
     "extendEnvironment": "readonly",
     "expect": "readonly",
-  }
+  },
+  "rules": {
+    "avoid-then/avoid-then": "error"
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "chai": "^4.2.0",
         "eslint": "^8.30.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-avoid-then": "github:frangio/eslint-plugin-avoid-then",
         "eth-sig-util": "^3.0.0",
         "ethereumjs-util": "^7.0.7",
         "ethereumjs-wallet": "^1.0.1",
@@ -5723,9 +5724,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
-      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
+      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
@@ -5788,6 +5789,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-avoid-then": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/frangio/eslint-plugin-avoid-then.git#54cfed9c617c711987167ad47905d7d7616be0bc",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^8.34.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -20761,9 +20771,9 @@
       }
     },
     "eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
-      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
+      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",
@@ -20900,6 +20910,12 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
       "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
       "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-avoid-then": {
+      "version": "git+ssh://git@github.com/frangio/eslint-plugin-avoid-then.git#54cfed9c617c711987167ad47905d7d7616be0bc",
+      "dev": true,
+      "from": "eslint-plugin-avoid-then@github:frangio/eslint-plugin-avoid-then",
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "chai": "^4.2.0",
     "eslint": "^8.30.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-avoid-then": "github:frangio/eslint-plugin-avoid-then",
     "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^7.0.7",
     "ethereumjs-wallet": "^1.0.1",


### PR DESCRIPTION
I believe we need to stick to `await` instead of `.then`. I find `.then` acceptable when it's used in one-liners, but elsewhere `await` is clearly more readable.

```js
x.then(y =>
  f(y)
);

// versus

const y = await x;
f(y);
```

Anyway we can use this PR to discuss. I'm proposing a linter rule so we can automate the guideline going forward.