### PR TITLE
Custom Errors For ERC20 and unit tests

### DIFF
--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -2,6 +2,8 @@ const { BN, constants, expectEvent, expectRevert } = require('@openzeppelin/test
 const { expect } = require('chai');
 const { ZERO_ADDRESS, MAX_UINT256 } = constants;
 
+const CUSTOM_ERROR = 'reverted with custom error ';
+
 function shouldBehaveLikeERC20(errorPrefix, initialSupply, initialHolder, recipient, anotherAccount) {
   describe('total supply', function () {
     it('returns the total amount of tokens', async function () {
@@ -87,7 +89,7 @@ function shouldBehaveLikeERC20(errorPrefix, initialSupply, initialHolder, recipi
             it('reverts', async function () {
               await expectRevert(
                 this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-                `${errorPrefix}: transfer amount exceeds balance`,
+                CUSTOM_ERROR + `'${errorPrefix}InsufficientBalance("${tokenOwner}", ${initialSupply - 1}, ${amount})'`,
               );
             });
           });
@@ -106,7 +108,7 @@ function shouldBehaveLikeERC20(errorPrefix, initialSupply, initialHolder, recipi
             it('reverts', async function () {
               await expectRevert(
                 this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-                `${errorPrefix}: insufficient allowance`,
+                CUSTOM_ERROR + `'${errorPrefix}InsufficientAllowance("${spender}", ${initialSupply - 1}, ${amount})'`,
               );
             });
           });
@@ -121,7 +123,7 @@ function shouldBehaveLikeERC20(errorPrefix, initialSupply, initialHolder, recipi
             it('reverts', async function () {
               await expectRevert(
                 this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-                `${errorPrefix}: transfer amount exceeds balance`,
+                CUSTOM_ERROR + `'${errorPrefix}InsufficientBalance("${tokenOwner}", ${initialSupply - 2}, ${amount})'`,
               );
             });
           });
@@ -155,7 +157,7 @@ function shouldBehaveLikeERC20(errorPrefix, initialSupply, initialHolder, recipi
         it('reverts', async function () {
           await expectRevert(
             this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
-            `${errorPrefix}: transfer to the zero address`,
+            CUSTOM_ERROR + `'${errorPrefix}InvalidReceiver("${to}")'`,
           );
         });
       });
@@ -167,7 +169,10 @@ function shouldBehaveLikeERC20(errorPrefix, initialSupply, initialHolder, recipi
       const to = recipient;
 
       it('reverts', async function () {
-        await expectRevert(this.token.transferFrom(tokenOwner, to, amount, { from: spender }), 'from the zero address');
+        await expectRevert(
+          this.token.transferFrom(tokenOwner, to, amount, { from: spender }),
+          CUSTOM_ERROR + `'${errorPrefix}InvalidApprover("${tokenOwner}")'`,
+        );
       });
     });
   });
@@ -191,7 +196,10 @@ function shouldBehaveLikeERC20Transfer(errorPrefix, from, to, balance, transfer)
       const amount = balance.addn(1);
 
       it('reverts', async function () {
-        await expectRevert(transfer.call(this, from, to, amount), `${errorPrefix}: transfer amount exceeds balance`);
+        await expectRevert(
+          transfer.call(this, from, to, amount),
+          CUSTOM_ERROR + `'${errorPrefix}InsufficientBalance("${from}", ${balance}, ${amount})'`,
+        );
       });
     });
 
@@ -232,7 +240,7 @@ function shouldBehaveLikeERC20Transfer(errorPrefix, from, to, balance, transfer)
     it('reverts', async function () {
       await expectRevert(
         transfer.call(this, from, ZERO_ADDRESS, balance),
-        `${errorPrefix}: transfer to the zero address`,
+        CUSTOM_ERROR + `'${errorPrefix}InvalidReceiver("${ZERO_ADDRESS}")'`,
       );
     });
   });
@@ -309,7 +317,7 @@ function shouldBehaveLikeERC20Approve(errorPrefix, owner, spender, supply, appro
     it('reverts', async function () {
       await expectRevert(
         approve.call(this, owner, ZERO_ADDRESS, supply),
-        `${errorPrefix}: approve to the zero address`,
+        CUSTOM_ERROR + `'${errorPrefix}InvalidSpender("${ZERO_ADDRESS}")'`,
       );
     });
   });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -11,6 +11,8 @@ const {
 const ERC20 = artifacts.require('$ERC20');
 const ERC20Decimals = artifacts.require('$ERC20DecimalsMock');
 
+const CUSTOM_ERROR = 'reverted with custom error ';
+
 contract('ERC20', function (accounts) {
   const [initialHolder, recipient, anotherAccount] = accounts;
 
@@ -56,7 +58,7 @@ contract('ERC20', function (accounts) {
           it('reverts', async function () {
             await expectRevert(
               this.token.decreaseAllowance(spender, amount, { from: initialHolder }),
-              'ERC20: decreased allowance below zero',
+              CUSTOM_ERROR + `'ERC20InvalidAllowanceReduction(0, ${amount})'`,
             );
           });
         });
@@ -90,7 +92,7 @@ contract('ERC20', function (accounts) {
           it('reverts when more than the full allowance is removed', async function () {
             await expectRevert(
               this.token.decreaseAllowance(spender, approvedAmount.addn(1), { from: initialHolder }),
-              'ERC20: decreased allowance below zero',
+              CUSTOM_ERROR + `'ERC20InvalidAllowanceReduction(${approvedAmount}, ${approvedAmount.addn(1)})'`,
             );
           });
         });
@@ -116,7 +118,7 @@ contract('ERC20', function (accounts) {
       it('reverts', async function () {
         await expectRevert(
           this.token.decreaseAllowance(spender, amount, { from: initialHolder }),
-          'ERC20: decreased allowance below zero',
+          CUSTOM_ERROR + `'ERC20InvalidSpender("${spender}")'`,
         );
       });
     });
@@ -197,7 +199,7 @@ contract('ERC20', function (accounts) {
       it('reverts', async function () {
         await expectRevert(
           this.token.increaseAllowance(spender, amount, { from: initialHolder }),
-          'ERC20: approve to the zero address',
+          CUSTOM_ERROR + `'ERC20InvalidSpender("${spender}")'`,
         );
       });
     });
@@ -206,7 +208,10 @@ contract('ERC20', function (accounts) {
   describe('_mint', function () {
     const amount = new BN(50);
     it('rejects a null account', async function () {
-      await expectRevert(this.token.$_mint(ZERO_ADDRESS, amount), 'ERC20: mint to the zero address');
+      await expectRevert(
+        this.token.$_mint(ZERO_ADDRESS, amount),
+        CUSTOM_ERROR + `'ERC20InvalidReceiver("${ZERO_ADDRESS}")'`,
+      );
     });
 
     describe('for a non zero account', function () {
@@ -233,14 +238,17 @@ contract('ERC20', function (accounts) {
 
   describe('_burn', function () {
     it('rejects a null account', async function () {
-      await expectRevert(this.token.$_burn(ZERO_ADDRESS, new BN(1)), 'ERC20: burn from the zero address');
+      await expectRevert(
+        this.token.$_burn(ZERO_ADDRESS, new BN(1)),
+        CUSTOM_ERROR + `'ERC20InvalidSender("${ZERO_ADDRESS}")'`,
+      );
     });
 
     describe('for a non zero account', function () {
       it('rejects burning more than balance', async function () {
         await expectRevert(
           this.token.$_burn(initialHolder, initialSupply.addn(1)),
-          'ERC20: burn amount exceeds balance',
+          CUSTOM_ERROR + `'ERC20InsufficientBalance("${initialHolder}", ${initialSupply}, ${initialSupply.addn(1)})'`,
         );
       });
 
@@ -282,7 +290,7 @@ contract('ERC20', function (accounts) {
       it('reverts', async function () {
         await expectRevert(
           this.token.$_transfer(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: transfer from the zero address',
+          CUSTOM_ERROR + `'ERC20InvalidSender("${ZERO_ADDRESS}")'`,
         );
       });
     });
@@ -297,7 +305,7 @@ contract('ERC20', function (accounts) {
       it('reverts', async function () {
         await expectRevert(
           this.token.$_approve(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: approve from the zero address',
+          CUSTOM_ERROR + `'ERC20InvalidApprover("${ZERO_ADDRESS}")'`,
         );
       });
     });

--- a/test/token/ERC20/extensions/ERC20Burnable.behavior.js
+++ b/test/token/ERC20/extensions/ERC20Burnable.behavior.js
@@ -3,6 +3,8 @@ const { ZERO_ADDRESS } = constants;
 
 const { expect } = require('chai');
 
+const CUSTOM_ERROR = 'reverted with custom error ';
+
 function shouldBehaveLikeERC20Burnable(owner, initialBalance, [burner]) {
   describe('burn', function () {
     describe('when the given amount is not greater than balance of the sender', function () {
@@ -37,7 +39,10 @@ function shouldBehaveLikeERC20Burnable(owner, initialBalance, [burner]) {
       const amount = initialBalance.addn(1);
 
       it('reverts', async function () {
-        await expectRevert(this.token.burn(amount, { from: owner }), 'ERC20: burn amount exceeds balance');
+        await expectRevert(
+          this.token.burn(amount, { from: owner }),
+          CUSTOM_ERROR + `'ERC20InsufficientBalance("${owner}", ${initialBalance}, ${amount})'`,
+        );
       });
     });
   });
@@ -83,7 +88,10 @@ function shouldBehaveLikeERC20Burnable(owner, initialBalance, [burner]) {
 
       it('reverts', async function () {
         await this.token.approve(burner, amount, { from: owner });
-        await expectRevert(this.token.burnFrom(owner, amount, { from: burner }), 'ERC20: burn amount exceeds balance');
+        await expectRevert(
+          this.token.burnFrom(owner, amount, { from: burner }),
+          CUSTOM_ERROR + `'ERC20InsufficientBalance("${owner}", ${initialBalance}, ${amount})'`,
+        );
       });
     });
 
@@ -94,7 +102,7 @@ function shouldBehaveLikeERC20Burnable(owner, initialBalance, [burner]) {
         await this.token.approve(burner, allowance, { from: owner });
         await expectRevert(
           this.token.burnFrom(owner, allowance.addn(1), { from: burner }),
-          'ERC20: insufficient allowance',
+          CUSTOM_ERROR + `'ERC20InsufficientAllowance("${burner}", ${allowance}, ${allowance.addn(1)})'`,
         );
       });
     });

--- a/test/token/ERC20/extensions/ERC20FlashMint.test.js
+++ b/test/token/ERC20/extensions/ERC20FlashMint.test.js
@@ -7,6 +7,8 @@ const { MAX_UINT256, ZERO_ADDRESS } = constants;
 const ERC20FlashMintMock = artifacts.require('$ERC20FlashMintMock');
 const ERC3156FlashBorrowerMock = artifacts.require('ERC3156FlashBorrowerMock');
 
+const CUSTOM_ERROR = 'reverted with custom error ';
+
 contract('ERC20FlashMint', function (accounts) {
   const [initialHolder, other, anotherAccount] = accounts;
 
@@ -89,7 +91,7 @@ contract('ERC20FlashMint', function (accounts) {
       const receiver = await ERC3156FlashBorrowerMock.new(true, false);
       await expectRevert(
         this.token.flashLoan(receiver.address, this.token.address, loanAmount, '0x'),
-        'ERC20: insufficient allowance',
+        CUSTOM_ERROR + `'ERC20InsufficientAllowance("${this.token.address}", 0, ${loanAmount})'`,
       );
     });
 
@@ -98,7 +100,7 @@ contract('ERC20FlashMint', function (accounts) {
       const data = this.token.contract.methods.transfer(other, 10).encodeABI();
       await expectRevert(
         this.token.flashLoan(receiver.address, this.token.address, loanAmount, data),
-        'ERC20: burn amount exceeds balance',
+        CUSTOM_ERROR + `'ERC20InsufficientBalance("${receiver.address}", ${loanAmount.addn(-10)}, ${loanAmount})'`,
       );
     });
 

--- a/test/token/ERC20/extensions/ERC20Wrapper.test.js
+++ b/test/token/ERC20/extensions/ERC20Wrapper.test.js
@@ -8,6 +8,8 @@ const NotAnERC20 = artifacts.require('CallReceiverMock');
 const ERC20Decimals = artifacts.require('$ERC20DecimalsMock');
 const ERC20Wrapper = artifacts.require('$ERC20Wrapper');
 
+const CUSTOM_ERROR = 'reverted with custom error ';
+
 contract('ERC20', function (accounts) {
   const [initialHolder, recipient, anotherAccount] = accounts;
 
@@ -68,7 +70,7 @@ contract('ERC20', function (accounts) {
     it('missing approval', async function () {
       await expectRevert(
         this.token.depositFor(initialHolder, initialSupply, { from: initialHolder }),
-        'ERC20: insufficient allowance',
+        CUSTOM_ERROR + `'ERC20InsufficientAllowance("${this.token.address}", 0, ${initialSupply})'`,
       );
     });
 
@@ -76,7 +78,7 @@ contract('ERC20', function (accounts) {
       await this.underlying.approve(this.token.address, MAX_UINT256, { from: initialHolder });
       await expectRevert(
         this.token.depositFor(initialHolder, MAX_UINT256, { from: initialHolder }),
-        'ERC20: transfer amount exceeds balance',
+        CUSTOM_ERROR + `'ERC20InsufficientBalance("${initialHolder}", ${initialSupply}, ${MAX_UINT256})'`,
       );
     });
 
@@ -105,7 +107,7 @@ contract('ERC20', function (accounts) {
     it('missing balance', async function () {
       await expectRevert(
         this.token.withdrawTo(initialHolder, MAX_UINT256, { from: initialHolder }),
-        'ERC20: burn amount exceeds balance',
+        CUSTOM_ERROR + `'ERC20InsufficientBalance("${initialHolder}", ${initialSupply}, ${MAX_UINT256})'`,
       );
     });
 


### PR DESCRIPTION
Fixes #2839

Add feature custom error to ERC20

Testing is raising errors for multicall, ERC777 and ERC 4626 because I have not added the feature to them yet, and they are using ERC20 behavior. Wanted to make sure the design decisions I made for the feature and testing are OK so I can move forward to the other contracts

- [ X ] Tests 
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
