### PR TITLE
Implement `0x00` version of EIP-191 in ECDSA Library

### DIFF
--- a/.changeset/small-cars-appear.md
+++ b/.changeset/small-cars-appear.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-Implement 0x00 version of EIP-191 in ECDSA Library
+`ECDSA`: Add a function `toDataWithIntendedValidatorHash` that encodes data with version 0x00 following EIP-191.

--- a/.changeset/small-cars-appear.md
+++ b/.changeset/small-cars-appear.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Implement 0x00 version of EIP-191 in ECDSA Library

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -204,4 +204,14 @@ library ECDSA {
             data := keccak256(ptr, 0x42)
         }
     }
+
+    /**
+     * @dev Returns an Ethereum Signed Data with intended validator, created from a 
+     * `validator` and `data` according to the version 0 of EIP-191.
+     *
+     * See {recover}.
+     */
+    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x00", validator, data));
+    }
 }

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -206,7 +206,7 @@ library ECDSA {
     }
 
     /**
-     * @dev Returns an Ethereum Signed Data with intended validator, created from a 
+     * @dev Returns an Ethereum Signed Data with intended validator, created from a
      * `validator` and `data` according to the version 0 of EIP-191.
      *
      * See {recover}.

--- a/test/helpers/sign.js
+++ b/test/helpers/sign.js
@@ -5,6 +5,21 @@ function toEthSignedMessageHash(messageHex) {
 }
 
 /**
+ * Create a signed data with intended validator according to the version 0 of EIP-191
+ * @param validatorAddress The address of the validator
+ * @param dataHex The data to be concatened with the prefix and signed
+ */
+function toDataWithIntendedValidatorHash(validatorAddress, dataHex) {
+  const validatorBuffer = Buffer.from(web3.utils.hexToBytes(validatorAddress));
+  const dataBuffer = Buffer.from(web3.utils.hexToBytes(dataHex));
+  const preambleBuffer = Buffer.from('\x19');
+  const versionBuffer = Buffer.from('\x00');
+  const ethMessage = Buffer.concat([preambleBuffer, versionBuffer, validatorBuffer, dataBuffer]);
+
+  return web3.utils.sha3(ethMessage);
+}
+
+/**
  * Create a signer between a contract and a signer for a voucher of method, args, and redeemer
  * Note that `method` is the web3 method, not the truffle-contract method
  * @param contract TruffleContract
@@ -43,5 +58,6 @@ const getSignFor =
 
 module.exports = {
   toEthSignedMessageHash,
+  toDataWithIntendedValidatorHash,
   getSignFor,
 };

--- a/test/helpers/sign.js
+++ b/test/helpers/sign.js
@@ -7,7 +7,7 @@ function toEthSignedMessageHash(messageHex) {
 /**
  * Create a signed data with intended validator according to the version 0 of EIP-191
  * @param validatorAddress The address of the validator
- * @param dataHex The data to be concatened with the prefix and signed
+ * @param dataHex The data to be concatenated with the prefix and signed
  */
 function toDataWithIntendedValidatorHash(validatorAddress, dataHex) {
   const validatorBuffer = Buffer.from(web3.utils.hexToBytes(validatorAddress));

--- a/test/utils/cryptography/ECDSA.test.js
+++ b/test/utils/cryptography/ECDSA.test.js
@@ -8,7 +8,7 @@ const ECDSA = artifacts.require('$ECDSA');
 const TEST_MESSAGE = web3.utils.sha3('OpenZeppelin');
 const WRONG_MESSAGE = web3.utils.sha3('Nope');
 const NON_HASH_MESSAGE = '0x' + Buffer.from('abcd').toString('hex');
-const RANDOM_ADDRESS = '0xA9d8C83D404d3397aDE08321E7551c8B36dbF4Ab';
+const RANDOM_ADDRESS = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
 
 function to2098Format(signature) {
   const long = web3.utils.hexToBytes(signature);

--- a/test/utils/cryptography/ECDSA.test.js
+++ b/test/utils/cryptography/ECDSA.test.js
@@ -1,5 +1,5 @@
 const { expectRevert } = require('@openzeppelin/test-helpers');
-const { toEthSignedMessageHash } = require('../../helpers/sign');
+const { toEthSignedMessageHash, toDataWithIntendedValidatorHash } = require('../../helpers/sign');
 
 const { expect } = require('chai');
 
@@ -8,6 +8,7 @@ const ECDSA = artifacts.require('$ECDSA');
 const TEST_MESSAGE = web3.utils.sha3('OpenZeppelin');
 const WRONG_MESSAGE = web3.utils.sha3('Nope');
 const NON_HASH_MESSAGE = '0x' + Buffer.from('abcd').toString('hex');
+const RANDOM_ADDRESS = '0xA9d8C83D404d3397aDE08321E7551c8B36dbF4Ab';
 
 function to2098Format(signature) {
   const long = web3.utils.hexToBytes(signature);
@@ -246,6 +247,14 @@ contract('ECDSA', function (accounts) {
       expect(await this.ecdsa.methods['$toEthSignedMessageHash(bytes)'](NON_HASH_MESSAGE)).to.equal(
         toEthSignedMessageHash(NON_HASH_MESSAGE),
       );
+    });
+  });
+
+  context('toDataWithIntendedValidatorHash', function () {
+    it('returns the hash correctly', async function () {
+      expect(
+        await this.ecdsa.methods['$toDataWithIntendedValidatorHash(address,bytes)'](RANDOM_ADDRESS, NON_HASH_MESSAGE),
+      ).to.equal(toDataWithIntendedValidatorHash(RANDOM_ADDRESS, NON_HASH_MESSAGE));
     });
   });
 });


### PR DESCRIPTION
## What does this PR introduce ?

- Add a new function `toDataWithIntendedValidator(...)` to be compatible with the version `0x00` of EIP-191 taking 2 parameters `<address validator>` and `<bytes dataToSign>`.

Fixes #3772 


#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
