### PR TITLE
Fix release merge script

### DIFF
--- a/scripts/release/workflow/prepare-release-merge.sh
+++ b/scripts/release/workflow/prepare-release-merge.sh
@@ -9,6 +9,7 @@ MERGE_BRANCH=merge/$GITHUB_REF_NAME
 git checkout -B "$MERGE_BRANCH" "$GITHUB_REF_NAME"
 
 # Get deleted changesets in this branch that might conflict with master
+# --diff-filter=D - Only deleted files
 readarray -t DELETED_CHANGESETS < <(git diff origin/master --diff-filter=D --name-only -- '.changeset/*.md')
 
 # Merge master, which will take those files cherry-picked. Auto-resolve conflicts favoring master.
@@ -18,6 +19,7 @@ git merge origin/master -m "Merge master to $GITHUB_REF_NAME" -X theirs || true
 # Remove the originally deleted changesets to correctly sync with master
 rm -f "${DELETED_CHANGESETS[@]}"
 
+# Only git add deleted files
 git ls-files --deleted .changeset/ | xargs git add
 
 # Allow empty here since there may be no changes if `rm -f` failed for all changesets

--- a/scripts/release/workflow/prepare-release-merge.sh
+++ b/scripts/release/workflow/prepare-release-merge.sh
@@ -9,15 +9,16 @@ MERGE_BRANCH=merge/$GITHUB_REF_NAME
 git checkout -B "$MERGE_BRANCH" "$GITHUB_REF_NAME"
 
 # Get deleted changesets in this branch that might conflict with master
-readarray -t DELETED_CHANGESETS < <(git diff origin/master --name-only -- '.changeset/*.md')
+readarray -t DELETED_CHANGESETS < <(git diff origin/master --diff-filter=D --name-only -- '.changeset/*.md')
 
 # Merge master, which will take those files cherry-picked. Auto-resolve conflicts favoring master.
-git merge origin/master -m "Merge master to $GITHUB_REF_NAME" -X theirs
+# Ignore conflicts that can't be resolved.
+git merge origin/master -m "Merge master to $GITHUB_REF_NAME" -X theirs || true
 
 # Remove the originally deleted changesets to correctly sync with master
 rm -f "${DELETED_CHANGESETS[@]}"
 
-git add .changeset/
+git ls-files --deleted .changeset/ | xargs git add
 
 # Allow empty here since there may be no changes if `rm -f` failed for all changesets
 git commit --allow-empty -m "Sync changesets with master"


### PR DESCRIPTION
In the case of conflicts when merging `release-vX.Y` with `master`, we are not doing our best to resolve them automatically.

This PR:
1. Adds ` || true` to allow `git merge` to continue even with conflicts. They should be resolved by the following `rm` and `git add` commands. If they are not resolved by that, `git commit` will fail, we have to resolve manually.
2. Adds `--diff-filter=D` to `git diff`, this just makes sure we are only listing deleted files and not anything else that has changed.
3. Uses `git ls-files --deleted` to make sure we don't `git add` anything that we don't intend to.

2 and 3 are not strictly related to the original issue but are just making the script more robust.