### PR TITLE
Fix spurious CI check failures

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -83,6 +83,8 @@ jobs:
         uses: ./.github/actions/setup
       - run: rm foundry.toml
       - uses: crytic/slither-action@v0.3.0
+        with:
+          node-version: 18
 
   codespell:
     if: github.repository != 'OpenZeppelin/openzeppelin-contracts-upgradeable'

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,3 @@
 [fuzz]
 runs = 10000
-max_test_rejects = 100000
+max_test_rejects = 150000


### PR DESCRIPTION
It's unclear why but we are seeing fuzz tests fail more often due to too many rejects.

Slither is also failing and it seems to be fixed by using Node 18.