### PR TITLE
Fix calldata encoding when signatures is an empty array

### DIFF
--- a/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
@@ -150,8 +150,11 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     ) private pure returns (bytes[] memory) {
         bytes[] memory fullcalldatas = new bytes[](calldatas.length);
 
-        for (uint256 i = 0; i < signatures.length; ++i) {
-            fullcalldatas[i] = bytes(signatures[i]).length == 0
+        bool noSignatures = signatures.length == 0;
+        require(noSignatures || signatures.length == calldatas.length, "GovernorBravo: invalid signatures length");
+
+        for (uint256 i = 0; i < fullcalldatas.length; ++i) {
+            fullcalldatas[i] = (noSignatures || bytes(signatures[i]).length == 0)
                 ? calldatas[i]
                 : abi.encodePacked(bytes4(keccak256(bytes(signatures[i]))), calldatas[i]);
         }

--- a/test/governance/compatibility/GovernorCompatibilityBravo.test.js
+++ b/test/governance/compatibility/GovernorCompatibilityBravo.test.js
@@ -232,7 +232,7 @@ contract('GovernorCompatibilityBravo', function (accounts) {
             { target, data: this.receiver.contract.methods.mockFunctionWithArgs(17, 42).encodeABI() },
           ],
           '<proposal description>',
-          true // force compatibility interface
+          true, // force compatibility interface
         );
 
         // replace `signatures` array that is ['', ..., ''] with an empty array

--- a/test/helpers/governance.js
+++ b/test/helpers/governance.js
@@ -144,17 +144,17 @@ class GovernorHelper {
    * 1) an array of objects [{ target, value, data, signature? }]
    * 2) an object of arrays { targets: [], values: [], data: [], signatures?: [] }
    */
-  setProposal(actions, description) {
+  setProposal(actions, description, forceCompatibilityInterface = false) {
     let targets, values, signatures, data, useCompatibilityInterface;
 
     if (Array.isArray(actions)) {
-      useCompatibilityInterface = actions.some(a => 'signature' in a);
+      useCompatibilityInterface = actions.some(a => 'signature' in a) || forceCompatibilityInterface;
       targets = actions.map(a => a.target);
       values = actions.map(a => a.value || '0');
       signatures = actions.map(a => a.signature || '');
       data = actions.map(a => a.data || '0x');
     } else {
-      useCompatibilityInterface = Array.isArray(actions.signatures);
+      useCompatibilityInterface = Array.isArray(actions.signatures) || forceCompatibilityInterface;
       ({ targets, values, signatures = [], data } = actions);
     }
 


### PR DESCRIPTION
Currently data encoding is not correct if the signature array passed in the GovernorCompatibilityBravo version of propose doesn't have the same length as the `calldatas` array.

This PR adds a check on the array length. It must either be empty (in which case we use empty strings for the signatures) or exactly match the calldatas array.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
