### PR TITLE
Fix attempt to delete nonexistent npm tag

### DIFF
--- a/scripts/release/workflow/publish.sh
+++ b/scripts/release/workflow/publish.sh
@@ -2,19 +2,25 @@
 
 set -euo pipefail
 
+PACKAGE_JSON_NAME="$(tar xfO "$TARBALL" package/package.json | jq -r .name)"
+PACKAGE_JSON_VERSION="$(tar xfO "$TARBALL" package/package.json | jq -r .version)"
+
 # Intentionally escape $ to avoid interpolation and writing the token to disk
 echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 # Actual publish
 npm publish "$TARBALL" --tag "$TAG"
 
+# Clean up tags
 delete_tag() {
-  PACKAGE_JSON_NAME="$(tar xfO "$TARBALL" package/package.json | jq -r .name)"
   npm dist-tag rm "$PACKAGE_JSON_NAME" "$1"
 }
 
 if [ "$TAG" = tmp ]; then
   delete_tag "$TAG"
 elif [ "$TAG" = latest ]; then
-  delete_tag next
+  # Delete the next tag if it exists and is a prerelease for what is currently being published
+  if npm dist-tag ls "$PACKAGE_JSON_NAME" | grep -q "next: $PACKAGE_JSON_VERSION"; then
+    delete_tag next
+  fi
 fi


### PR DESCRIPTION
The release workflows for 4.9.1 and 4.9.2 [failed](https://github.com/OpenZeppelin/openzeppelin-contracts/actions/runs/5294042249/jobs/9582925626) because there's an attempt to delete the `next` tag, which is not present when we're releasing a patch. This PR will first check if the next tag exists, but also if it should be deleted. If we have `next: 5.0.0-rc.0` and we publish `latest: 4.9.4` we don't want to delete the `next` tag in that case.