### PR TITLE
Remove further hardcoded function resolution

### DIFF
--- a/.changeset/red-dots-fold.md
+++ b/.changeset/red-dots-fold.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': major
 ---
 
-Overrides are now used internally for a number of functions that were previously hardcoded to their default implementation in certain locations: `ERC1155Supply.totalSupply`, `ERC721.ownerOf`, `ERC721.balanceOf` in `ERC721Enumerable`, and `ERC20.totalSupply` in `ERC20FlashMint`.
+Overrides are now used internally for a number of functions that were previously hardcoded to their default implementation in certain locations: `ERC1155Supply.totalSupply`, `ERC721.ownerOf`, `ERC721.balanceOf` and `ERC721.totalSupply` in `ERC721Enumerable`, `ERC20.totalSupply` in `ERC20FlashMint`, and `ERC1967._getImplementation` in `ERC1967Proxy`.

--- a/contracts/mocks/proxy/UUPSUpgradeableMock.sol
+++ b/contracts/mocks/proxy/UUPSUpgradeableMock.sol
@@ -23,10 +23,10 @@ contract UUPSUpgradeableMock is NonUpgradeableMock, UUPSUpgradeable {
 
 contract UUPSUpgradeableUnsafeMock is UUPSUpgradeableMock {
     function upgradeTo(address newImplementation) public override {
-        ERC1967Upgrade._upgradeToAndCall(newImplementation, bytes(""), false);
+        _upgradeToAndCall(newImplementation, bytes(""), false);
     }
 
     function upgradeToAndCall(address newImplementation, bytes memory data) public payable override {
-        ERC1967Upgrade._upgradeToAndCall(newImplementation, data, false);
+        _upgradeToAndCall(newImplementation, data, false);
     }
 }

--- a/contracts/proxy/ERC1967/ERC1967Proxy.sol
+++ b/contracts/proxy/ERC1967/ERC1967Proxy.sol
@@ -31,6 +31,6 @@ contract ERC1967Proxy is Proxy, ERC1967Upgrade {
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
     function _implementation() internal view virtual override returns (address impl) {
-        return ERC1967Upgrade._getImplementation();
+        return _getImplementation();
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -50,7 +50,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      * @dev See {IERC721Enumerable-tokenByIndex}.
      */
     function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
-        require(index < ERC721Enumerable.totalSupply(), "ERC721Enumerable: global index out of bounds");
+        require(index < totalSupply(), "ERC721Enumerable: global index out of bounds");
         return _allTokens[index];
     }
 
@@ -116,7 +116,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
         // To prevent a gap in from's tokens array, we store the last token in the index of the token to delete, and
         // then delete the last slot (swap and pop).
 
-        uint256 lastTokenIndex = ERC721.balanceOf(from) - 1;
+        uint256 lastTokenIndex = balanceOf(from) - 1;
         uint256 tokenIndex = _ownedTokensIndex[tokenId];
 
         // When the token to delete is the last token, the swap operation is unnecessary

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -7,9 +7,11 @@ import "../ERC721.sol";
 import "./IERC721Enumerable.sol";
 
 /**
- * @dev This implements an optional extension of {ERC721} defined in the EIP that adds
- * enumerability of all the token ids in the contract as well as all token ids owned by each
- * account.
+ * @dev This implements an optional extension of {ERC721} defined in the EIP that adds enumerability
+ * of all the token ids in the contract as well as all token ids owned by each account.
+ *
+ * CAUTION: `ERC721` extensions that implement custom `balanceOf` logic, such as `ERC721Consecutive`,
+ * interfere with enumerability and should not be used together with `ERC721Enumerable`.
  */
 abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     // Mapping from owner to list of owned token IDs


### PR DESCRIPTION
For some reason I missed these in #4299.

The one in `ERC721Enumerable._removeTokenFromOwnerEnumeration` is interesting and deserves attention. We were using `ERC721.balanceOf` because we are more confident that it's the length of the enumeration than when we use the potentially overridden `balanceOf`. I've just made it call `balanceOf` now because I don't see a way around this, other than introducing a storage inefficiency by storing the length which is redundant with the balance mapping.

---

For the record here is how I am checking that these changes are exhaustive. (`rg` = ripgrep)

```
rg '^(abstract )?contract (\w+).*' contracts -I -g '*.sol' --replace '\b$2\.\w+\(' > patterns
rg -f patterns -g '*.sol'
```

The only remaining ones are `ERC2771Context._msgData()` and `ERC2771Context._msgSender()` in a mock, but without this we get a compiler warning.