### PR TITLE
Highlight Reentrancy Risk in IERC1155 SafeTransferFrom Function

### DIFF
--- a/contracts/token/ERC1155/IERC1155.sol
+++ b/contracts/token/ERC1155/IERC1155.sol
@@ -86,6 +86,11 @@ interface IERC1155 is IERC165 {
     /**
      * @dev Transfers `amount` tokens of token type `id` from `from` to `to`.
      *
+     * WARNING: This function can potentially allow a reentrancy attack when transferring tokens 
+     * to an untrusted contract, via the internally called _doSafeTransferAcceptanceCheck function.
+     * Ensure to follow the checks-effects-interactions pattern and consider employing 
+     * reentrancy guards when interacting with untrusted contracts.
+     *
      * Emits a {TransferSingle} event.
      *
      * Requirements:
@@ -100,6 +105,12 @@ interface IERC1155 is IERC165 {
 
     /**
      * @dev xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {safeTransferFrom}.
+     *
+     *
+     * WARNING: This function can potentially allow a reentrancy attack when transferring tokens 
+     * to an untrusted contract, via the internally called _doSafeBatchTransferAcceptanceCheck function.
+     * Ensure to follow the checks-effects-interactions pattern and consider employing 
+     * reentrancy guards when interacting with untrusted contracts.
      *
      * Emits a {TransferBatch} event.
      *


### PR DESCRIPTION

This PR aims to improve the documentation of the OpenZeppelin IERC1155 contract by highlighting the potential reentrancy risk associated with the `safeTransferFrom` function. The function internally calls `_doSafeTransferAcceptanceCheck`, which can potentially expose a reentrancy vulnerability when interacting with untrusted contracts.

While the checks-effects-interactions pattern can help mitigate this risk, it might not be immediately obvious to all developers, especially those new to smart contract development or the specifics of reentrancy attacks. By explicitly documenting this in the function comments, we can better ensure that developers are aware of this risk when using the function. 

This change can contribute to safer smart contract development practices and prevent potential security incidents.
