### PR TITLE
Fix Checkpoints fuzz overflow

### DIFF
--- a/scripts/generate/templates/Checkpoints.t.js
+++ b/scripts/generate/templates/Checkpoints.t.js
@@ -176,11 +176,13 @@ function testPush(
     // Can't push any key in the past
     if (keys.length > 0) {
         ${opts.keyTypeName} lastKey = keys[keys.length - 1];
-        pastKey = _bound${capitalize(opts.keyTypeName)}(pastKey, 0, lastKey - 1);
-
-        vm.roll(pastKey);
-        vm.expectRevert();
-        this.push(values[keys.length % values.length]);
+        if (lastKey > 0) {
+            pastKey = _bound${capitalize(opts.keyTypeName)}(pastKey, 0, lastKey - 1);
+    
+            vm.roll(pastKey);
+            vm.expectRevert();
+            this.push(values[keys.length % values.length]);
+        }
     }
 }
 

--- a/scripts/generate/templates/Checkpoints.t.js
+++ b/scripts/generate/templates/Checkpoints.t.js
@@ -87,8 +87,7 @@ function testPush(
     if (keys.length > 0) {
         ${opts.keyTypeName} lastKey = keys[keys.length - 1];
         if (lastKey > 0) {
-            ${opts.keyTypeName} maxKey = lastKey == 0 ? 0 : lastKey - 1;
-            pastKey = _bound${capitalize(opts.keyTypeName)}(pastKey, 0, maxKey);
+            pastKey = _bound${capitalize(opts.keyTypeName)}(pastKey, 0, lastKey - 1);
     
             vm.expectRevert();
             this.push(pastKey, values[keys.length % values.length]);

--- a/scripts/generate/templates/Checkpoints.t.js
+++ b/scripts/generate/templates/Checkpoints.t.js
@@ -86,10 +86,13 @@ function testPush(
 
     if (keys.length > 0) {
         ${opts.keyTypeName} lastKey = keys[keys.length - 1];
-        pastKey = _bound${capitalize(opts.keyTypeName)}(pastKey, 0, lastKey - 1);
-
-        vm.expectRevert();
-        this.push(pastKey, values[keys.length % values.length]);
+        if (lastKey > 0) {
+            ${opts.keyTypeName} maxKey = lastKey == 0 ? 0 : lastKey - 1;
+            pastKey = _bound${capitalize(opts.keyTypeName)}(pastKey, 0, maxKey);
+    
+            vm.expectRevert();
+            this.push(pastKey, values[keys.length % values.length]);
+        }
     }
 }
 

--- a/test/utils/Checkpoints.t.sol
+++ b/test/utils/Checkpoints.t.sol
@@ -185,10 +185,13 @@ contract CheckpointsTrace224Test is Test {
 
         if (keys.length > 0) {
             uint32 lastKey = keys[keys.length - 1];
-            pastKey = _boundUint32(pastKey, 0, lastKey - 1);
+            if (lastKey > 0) {
+                uint32 maxKey = lastKey == 0 ? 0 : lastKey - 1;
+                pastKey = _boundUint32(pastKey, 0, maxKey);
 
-            vm.expectRevert();
-            this.push(pastKey, values[keys.length % values.length]);
+                vm.expectRevert();
+                this.push(pastKey, values[keys.length % values.length]);
+            }
         }
     }
 
@@ -291,10 +294,13 @@ contract CheckpointsTrace160Test is Test {
 
         if (keys.length > 0) {
             uint96 lastKey = keys[keys.length - 1];
-            pastKey = _boundUint96(pastKey, 0, lastKey - 1);
+            if (lastKey > 0) {
+                uint96 maxKey = lastKey == 0 ? 0 : lastKey - 1;
+                pastKey = _boundUint96(pastKey, 0, maxKey);
 
-            vm.expectRevert();
-            this.push(pastKey, values[keys.length % values.length]);
+                vm.expectRevert();
+                this.push(pastKey, values[keys.length % values.length]);
+            }
         }
     }
 

--- a/test/utils/Checkpoints.t.sol
+++ b/test/utils/Checkpoints.t.sol
@@ -188,8 +188,7 @@ contract CheckpointsTrace224Test is Test {
         if (keys.length > 0) {
             uint32 lastKey = keys[keys.length - 1];
             if (lastKey > 0) {
-                uint32 maxKey = lastKey == 0 ? 0 : lastKey - 1;
-                pastKey = _boundUint32(pastKey, 0, maxKey);
+                pastKey = _boundUint32(pastKey, 0, lastKey - 1);
 
                 vm.expectRevert();
                 this.push(pastKey, values[keys.length % values.length]);
@@ -297,8 +296,7 @@ contract CheckpointsTrace160Test is Test {
         if (keys.length > 0) {
             uint96 lastKey = keys[keys.length - 1];
             if (lastKey > 0) {
-                uint96 maxKey = lastKey == 0 ? 0 : lastKey - 1;
-                pastKey = _boundUint96(pastKey, 0, maxKey);
+                pastKey = _boundUint96(pastKey, 0, lastKey - 1);
 
                 vm.expectRevert();
                 this.push(pastKey, values[keys.length % values.length]);

--- a/test/utils/Checkpoints.t.sol
+++ b/test/utils/Checkpoints.t.sol
@@ -66,11 +66,13 @@ contract CheckpointsHistoryTest is Test {
         // Can't push any key in the past
         if (keys.length > 0) {
             uint32 lastKey = keys[keys.length - 1];
-            pastKey = _boundUint32(pastKey, 0, lastKey - 1);
+            if (lastKey > 0) {
+                pastKey = _boundUint32(pastKey, 0, lastKey - 1);
 
-            vm.roll(pastKey);
-            vm.expectRevert();
-            this.push(values[keys.length % values.length]);
+                vm.roll(pastKey);
+                vm.expectRevert();
+                this.push(values[keys.length % values.length]);
+            }
         }
     }
 


### PR DESCRIPTION
There was an edge case on the property tests for `Checkpoints.sol` when checking for reverts when setting past keys. When the key is 0, substracting 1 results on an Arithmetic overflow/underflow error.