### PR TITLE
Add validation in Governor on ERC-721 or ERC-1155 received

### DIFF
--- a/.changeset/mighty-donuts-smile.md
+++ b/.changeset/mighty-donuts-smile.md
@@ -2,4 +2,5 @@
 'openzeppelin-solidity': patch
 ---
 
-Add validation in Governor ERC1155 and ERC721 receiver hooks to ensure Governor is the executor
+`Governor`: Add validation in ERC1155 and ERC721 receiver hooks to ensure Governor is the executor.
+

--- a/.changeset/mighty-donuts-smile.md
+++ b/.changeset/mighty-donuts-smile.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Add validation in Governor ERC1155 and ERC721 receiver hooks to ensure Governor is the executor

--- a/.changeset/thin-camels-matter.md
+++ b/.changeset/thin-camels-matter.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC1155`: bubble custom errors triggered in the `onERC1155Received` and `onERC1155BatchReceived` hooks.
+`ERC1155`: Bubble custom errors triggered in the `onERC1155Received` and `onERC1155BatchReceived` hooks.

--- a/.changeset/thin-camels-matter.md
+++ b/.changeset/thin-camels-matter.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC1155`: bubble custom errors triggered in the `onERC1155Received` and `onERC1155BatchReceived` hooks.

--- a/.changeset/thin-camels-matter.md
+++ b/.changeset/thin-camels-matter.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC1155`: Bubble custom errors triggered in the `onERC1155Received` and `onERC1155BatchReceived` hooks.
+`ERC1155`: Bubble errors triggered in the `onERC1155Received` and `onERC1155BatchReceived` hooks.

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -603,7 +603,8 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC721Receiver-onERC721Received}(disabled if executor is a third party contract).
+     * @dev See {IERC721Receiver-onERC721Received}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
      */
     function onERC721Received(address, address, uint256, bytes memory) public virtual override returns (bytes4) {
         require(_executor() == address(this), "Governor: must send to executor");
@@ -611,7 +612,8 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC1155Receiver-onERC1155Received}(disabled if executor is a third party contract).
+     * @dev See {IERC1155Receiver-onERC1155Received}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
      */
     function onERC1155Received(
         address,
@@ -625,7 +627,8 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC1155Receiver-onERC1155BatchReceived}(disabled if executor is a third party contract).
+     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
      */
     function onERC1155BatchReceived(
         address,

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -603,14 +603,15 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
     }
 
     /**
-     * @dev See {IERC721Receiver-onERC721Received}.
+     * @dev See {IERC721Receiver-onERC721Received}(disabled if executor is a third party contract).
      */
     function onERC721Received(address, address, uint256, bytes memory) public virtual override returns (bytes4) {
+        require(_executor() == address(this), "Governor: must send to executor");
         return this.onERC721Received.selector;
     }
 
     /**
-     * @dev See {IERC1155Receiver-onERC1155Received}.
+     * @dev See {IERC1155Receiver-onERC1155Received}(disabled if executor is a third party contract).
      */
     function onERC1155Received(
         address,
@@ -619,11 +620,12 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         uint256,
         bytes memory
     ) public virtual override returns (bytes4) {
+        require(_executor() == address(this), "Governor: must send to executor");
         return this.onERC1155Received.selector;
     }
 
     /**
-     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
+     * @dev See {IERC1155Receiver-onERC1155BatchReceived}(disabled if executor is a third party contract).
      */
     function onERC1155BatchReceived(
         address,
@@ -632,6 +634,7 @@ abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receive
         uint256[] memory,
         bytes memory
     ) public virtual override returns (bytes4) {
+        require(_executor() == address(this), "Governor: must send to executor");
         return this.onERC1155BatchReceived.selector;
     }
 }

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -360,11 +360,16 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI, IERC1155Erro
                     // Tokens rejected
                     revert ERC1155InvalidReceiver(to);
                 }
-            } catch Error(string memory reason) {
-                revert(reason);
-            } catch {
-                // non-ERC1155Receiver implementer
-                revert ERC1155InvalidReceiver(to);
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    // non-ERC1155Receiver implementer
+                    revert ERC1155InvalidReceiver(to);
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
             }
         }
     }
@@ -385,11 +390,16 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI, IERC1155Erro
                     // Tokens rejected
                     revert ERC1155InvalidReceiver(to);
                 }
-            } catch Error(string memory reason) {
-                revert(reason);
-            } catch {
-                // non-ERC1155Receiver implementer
-                revert ERC1155InvalidReceiver(to);
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    // non-ERC1155Receiver implementer
+                    revert ERC1155InvalidReceiver(to);
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
             }
         }
     }

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -257,8 +257,8 @@ contract('GovernorTimelockCompound', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'ERC1155InvalidReceiver',
-                [this.mock.address],
+                'GovernorDisabledDeposit',
+                [],
               );
             });
 
@@ -272,8 +272,8 @@ contract('GovernorTimelockCompound', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'ERC1155InvalidReceiver',
-                [this.mock.address],
+                'GovernorDisabledDeposit',
+                [],
               );
             });
           });

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -227,9 +227,10 @@ contract('GovernorTimelockCompound', function (accounts) {
             });
 
             it("can't receive an ERC721 safeTransfer", async function () {
-              await expectRevert(
+              await expectRevertCustomError(
                 this.token.safeTransferFrom(owner, this.mock.address, tokenId, { from: owner }),
-                'Governor: must send to executor',
+                'GovernorDisabledDeposit',
+                [],
               );
             });
           });
@@ -248,7 +249,7 @@ contract('GovernorTimelockCompound', function (accounts) {
             });
 
             it("can't receive ERC1155 safeTransfer", async function () {
-              await expectRevert(
+              await expectRevertCustomError(
                 this.token.safeTransferFrom(
                   owner,
                   this.mock.address,
@@ -256,12 +257,13 @@ contract('GovernorTimelockCompound', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'Governor: must send to executor',
+                'ERC1155InvalidReceiver',
+                [this.mock.address],
               );
             });
 
             it("can't receive ERC1155 safeBatchTransfer", async function () {
-              await expectRevert(
+              await expectRevertCustomError(
                 this.token.safeBatchTransferFrom(
                   owner,
                   this.mock.address,
@@ -270,7 +272,8 @@ contract('GovernorTimelockCompound', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'Governor: must send to executor',
+                'ERC1155InvalidReceiver',
+                [this.mock.address],
               );
             });
           });

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -217,8 +217,9 @@ contract('GovernorTimelockCompound', function (accounts) {
             });
 
             it("can't receive an ERC721 safeTransfer", async function () {
-              await expectRevert.unspecified(
+              await expectRevert(
                 this.token.safeTransferFrom(owner, this.mock.address, tokenId, { from: owner }),
+                'Governor: must send to executor',
               );
             });
           });
@@ -237,7 +238,7 @@ contract('GovernorTimelockCompound', function (accounts) {
             });
 
             it("can't receive ERC1155 safeTransfer", async function () {
-              await expectRevert.unspecified(
+              await expectRevert(
                 this.token.safeTransferFrom(
                   owner,
                   this.mock.address,
@@ -245,11 +246,12 @@ contract('GovernorTimelockCompound', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
+                'Governor: must send to executor',
               );
             });
 
             it("can't receive ERC1155 safeBatchTransfer", async function () {
-              await expectRevert.unspecified(
+              await expectRevert(
                 this.token.safeBatchTransferFrom(
                   owner,
                   this.mock.address,
@@ -258,6 +260,7 @@ contract('GovernorTimelockCompound', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
+                'Governor: must send to executor',
               );
             });
           });

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -10,6 +10,8 @@ const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsI
 const Timelock = artifacts.require('CompTimelock');
 const Governor = artifacts.require('$GovernorTimelockCompoundMock');
 const CallReceiver = artifacts.require('CallReceiverMock');
+const ERC721 = artifacts.require('$ERC721');
+const ERC1155 = artifacts.require('$ERC1155');
 
 function makeContractAddress(creator, nonce) {
   return web3.utils.toChecksumAddress(
@@ -200,6 +202,64 @@ contract('GovernorTimelockCompound', function (accounts) {
             await this.helper.waitForEta();
             await this.helper.execute();
             await expectRevert(this.helper.execute(), 'Governor: proposal not successful');
+          });
+        });
+
+        describe('on safe receive', function () {
+          describe('ERC721', function () {
+            const name = 'Non Fungible Token';
+            const symbol = 'NFT';
+            const tokenId = web3.utils.toBN(1);
+
+            beforeEach(async function () {
+              this.token = await ERC721.new(name, symbol);
+              await this.token.$_mint(owner, tokenId);
+            });
+
+            it("can't receive an ERC721 safeTransfer", async function () {
+              await expectRevert.unspecified(
+                this.token.safeTransferFrom(owner, this.mock.address, tokenId, { from: owner }),
+              );
+            });
+          });
+
+          describe('ERC1155', function () {
+            const uri = 'https://token-cdn-domain/{id}.json';
+            const tokenIds = {
+              1: web3.utils.toBN(1000),
+              2: web3.utils.toBN(2000),
+              3: web3.utils.toBN(3000),
+            };
+
+            beforeEach(async function () {
+              this.token = await ERC1155.new(uri);
+              await this.token.$_mintBatch(owner, Object.keys(tokenIds), Object.values(tokenIds), '0x');
+            });
+
+            it("can't receive ERC1155 safeTransfer", async function () {
+              await expectRevert.unspecified(
+                this.token.safeTransferFrom(
+                  owner,
+                  this.mock.address,
+                  ...Object.entries(tokenIds)[0], // id + amount
+                  '0x',
+                  { from: owner },
+                ),
+              );
+            });
+
+            it("can't receive ERC1155 safeBatchTransfer", async function () {
+              await expectRevert.unspecified(
+                this.token.safeBatchTransferFrom(
+                  owner,
+                  this.mock.address,
+                  Object.keys(tokenIds),
+                  Object.values(tokenIds),
+                  '0x',
+                  { from: owner },
+                ),
+              );
+            });
           });
         });
       });

--- a/test/governance/extensions/GovernorTimelockControl.test.js
+++ b/test/governance/extensions/GovernorTimelockControl.test.js
@@ -9,6 +9,8 @@ const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsI
 const Timelock = artifacts.require('TimelockController');
 const Governor = artifacts.require('$GovernorTimelockControlMock');
 const CallReceiver = artifacts.require('CallReceiverMock');
+const ERC721 = artifacts.require('$ERC721');
+const ERC1155 = artifacts.require('$ERC1155');
 
 const TOKENS = [
   { Token: artifacts.require('$ERC20Votes'), mode: 'blocknumber' },
@@ -437,6 +439,64 @@ contract('GovernorTimelockControl', function (accounts) {
             // This path clears _governanceCall as part of the afterExecute call,
             // but we have not way to check that the cleanup actually happened other
             // then coverage reports.
+          });
+        });
+
+        describe('on safe receive', function () {
+          describe('ERC721', function () {
+            const name = 'Non Fungible Token';
+            const symbol = 'NFT';
+            const tokenId = web3.utils.toBN(1);
+
+            beforeEach(async function () {
+              this.token = await ERC721.new(name, symbol);
+              await this.token.$_mint(owner, tokenId);
+            });
+
+            it("can't receive an ERC721 safeTransfer", async function () {
+              await expectRevert.unspecified(
+                this.token.safeTransferFrom(owner, this.mock.address, tokenId, { from: owner }),
+              );
+            });
+          });
+
+          describe('ERC1155', function () {
+            const uri = 'https://token-cdn-domain/{id}.json';
+            const tokenIds = {
+              1: web3.utils.toBN(1000),
+              2: web3.utils.toBN(2000),
+              3: web3.utils.toBN(3000),
+            };
+
+            beforeEach(async function () {
+              this.token = await ERC1155.new(uri);
+              await this.token.$_mintBatch(owner, Object.keys(tokenIds), Object.values(tokenIds), '0x');
+            });
+
+            it("can't receive ERC1155 safeTransfer", async function () {
+              await expectRevert.unspecified(
+                this.token.safeTransferFrom(
+                  owner,
+                  this.mock.address,
+                  ...Object.entries(tokenIds)[0], // id + amount
+                  '0x',
+                  { from: owner },
+                ),
+              );
+            });
+
+            it("can't receive ERC1155 safeBatchTransfer", async function () {
+              await expectRevert.unspecified(
+                this.token.safeBatchTransferFrom(
+                  owner,
+                  this.mock.address,
+                  Object.keys(tokenIds),
+                  Object.values(tokenIds),
+                  '0x',
+                  { from: owner },
+                ),
+              );
+            });
           });
         });
       });

--- a/test/governance/extensions/GovernorTimelockControl.test.js
+++ b/test/governance/extensions/GovernorTimelockControl.test.js
@@ -481,9 +481,10 @@ contract('GovernorTimelockControl', function (accounts) {
             });
 
             it("can't receive an ERC721 safeTransfer", async function () {
-              await expectRevert(
+              await expectRevertCustomError(
                 this.token.safeTransferFrom(owner, this.mock.address, tokenId, { from: owner }),
-                'Governor: must send to executor',
+                'GovernorDisabledDeposit',
+                [],
               );
             });
           });
@@ -502,7 +503,7 @@ contract('GovernorTimelockControl', function (accounts) {
             });
 
             it("can't receive ERC1155 safeTransfer", async function () {
-              await expectRevert(
+              await expectRevertCustomError(
                 this.token.safeTransferFrom(
                   owner,
                   this.mock.address,
@@ -510,12 +511,13 @@ contract('GovernorTimelockControl', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'Governor: must send to executor',
+                'ERC1155InvalidReceiver',
+                [this.mock.address],
               );
             });
 
             it("can't receive ERC1155 safeBatchTransfer", async function () {
-              await expectRevert(
+              await expectRevertCustomError(
                 this.token.safeBatchTransferFrom(
                   owner,
                   this.mock.address,
@@ -524,7 +526,8 @@ contract('GovernorTimelockControl', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'Governor: must send to executor',
+                'ERC1155InvalidReceiver',
+                [this.mock.address],
               );
             });
           });

--- a/test/governance/extensions/GovernorTimelockControl.test.js
+++ b/test/governance/extensions/GovernorTimelockControl.test.js
@@ -454,8 +454,9 @@ contract('GovernorTimelockControl', function (accounts) {
             });
 
             it("can't receive an ERC721 safeTransfer", async function () {
-              await expectRevert.unspecified(
+              await expectRevert(
                 this.token.safeTransferFrom(owner, this.mock.address, tokenId, { from: owner }),
+                'Governor: must send to executor',
               );
             });
           });
@@ -474,7 +475,7 @@ contract('GovernorTimelockControl', function (accounts) {
             });
 
             it("can't receive ERC1155 safeTransfer", async function () {
-              await expectRevert.unspecified(
+              await expectRevert(
                 this.token.safeTransferFrom(
                   owner,
                   this.mock.address,
@@ -482,11 +483,12 @@ contract('GovernorTimelockControl', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
+                'Governor: must send to executor',
               );
             });
 
             it("can't receive ERC1155 safeBatchTransfer", async function () {
-              await expectRevert.unspecified(
+              await expectRevert(
                 this.token.safeBatchTransferFrom(
                   owner,
                   this.mock.address,
@@ -495,6 +497,7 @@ contract('GovernorTimelockControl', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
+                'Governor: must send to executor',
               );
             });
           });

--- a/test/governance/extensions/GovernorTimelockControl.test.js
+++ b/test/governance/extensions/GovernorTimelockControl.test.js
@@ -511,8 +511,8 @@ contract('GovernorTimelockControl', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'ERC1155InvalidReceiver',
-                [this.mock.address],
+                'GovernorDisabledDeposit',
+                [],
               );
             });
 
@@ -526,8 +526,8 @@ contract('GovernorTimelockControl', function (accounts) {
                   '0x',
                   { from: owner },
                 ),
-                'ERC1155InvalidReceiver',
-                [this.mock.address],
+                'GovernorDisabledDeposit',
+                [],
               );
             });
           });

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -433,7 +433,7 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
             RevertType.None,
           );
 
-          await expectRevert(
+          await expectRevertCustomError(
             this.token.safeTransferFrom(multiTokenHolder, receiver.address, firstTokenId, firstAmount, '0x', {
               from: multiTokenHolder,
             }),

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -372,7 +372,12 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
 
       context('to a receiver contract returning unexpected value', function () {
         beforeEach(async function () {
-          this.receiver = await ERC1155ReceiverMock.new('0x00c0ffee', RevertType.None, RECEIVER_BATCH_MAGIC_VALUE, RevertType.None);
+          this.receiver = await ERC1155ReceiverMock.new(
+            '0x00c0ffee',
+            RevertType.None,
+            RECEIVER_BATCH_MAGIC_VALUE,
+            RevertType.None,
+          );
         });
 
         it('reverts', async function () {

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -5,8 +5,10 @@ const { expect } = require('chai');
 
 const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
 const { expectRevertCustomError } = require('../../helpers/customError');
+const { Enum } = require('../../helpers/enums');
 
 const ERC1155ReceiverMock = artifacts.require('ERC1155ReceiverMock');
+const RevertType = Enum('None', 'Empty', 'String', 'Custom');
 
 function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, multiTokenHolder, recipient, proxy]) {
   const firstTokenId = new BN(1);
@@ -296,9 +298,9 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
         beforeEach(async function () {
           this.receiver = await ERC1155ReceiverMock.new(
             RECEIVER_SINGLE_MAGIC_VALUE,
-            false,
+            RevertType.None,
             RECEIVER_BATCH_MAGIC_VALUE,
-            false,
+            RevertType.None,
           );
         });
 
@@ -370,7 +372,7 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
 
       context('to a receiver contract returning unexpected value', function () {
         beforeEach(async function () {
-          this.receiver = await ERC1155ReceiverMock.new('0x00c0ffee', false, RECEIVER_BATCH_MAGIC_VALUE, false);
+          this.receiver = await ERC1155ReceiverMock.new('0x00c0ffee', RevertType.None, RECEIVER_BATCH_MAGIC_VALUE, RevertType.None);
         });
 
         it('reverts', async function () {
@@ -385,21 +387,53 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
       });
 
       context('to a receiver contract that reverts', function () {
-        beforeEach(async function () {
-          this.receiver = await ERC1155ReceiverMock.new(
+        it('with empty reason', async function () {
+          const receiver = await ERC1155ReceiverMock.new(
             RECEIVER_SINGLE_MAGIC_VALUE,
-            true,
+            RevertType.Empty,
             RECEIVER_BATCH_MAGIC_VALUE,
-            false,
+            RevertType.None,
+          );
+
+          await expectRevertCustomError(
+            this.token.safeTransferFrom(multiTokenHolder, receiver.address, firstTokenId, firstAmount, '0x', {
+              from: multiTokenHolder,
+            }),
+            'ERC1155InvalidReceiver',
+            [receiver.address],
           );
         });
 
-        it('reverts', async function () {
+        it('with reason string', async function () {
+          const receiver = await ERC1155ReceiverMock.new(
+            RECEIVER_SINGLE_MAGIC_VALUE,
+            RevertType.String,
+            RECEIVER_BATCH_MAGIC_VALUE,
+            RevertType.None,
+          );
+
           await expectRevert(
-            this.token.safeTransferFrom(multiTokenHolder, this.receiver.address, firstTokenId, firstAmount, '0x', {
+            this.token.safeTransferFrom(multiTokenHolder, receiver.address, firstTokenId, firstAmount, '0x', {
               from: multiTokenHolder,
             }),
             'ERC1155ReceiverMock: reverting on receive',
+          );
+        });
+
+        it('with custom error', async function () {
+          const receiver = await ERC1155ReceiverMock.new(
+            RECEIVER_SINGLE_MAGIC_VALUE,
+            RevertType.Custom,
+            RECEIVER_BATCH_MAGIC_VALUE,
+            RevertType.None,
+          );
+
+          await expectRevert(
+            this.token.safeTransferFrom(multiTokenHolder, receiver.address, firstTokenId, firstAmount, '0x', {
+              from: multiTokenHolder,
+            }),
+            'ERC1155ReceiverMockError',
+            [],
           );
         });
       });
@@ -582,9 +616,9 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
         beforeEach(async function () {
           this.receiver = await ERC1155ReceiverMock.new(
             RECEIVER_SINGLE_MAGIC_VALUE,
-            false,
+            RevertType.None,
             RECEIVER_BATCH_MAGIC_VALUE,
-            false,
+            RevertType.None,
           );
         });
 
@@ -658,9 +692,9 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
         beforeEach(async function () {
           this.receiver = await ERC1155ReceiverMock.new(
             RECEIVER_SINGLE_MAGIC_VALUE,
-            false,
+            RevertType.None,
             RECEIVER_SINGLE_MAGIC_VALUE,
-            false,
+            RevertType.None,
           );
         });
 
@@ -681,20 +715,40 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
       });
 
       context('to a receiver contract that reverts', function () {
-        beforeEach(async function () {
-          this.receiver = await ERC1155ReceiverMock.new(
+        it('with empty reason', async function () {
+          const receiver = await ERC1155ReceiverMock.new(
             RECEIVER_SINGLE_MAGIC_VALUE,
-            false,
+            RevertType.None,
             RECEIVER_BATCH_MAGIC_VALUE,
-            true,
+            RevertType.Empty,
+          );
+
+          await expectRevertCustomError(
+            this.token.safeBatchTransferFrom(
+              multiTokenHolder,
+              receiver.address,
+              [firstTokenId, secondTokenId],
+              [firstAmount, secondAmount],
+              '0x',
+              { from: multiTokenHolder },
+            ),
+            'ERC1155InvalidReceiver',
+            [receiver.address],
           );
         });
 
-        it('reverts', async function () {
+        it('with reason string', async function () {
+          const receiver = await ERC1155ReceiverMock.new(
+            RECEIVER_SINGLE_MAGIC_VALUE,
+            RevertType.None,
+            RECEIVER_BATCH_MAGIC_VALUE,
+            RevertType.String,
+          );
+
           await expectRevert(
             this.token.safeBatchTransferFrom(
               multiTokenHolder,
-              this.receiver.address,
+              receiver.address,
               [firstTokenId, secondTokenId],
               [firstAmount, secondAmount],
               '0x',
@@ -703,15 +757,37 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
             'ERC1155ReceiverMock: reverting on batch receive',
           );
         });
+
+        it('with custom error', async function () {
+          const receiver = await ERC1155ReceiverMock.new(
+            RECEIVER_SINGLE_MAGIC_VALUE,
+            RevertType.None,
+            RECEIVER_BATCH_MAGIC_VALUE,
+            RevertType.Custom,
+          );
+
+          await expectRevertCustomError(
+            this.token.safeBatchTransferFrom(
+              multiTokenHolder,
+              receiver.address,
+              [firstTokenId, secondTokenId],
+              [firstAmount, secondAmount],
+              '0x',
+              { from: multiTokenHolder },
+            ),
+            'ERC1155ReceiverMockError',
+            [],
+          );
+        });
       });
 
       context('to a receiver contract that reverts only on single transfers', function () {
         beforeEach(async function () {
           this.receiver = await ERC1155ReceiverMock.new(
             RECEIVER_SINGLE_MAGIC_VALUE,
-            true,
+            RevertType.String,
             RECEIVER_BATCH_MAGIC_VALUE,
-            false,
+            RevertType.None,
           );
 
           this.toWhom = this.receiver.address;


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #4307  <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
Add validation to `onERC1155Received`, `onERC1155BatchReceived`, and `onERC721Received` hooks in Governor to check it is the executor.
Add test to the validations.

Note: This PR should be refactored after merging #4261 and #4284 
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
