### PR TITLE
Minor update Multicall.sol

### DIFF
--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -15,8 +15,8 @@ abstract contract Multicall {
      * @dev Receives and executes a batch of function calls on this contract.
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
-    function multicall(bytes[] calldata data) external virtual returns (bytes[] memory results) {
-        results = new bytes[](data.length);
+    function multicall(bytes[] calldata data) external virtual returns (bytes[] memory) {
+        bytes[] memory results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
             results[i] = Address.functionDelegateCall(address(this), data[i]);
         }


### PR DESCRIPTION
Hello, I was studying your code base and noticed a mistake in the written code. Here is the modified code in the Multicall contract method:

```solidity
function multicall(bytes[] calldata data) external virtual returns (bytes[] memory) {
    bytes[] memory results = new bytes[](data.length);
    for (uint256 i = 0; i < data.length; i++) {
        results[i] = Address.functionDelegateCall(address(this), data[i]);
    }
    return results;
}
```

The change in the code is that the variable results is now declared directly in the function signature instead of being assigned later. This change improves readability and ensures that the variable is initialized correctly.