### PR TITLE
Fix ERC4906 compliance of ERC721URIStorage

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -16,6 +16,13 @@ abstract contract ERC721URIStorage is IERC4906, ERC721 {
     mapping(uint256 => string) private _tokenURIs;
 
     /**
+     * @dev See {IERC165-supportsInterface}
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, IERC165) returns (bool) {
+        return interfaceId == bytes4(0x49064906) || super.supportsInterface(interfaceId);
+    }
+
+    /**
      * @dev See {IERC721Metadata-tokenURI}.
      */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {

--- a/test/token/ERC721/extensions/ERC721URIStorage.test.js
+++ b/test/token/ERC721/extensions/ERC721URIStorage.test.js
@@ -1,6 +1,7 @@
 const { BN, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
-
 const { expect } = require('chai');
+
+const { shouldSupportInterfaces } = require('../../../utils/introspection/SupportsInterface.behavior');
 
 const ERC721URIStorageMock = artifacts.require('$ERC721URIStorageMock');
 
@@ -16,6 +17,8 @@ contract('ERC721URIStorage', function (accounts) {
   beforeEach(async function () {
     this.token = await ERC721URIStorageMock.new(name, symbol);
   });
+
+  shouldSupportInterfaces(['0x49064906']);
 
   describe('token URI', function () {
     beforeEach(async function () {

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -100,20 +100,22 @@ function shouldSupportInterfaces(interfaces = []) {
 
     it('supportsInterface uses less than 30k gas', async function () {
       for (const k of interfaces) {
-        const interfaceId = INTERFACE_IDS[k];
+        const interfaceId = INTERFACE_IDS[k] ?? k;
         expect(await this.contractUnderTest.supportsInterface.estimateGas(interfaceId)).to.be.lte(30000);
       }
     });
 
     it('all interfaces are reported as supported', async function () {
       for (const k of interfaces) {
-        const interfaceId = INTERFACE_IDS[k];
+        const interfaceId = INTERFACE_IDS[k] ?? k;
         expect(await this.contractUnderTest.supportsInterface(interfaceId)).to.equal(true);
       }
     });
 
     it('all interface functions are in ABI', async function () {
       for (const k of interfaces) {
+        // skip interfaces for which we don't have a function list
+        if (INTERFACES[k] == undefined) continue;
         for (const fnName of INTERFACES[k]) {
           const fnSig = FN_SIGNATURES[fnName];
           expect(this.contractUnderTest.abi.filter(fn => fn.signature === fnSig).length).to.equal(1);

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -115,7 +115,7 @@ function shouldSupportInterfaces(interfaces = []) {
     it('all interface functions are in ABI', async function () {
       for (const k of interfaces) {
         // skip interfaces for which we don't have a function list
-        if (INTERFACES[k] == undefined) continue;
+        if (INTERFACES[k] === undefined) continue;
         for (const fnName of INTERFACES[k]) {
           const fnSig = FN_SIGNATURES[fnName];
           expect(this.contractUnderTest.abi.filter(fn => fn.signature === fnSig).length).to.equal(1);


### PR DESCRIPTION
As pointed out by @pcaversaccio in [this post](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4012#issuecomment-1434665993)

#4012 missed the ERC165 part of ERC4906. Its unclear how this value was produced, and why an ERC that doesn't include any function (only event) would have an ERC165 interfaceId.

Still, this PR makes `ERC721URIStorage` compliant with the ERC165 part of ERC4906.

#### PR Checklist

- [x] Tests
