### PR TITLE
Fix spelling error in CHANGELOG.md

### DIFF
--- a/.changeset/tender-needles-dance.md
+++ b/.changeset/tender-needles-dance.md
@@ -2,6 +2,6 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitelly forbiden.
+`ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitly forbiden.
 
 commit: 3214f6c25

--- a/.changeset/tender-needles-dance.md
+++ b/.changeset/tender-needles-dance.md
@@ -2,6 +2,6 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitly forbiden.
+`ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitly forbidden.
 
 commit: 3214f6c25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `SignatureChecker`: Add `isValidERC1271SignatureNow` for checking a signature directly against a smart contract using ERC-1271. ([#3932](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3932))
 - `SafeERC20`: Add a `forceApprove` function to improve compatibility with tokens behaving like USDT. ([#4067](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4067))
 - `ERC1967Upgrade`: removed contract-wide `oz-upgrades-unsafe-allow delegatecall` annotation, replaced by granular annotation in `UUPSUpgradeable`. ([#3971](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3971))
-- `ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitely forbidden. ([#4100](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4100))
+- `ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitly forbidden. ([#4100](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4100))
 - `ECDSA`: optimize bytes32 computation by using assembly instead of `abi.encodePacked`. ([#3853](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3853))
 - `ERC721URIStorage`: Emit ERC-4906 `MetadataUpdate` in `_setTokenURI`. ([#4012](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4012))
 - `ShortStrings`: Added a library for handling short strings in a gas efficient way, with fallback to storage for longer strings. ([#4023](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4023))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `SignatureChecker`: Add `isValidERC1271SignatureNow` for checking a signature directly against a smart contract using ERC-1271. ([#3932](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3932))
 - `SafeERC20`: Add a `forceApprove` function to improve compatibility with tokens behaving like USDT. ([#4067](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4067))
 - `ERC1967Upgrade`: removed contract-wide `oz-upgrades-unsafe-allow delegatecall` annotation, replaced by granular annotation in `UUPSUpgradeable`. ([#3971](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3971))
-- `ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitelly forbiden. ([#4100](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4100))
+- `ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitely forbidden. ([#4100](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4100))
 - `ECDSA`: optimize bytes32 computation by using assembly instead of `abi.encodePacked`. ([#3853](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3853))
 - `ERC721URIStorage`: Emit ERC-4906 `MetadataUpdate` in `_setTokenURI`. ([#4012](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4012))
 - `ShortStrings`: Added a library for handling short strings in a gas efficient way, with fallback to storage for longer strings. ([#4023](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4023))


### PR DESCRIPTION
I noticed that #4231 (that targets [release-v4.9](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/release-v4.9)) is failing codespell. 
