### PR TITLE
Merge branch 'release-v4.9' into master

### DIFF
--- a/.changeset/shy-crews-teach.md
+++ b/.changeset/shy-crews-teach.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`MerkleProof`: Fix a bug in `processMultiProof` and `processMultiProofCalldata` that allows proving arbitrary leaves if the tree contains a node with value 0 at depth 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ function supportsInterface(bytes4 interfaceId) public view virtual override retu
 }
 ```
 
+## 4.9.2 (2023-06-16)
+
+- `MerkleProof`: Fix a bug in `processMultiProof` and `processMultiProofCalldata` that allows proving arbitrary leaves if the tree contains a node with value 0 at depth 1.
+
 ## 4.9.1 (2023-06-07)
 
 - `Governor`: Add a mechanism to restrict the address of the proposer using a suffix in the description.

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openzeppelin/contracts",
   "description": "Secure Smart Contract library for Solidity",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "files": [
     "**/*.sol",
     "/build/contracts/*.json",

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v4.9.0) (utils/cryptography/MerkleProof.sol)
+// OpenZeppelin Contracts (last updated v4.9.2) (utils/cryptography/MerkleProof.sol)
 
 pragma solidity ^0.8.19;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openzeppelin-solidity",
-  "version": "4.9.0",
+  "version": "4.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openzeppelin-solidity",
-      "version": "4.9.0",
+      "version": "4.9.2",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openzeppelin-solidity",
   "description": "Secure Smart Contract library for Solidity",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "files": [
     "/contracts/**/*.sol",
     "/build/contracts/*.json",


### PR DESCRIPTION
This brings the latest changes from `release-v4.9` including the changelog and version header updates.

This part of our release workflow is broken, as can be seen in https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4366. Due to squashing these merge commits, resolved conflicts are "forgotten" and for each new patch we have to re-resolve them. I don't have a sustainable solution for this yet. In the meantime I did the merge manually.