### PR TITLE
Update docs for `SafeERC20.forceApprove`

### DIFF
--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -70,8 +70,8 @@ library SafeERC20 {
 
     /**
      * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful. Compatible with tokens that require the approval to be set to
-     * 0 before setting it to a non-zero value.
+     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval
+     * to be set to zero before setting it to a non-zero value, such as USDT.
      */
     function forceApprove(IERC20 token, address spender, uint256 value) internal {
         bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));


### PR DESCRIPTION
I was reading the release notes of [v4.9.0-rc.0](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v4.9.0-rc.0), when I saw this PR mentioned:

https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4067

This, in turn, led me to this PR:

https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3851

I read all the comments there, but I was still unsure what the goal of `forceApprove` is. Then, I looked at [USDT's source code](https://gist.github.com/plutoegg/a8794a24dfa84d0b0104141612b52977#file-tethertoken-sol-L267-L271), and it all became clear to me.

This PR rewrites the NatSpec of `SafeERC20.forceApprove` to mention USDT since Tether is the primary use case for this function.