### PR TITLE
Configure Codespell to check hidden files

### DIFF
--- a/.changeset/tender-needles-dance.md
+++ b/.changeset/tender-needles-dance.md
@@ -2,6 +2,6 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitelly forbiden.
+`ERC20Wrapper`: self wrapping and deposit by the wrapper itself are now explicitly forbidden.
 
 commit: 3214f6c25

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,5 +109,6 @@ jobs:
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@v2.0
         with:
+          check_hidden: true
           check_filenames: true
           skip: package-lock.json,*.pdf


### PR DESCRIPTION
Spell checking is currently skipping hidden files like changesets.