### PR TITLE
Prevent attempt to publish to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "lodash.zip": "^4.2.0",
         "merkletreejs": "^0.2.13",
         "micromatch": "^4.0.2",
-        "node-fetch": "^2.6.11",
         "p-limit": "^3.1.0",
         "prettier": "^2.8.1",
         "prettier-plugin-solidity": "^1.1.0",
@@ -49,6 +48,7 @@
         "solidity-ast": "^0.4.25",
         "solidity-coverage": "^0.8.0",
         "solidity-docgen": "^0.6.0-beta.29",
+        "undici": "^5.22.1",
         "web3": "^1.3.0",
         "yargs": "^17.0.0"
       }
@@ -10771,9 +10771,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -15176,9 +15176,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
       "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -24628,9 +24628,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -27986,9 +27986,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
       "dev": true,
       "requires": {
         "busboy": "^1.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "lodash.zip": "^4.2.0",
         "merkletreejs": "^0.2.13",
         "micromatch": "^4.0.2",
+        "node-fetch": "^2.6.11",
         "p-limit": "^3.1.0",
         "prettier": "^2.8.1",
         "prettier-plugin-solidity": "^1.1.0",
@@ -10770,9 +10771,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -24627,9 +24628,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "lodash.zip": "^4.2.0",
     "merkletreejs": "^0.2.13",
     "micromatch": "^4.0.2",
-    "node-fetch": "^2.6.11",
     "p-limit": "^3.1.0",
     "prettier": "^2.8.1",
     "prettier-plugin-solidity": "^1.1.0",
@@ -90,6 +89,7 @@
     "solidity-ast": "^0.4.25",
     "solidity-coverage": "^0.8.0",
     "solidity-docgen": "^0.6.0-beta.29",
+    "undici": "^5.22.1",
     "web3": "^1.3.0",
     "yargs": "^17.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "lodash.zip": "^4.2.0",
     "merkletreejs": "^0.2.13",
     "micromatch": "^4.0.2",
+    "node-fetch": "^2.6.11",
     "p-limit": "^3.1.0",
     "prettier": "^2.8.1",
     "prettier-plugin-solidity": "^1.1.0",

--- a/scripts/release/workflow/state.js
+++ b/scripts/release/workflow/state.js
@@ -1,7 +1,8 @@
 const { readPreState } = require('@changesets/pre');
 const { default: readChangesets } = require('@changesets/read');
 const { join } = require('path');
-const { version } = require(join(__dirname, '../../../package.json'));
+const fetch = require('node-fetch');
+const { version, name: packageName } = require(join(__dirname, '../../../contracts/package.json'));
 
 module.exports = async ({ github, context, core }) => {
   const state = await getState({ github, context, core });
@@ -34,8 +35,8 @@ function shouldRunChangesets({ isReleaseBranch, isPush, isWorkflowDispatch, botR
   return (isReleaseBranch && isPush) || (isReleaseBranch && isWorkflowDispatch && botRun);
 }
 
-function shouldRunPublish({ isReleaseBranch, isPush, hasPendingChangesets }) {
-  return isReleaseBranch && isPush && !hasPendingChangesets;
+function shouldRunPublish({ isReleaseBranch, isPush, hasPendingChangesets, isPublishedOnNpm }) {
+  return isReleaseBranch && isPush && !hasPendingChangesets && !isPublishedOnNpm;
 }
 
 function shouldRunMerge({
@@ -80,6 +81,8 @@ async function getState({ github, context, core }) {
 
   state.prBackExists = prs.length === 0;
 
+  state.isPublishedOnNpm = await isPublishedOnNpm(packageName, version);
+
   // Log every state value in debug mode
   if (core.isDebug()) for (const [key, value] of Object.entries(state)) core.debug(`${key}: ${value}`);
 
@@ -101,4 +104,9 @@ async function readChangesetState(cwd = process.cwd()) {
     preState: isInPreMode ? preState : undefined,
     changesets,
   };
+}
+
+async function isPublishedOnNpm(package, version) {
+  const res = await fetch(`https://registry.npmjs.com/${package}/${version}`);
+  return res.ok;
 }

--- a/scripts/release/workflow/state.js
+++ b/scripts/release/workflow/state.js
@@ -1,7 +1,7 @@
 const { readPreState } = require('@changesets/pre');
 const { default: readChangesets } = require('@changesets/read');
 const { join } = require('path');
-const fetch = require('node-fetch');
+const { fetch } = require('undici');
 const { version, name: packageName } = require(join(__dirname, '../../../contracts/package.json'));
 
 module.exports = async ({ github, context, core }) => {


### PR DESCRIPTION
Commits in the release branches when there are no new changesets will currently result in an attempt to publish to npm, even though the version has already been published and it would fail. This should prevent that error.