### PR TITLE
Clean up pending admin schedule on renounce in DefaultAdminRules

### DIFF
--- a/.changeset/loud-wolves-promise.md
+++ b/.changeset/loud-wolves-promise.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`AccessControlDefaultAdminRules`: Clean up pending admin schedule on renounce.

--- a/contracts/access/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/AccessControlDefaultAdminRules.sol
@@ -112,6 +112,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
                 newDefaultAdmin == address(0) && _isScheduleSet(schedule) && _hasSchedulePassed(schedule),
                 "AccessControl: only can renounce in two delayed steps"
             );
+            delete _pendingDefaultAdminSchedule;
         }
         super.renounceRole(role, account);
     }

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -267,7 +267,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
         [0, 'exactly when'],
         [1, 'after'],
       ]) {
-        it(`returns pending admin and delay ${tag} delay schedule passes if not accepted`, async function () {
+        it(`returns pending admin and schedule ${tag} it passes if not accepted`, async function () {
           // Wait until schedule + fromSchedule
           const { schedule: firstSchedule } = await this.accessControl.pendingDefaultAdmin();
           await time.setNextBlockTimestamp(firstSchedule.toNumber() + fromSchedule);
@@ -279,7 +279,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
         });
       }
 
-      it('returns 0 after delay schedule passes and the transfer was accepted', async function () {
+      it('returns 0 after schedule passes and the transfer was accepted', async function () {
         // Wait after schedule
         const { schedule: firstSchedule } = await this.accessControl.pendingDefaultAdmin();
         await time.setNextBlockTimestamp(firstSchedule.addn(1));

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -660,6 +660,9 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
         account: defaultAdmin,
       });
       expect(await this.accessControl.owner()).to.equal(constants.ZERO_ADDRESS);
+      const { newAdmin, schedule } = await this.accessControl.pendingDefaultAdmin();
+      expect(newAdmin).to.eq(ZERO_ADDRESS);
+      expect(schedule).to.be.bignumber.eq(ZERO);
     });
 
     it('allows to recover access using the internal _grantRole', async function () {


### PR DESCRIPTION
In `AccessControlDefaultAdminRules` we realized that we are not cleaning up the schedule value in storage after renouncing. This doesn't seem to have any consequences other than misrepresenting the state of the contract through one of its getters.

I'm also including an unrelated change in this PR but I noticed two of the descriptions in the test suite were not using the right wording (delay vs schedule).

Fixes LIB-862