### PR TITLE
Optimize array access in ERC1155

### DIFF
--- a/.changeset/hot-coins-judge.md
+++ b/.changeset/hot-coins-judge.md
@@ -2,4 +2,5 @@
 'openzeppelin-solidity': patch
 ---
 
-Array optimization in ERC1155
+`Arrays`: Add `unsafeMemoryAccess` helpers to read from a memory array without checking the length.
+`ERC1155`: optimize memory accesses

--- a/.changeset/hot-coins-judge.md
+++ b/.changeset/hot-coins-judge.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Array optimization in ERC1155

--- a/.changeset/hot-coins-judge.md
+++ b/.changeset/hot-coins-judge.md
@@ -1,6 +1,5 @@
 ---
-'openzeppelin-solidity': patch
+'openzeppelin-solidity': minor
 ---
 
 `Arrays`: Add `unsafeMemoryAccess` helpers to read from a memory array without checking the length.
-`ERC1155`: optimize memory accesses

--- a/.changeset/tough-drinks-hammer.md
+++ b/.changeset/tough-drinks-hammer.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC1155`: Optimize array accesses by skipping bounds checking when unnecessary.

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -8,6 +8,7 @@ import "./IERC1155Receiver.sol";
 import "./extensions/IERC1155MetadataURI.sol";
 import "../../utils/Context.sol";
 import "../../utils/introspection/ERC165.sol";
+import "../../utils/Arrays.sol";
 
 /**
  * @dev Implementation of the basic standard multi-token.
@@ -17,6 +18,9 @@ import "../../utils/introspection/ERC165.sol";
  * _Available since v3.1._
  */
 contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
+    using Arrays for uint256[];
+    using Arrays for address[];
+
     // Mapping from token ID to account balances
     mapping(uint256 => mapping(address => uint256)) private _balances;
 
@@ -84,7 +88,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         uint256[] memory batchBalances = new uint256[](accounts.length);
 
         for (uint256 i = 0; i < accounts.length; ++i) {
-            batchBalances[i] = balanceOf(accounts[i], ids[i]);
+            batchBalances[i] = balanceOf(accounts.unsafeMemoryAccess(i), ids.unsafeMemoryAccess(i));
         }
 
         return batchBalances;
@@ -160,8 +164,8 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         address operator = _msgSender();
 
         for (uint256 i = 0; i < ids.length; ++i) {
-            uint256 id = ids[i];
-            uint256 amount = amounts[i];
+            uint256 id = ids.unsafeMemoryAccess(i);
+            uint256 amount = amounts.unsafeMemoryAccess(i);
 
             if (from != address(0)) {
                 uint256 fromBalance = _balances[id][from];
@@ -177,8 +181,9 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         }
 
         if (ids.length == 1) {
-            uint256 id = ids[0];
-            uint256 amount = amounts[0];
+            uint256 id = ids.unsafeMemoryAccess(0);
+            uint256 amount = amounts.unsafeMemoryAccess(0);
+
             emit TransferSingle(operator, from, to, id, amount);
             if (to != address(0)) {
                 _doSafeTransferAcceptanceCheck(operator, from, to, id, amount, data);

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -183,7 +183,6 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         if (ids.length == 1) {
             uint256 id = ids.unsafeMemoryAccess(0);
             uint256 amount = amounts.unsafeMemoryAccess(0);
-
             emit TransferSingle(operator, from, to, id, amount);
             if (to != address(0)) {
                 _doSafeTransferAcceptanceCheck(operator, from, to, id, amount, data);

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -102,4 +102,18 @@ library Arrays {
         }
         return slot.getUint256Slot();
     }
+
+    function unsafeMemoryAccess(uint256[] memory arr, uint256 pos) internal pure returns (uint256 res) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
+        }
+    }
+
+    function unsafeMemoryAccess(address[] memory arr, uint256 pos) internal pure returns (address res) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
+        }
+    }
 }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -103,12 +103,22 @@ library Arrays {
         return slot.getUint256Slot();
     }
 
+    /**
+     * @dev Access an array in an "unsafe" way. Skips solidity "index-out-of-range" check.
+     *
+     * WARNING: Only use if you are certain `pos` is lower than the array length.
+     */
     function unsafeMemoryAccess(uint256[] memory arr, uint256 pos) internal pure returns (uint256 res) {
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
         }
     }
 
+    /**
+     * @dev Access an array in an "unsafe" way. Skips solidity "index-out-of-range" check.
+     *
+     * WARNING: Only use if you are certain `pos` is lower than the array length.
+     */
     function unsafeMemoryAccess(address[] memory arr, uint256 pos) internal pure returns (address res) {
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -104,14 +104,12 @@ library Arrays {
     }
 
     function unsafeMemoryAccess(uint256[] memory arr, uint256 pos) internal pure returns (uint256 res) {
-        /// @solidity memory-safe-assembly
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
         }
     }
 
     function unsafeMemoryAccess(address[] memory arr, uint256 pos) internal pure returns (address res) {
-        /// @solidity memory-safe-assembly
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
         }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #3940 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
Add a function to access memory unsafely and refactor ERC1155 using it.
<!-- Include any context necessary for understanding the PR's purpose. -->

NOTE: I would recommend extending the current function to other datatypes as it's currently being done with the `unsafeAccess` one, it was out of this task scope so is not being done on this PR.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
