### PR TITLE
`IERC1155`: Fix `safeBatchTransferFrom` documentation

### DIFF
--- a/contracts/token/ERC1155/IERC1155.sol
+++ b/contracts/token/ERC1155/IERC1155.sol
@@ -108,7 +108,7 @@ interface IERC1155 is IERC165 {
      *
      *
      * WARNING: This function can potentially allow a reentrancy attack when transferring tokens
-     * to an untrusted contract, when invoking {onERC1155Received} on the receiver.
+     * to an untrusted contract, when invoking {onERC1155BatchReceived} on the receiver.
      * Ensure to follow the checks-effects-interactions pattern and consider employing
      * reentrancy guards when interacting with untrusted contracts.
      *


### PR DESCRIPTION
As title. The function `safeBatchTransferFrom` invokes `onERC1155BatchReceived` and not `onERC1155Received`. No `Changeset` is required since it's a simple documentation correction.