### PR TITLE
Improve release merge script for deleted files

### DIFF
--- a/scripts/release/workflow/prepare-release-merge.sh
+++ b/scripts/release/workflow/prepare-release-merge.sh
@@ -16,6 +16,10 @@ readarray -t DELETED_CHANGESETS < <(git diff origin/master --diff-filter=D --nam
 # Ignore conflicts that can't be resolved.
 git merge origin/master -m "Merge master to $GITHUB_REF_NAME" -X theirs || true
 
+# When files were modified in the release branch but removed in master, git will not finish the merge
+# and will leave the files in the index. We need to remove them manually.
+git diff --name-only --diff-filter=U | xargs git rm
+
 # Remove the originally deleted changesets to correctly sync with master
 rm -f "${DELETED_CHANGESETS[@]}"
 

--- a/scripts/release/workflow/prepare-release-merge.sh
+++ b/scripts/release/workflow/prepare-release-merge.sh
@@ -18,6 +18,7 @@ git merge origin/master -m "Merge master to $GITHUB_REF_NAME" -X theirs || true
 
 # When files were modified in the release branch but removed in master, git will not finish the merge
 # and will leave the files in the index. We need to remove them manually.
+# --diff-filter=U - Only unmerged files
 git diff --name-only --diff-filter=U | xargs git rm
 
 # Remove the originally deleted changesets to correctly sync with master


### PR DESCRIPTION
## Description

Recently, the [release scripts failed](https://github.com/OpenZeppelin/openzeppelin-contracts/actions/runs/5260126331) trying to merge the `release-v4.9` branch back to master. The reason is that merging with `-X theirs` strategy doesn't solve conflicts for files modified in `release-v4.9` and deleted in `master`, which is the case for multiple contracts we've removed for 5.0

With this change, the conflicts will be solved by removing the files as they're removed in master.