### PR TITLE
added cw3d reference to wizard.adoc file

### DIFF
--- a/docs/modules/ROOT/pages/wizard.adoc
+++ b/docs/modules/ROOT/pages/wizard.adoc
@@ -1,15 +1,14 @@
 = Contracts Wizard
 :page-notoc:
 
-Not sure where to start? Use the interactive generator below to bootstrap your
-contract and learn about the components offered in OpenZeppelin Contracts.
+Not sure where to start? Use the interactive generator below to bootstrap your contract and learn about the components offered in OpenZeppelin Contracts.
 
 TIP: Place the resulting contract in your `contracts` directory in order to compile it with a tool like Hardhat or Truffle. Consider reading our guide on xref:learn::developing-smart-contracts.adoc[Developing Smart Contracts] for more guidance!
 
-++++
-<script async src="https://wizard.openzeppelin.com/build/embed.js"></script>
+Alternatively, use xref:create-web3-dapp[create-web3-dapp] for a CLI version of OpenZeppelin Contracts Wizard. This will also automatically handle the project configuration for you.
 
+++++
+
+<script async src="https://wizard.openzeppelin.com/build/embed.js"></script>
 <oz-wizard style="display: block; min-height: 40rem;"></oz-wizard>
 ++++
-
-


### PR DESCRIPTION
Added reference to [`create-web3-dapp`](https://createweb3dapp.alchemy.com/) tool in the Contracts Wizard docs because this tool provides a CLI interface for the Wizard.

This is also helpful for people who don't know much about configuring the project and how to compile the contracts after generating them with OpenZeppelin Wizard UI as [`create-web3-dapp`](https://createweb3dapp.alchemy.com/) handles this for the users.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->