### PR TITLE
`ECDSA`: Rename "`ecrecover` opcode" to "`ecrecover` precompile"

### DIFF
--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -35,7 +35,7 @@ library ECDSA {
      * @dev Returns the address that signed a hashed message (`hash`) with
      * `signature` or error string. This address can then be used for verification purposes.
      *
-     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
@@ -74,7 +74,7 @@ library ECDSA {
      * @dev Returns the address that signed a hashed message (`hash`) with
      * `signature`. This address can then be used for verification purposes.
      *
-     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *


### PR DESCRIPTION
As title. No `Changeset` is required since it's a simple documentation correction.