### PR TITLE
Fix an upgrade replay bug in Governor.propose

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -276,7 +276,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         require(targets.length == values.length, "Governor: invalid proposal length");
         require(targets.length == calldatas.length, "Governor: invalid proposal length");
         require(targets.length > 0, "Governor: empty proposal");
-        require(_proposals[proposalId].proposer == address(0), "Governor: proposal already exists");
+        require(_proposals[proposalId].voteStart == 0, "Governor: proposal already exists");
 
         uint256 snapshot = currentTimepoint + votingDelay();
         uint256 deadline = snapshot + votingPeriod();


### PR DESCRIPTION
The `proposer` is not set for proposal created before a smart contract upgrade.

This would allow anyone to re-propose a proposal created before the upgrade. The timers + flags (execute/cancel) would be reset, but the votes would not. Old vote count (if any) still hold. Accounts that already voted cannot re-vote to oppose. New vote use a new snapshot.

This is a fix to an bug introduced in unreleased code. Do we need a changeset?

#### PR Checklist

- [ ] Changeset entry (run `npx changeset add`)
