### PR TITLE
Replace some uses of abi.encodePacked with more explicit alternatives

### DIFF
--- a/.changeset/flat-bottles-wonder.md
+++ b/.changeset/flat-bottles-wonder.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-Replace some uses of `abi.encodePacked` with clearer alternatives
+Replace some uses of `abi.encodePacked` with clearer alternatives (e.g. `bytes.concat`, `string.concat`).

--- a/.changeset/flat-bottles-wonder.md
+++ b/.changeset/flat-bottles-wonder.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Replace some uses of `abi.encodePacked` with clearer alternatives

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -108,13 +108,11 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
     function _checkRole(bytes32 role, address account) internal view virtual {
         if (!hasRole(role, account)) {
             revert(
-                string(
-                    abi.encodePacked(
-                        "AccessControl: account ",
-                        Strings.toHexString(account),
-                        " is missing role ",
-                        Strings.toHexString(uint256(role), 32)
-                    )
+                string.concat(
+                    "AccessControl: account ",
+                    Strings.toHexString(account),
+                    " is missing role ",
+                    Strings.toHexString(uint256(role), 32)
                 )
             );
         }

--- a/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravo.sol
@@ -152,7 +152,7 @@ abstract contract GovernorCompatibilityBravo is IGovernorTimelock, IGovernorComp
         for (uint256 i = 0; i < fullcalldatas.length; ++i) {
             fullcalldatas[i] = bytes(signatures[i]).length == 0
                 ? calldatas[i]
-                : abi.encodePacked(bytes4(keccak256(bytes(signatures[i]))), calldatas[i]);
+                : bytes.concat(abi.encodeWithSignature(signatures[i]), calldatas[i]);
         }
 
         return fullcalldatas;

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.19;
 import "../utils/Context.sol";
 
 contract ReentrancyAttack is Context {
-    function callSender(bytes4 data) public {
-        (bool success, ) = _msgSender().call(abi.encodeWithSelector(data));
+    function callSender(bytes calldata data) public {
+        (bool success, ) = _msgSender().call(data);
         require(success, "ReentrancyAttack: failed call");
     }
 }

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -26,15 +26,14 @@ contract ReentrancyMock is ReentrancyGuard {
     function countThisRecursive(uint256 n) public nonReentrant {
         if (n > 0) {
             _count();
-            (bool success, ) = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
+            (bool success, ) = address(this).call(abi.encodeCall(this.countThisRecursive, (n - 1)));
             require(success, "ReentrancyMock: failed call");
         }
     }
 
     function countAndCall(ReentrancyAttack attacker) public nonReentrant {
         _count();
-        bytes4 func = bytes4(keccak256("callback()"));
-        attacker.callSender(func);
+        attacker.callSender(abi.encodeCall(this.callback, ()));
     }
 
     function _count() private {

--- a/contracts/token/ERC1155/extensions/ERC1155URIStorage.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155URIStorage.sol
@@ -42,8 +42,8 @@ abstract contract ERC1155URIStorage is ERC1155 {
     function uri(uint256 tokenId) public view virtual override returns (string memory) {
         string memory tokenURI = _tokenURIs[tokenId];
 
-        // If token URI is set, concatenate base URI and tokenURI (via abi.encodePacked).
-        return bytes(tokenURI).length > 0 ? string(abi.encodePacked(_baseURI, tokenURI)) : super.uri(tokenId);
+        // If token URI is set, concatenate base URI and tokenURI (via string.concat).
+        return bytes(tokenURI).length > 0 ? string.concat(_baseURI, tokenURI) : super.uri(tokenId);
     }
 
     /**

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -92,7 +92,7 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         _requireMinted(tokenId);
 
         string memory baseURI = _baseURI();
-        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+        return bytes(baseURI).length > 0 ? string.concat(baseURI, tokenId.toString()) : "";
     }
 
     /**

--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -35,9 +35,9 @@ abstract contract ERC721URIStorage is IERC4906, ERC721 {
         if (bytes(base).length == 0) {
             return _tokenURI;
         }
-        // If both are set, concatenate the baseURI and tokenURI (via abi.encodePacked).
+        // If both are set, concatenate the baseURI and tokenURI (via string.concat).
         if (bytes(_tokenURI).length > 0) {
-            return string(abi.encodePacked(base, _tokenURI));
+            return string.concat(base, _tokenURI);
         }
 
         return super.tokenURI(tokenId);

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -42,7 +42,7 @@ library Strings {
      * @dev Converts a `int256` to its ASCII `string` decimal representation.
      */
     function toString(int256 value) internal pure returns (string memory) {
-        return string(abi.encodePacked(value < 0 ? "-" : "", toString(SignedMath.abs(value))));
+        return string.concat(value < 0 ? "-" : "", toString(SignedMath.abs(value)));
     }
 
     /**


### PR DESCRIPTION
Some occurences of abi.encodePacked were purposefully left:
- when its part of a "vendored" contracted that we use for testing
- when the different blocks being encoded have various types (string+bytes+...)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
