### PR TITLE
Update IERC3156FlashBorrower.sol

### DIFF
--- a/contracts/interfaces/IERC3156FlashBorrower.sol
+++ b/contracts/interfaces/IERC3156FlashBorrower.sol
@@ -17,7 +17,7 @@ interface IERC3156FlashBorrower {
      * @param amount The amount of tokens lent.
      * @param fee The additional amount of tokens to repay.
      * @param data Arbitrary data structure, intended to contain user-defined parameters.
-     * @return The keccak256 hash of "IERC3156FlashBorrower.onFlashLoan"
+     * @return The keccak256 hash of "ERC3156FlashBorrower.onFlashLoan"
      */
     function onFlashLoan(
         address initiator,


### PR DESCRIPTION
Fix documentation as per ERC-3156

> The lender MUST verify that the onFlashLoan callback returns the keccak256 hash of “ERC3156FlashBorrower.onFlashLoan”.
