### PR TITLE
Bump and pin Forge Std submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "lib/forge-std"]
+	branch = v1
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/erc4626-tests"]


### PR DESCRIPTION
Bumps and also pins `forge-std` to `v1`.

The benefit of pinning is that it leads to more predictable repo checkouts.

We use the `release-v4.8` branch (`solidity-generators`) in a project with many git submodules. Pinning your version of `forge-std` to `v1` helps reduce the installation time when pulling a fresh copy of the repo for the first time, because it leads to the same commit for `forge-std`.