### PR TITLE
Moved 'to != owner' from ERC721.approval to ERC721._approval

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -365,8 +365,8 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * Emits an {Approval} event.
      */
     function _approve(address to, uint256 tokenId) internal virtual {
-         address owner = ERC721.ownerOf(tokenId);
-         require(to != owner, "ERC721: approval to current owner");
+        address owner = ERC721.ownerOf(tokenId);
+        require(to != owner, "ERC721: approval to current owner");
         _tokenApprovals[tokenId] = to;
         emit Approval(owner, to, tokenId);
     }

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -111,8 +111,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      */
     function approve(address to, uint256 tokenId) public virtual override {
         address owner = ERC721.ownerOf(tokenId);
-        require(to != owner, "ERC721: approval to current owner");
-
+        
         require(
             _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
             "ERC721: approve caller is not token owner or approved for all"
@@ -364,6 +363,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * Emits an {Approval} event.
      */
     function _approve(address to, uint256 tokenId) internal virtual {
+         require(to != owner, "ERC721: approval to current owner");
         _tokenApprovals[tokenId] = to;
         emit Approval(ERC721.ownerOf(tokenId), to, tokenId);
     }

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -182,7 +182,8 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * - `from` cannot be the zero address.
      * - `to` cannot be the zero address.
      * - `tokenId` token must exist and be owned by `from`.
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, 
+     *   which is called upon a safe transfer.
      *
      * Emits a {Transfer} event.
      */
@@ -228,7 +229,8 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * Requirements:
      *
      * - `tokenId` must not exist.
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, 
+     *   which is called upon a safe transfer.
      *
      * Emits a {Transfer} event.
      */
@@ -363,9 +365,10 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * Emits an {Approval} event.
      */
     function _approve(address to, uint256 tokenId) internal virtual {
+         address owner = ERC721.ownerOf(tokenId);
          require(to != owner, "ERC721: approval to current owner");
         _tokenApprovals[tokenId] = to;
-        emit Approval(ERC721.ownerOf(tokenId), to, tokenId);
+        emit Approval(owner, to, tokenId);
     }
 
     /**


### PR DESCRIPTION
Fixes #4136  

'to!=owner' check has been moved from ERC721.approve to ERC721._approve internal function