### PR TITLE
Reduce frequency of version comment updates

### DIFF
--- a/scripts/release/update-comment.js
+++ b/scripts/release/update-comment.js
@@ -16,7 +16,7 @@ const { version } = require('../../package.json');
 const [tag] = run('git', 'tag')
   .split(/\r?\n/)
   .filter(semver.coerce) // check version can be processed
-  .filter(v => semver.lt(semver.coerce(v), version)) // only consider older tags, ignore current prereleases
+  .filter(v => semver.satisfies(v, `< ${version}`)) // ignores prereleases unless currently a prerelease
   .sort(semver.rcompare);
 
 // Ordering tag → HEAD is important here.


### PR DESCRIPTION
In https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4243 we see that every file changed in 4.9.0-rc.0 is getting its version header bumped again to 4.9.0-rc.1 even though only one file is updated in rc.1.

The change in this PR is subtle but causes the effect we want.

When bumping from v4.9.0-rc.0 to v4.9.0-rc.1, it compares against the v4.9.0-rc.0 tag to figure out what files to update. When bumping from v4.9.0-rc.1 to v4.9.0, it compares against the v4.8.3 tag to figure out what files to update.