### PR TITLE
ReentrancyGuard gas optimization

### DIFF
--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -55,7 +55,7 @@ abstract contract ReentrancyGuard {
 
     function _nonReentrantBefore() private {
         // On the first call to nonReentrant, _status will be _NOT_ENTERED
-        require(_status > _ENTERED, "ReentrancyGuard: reentrant call");
+        require(_status == _NOT_ENTERED, "ReentrancyGuard: reentrant call");
 
         // Any calls to nonReentrant after this point will fail
         _status = _ENTERED;

--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -32,7 +32,7 @@ abstract contract ReentrancyGuard {
     // transaction's gas, it is best to keep them low in cases like this one, to
     // increase the likelihood of the full refund coming into effect.
     uint256 private constant _NOT_ENTERED = 1;
-    uint256 private constant _ENTERED = 2;
+    uint256 private constant _ENTERED = 0;
 
     uint256 private _status;
 
@@ -55,7 +55,7 @@ abstract contract ReentrancyGuard {
 
     function _nonReentrantBefore() private {
         // On the first call to nonReentrant, _status will be _NOT_ENTERED
-        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+        require(_status > _ENTERED, "ReentrancyGuard: reentrant call");
 
         // Any calls to nonReentrant after this point will fail
         _status = _ENTERED;


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

By setting `_NOT_ENTERED` to `1` and `_ENTERED` to `0`, and modifying the `_status` check to be`==`, this saves 51 gas.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [X] Tests - no new test needed
- [X] Documentation - no documentation update needed
- [ ] Changeset entry (run `npx changeset add`)
