### PR TITLE
Fix error when running hardhat test with parameters

### DIFF
--- a/hardhat/task-test-get-files.js
+++ b/hardhat/task-test-get-files.js
@@ -3,33 +3,23 @@ const { TASK_TEST_GET_TEST_FILES } = require('hardhat/builtin-tasks/task-names')
 
 // Modifies `hardhat test` to skip the proxy tests after proxies are removed by the transpiler for upgradeability.
 
-internalTask(TASK_TEST_GET_TEST_FILES).setAction(async ({ testFiles }, { config }) => {
-  if (testFiles.length !== 0) {
-    return testFiles;
-  }
-
-  const globAsync = require('glob');
+internalTask(TASK_TEST_GET_TEST_FILES).setAction(async (args, hre, runSuper) => {
   const path = require('path');
   const { promises: fs } = require('fs');
-  const { promisify } = require('util');
-
-  const glob = promisify(globAsync);
 
   const hasProxies = await fs
-    .access(path.join(config.paths.sources, 'proxy/Proxy.sol'))
+    .access(path.join(hre.config.paths.sources, 'proxy/Proxy.sol'))
     .then(() => true)
     .catch(() => false);
 
-  return await glob(path.join(config.paths.tests, '**/*.js'), {
-    ignore: hasProxies
-      ? []
-      : [
-          'proxy/beacon/BeaconProxy.test.js',
-          'proxy/beacon/UpgradeableBeacon.test.js',
-          'proxy/ERC1967/ERC1967Proxy.test.js',
-          'proxy/transparent/ProxyAdmin.test.js',
-          'proxy/transparent/TransparentUpgradeableProxy.test.js',
-          'proxy/utils/UUPSUpgradeable.test.js',
-        ].map(p => path.join(config.paths.tests, p)),
-  });
+  const ignoredIfProxy = [
+    'proxy/beacon/BeaconProxy.test.js',
+    'proxy/beacon/UpgradeableBeacon.test.js',
+    'proxy/ERC1967/ERC1967Proxy.test.js',
+    'proxy/transparent/ProxyAdmin.test.js',
+    'proxy/transparent/TransparentUpgradeableProxy.test.js',
+    'proxy/utils/UUPSUpgradeable.test.js',
+  ].map(p => path.join(hre.config.paths.tests, p));
+
+  return await runSuper(args).then(files => files.filter(file => hasProxies || !ignoredIfProxy.includes(file)));
 });

--- a/hardhat/task-test-get-files.js
+++ b/hardhat/task-test-get-files.js
@@ -21,5 +21,5 @@ internalTask(TASK_TEST_GET_TEST_FILES).setAction(async (args, hre, runSuper) => 
     'proxy/utils/UUPSUpgradeable.test.js',
   ].map(p => path.join(hre.config.paths.tests, p));
 
-  return await runSuper(args).then(files => files.filter(file => hasProxies || !ignoredIfProxy.includes(file)));
+  return (await runSuper(args)).filter(file => hasProxies || !ignoredIfProxy.includes(file));
 });


### PR DESCRIPTION
Fixes a testing error that happens when running specific tests using `npx hardhat test <sometestfile>