### PR TITLE
Implement extra suggestions from audit review of 4.9

### DIFF
--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -174,6 +174,8 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
 
     /**
      * @dev Returns the current admin.
+     * 
+     * CAUTION: This function is deprecated. Use {ERC1967Upgrade-_getAdmin} instead.
      */
     function _admin() internal view virtual returns (address) {
         return _getAdmin();

--- a/contracts/utils/Checkpoints.sol
+++ b/contracts/utils/Checkpoints.sol
@@ -234,7 +234,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key.
+     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero if there is none.
      */
     function upperLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
@@ -243,7 +243,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key.
+     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimised to find "recent" checkpoint (checkpoints with high keys).
      */
@@ -410,7 +410,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key.
+     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero if there is none.
      */
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
@@ -419,7 +419,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key.
+     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimised to find "recent" checkpoint (checkpoints with high keys).
      */

--- a/contracts/utils/ShortStrings.sol
+++ b/contracts/utils/ShortStrings.sol
@@ -4,13 +4,18 @@ pragma solidity ^0.8.8;
 
 import "./StorageSlot.sol";
 
+// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |
+// | length  | 0x                                                              BB |
 type ShortString is bytes32;
 
 /**
  * @dev This library provides functions to convert short memory strings
  * into a `ShortString` type that can be used as an immutable variable.
- * Strings of arbitrary length can be optimized if they are short enough by
- * the addition of a storage variable used as fallback.
+ *
+ * Strings of arbitrary length can be optimized using this library if
+ * they are short enough (up to 31 bytes) by packing them with their
+ * length (1 byte) in a single EVM word (32 bytes). Additionally, a
+ * fallback mechanism can be used for every other case.
  *
  * Usage example:
  *
@@ -32,6 +37,7 @@ type ShortString is bytes32;
  * ```
  */
 library ShortStrings {
+    // Used as an identifier for strings longer than 31 bytes.
     bytes32 private constant _FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;
 
     error StringTooLong(string str);

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -42,7 +42,7 @@ library Strings {
      * @dev Converts a `int256` to its ASCII `string` decimal representation.
      */
     function toString(int256 value) internal pure returns (string memory) {
-        return string(abi.encodePacked(value < 0 ? "-" : "", toString(SignedMath.abs(value))));
+        return string.concat(value < 0 ? "-" : "", toString(SignedMath.abs(value)));
     }
 
     /**

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -55,7 +55,7 @@ function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
 }
 
 /**
- * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key.
+ * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero if there is none.
  */
 function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
@@ -64,7 +64,7 @@ function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
 }
 
 /**
- * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key.
+ * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero if there is none.
  *
  * NOTE: This is a variant of {upperLookup} that is optimised to find "recent" checkpoint (checkpoints with high keys).
  */


### PR DESCRIPTION
Audit report to be published soon.

# Requirements

Using audit report codes

- [ ] N-01: Added docstrings for `Trace224` and `Trace160` and comments for ShortStrings
- [ ] N-02: Added note for deprecation with a recommendation
- [x] N-03: Couldn't be addressed since the functions access `msg.value`, can't be view
- [ ] N-04: Changed `string(abi.encodePacked(...))` for `string.concat(...)`