### PR TITLE
`ECDSA`: Use unchecked arithmetic for the `tryRecover` function

### DIFF
--- a/.changeset/four-adults-knock.md
+++ b/.changeset/four-adults-knock.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ECDSA`: Use unchecked arithmetic for the `tryRecover` function that receives the `r` and `vs` short-signature fields separately.

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -98,9 +98,12 @@ library ECDSA {
      * _Available since v4.3._
      */
     function tryRecover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address, RecoverError) {
-        bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
-        uint8 v = uint8((uint256(vs) >> 255) + 27);
-        return tryRecover(hash, v, r, s);
+        unchecked {
+            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+            // We do not check for an overflow here since the shift operation results in 0 or 1.
+            uint8 v = uint8((uint256(vs) >> 255) + 27);
+            return tryRecover(hash, v, r, s);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds the usage of unchecked arithmetic for the `tryRecover` function that receives the `r` and `vs` short-signature fields separately. The addition can't overflow (in my understanding) by design since the shift operation results in 0 or 1. 

#### PR Checklist
- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
