### PR TITLE
Downgrade Node for Slither

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,7 +86,7 @@ jobs:
       - run: rm foundry.toml
       - uses: crytic/slither-action@v0.3.0
         with:
-          node-version: 18
+          node-version: 18.15
 
   codespell:
     if: github.repository != 'OpenZeppelin/openzeppelin-contracts-upgradeable'


### PR DESCRIPTION
The Slither check is currently randomly failing, but it seems caused by Hardhat, and allegedly downgrading Node.js should fix it.

- https://github.com/crytic/slither-action/issues/56
- https://github.com/NomicFoundation/hardhat/issues/3877