### PR TITLE
Improve `ERC4626` test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `ERC4626`: Improved test coverage by adding further unit tests covering the internal function `_tryGetAssetDecimals` and an overflow test for `decimals`. ([#]())
+
 ### Breaking changes
 
 - `EIP712`: Addition of ERC5267 support requires support for user defined value types, which was released in Solidity version 0.8.8. This requires a pragma change from `^0.8.0` to `^0.8.8`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- `ERC4626`: Improved test coverage by adding further unit tests covering the internal function `_tryGetAssetDecimals` and an overflow test for `decimals`. ([#]())
+- `ERC4626`: Improved test coverage by adding further unit tests covering the internal function `_tryGetAssetDecimals` and an overflow test for `decimals`. ([#4134](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4134))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- `ERC4626`: Improved test coverage by adding further unit tests covering the internal function `_tryGetAssetDecimals` and an overflow test for `decimals`. ([#4134](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4134))
-
 ### Breaking changes
 
 - `EIP712`: Addition of ERC5267 support requires support for user defined value types, which was released in Solidity version 0.8.8. This requires a pragma change from `^0.8.0` to `^0.8.8`.

--- a/contracts/mocks/token/ERC20ExcessDecimalsMock.sol
+++ b/contracts/mocks/token/ERC20ExcessDecimalsMock.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+contract ERC20ExcessDecimalsMock {
+    function decimals() public pure returns (uint256) {
+        return type(uint256).max;
+    }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+openzeppelin/=contracts/

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -19,10 +19,10 @@ contract ERC4626VaultOffsetMock is ERC4626OffsetMock {
 }
 
 contract ERC4626StdTest is ERC4626Test {
-    ERC20 private underlying = new ERC20Mock();
+    ERC20 private _underlying = new ERC20Mock();
 
     function setUp() public override {
-        _underlying_ = address(underlying);
+        _underlying_ = address(_underlying);
         _vault_ = address(new ERC4626Mock(_underlying_));
         _delta_ = 0;
         _vaultMayBeEmpty = true;
@@ -33,9 +33,9 @@ contract ERC4626StdTest is ERC4626Test {
      * @dev Check the case where calculated `decimals` value overflows the `uint8` type.
      */
     function testFuzzDecimalsOverflow(uint8 offset) public {
-        /// @dev Remember that the `underlying` exhibits a `decimals` value of 18.
+        /// @dev Remember that the `_underlying` exhibits a `decimals` value of 18.
         offset = uint8(bound(uint256(offset), 238, uint256(type(uint8).max)));
-        ERC4626VaultOffsetMock erc4626VaultOffsetMock = new ERC4626VaultOffsetMock(underlying, offset);
+        ERC4626VaultOffsetMock erc4626VaultOffsetMock = new ERC4626VaultOffsetMock(_underlying, offset);
         vm.expectRevert();
         erc4626VaultOffsetMock.decimals();
     }

--- a/test/token/ERC20/extensions/ERC4626.t.sol
+++ b/test/token/ERC20/extensions/ERC4626.t.sol
@@ -1,18 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "erc4626-tests/ERC4626.test.sol";
+import {ERC4626Test} from "erc4626-tests/ERC4626.test.sol";
 
-import {SafeCast} from "../../../../contracts/utils/math/SafeCast.sol";
-import {ERC20Mock} from "../../../../contracts/mocks/ERC20Mock.sol";
-import {ERC4626Mock} from "../../../../contracts/mocks/ERC4626Mock.sol";
+import {SafeCast} from "openzeppelin/utils/math/SafeCast.sol";
+import {ERC20} from "openzeppelin/token/ERC20/ERC20.sol";
+import {ERC4626} from "openzeppelin/token/ERC20/extensions/ERC4626.sol";
+
+import {ERC20Mock} from "openzeppelin/mocks/ERC20Mock.sol";
+import {ERC4626Mock} from "openzeppelin/mocks/ERC4626Mock.sol";
+import {ERC4626OffsetMock} from "openzeppelin/mocks/token/ERC4626OffsetMock.sol";
+
+contract ERC4626VaultOffsetMock is ERC4626OffsetMock {
+    constructor(
+        ERC20 underlying_,
+        uint8 offset_
+    ) ERC20("My Token Vault", "MTKNV") ERC4626(underlying_) ERC4626OffsetMock(offset_) {}
+}
 
 contract ERC4626StdTest is ERC4626Test {
+    ERC20 private underlying = new ERC20Mock();
+
     function setUp() public override {
-        _underlying_ = address(new ERC20Mock());
+        _underlying_ = address(underlying);
         _vault_ = address(new ERC4626Mock(_underlying_));
         _delta_ = 0;
         _vaultMayBeEmpty = true;
         _unlimitedAmount = true;
+    }
+
+    /**
+     * @dev Check the case where calculated `decimals` value overflows the `uint8` type.
+     */
+    function testFuzzDecimalsOverflow(uint8 offset) public {
+        /// @dev Remember that the `underlying` exhibits a `decimals` value of 18.
+        offset = uint8(bound(uint256(offset), 238, uint256(type(uint8).max)));
+        ERC4626VaultOffsetMock erc4626VaultOffsetMock = new ERC4626VaultOffsetMock(underlying, offset);
+        vm.expectRevert();
+        erc4626VaultOffsetMock.decimals();
     }
 }

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -5,6 +5,7 @@ const ERC20Decimals = artifacts.require('$ERC20DecimalsMock');
 const ERC4626 = artifacts.require('$ERC4626');
 const ERC4626OffsetMock = artifacts.require('$ERC4626OffsetMock');
 const ERC4626FeesMock = artifacts.require('$ERC4626FeesMock');
+const ERC20ExcessDecimalsMock = artifacts.require('ERC20ExcessDecimalsMock');
 
 contract('ERC4626', function (accounts) {
   const [holder, recipient, spender, other, user1, user2] = accounts;
@@ -18,6 +19,30 @@ contract('ERC4626', function (accounts) {
       const token = await ERC20Decimals.new('', '', decimals);
       const vault = await ERC4626.new('', '', token.address);
       expect(await vault.decimals()).to.be.bignumber.equal(decimals);
+    }
+  });
+
+  it('asset has not yet been created', async function () {
+    for (let i = 0; i < 6; i++) {
+      const vault = await ERC4626.new('', '', accounts[i]);
+      expect(await vault.decimals()).to.be.bignumber.equal(decimals);
+    }
+  });
+
+  it('underlying excess decimals', async function () {
+    const token = await ERC20ExcessDecimalsMock.new();
+    const vault = await ERC4626.new('', '', token.address);
+    expect(await vault.decimals()).to.be.bignumber.equal(decimals);
+  });
+
+  it('decimals overflow', async function () {
+    for (const offset of [243, 250, 255].map(web3.utils.toBN)) {
+      const token = await ERC20Decimals.new('', '', decimals);
+      const vault = await ERC4626OffsetMock.new(name + ' Vault', symbol + 'V', token.address, offset);
+      await expectRevert(
+        vault.decimals(),
+        'reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)',
+      );
     }
   });
 

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -23,10 +23,8 @@ contract('ERC4626', function (accounts) {
   });
 
   it('asset has not yet been created', async function () {
-    for (let i = 0; i < 6; i++) {
-      const vault = await ERC4626.new('', '', accounts[i]);
-      expect(await vault.decimals()).to.be.bignumber.equal(decimals);
-    }
+    const vault = await ERC4626.new('', '', other);
+    expect(await vault.decimals()).to.be.bignumber.equal(decimals);
   });
 
   it('underlying excess decimals', async function () {


### PR DESCRIPTION
Fixes #4075. I added loops for the tests to iterate over multiple values.

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)