### PR TITLE
Improve cancelling with GovernorTimelockControl

### DIFF
--- a/.changeset/six-oranges-repair.md
+++ b/.changeset/six-oranges-repair.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': major
+---
+
+Include \_cancel(uint256 proposal_id) in GovernorTimelockControl

--- a/contracts/governance/extensions/GovernorTimelockControl.sol
+++ b/contracts/governance/extensions/GovernorTimelockControl.sol
@@ -132,7 +132,18 @@ abstract contract GovernorTimelockControl is IGovernorTimelock, Governor {
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) internal virtual override returns (uint256) {
-        uint256 proposalId = super._cancel(targets, values, calldatas, descriptionHash);
+        return _cancel(hashProposal(targets, values, calldatas, descriptionHash));
+    }
+
+    /**
+     * @dev Overridden version of the {Governor-_cancel} function to cancel the timelocked proposal if it as already
+     * been queued.
+     */
+    // This function can reenter through the external call to the timelock, but we assume the timelock is trusted and
+    // well behaved (according to TimelockController) and this will not happen.
+    // slither-disable-next-line reentrancy-no-eth
+    function _cancel(uint256 proposalId) internal virtual override returns (uint256) {
+        super._cancel(proposalId);
 
         if (_timelockIds[proposalId] != 0) {
             _timelock.cancel(_timelockIds[proposalId]);

--- a/contracts/mocks/governance/GovernorTimelockControlMock.sol
+++ b/contracts/mocks/governance/GovernorTimelockControlMock.sol
@@ -52,6 +52,10 @@ abstract contract GovernorTimelockControlMock is
         return super._cancel(targets, values, calldatas, descriptionHash);
     }
 
+    function _cancel(uint256 proposalId) internal override(Governor, GovernorTimelockControl) returns (uint256) {
+        return super._cancel(proposalId);
+    }
+
     function _executor() internal view override(Governor, GovernorTimelockControl) returns (address) {
         return super._executor();
     }

--- a/contracts/mocks/wizard/MyGovernor1.sol
+++ b/contracts/mocks/wizard/MyGovernor1.sol
@@ -67,6 +67,10 @@ contract MyGovernor1 is
         return super._cancel(targets, values, calldatas, descriptionHash);
     }
 
+    function _cancel(uint256 proposalId) internal override(Governor, GovernorTimelockControl) returns (uint256) {
+        return super._cancel(proposalId);
+    }
+
     function _executor() internal view override(Governor, GovernorTimelockControl) returns (address) {
         return super._executor();
     }

--- a/contracts/mocks/wizard/MyGovernor2.sol
+++ b/contracts/mocks/wizard/MyGovernor2.sol
@@ -73,6 +73,10 @@ contract MyGovernor2 is
         return super._cancel(targets, values, calldatas, descriptionHash);
     }
 
+    function _cancel(uint256 proposalId) internal override(Governor, GovernorTimelockControl) returns (uint256) {
+        return super._cancel(proposalId);
+    }
+
     function _executor() internal view override(Governor, GovernorTimelockControl) returns (address) {
         return super._executor();
     }

--- a/contracts/mocks/wizard/MyGovernor3.sol
+++ b/contracts/mocks/wizard/MyGovernor3.sol
@@ -77,6 +77,10 @@ contract MyGovernor is
         return super._cancel(targets, values, calldatas, descriptionHash);
     }
 
+    function _cancel(uint256 proposalId) internal override(Governor, GovernorTimelockControl) returns (uint256) {
+        return super._cancel(proposalId);
+    }
+
     function _executor() internal view override(Governor, GovernorTimelockControl) returns (address) {
         return super._executor();
     }


### PR DESCRIPTION
Fixes #4052

The update adds an overridden ```_cancel(uint256 proposal_id) internal``` to GovernorTimelockControl, making it accessible from an overridden ```cancel(uint256 proposal_id) public```.

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
