### PR TITLE
Alternative fix  for the TransparentUpgradeableProxy "decoding" bug

### DIFF
--- a/contracts/proxy/README.adoc
+++ b/contracts/proxy/README.adoc
@@ -66,8 +66,6 @@ The current implementation of this security mechanism uses https://eips.ethereum
 
 {{TransparentUpgradeableProxy}}
 
-{{ITransparentUpgradeableProxy}}
-
 {{ProxyAdmin}}
 
 == Beacon

--- a/contracts/proxy/README.adoc
+++ b/contracts/proxy/README.adoc
@@ -56,6 +56,8 @@ The current implementation of this security mechanism uses https://eips.ethereum
 
 == ERC1967
 
+{{IERC1967}}
+
 {{ERC1967Proxy}}
 
 {{ERC1967Upgrade}}
@@ -63,6 +65,8 @@ The current implementation of this security mechanism uses https://eips.ethereum
 == Transparent Proxy
 
 {{TransparentUpgradeableProxy}}
+
+{{ITransparentUpgradeableProxy}}
 
 {{ProxyAdmin}}
 

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -49,7 +49,7 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  * NOTE: The real interface of this proxy is that defined in `ITransparentUpgradeableProxy`. This contract does not
  * inherit from that interface, and instead you will see some admin functions are implemented by oddly named functions.
  * These functions are designed to match the selectors of `ITransparentUpgradeableProxy`, but without any arguments.
- * This is necessary to fully implement transparency without decoding errors caused by selector clashes between the
+ * This is necessary to fully implement transparency without decoding reverts caused by selector clashes between the
  * proxy and the implementation.
  */
 contract TransparentUpgradeableProxy is ERC1967Proxy {

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -6,24 +6,6 @@ pragma solidity ^0.8.0;
 import "../ERC1967/ERC1967Proxy.sol";
 
 /**
- * @dev Interface for the {TransparentUpgradeableProxy}. This is useful because {TransparentUpgradeableProxy} uses a
- * custom call-routing mechanism, the compiler is unaware of the functions being exposed, and cannot list them. Also
- * {TransparentUpgradeableProxy} does not inherit from this interface because it's implemented in a way that the
- * compiler doesn't understand and cannot verify.
- */
-interface ITransparentUpgradeableProxy is IERC1967 {
-    function admin() external view returns (address);
-
-    function implementation() external view returns (address);
-
-    function changeAdmin(address) external;
-
-    function upgradeTo(address) external;
-
-    function upgradeToAndCall(address, bytes memory) external payable;
-}
-
-/**
  * @dev This contract implements a proxy that is upgradeable by an admin.
  *
  * To avoid https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357[proxy selector
@@ -43,13 +25,6 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  *
  * Our recommendation is for the dedicated account to be an instance of the {ProxyAdmin} contract. If set up this way,
  * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
- *
- * WARNING: This contract does not inherit from {ITransparentUpgradeableProxy}, and the admin function is implicitly
- * implemented using a custom call-routing mechanism in `_fallback`. Consequently, the compiler will not produce an
- * ABI for this contract. Also, if you inherit from this contract and add additional functions, the compiler will not
- * check that there are no selector conflicts. A selector clash between any new function and the functions declared in
- * {ITransparentUpgradeableProxy} will be resolved in favor of the new one. This could render the admin operations
- * inaccessible, which could prevent upgradeability.
  */
 contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
@@ -62,9 +37,6 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
 
     /**
      * @dev Modifier used internally that will delegate the call to the implementation unless the sender is the admin.
-     *
-     * CAUTION: This modifier is deprecated, as it could cause issues if the modified function has arguments, and the
-     * implementation provides a function with the same selector.
      */
     modifier ifAdmin() {
         if (msg.sender == _getAdmin()) {
@@ -75,97 +47,64 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     }
 
     /**
-     * @dev If caller is the admin process the call internally, otherwise transparently fallback to the proxy behavior
-     */
-    function _fallback() internal virtual override {
-        if (msg.sender == _getAdmin()) {
-            bytes memory ret;
-            bytes4 selector = msg.sig;
-            if (selector == ITransparentUpgradeableProxy.upgradeTo.selector) {
-                ret = _dispatchUpgradeTo();
-            } else if (selector == ITransparentUpgradeableProxy.upgradeToAndCall.selector) {
-                ret = _dispatchUpgradeToAndCall();
-            } else if (selector == ITransparentUpgradeableProxy.changeAdmin.selector) {
-                ret = _dispatchChangeAdmin();
-            } else if (selector == ITransparentUpgradeableProxy.admin.selector) {
-                ret = _dispatchAdmin();
-            } else if (selector == ITransparentUpgradeableProxy.implementation.selector) {
-                ret = _dispatchImplementation();
-            } else {
-                revert("TransparentUpgradeableProxy: admin cannot fallback to proxy target");
-            }
-            assembly {
-                return(add(ret, 0x20), mload(ret))
-            }
-        } else {
-            super._fallback();
-        }
-    }
-
-    /**
      * @dev Returns the current admin.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyAdmin}.
      *
      * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
      */
-    function _dispatchAdmin() private returns (bytes memory) {
+    function admin() external payable ifAdmin returns (address admin_) {
         _requireZeroValue();
-
-        address admin = _getAdmin();
-        return abi.encode(admin);
+        admin_ = _getAdmin();
     }
 
     /**
      * @dev Returns the current implementation.
      *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyImplementation}.
+     *
      * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function _dispatchImplementation() private returns (bytes memory) {
+    function implementation() external payable ifAdmin returns (address implementation_) {
         _requireZeroValue();
-
-        address implementation = _implementation();
-        return abi.encode(implementation);
+        implementation_ = _implementation();
     }
 
     /**
      * @dev Changes the admin of the proxy.
      *
      * Emits an {AdminChanged} event.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-changeProxyAdmin}.
      */
-    function _dispatchChangeAdmin() private returns (bytes memory) {
+    function changeAdmin(address newAdmin) external payable virtual ifAdmin {
         _requireZeroValue();
-
-        address newAdmin = abi.decode(msg.data[4:], (address));
         _changeAdmin(newAdmin);
-
-        return "";
     }
 
     /**
      * @dev Upgrade the implementation of the proxy.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
      */
-    function _dispatchUpgradeTo() private returns (bytes memory) {
+    function upgradeTo(address newImplementation) external payable ifAdmin {
         _requireZeroValue();
-
-        address newImplementation = abi.decode(msg.data[4:], (address));
         _upgradeToAndCall(newImplementation, bytes(""), false);
-
-        return "";
     }
 
     /**
      * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
      * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
      * proxied contract.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
      */
-    function _dispatchUpgradeToAndCall() private returns (bytes memory) {
-        (address newImplementation, bytes memory data) = abi.decode(msg.data[4:], (address, bytes));
+    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable ifAdmin {
         _upgradeToAndCall(newImplementation, data, true);
-
-        return "";
     }
 
     /**
@@ -173,6 +112,14 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      */
     function _admin() internal view virtual returns (address) {
         return _getAdmin();
+    }
+
+    /**
+     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
+     */
+    function _beforeFallback() internal virtual override {
+        require(msg.sender != _getAdmin(), "TransparentUpgradeableProxy: admin cannot fallback to proxy target");
+        super._beforeFallback();
     }
 
     /**

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -47,7 +47,7 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
  *
  * NOTE: The real interface of this proxy is that defined in {ITransparentUpgradeableProxy}. This contract does not
- * inherit from that interface, and instead you will see the admin functions are implemented by oddly named functions.
+ * inherit from that interface, and instead you will see some admin functions are implemented by oddly named functions.
  * These functions are designed to match the selectors of {ITransparentUpgradeableProxy}, but without any arguments.
  * This is necessary to fully implement transparency without decoding errors caused by selector clashes between the
  * proxy and the implementation.
@@ -103,8 +103,8 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
      * @dev Changes the admin of the proxy.
      *
-     * This function's name is designed to have the same selector as {ITransparentUpgradeableProxy-changeAdmin}. This
-     * is so the argument decoding is done manually after the ifAdmin modifier has had a change to proxy the call.
+     * Implements signature `changeAdmin(address)` with the same function selector but manual argument decoding.
+     * See {ITransparentUpgradeableProxy-changeAdmin}.
      *
      * Emits an {AdminChanged} event.
      *
@@ -120,8 +120,8 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
      * @dev Upgrade the implementation of the proxy.
      *
-     * This function's name is designed to have the same selector as {ITransparentUpgradeableProxy-upgradeTo}. This
-     * is so the argument decoding is done manually after the ifAdmin modifier has had a change to proxy the call.
+     * Implements signature `upgradeTo(address)` with the same function selector but manual argument decoding.
+     * See {ITransparentUpgradeableProxy-upgradeTo}.
      *
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
      */
@@ -137,8 +137,8 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
      * proxied contract.
      *
-     * This function's name is designed to have the same selector as {ITransparentUpgradeableProxy-upgradeToAndCall}.
-     * This is so the argument decoding is done manually after the ifAdmin modifier has had a change to proxy the call.
+     * Implements signature `upgradeToAndCall(address,bytes)` with the same function selector but manual argument decoding.
+     * See {ITransparentUpgradeableProxy-upgradeToAndCall}.
      *
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
      */

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -6,10 +6,10 @@ pragma solidity ^0.8.0;
 import "../ERC1967/ERC1967Proxy.sol";
 
 /**
- * @dev Interface for the {TransparentUpgradeableProxy}. This is useful because {TransparentUpgradeableProxy} uses a
- * custom call-routing mechanism, the compiler is unaware of the functions being exposed, and cannot list them. Also
- * {TransparentUpgradeableProxy} does not inherit from this interface because it's implemented in a way that the
- * compiler doesn't understand and cannot verify.
+ * @dev Interface for {TransparentUpgradeableProxy}. In order to implement transparency, {TransparentUpgradeableProxy}
+ * does not implement this interface directly, and some of its functions are implemented by functions without arguments
+ * that match in function selector. The compiler is unaware that these functions are implemented by
+ * {TransparentUpgradeableProxy} and will not include them in the ABI so this interface must be used to interact with it.
  */
 interface ITransparentUpgradeableProxy is IERC1967 {
     function admin() external view returns (address);
@@ -46,9 +46,9 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  * Our recommendation is for the dedicated account to be an instance of the {ProxyAdmin} contract. If set up this way,
  * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
  *
- * NOTE: The real interface of this proxy is that defined in {ITransparentUpgradeableProxy}. This contract does not
+ * NOTE: The real interface of this proxy is that defined in `ITransparentUpgradeableProxy`. This contract does not
  * inherit from that interface, and instead you will see some admin functions are implemented by oddly named functions.
- * These functions are designed to match the selectors of {ITransparentUpgradeableProxy}, but without any arguments.
+ * These functions are designed to match the selectors of `ITransparentUpgradeableProxy`, but without any arguments.
  * This is necessary to fully implement transparency without decoding errors caused by selector clashes between the
  * proxy and the implementation.
  */
@@ -103,8 +103,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
      * @dev Changes the admin of the proxy.
      *
-     * Implements signature `changeAdmin(address)` with the same function selector but manual argument decoding.
-     * See {ITransparentUpgradeableProxy-changeAdmin}.
+     * This function must be invoked as `changeAdmin(address newAdmin)`, which has the same function selector.
      *
      * Emits an {AdminChanged} event.
      *
@@ -120,8 +119,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
      * @dev Upgrade the implementation of the proxy.
      *
-     * Implements signature `upgradeTo(address)` with the same function selector but manual argument decoding.
-     * See {ITransparentUpgradeableProxy-upgradeTo}.
+     * This function must be invoked as `upgradeTo(address newImplementation)`, which has the same function selector.
      *
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
      */
@@ -137,8 +135,8 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
      * proxied contract.
      *
-     * Implements signature `upgradeToAndCall(address,bytes)` with the same function selector but manual argument decoding.
-     * See {ITransparentUpgradeableProxy-upgradeToAndCall}.
+     * This function must be invoked as `upgradeTo(address newImplementation, bytes data)`, which has the same function
+     * selector.
      *
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
      */

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -46,11 +46,11 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  * Our recommendation is for the dedicated account to be an instance of the {ProxyAdmin} contract. If set up this way,
  * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
  *
- * WARNING: This contract does not inherit from {ITransparentUpgradeableProxy}, and the admin functions are
- * implemented by functions that have signature designed to match the selector of the {ITransparentUpgradeableProxy}
- * interface, but without any arguments. This allows use to decode the argument manually after the `ifAdmin` modifier
- * has had a change to forward the call. This is done so that the argument decoding does not fail here in case the
- * proxy and the implementation have "selector clash".
+ * NOTE: The real interface of this proxy is that defined in {ITransparentUpgradeableProxy}. This contract does not
+ * inherit from that interface, and instead you will see the admin functions are implemented by oddly named functions.
+ * These functions are designed to match the selectors of {ITransparentUpgradeableProxy}, but without any arguments.
+ * This is necessary to fully implement transparency without decoding errors caused by selector clashes between the
+ * proxy and the implementation.
  */
 contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -23,6 +23,8 @@ interface ITransparentUpgradeableProxy is IERC1967 {
     function upgradeToAndCall(address, bytes memory) external payable;
 }
 
+// solhint-disable func-name-mixedcase
+
 /**
  * @dev This contract implements a proxy that is upgradeable by an admin.
  *


### PR DESCRIPTION
Partly revert and replace #4154.

This alternative fix is motivated by the goal to make more localized changes, since #4154 is a larger refactor.

Since the first commit in this PR is a revert of 5523c14 (#4154), it's better to see the [diff against its parent](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/5523c14~1...Amxx:openzeppelin-contracts:fix/proxy/TransparentUpgradeableProxy).