### PR TITLE
Add requires for account != zero address

### DIFF
--- a/.changeset/two-pandas-pump.md
+++ b/.changeset/two-pandas-pump.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': major
+---
+
+Add reject zero address on grant and revoke roles in AccessControl

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -133,8 +133,8 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
     /**
      * @dev Grants `role` to `account`.
      *
-     * If `account` had not been already granted `role`, emits a {RoleGranted}
-     * event.
+     * If `account` had not been already granted `role`, and it's not the
+     * zero address emits a {RoleGranted} event.
      *
      * Requirements:
      *
@@ -143,8 +143,14 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
      * May emit a {RoleGranted} event.
      */
     function grantRole(bytes32 role, address account) public virtual override onlyRole(getRoleAdmin(role)) {
+        require(account != address(0), "AccessControl: account is the zero address");
+
         _grantRole(role, account);
     }
+
+    /**
+     * @dev Grants
+     */
 
     /**
      * @dev Revokes `role` from `account`.
@@ -154,10 +160,13 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
      * Requirements:
      *
      * - the caller must have ``role``'s admin role.
+     * - the account must not be the zero address.
      *
      * May emit a {RoleRevoked} event.
      */
     function revokeRole(bytes32 role, address account) public virtual override onlyRole(getRoleAdmin(role)) {
+        require(account != address(0), "AccessControl: account is the zero address");
+
         _revokeRole(role, account);
     }
 
@@ -174,10 +183,12 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
      * Requirements:
      *
      * - the caller must be `account`.
+     * - the account must not be the zero address.
      *
      * May emit a {RoleRevoked} event.
      */
     function renounceRole(bytes32 role, address account) public virtual override {
+        require(account != address(0), "AccessControl: account is the zero address");
         require(account == _msgSender(), "AccessControl: can only renounce roles for self");
 
         _revokeRole(role, account);

--- a/contracts/access/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/AccessControlDefaultAdminRules.sol
@@ -129,6 +129,8 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
      * After its execution, it will not be possible to call `onlyRole(DEFAULT_ADMIN_ROLE)`
      * functions.
      *
+     * Can't renounce to the zero address.
+     *
      * For other roles, see {AccessControl-renounceRole}.
      *
      * NOTE: Renouncing `DEFAULT_ADMIN_ROLE` will leave the contract without a defaultAdmin,
@@ -136,6 +138,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
      * possibility of reassigning a non-administrated role.
      */
     function renounceRole(bytes32 role, address account) public virtual override(AccessControl, IAccessControl) {
+        require(account != address(0), "AccessControl: account is the zero address");
         if (role == DEFAULT_ADMIN_ROLE) {
             require(
                 pendingDefaultAdmin() == address(0) && _hasDefaultAdminTransferDelayPassed(),
@@ -146,17 +149,19 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
     }
 
     /**
-     * @dev See {AccessControl-grantRole}. Reverts for `DEFAULT_ADMIN_ROLE`.
+     * @dev See {AccessControl-grantRole}. Reverts for `DEFAULT_ADMIN_ROLE` and zero address.
      */
     function grantRole(bytes32 role, address account) public virtual override(AccessControl, IAccessControl) {
+        require(account != address(0), "AccessControl: account is the zero address");
         require(role != DEFAULT_ADMIN_ROLE, "AccessControl: can't directly grant default admin role");
         super.grantRole(role, account);
     }
 
     /**
-     * @dev See {AccessControl-revokeRole}. Reverts for `DEFAULT_ADMIN_ROLE`.
+     * @dev See {AccessControl-revokeRole}. Reverts for `DEFAULT_ADMIN_ROLE` and zero address.
      */
     function revokeRole(bytes32 role, address account) public virtual override(AccessControl, IAccessControl) {
+        require(account != address(0), "AccessControl: account is the zero address");
         require(role != DEFAULT_ADMIN_ROLE, "AccessControl: can't directly revoke default admin role");
         super.revokeRole(role, account);
     }

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -31,6 +31,13 @@ function shouldBehaveLikeAccessControl(errorPrefix, admin, authorized, other, ot
       await this.accessControl.grantRole(ROLE, authorized, { from: admin });
     });
 
+    it('cannot grant role to zero account', async function () {
+      await expectRevert(
+        this.accessControl.grantRole(ROLE, ZERO_ADDRESS, { from: admin }),
+        `${errorPrefix}: account is the zero address`,
+      );
+    });
+
     it('non-admin cannot grant role to other accounts', async function () {
       await expectRevert(
         this.accessControl.grantRole(ROLE, authorized, { from: other }),
@@ -56,6 +63,13 @@ function shouldBehaveLikeAccessControl(errorPrefix, admin, authorized, other, ot
     context('with granted role', function () {
       beforeEach(async function () {
         await this.accessControl.grantRole(ROLE, authorized, { from: admin });
+      });
+
+      it('cannot revoke role from zero account', async function () {
+        await expectRevert(
+          this.accessControl.revokeRole(ROLE, ZERO_ADDRESS, { from: admin }),
+          `${errorPrefix}: account is the zero address`,
+        );
       });
 
       it('admin can revoke role', async function () {
@@ -129,6 +143,13 @@ function shouldBehaveLikeAccessControl(errorPrefix, admin, authorized, other, ot
 
     it("a role's admin role can be changed", async function () {
       expect(await this.accessControl.getRoleAdmin(ROLE)).to.equal(OTHER_ROLE);
+    });
+
+    it('cannot grant role to zero account', async function () {
+      await expectRevert(
+        this.accessControl.grantRole(ROLE, ZERO_ADDRESS, { from: otherAdmin }),
+        `${errorPrefix}: account is the zero address`,
+      );
     });
 
     it('the new admin can grant roles', async function () {

--- a/test/governance/extensions/GovernorTimelockControl.test.js
+++ b/test/governance/extensions/GovernorTimelockControl.test.js
@@ -63,7 +63,9 @@ contract('GovernorTimelockControl', function (accounts) {
         await this.timelock.grantRole(PROPOSER_ROLE, owner);
         await this.timelock.grantRole(CANCELLER_ROLE, this.mock.address);
         await this.timelock.grantRole(CANCELLER_ROLE, owner);
-        await this.timelock.grantRole(EXECUTOR_ROLE, constants.ZERO_ADDRESS);
+        await this.timelock.grantRole(EXECUTOR_ROLE, this.mock.address);
+        await this.timelock.grantRole(EXECUTOR_ROLE, owner);
+        await this.timelock.grantRole(EXECUTOR_ROLE, deployer);
         await this.timelock.revokeRole(TIMELOCK_ADMIN_ROLE, deployer);
 
         await this.token.$_mint(owner, tokenSupply);


### PR DESCRIPTION
Fixes #3862

Add require that address is different from zero address for grant and renounce role of access control contract.

Didn't identify the need to change the docs, but included the reverts on comments.

Have a failed test on migrate-imports which already happens in master.

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
