### PR TITLE
Avoid accessing SELFBALANCE opcode for zero-value function calls

### DIFF
--- a/.changeset/gorgeous-jars-yawn.md
+++ b/.changeset/gorgeous-jars-yawn.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Avoid accessing SELFBALANCE opcode for zero-value function calls

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -131,7 +131,7 @@ library Address {
         uint256 value,
         string memory errorMessage
     ) internal returns (bytes memory) {
-        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(value == 0 || address(this).balance >= value, "Address: insufficient balance for call");
         (bool success, bytes memory returndata) = target.call{value: value}(data);
         return verifyCallResultFromTarget(target, success, returndata, errorMessage);
     }


### PR DESCRIPTION
'functionCallWithValue' is often called from 'functionCall' which means 'value' is often zero and getting 'address(this).balance' is excessive.

Additionally, the ERC-4337 explicitly forbids using 'balance' opcode in the verification context which prevents using SafeERC20 library: https://github.com/eth-infinitism/account-abstraction/pull/286#discussion_r1200947018

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [X] Changeset entry (run `npx changeset add`)
