### PR TITLE
Removes zero address check from balanceOf in ERC1155

### DIFF
--- a/.changeset/smooth-books-wink.md
+++ b/.changeset/smooth-books-wink.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': major
+---
+
+`ERC1155`: Remove check for address zero in `balanceOf`.

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -68,7 +68,6 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
      * - `account` cannot be the zero address.
      */
     function balanceOf(address account, uint256 id) public view virtual override returns (uint256) {
-        require(account != address(0), "ERC1155: address zero is not a valid owner");
         return _balances[id][account];
     }
 

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -74,7 +74,10 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
       });
 
       it('should return 0 as the balance when one of the addresses is the zero address', async function () {
-        const result = await this.token.balanceOfBatch([firstTokenHolder, secondTokenHolder, ZERO_ADDRESS], [firstTokenId, secondTokenId, unknownTokenId]);
+        const result = await this.token.balanceOfBatch(
+          [firstTokenHolder, secondTokenHolder, ZERO_ADDRESS],
+          [firstTokenId, secondTokenId, unknownTokenId],
+        );
         expect(result).to.be.an('array');
         expect(result[0]).to.be.a.bignumber.equal('0');
         expect(result[1]).to.be.a.bignumber.equal('0');

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -20,11 +20,8 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
 
   describe('like an ERC1155', function () {
     describe('balanceOf', function () {
-      it('reverts when queried about the zero address', async function () {
-        await expectRevert(
-          this.token.balanceOf(ZERO_ADDRESS, firstTokenId),
-          'ERC1155: address zero is not a valid owner',
-        );
+      it('should return 0 when queried about the zero address', async function () {
+        expect(await this.token.balanceOf(ZERO_ADDRESS, firstTokenId)).to.be.bignumber.equal('0');
       });
 
       context("when accounts don't own tokens", function () {
@@ -76,14 +73,12 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
         );
       });
 
-      it('reverts when one of the addresses is the zero address', async function () {
-        await expectRevert(
-          this.token.balanceOfBatch(
-            [firstTokenHolder, secondTokenHolder, ZERO_ADDRESS],
-            [firstTokenId, secondTokenId, unknownTokenId],
-          ),
-          'ERC1155: address zero is not a valid owner',
-        );
+      it('should return 0 as the balance when one of the addresses is the zero address', async function () {
+        const result = await this.token.balanceOfBatch([firstTokenHolder, secondTokenHolder, ZERO_ADDRESS], [firstTokenId, secondTokenId, unknownTokenId]);
+        expect(result).to.be.an('array');
+        expect(result[0]).to.be.a.bignumber.equal('0');
+        expect(result[1]).to.be.a.bignumber.equal('0');
+        expect(result[2]).to.be.a.bignumber.equal('0');
       });
 
       context("when accounts don't own tokens", function () {


### PR DESCRIPTION
* updates ERC1155 contract and tests
* removes address zero check from balanceOf function
* makes necessary changes in the ERC1155.test.js file
* ensures all tests are passing

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #4259 <!-- Fill in with issue number -->
Fixes LIB-871

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [All are passing] Tests
- [None] Documentation
- [None] Changeset entry (run `npx changeset add`)
