### PR TITLE
Merge changesets for transparency improvements

### DIFF
--- a/.changeset/many-panthers-hide.md
+++ b/.changeset/many-panthers-hide.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-`TransparentUpgradeableProxy`: support value passthrough for all ifAdmin function.

--- a/.changeset/thirty-shrimps-mix.md
+++ b/.changeset/thirty-shrimps-mix.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`TransparentUpgradeableProxy`: Fix transparency in case of selector clash with non-decodable calldata.
+`TransparentUpgradeableProxy`: Fix transparency in case of selector clash with non-decodable calldata or payable mutability.


### PR DESCRIPTION
Merging changesets from #3977 and #4154. The latter subsumes the former, which no longer applies in the way it was originally described (by reference to `ifAdmin`).