### PR TITLE
docs: clarify the interplay between inheritance and the Initializable contract

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -35,8 +35,11 @@ import "../../utils/Address.sol";
  * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
  * possible by providing the encoded function call as the `_data` argument to {ERC1967Proxy-constructor}.
  *
- * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
- * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ * CAUTION: while Solidity takes care of automatically invoking the constructors of all ancestors of a contract and
+ * doing it just once, the same does not apply to initializer functions. Instead, you need to take special care to
+ * manually call the initializer functions of all parent contracts and ensure they are either called no more than once
+ * or designed to be idempotent. Additionally, please note that the initializer modifier can only be called once, even
+ * when utilizing inheritance. Therefore, parent contracts should utilize the onlyInitializing modifier.
  *
  * [CAUTION]
  * ====


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

It was hard to understand the documentation of the `Initializable` contract, specifically how it should be used for contracts with inheritance. I used the [online documentation](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializers) and my own interpretation of the text to produce a version that's hopefully clearer, and also includes discussion of using `initializer` vs. `onlyInitializing` modifiers for parent contracts.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
