### PR TITLE
Revert upgradeTo in favor of upgradeToAndCall

### DIFF
--- a/contracts/mocks/proxy/UUPSUpgradeableMock.sol
+++ b/contracts/mocks/proxy/UUPSUpgradeableMock.sol
@@ -22,12 +22,8 @@ contract UUPSUpgradeableMock is NonUpgradeableMock, UUPSUpgradeable {
 }
 
 contract UUPSUpgradeableUnsafeMock is UUPSUpgradeableMock {
-    function upgradeTo(address newImplementation) public override {
-        ERC1967Utils.upgradeToAndCall(newImplementation, bytes(""), false);
-    }
-
     function upgradeToAndCall(address newImplementation, bytes memory data) public payable override {
-        ERC1967Utils.upgradeToAndCall(newImplementation, data, false);
+        ERC1967Utils.upgradeToAndCall(newImplementation, data);
     }
 }
 

--- a/contracts/proxy/ERC1967/ERC1967Proxy.sol
+++ b/contracts/proxy/ERC1967/ERC1967Proxy.sol
@@ -20,7 +20,7 @@ contract ERC1967Proxy is Proxy {
      * function call, and allows initializing the storage of the proxy like a Solidity constructor.
      */
     constructor(address _logic, bytes memory _data) payable {
-        ERC1967Utils.upgradeToAndCall(_logic, _data, false);
+        ERC1967Utils.upgradeToAndCall(_logic, _data);
     }
 
     /**

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -86,9 +86,9 @@ library ERC1967Utils {
      *
      * Emits an {IERC1967-Upgraded} event.
      */
-    function upgradeToAndCall(address newImplementation, bytes memory data, bool forceCall) internal {
+    function upgradeToAndCall(address newImplementation, bytes memory data) internal {
         upgradeTo(newImplementation);
-        if (data.length > 0 || forceCall) {
+        if (data.length > 0) {
             Address.functionDelegateCall(newImplementation, data);
         }
     }

--- a/contracts/proxy/transparent/ProxyAdmin.sol
+++ b/contracts/proxy/transparent/ProxyAdmin.sol
@@ -28,17 +28,6 @@ contract ProxyAdmin is Ownable {
     }
 
     /**
-     * @dev Upgrades `proxy` to `implementation`. See {TransparentUpgradeableProxy-upgradeTo}.
-     *
-     * Requirements:
-     *
-     * - This contract must be the admin of `proxy`.
-     */
-    function upgrade(ITransparentUpgradeableProxy proxy, address implementation) public virtual onlyOwner {
-        proxy.upgradeTo(implementation);
-    }
-
-    /**
      * @dev Upgrades `proxy` to `implementation` and calls a function on the new implementation. See
      * {TransparentUpgradeableProxy-upgradeToAndCall}.
      *

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -15,8 +15,6 @@ import "../../interfaces/IERC1967.sol";
 interface ITransparentUpgradeableProxy is IERC1967 {
     function changeAdmin(address) external;
 
-    function upgradeTo(address) external;
-
     function upgradeToAndCall(address, bytes memory) external payable;
 }
 
@@ -78,9 +76,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
         if (msg.sender == ERC1967Utils.getAdmin()) {
             bytes memory ret;
             bytes4 selector = msg.sig;
-            if (selector == ITransparentUpgradeableProxy.upgradeTo.selector) {
-                ret = _dispatchUpgradeTo();
-            } else if (selector == ITransparentUpgradeableProxy.upgradeToAndCall.selector) {
+            if (selector == ITransparentUpgradeableProxy.upgradeToAndCall.selector) {
                 ret = _dispatchUpgradeToAndCall();
             } else if (selector == ITransparentUpgradeableProxy.changeAdmin.selector) {
                 ret = _dispatchChangeAdmin();
@@ -110,25 +106,13 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     }
 
     /**
-     * @dev Upgrade the implementation of the proxy.
-     */
-    function _dispatchUpgradeTo() private returns (bytes memory) {
-        _requireZeroValue();
-
-        address newImplementation = abi.decode(msg.data[4:], (address));
-        ERC1967Utils.upgradeToAndCall(newImplementation, bytes(""), false);
-
-        return "";
-    }
-
-    /**
      * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
      * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
      * proxied contract.
      */
     function _dispatchUpgradeToAndCall() private returns (bytes memory) {
         (address newImplementation, bytes memory data) = abi.decode(msg.data[4:], (address, bytes));
-        ERC1967Utils.upgradeToAndCall(newImplementation, data, true);
+        ERC1967Utils.upgradeToAndCall(newImplementation, data);
 
         return "";
     }

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -74,20 +74,6 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
     }
 
     /**
-     * @dev Upgrade the implementation of the proxy to `newImplementation`.
-     *
-     * Calls {_authorizeUpgrade}.
-     *
-     * Emits an {Upgraded} event.
-     *
-     * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
-     */
-    function upgradeTo(address newImplementation) public virtual onlyProxy {
-        _authorizeUpgrade(newImplementation);
-        _upgradeToAndCallUUPS(newImplementation, new bytes(0), false);
-    }
-
-    /**
      * @dev Upgrade the implementation of the proxy to `newImplementation`, and subsequently execute the function call
      * encoded in `data`.
      *
@@ -99,7 +85,7 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
      */
     function upgradeToAndCall(address newImplementation, bytes memory data) public payable virtual onlyProxy {
         _authorizeUpgrade(newImplementation);
-        _upgradeToAndCallUUPS(newImplementation, data, true);
+        _upgradeToAndCallUUPS(newImplementation, data);
     }
 
     /**
@@ -119,12 +105,12 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
      *
      * Emits an {IERC1967-Upgraded} event.
      */
-    function _upgradeToAndCallUUPS(address newImplementation, bytes memory data, bool forceCall) private {
+    function _upgradeToAndCallUUPS(address newImplementation, bytes memory data) private {
         try IERC1822Proxiable(newImplementation).proxiableUUID() returns (bytes32 slot) {
             if (slot != ERC1967Utils.IMPLEMENTATION_SLOT) {
                 revert UUPSUnsupportedProxiableUUID(slot);
             }
-            ERC1967Utils.upgradeToAndCall(newImplementation, data, forceCall);
+            ERC1967Utils.upgradeToAndCall(newImplementation, data);
         } catch {
             // The implementation is not UUPS
             revert ERC1967Utils.ERC1967InvalidImplementation(newImplementation);

--- a/test/helpers/customError.js
+++ b/test/helpers/customError.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const { expect, AssertionError } = require('chai');
 
 /** Revert handler that supports custom errors. */
 async function expectRevertCustomError(promise, expectedErrorName, args) {
@@ -6,6 +6,10 @@ async function expectRevertCustomError(promise, expectedErrorName, args) {
     await promise;
     expect.fail("Expected promise to throw but it didn't");
   } catch (revert) {
+    if (revert instanceof AssertionError) {
+      expect.fail(revert.message);
+    }
+
     if (!Array.isArray(args)) {
       expect.fail('Expected 3rd array parameter for error arguments');
     }

--- a/test/proxy/transparent/ProxyAdmin.test.js
+++ b/test/proxy/transparent/ProxyAdmin.test.js
@@ -49,27 +49,6 @@ contract('ProxyAdmin', function (accounts) {
     });
   });
 
-  describe('#upgrade', function () {
-    context('with unauthorized account', function () {
-      it('fails to upgrade', async function () {
-        await expectRevertCustomError(
-          this.proxyAdmin.upgrade(this.proxy.address, this.implementationV2.address, { from: anotherAccount }),
-          'OwnableUnauthorizedAccount',
-          [anotherAccount],
-        );
-      });
-    });
-
-    context('with authorized account', function () {
-      it('upgrades implementation', async function () {
-        await this.proxyAdmin.upgrade(this.proxy.address, this.implementationV2.address, { from: proxyAdminOwner });
-
-        const implementationAddress = await getAddressInSlot(this.proxy, ImplementationSlot);
-        expect(implementationAddress).to.be.equal(this.implementationV2.address);
-      });
-    });
-  });
-
   describe('#upgradeAndCall', function () {
     context('with unauthorized account', function () {
       it('fails to upgrade', async function () {
@@ -85,6 +64,17 @@ contract('ProxyAdmin', function (accounts) {
     });
 
     context('with authorized account', function () {
+      context('with empty callData', function () {
+        it('upgrades implementation', async function () {
+          const callData = '0x';
+          await this.proxyAdmin.upgradeAndCall(this.proxy.address, this.implementationV2.address, callData, {
+            from: proxyAdminOwner,
+          });
+          const implementationAddress = await getAddressInSlot(this.proxy, ImplementationSlot);
+          expect(implementationAddress).to.be.equal(this.implementationV2.address);
+        });
+      });
+
       context('with invalid callData', function () {
         it('fails to upgrade', async function () {
           const callData = '0x12345678';


### PR DESCRIPTION
Depends on #4354 (conflicts will have to be fixed)

Remove the upgradeToAndCall to reduce the size (and deployment cost) of: 
- UUPSUpgradeable
- TransparentUpgradeableProxy
- ProxyAdmin

This includes a refactor of the upgradeToAndCall workflow: if the calldata for the call is empty, is call is no longer performed. 

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
