### PR TITLE
Fix bug allowing anyone to cancel an admin renounce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,3 @@ contracts-exposed
 .last_confs
 certora_*
 .zip-output-url.txt
-.worktree

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ contracts-exposed
 .last_confs
 certora_*
 .zip-output-url.txt
+.worktree

--- a/contracts/access/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/AccessControlDefaultAdminRules.sol
@@ -106,7 +106,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
      * non-administrated role.
      */
     function renounceRole(bytes32 role, address account) public virtual override(AccessControl, IAccessControl) {
-        if (role == DEFAULT_ADMIN_ROLE) {
+        if (role == DEFAULT_ADMIN_ROLE && account == defaultAdmin()) {
             (address newDefaultAdmin, uint48 schedule) = pendingDefaultAdmin();
             require(
                 newDefaultAdmin == address(0) && _isScheduleSet(schedule) && _hasSchedulePassed(schedule),
@@ -138,7 +138,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
      * @dev See {AccessControl-_revokeRole}.
      */
     function _revokeRole(bytes32 role, address account) internal virtual override {
-        if (role == DEFAULT_ADMIN_ROLE && account == _currentDefaultAdmin) {
+        if (role == DEFAULT_ADMIN_ROLE && account == defaultAdmin()) {
             delete _currentDefaultAdmin;
         }
         super._revokeRole(role, account);

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -627,9 +627,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
 
     beforeEach(async function () {
       await this.accessControl.beginDefaultAdminTransfer(constants.ZERO_ADDRESS, { from: defaultAdmin });
-      expectedSchedule = web3.utils
-        .toBN(await time.latest())
-        .add(delay);
+      expectedSchedule = web3.utils.toBN(await time.latest()).add(delay);
       delayNotPassed = expectedSchedule;
       delayPassed = expectedSchedule.addn(1);
     });
@@ -649,7 +647,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
       const { newAdmin, schedule } = await this.accessControl.pendingDefaultAdmin();
       expect(newAdmin).to.equal(constants.ZERO_ADDRESS);
       expect(schedule).to.be.bignumber.equal(expectedSchedule);
-  });
+    });
 
     it('keeps defaultAdmin consistent with hasRole if another non-defaultAdmin user renounces the DEFAULT_ADMIN_ROLE', async function () {
       await time.setNextBlockTimestamp(delayPassed);

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -640,7 +640,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
       );
     });
 
-    it('renouncing the admin role when not an admin doesn't affect the schedule', async function () {
+    it("renouncing the admin role when not an admin doesn't affect the schedule", async function () {
       await time.setNextBlockTimestamp(delayPassed);
       await this.accessControl.renounceRole(DEFAULT_ADMIN_ROLE, other, { from: other });
 

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -640,7 +640,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules(errorPrefix, delay, defa
       );
     });
 
-    it('no op if renouncing when not having the role', async function () {
+    it('renouncing the admin role when not an admin doesn't affect the schedule', async function () {
       await time.setNextBlockTimestamp(delayPassed);
       await this.accessControl.renounceRole(DEFAULT_ADMIN_ROLE, other, { from: other });
 


### PR DESCRIPTION
Changes introduced in #4230 include a bug allowing anyone to reset the schedule of an admin renounce:

- Alice (admin) starts a transfer to address(0)
- Delay passes
- Bob (not admin) does `renounceRole(0, bob)
  - `if (role == DEFAULT_ADMIN_ROLE)` passes
    - `newDefaultAdmin == address(0)` is true
    - schedule is good
      - `delete _pendingDefaultAdminSchedule`
  - super.renounceRole
    - caller is the account (bob)
    - caller doesn't have the role: nothing happens (no-op does not revert)

So Bob was able to `delete _pendingDefaultAdminSchedule`, which shouldn't have been possible