### PR TITLE
Refactor PaymentSplitter require condition

### DIFF
--- a/contracts/finance/PaymentSplitter.sol
+++ b/contracts/finance/PaymentSplitter.sol
@@ -49,8 +49,8 @@ contract PaymentSplitter is Context {
      * duplicates in `payees`.
      */
     constructor(address[] memory payees, uint256[] memory shares_) payable {
-        require(payees.length == shares_.length, "PaymentSplitter: payees and shares length mismatch");
         require(payees.length > 0, "PaymentSplitter: no payees");
+        require(payees.length == shares_.length, "PaymentSplitter: payees and shares length mismatch");
 
         for (uint256 i = 0; i < payees.length; i++) {
             _addPayee(payees[i], shares_[i]);


### PR DESCRIPTION
There is no need to check for payees and shares length mismatch if `payees.length` is 0

