### PR TITLE
Add effect checks on the accesscontrol specs

### DIFF
--- a/certora/specs/AccessControl.spec
+++ b/certora/specs/AccessControl.spec
@@ -16,20 +16,20 @@ methods {
 rule onlyGrantCanGrant(env e, bytes32 role, address account) {
     method f; calldataarg args;
 
-    bool hasRoleBefore = hasRole(role, account);
+    bool hasOtherRoleBefore = hasRole(role, account);
     f(e, args);
-    bool hasRoleAfter = hasRole(role, account);
+    bool hasOtherRoleAfter = hasRole(role, account);
 
     assert (
-        !hasRoleBefore &&
-        hasRoleAfter
+        !hasOtherRoleBefore &&
+        hasOtherRoleAfter
     ) => (
         f.selector == grantRole(bytes32, address).selector
     );
 
     assert (
-        hasRoleBefore &&
-        !hasRoleAfter
+        hasOtherRoleBefore &&
+        !hasOtherRoleAfter
     ) => (
         f.selector == revokeRole(bytes32, address).selector ||
         f.selector == renounceRole(bytes32, address).selector
@@ -50,10 +50,12 @@ rule grantRoleEffect(env e) {
     address otherAccount;
 
     bool isCallerAdmin = hasRole(getRoleAdmin(role), e.msg.sender);
-    bool hasRoleBefore = hasRole(otherRole, otherAccount);
+    bool hasOtherRoleBefore = hasRole(otherRole, otherAccount);
 
     grantRole@withrevert(e, role, account);
     bool success = !lastReverted;
+
+    bool hasOtherRoleAfter = hasRole(otherRole, otherAccount);
 
     // liveness
     assert success <=> isCallerAdmin;
@@ -62,7 +64,7 @@ rule grantRoleEffect(env e) {
     assert success => hasRole(role, account);
 
     // no side effect
-    assert hasRoleBefore != hasRole(otherRole, otherAccount) => (otherRole == role && otherAccount == account);
+    assert hasOtherRoleBefore != hasOtherRoleAfter => (role == otherRole && account == otherAccount);
 }
 
 /*
@@ -79,10 +81,12 @@ rule revokeRoleEffect(env e) {
     address otherAccount;
 
     bool isCallerAdmin = hasRole(getRoleAdmin(role), e.msg.sender);
-    bool hasRoleBefore = hasRole(otherRole, otherAccount);
+    bool hasOtherRoleBefore = hasRole(otherRole, otherAccount);
 
     revokeRole@withrevert(e, role, account);
     bool success = !lastReverted;
+
+    bool hasOtherRoleAfter = hasRole(otherRole, otherAccount);
 
     // liveness
     assert success <=> isCallerAdmin;
@@ -91,7 +95,7 @@ rule revokeRoleEffect(env e) {
     assert success => !hasRole(role, account);
 
     // no side effect
-    assert hasRoleBefore != hasRole(otherRole, otherAccount) => (otherRole == role && otherAccount == account);
+    assert hasOtherRoleBefore != hasOtherRoleAfter => (role == otherRole && account == otherAccount);
 }
 
 /*
@@ -107,10 +111,12 @@ rule renounceRoleEffect(env e) {
     address account;
     address otherAccount;
 
-    bool hasRoleBefore = hasRole(otherRole, otherAccount);
+    bool hasOtherRoleBefore = hasRole(otherRole, otherAccount);
 
     renounceRole@withrevert(e, role, account);
     bool success = !lastReverted;
+
+    bool hasOtherRoleAfter = hasRole(otherRole, otherAccount);
 
     // liveness
     assert success <=> account == e.msg.sender;
@@ -119,5 +125,5 @@ rule renounceRoleEffect(env e) {
     assert success => !hasRole(role, account);
 
     // no side effect
-    assert hasRoleBefore != hasRole(otherRole, otherAccount) => (otherRole == role && otherAccount == account);
+    assert hasOtherRoleBefore != hasOtherRoleAfter => (role == otherRole && account == otherAccount);
 }

--- a/certora/specs/AccessControl.spec
+++ b/certora/specs/AccessControl.spec
@@ -44,22 +44,25 @@ rule onlyGrantCanGrant(env e, bytes32 role, address account) {
 rule grantRoleEffect(env e) {
     require nonpayable(e);
 
-    bytes32 role1; bytes32 role2;
-    address account1; address account2;
+    bytes32 role;
+    bytes32 otherRole;
+    address account;
+    address otherAccount;
 
-    bool isCallerAdmin = hasRole(getRoleAdmin(role2), e.msg.sender);
-    bool hasRoleBefore = hasRole(role1, account1);
+    bool isCallerAdmin = hasRole(getRoleAdmin(role), e.msg.sender);
+    bool hasRoleBefore = hasRole(otherRole, otherAccount);
 
-    grantRole@withrevert(e, role2, account2);
-    assert !lastReverted <=> isCallerAdmin;
+    grantRole@withrevert(e, role, account);
+    bool success = !lastReverted;
 
-    bool hasRoleAfter = hasRole(role1, account1);
+    // liveness
+    assert success <=> isCallerAdmin;
 
-    assert (
-        hasRoleBefore != hasRoleAfter
-    ) => (
-        hasRoleAfter == true && role1 == role2 && account1 == account2
-    );
+    // effect
+    assert success => hasRole(role, account);
+
+    // no side effect
+    assert hasRoleBefore != hasRole(otherRole, otherAccount) => (otherRole == role && otherAccount == account);
 }
 
 /*
@@ -70,22 +73,25 @@ rule grantRoleEffect(env e) {
 rule revokeRoleEffect(env e) {
     require nonpayable(e);
 
-    bytes32 role1; bytes32 role2;
-    address account1; address account2;
+    bytes32 role;
+    bytes32 otherRole;
+    address account;
+    address otherAccount;
 
-    bool isCallerAdmin = hasRole(getRoleAdmin(role2), e.msg.sender);
-    bool hasRoleBefore = hasRole(role1, account1);
+    bool isCallerAdmin = hasRole(getRoleAdmin(role), e.msg.sender);
+    bool hasRoleBefore = hasRole(otherRole, otherAccount);
 
-    revokeRole@withrevert(e, role2, account2);
-    assert !lastReverted <=> isCallerAdmin;
+    revokeRole@withrevert(e, role, account);
+    bool success = !lastReverted;
 
-    bool hasRoleAfter = hasRole(role1, account1);
+    // liveness
+    assert success <=> isCallerAdmin;
 
-    assert (
-        hasRoleBefore != hasRoleAfter
-    ) => (
-        hasRoleAfter == false && role1 == role2 && account1 == account2
-    );
+    // effect
+    assert success => !hasRole(role, account);
+
+    // no side effect
+    assert hasRoleBefore != hasRole(otherRole, otherAccount) => (otherRole == role && otherAccount == account);
 }
 
 /*
@@ -96,19 +102,22 @@ rule revokeRoleEffect(env e) {
 rule renounceRoleEffect(env e) {
     require nonpayable(e);
 
-    bytes32 role1; bytes32 role2;
-    address account1; address account2;
+    bytes32 role;
+    bytes32 otherRole;
+    address account;
+    address otherAccount;
 
-    bool hasRoleBefore = hasRole(role1, account1);
+    bool hasRoleBefore = hasRole(otherRole, otherAccount);
 
-    renounceRole@withrevert(e, role2, account2);
-    assert !lastReverted <=> account2 == e.msg.sender;
+    renounceRole@withrevert(e, role, account);
+    bool success = !lastReverted;
 
-    bool hasRoleAfter = hasRole(role1, account1);
+    // liveness
+    assert success <=> account == e.msg.sender;
 
-    assert (
-        hasRoleBefore != hasRoleAfter
-    ) => (
-        hasRoleAfter == false && role1 == role2 && account1 == account2
-    );
+    // effect
+    assert success => !hasRole(role, account);
+
+    // no side effect
+    assert hasRoleBefore != hasRole(otherRole, otherAccount) => (otherRole == role && otherAccount == account);
 }

--- a/certora/specs/AccessControl.spec
+++ b/certora/specs/AccessControl.spec
@@ -16,20 +16,20 @@ methods {
 rule onlyGrantCanGrant(env e, bytes32 role, address account) {
     method f; calldataarg args;
 
-    bool hasOtherRoleBefore = hasRole(role, account);
+    bool hasRoleBefore = hasRole(role, account);
     f(e, args);
-    bool hasOtherRoleAfter = hasRole(role, account);
+    bool hasRoleAfter = hasRole(role, account);
 
     assert (
-        !hasOtherRoleBefore &&
-        hasOtherRoleAfter
+        !hasRoleBefore &&
+        hasRoleAfter
     ) => (
         f.selector == grantRole(bytes32, address).selector
     );
 
     assert (
-        hasOtherRoleBefore &&
-        !hasOtherRoleAfter
+        hasRoleBefore &&
+        !hasRoleAfter
     ) => (
         f.selector == revokeRole(bytes32, address).selector ||
         f.selector == renounceRole(bytes32, address).selector


### PR DESCRIPTION
During today's call, we noticed that the rules did not actually verify that the effect was applied when calls are successfull.

This PR adds that missing property, and rewrite the other for improved readability.