### PR TITLE
uncheck ’+1‘ operation of large integer to save gas

### DIFF
--- a/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
@@ -150,10 +150,13 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
     ) private pure returns (bytes[] memory) {
         bytes[] memory fullcalldatas = new bytes[](calldatas.length);
 
-        for (uint256 i = 0; i < signatures.length; ++i) {
+        for (uint256 i = 0; i < signatures.length;) {
             fullcalldatas[i] = bytes(signatures[i]).length == 0
                 ? calldatas[i]
                 : abi.encodePacked(bytes4(keccak256(bytes(signatures[i]))), calldatas[i]);
+            unchecked{
+                ++i;
+            }
         }
 
         return fullcalldatas;

--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -105,7 +105,9 @@ contract ReinitializerMock is Initializable {
     }
 
     function doStuff() public onlyInitializing {
-        counter++;
+        unchecked {
+            counter++;
+        }
     }
 }
 

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -14,7 +14,9 @@ contract PausableMock is Pausable {
     }
 
     function normalProcess() external whenNotPaused {
-        count++;
+        unchecked{
+            count++;
+        }
     }
 
     function drasticMeasure() external whenPaused {

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -38,7 +38,9 @@ contract ReentrancyMock is ReentrancyGuard {
     }
 
     function _count() private {
-        counter += 1;
+        unchecked{
+            counter += 1;
+        }
     }
 
     function guardedCheckEntered() public nonReentrant {

--- a/contracts/mocks/VotesMock.sol
+++ b/contracts/mocks/VotesMock.sol
@@ -21,7 +21,9 @@ abstract contract VotesMock is Votes {
     }
 
     function _mint(address account, uint256 voteId) internal {
-        _balances[account] += 1;
+        unchecked{
+            _balances[account] += 1;
+        }
         _owners[voteId] = account;
         _transferVotingUnits(address(0), account, 1);
     }

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -47,8 +47,11 @@ library MerkleProof {
      */
     function processProof(bytes32[] memory proof, bytes32 leaf) internal pure returns (bytes32) {
         bytes32 computedHash = leaf;
-        for (uint256 i = 0; i < proof.length; i++) {
+        for (uint256 i = 0; i < proof.length; ) {
             computedHash = _hashPair(computedHash, proof[i]);
+            unchecked {
+                i++;
+            }
         }
         return computedHash;
     }
@@ -60,8 +63,11 @@ library MerkleProof {
      */
     function processProofCalldata(bytes32[] calldata proof, bytes32 leaf) internal pure returns (bytes32) {
         bytes32 computedHash = leaf;
-        for (uint256 i = 0; i < proof.length; i++) {
+        for (uint256 i = 0; i < proof.length; ) {
             computedHash = _hashPair(computedHash, proof[i]);
+            unchecked {
+                i++;
+            }
         }
         return computedHash;
     }
@@ -137,12 +143,15 @@ library MerkleProof {
         //   get the next hash.
         // - depending on the flag, either another value from the "main queue" (merging branches) or an element from the
         //   `proof` array.
-        for (uint256 i = 0; i < totalHashes; i++) {
+        for (uint256 i = 0; i < totalHashes; ) {
             bytes32 a = leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++];
             bytes32 b = proofFlags[i]
                 ? (leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++])
                 : proof[proofPos++];
             hashes[i] = _hashPair(a, b);
+            unchecked {
+                i++;
+            }
         }
 
         if (totalHashes > 0) {
@@ -189,12 +198,15 @@ library MerkleProof {
         //   get the next hash.
         // - depending on the flag, either another value from the "main queue" (merging branches) or an element from the
         //   `proof` array.
-        for (uint256 i = 0; i < totalHashes; i++) {
+        for (uint256 i = 0; i < totalHashes; ) {
             bytes32 a = leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++];
             bytes32 b = proofFlags[i]
                 ? (leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++])
                 : proof[proofPos++];
             hashes[i] = _hashPair(a, b);
+            unchecked {
+                i++;
+            }
         }
 
         if (totalHashes > 0) {

--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -139,7 +139,9 @@ library Math {
     function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {
         uint256 result = mulDiv(x, y, denominator);
         if (rounding == Rounding.Up && mulmod(x, y, denominator) > 0) {
-            result += 1;
+            unchecked{
+                result += 1;
+            }
         }
         return result;
     }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Large integers such as uint128, uint256 are unlikely to overflow in the ```+1``` operation. So adding ```unchecked``` to these statements can save much gas.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
