### PR TITLE
Fix early reporting of FV prover's output

### DIFF
--- a/certora/run.js
+++ b/certora/run.js
@@ -139,8 +139,8 @@ function writeEntry(spec, contract, success, url) {
       spec,
       contract,
       success ? ':x:' : ':heavy_check_mark:',
+      url ? `[link](${url?.replace('/output/', '/jobStatus/')})` : 'error',
       url ? `[link](${url})` : 'error',
-      url ? `[link](${url?.replace('/jobStatus/', '/output/')})` : 'error',
     ),
   );
 }

--- a/certora/run.js
+++ b/certora/run.js
@@ -73,7 +73,7 @@ async function runCertora(spec, contract, files, options = []) {
   child.stdout.pipe(stream, { end: false });
   child.stderr.pipe(stream, { end: false });
 
-  // as soon as we have a jobStatus link, print it
+  // as soon as we have a job id, print the output link
   stream.on('data', function logStatusUrl(data) {
     const { '-DjobId': jobId, '-DuserId': userId } = Object.fromEntries(
       data


### PR DESCRIPTION
When we wrote the `certora/run.js` script we wanted to provide feedback (in the stderr) as early as possible. However, changes to certora's output did break this, resulting in invalid reporting by the CI workflow.

This PR fixed that behavior (until certora's output changes and it breaks again)