### PR TITLE
Optimized remove function on EnumerableSet

### DIFF
--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -98,8 +98,6 @@ library EnumerableSet {
 
                 // Move the last value to the index where the value to delete is
                 set._values[toDeleteIndex] = lastValue;
-                // Update the index for the moved value
-                set._indexes[lastValue] = valueIndex; // Replace lastValue's index to valueIndex
             }
 
             // Delete the slot where the moved value was stored


### PR DESCRIPTION
we doesn't need update last index update when removing from the EnumerableSet.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
