### PR TITLE
Rename `ERC1155InsufficientApprovalForAll` to `ERC1155MissingApprovalForAll`

### DIFF
--- a/contracts/interfaces/draft-IERC6093.sol
+++ b/contracts/interfaces/draft-IERC6093.sol
@@ -138,7 +138,7 @@ interface IERC1155Errors {
      * @param operator Address that may be allowed to operate on tokens without being their owner.
      * @param owner Address of the current owner of a token.
      */
-    error ERC1155InsufficientApprovalForAll(address operator, address owner);
+    error ERC1155MissingApprovalForAll(address operator, address owner);
 
     /**
      * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -116,7 +116,7 @@ abstract contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI, IER
      */
     function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes memory data) public virtual {
         if (from != _msgSender() && !isApprovedForAll(from, _msgSender())) {
-            revert ERC1155InsufficientApprovalForAll(_msgSender(), from);
+            revert ERC1155MissingApprovalForAll(_msgSender(), from);
         }
         _safeTransferFrom(from, to, id, amount, data);
     }
@@ -132,7 +132,7 @@ abstract contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI, IER
         bytes memory data
     ) public virtual {
         if (from != _msgSender() && !isApprovedForAll(from, _msgSender())) {
-            revert ERC1155InsufficientApprovalForAll(_msgSender(), from);
+            revert ERC1155MissingApprovalForAll(_msgSender(), from);
         }
         _safeBatchTransferFrom(from, to, ids, amounts, data);
     }

--- a/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
@@ -14,7 +14,7 @@ import "../ERC1155.sol";
 abstract contract ERC1155Burnable is ERC1155 {
     function burn(address account, uint256 id, uint256 value) public virtual {
         if (account != _msgSender() && !isApprovedForAll(account, _msgSender())) {
-            revert ERC1155InsufficientApprovalForAll(_msgSender(), account);
+            revert ERC1155MissingApprovalForAll(_msgSender(), account);
         }
 
         _burn(account, id, value);
@@ -22,7 +22,7 @@ abstract contract ERC1155Burnable is ERC1155 {
 
     function burnBatch(address account, uint256[] memory ids, uint256[] memory values) public virtual {
         if (account != _msgSender() && !isApprovedForAll(account, _msgSender())) {
-            revert ERC1155InsufficientApprovalForAll(_msgSender(), account);
+            revert ERC1155MissingApprovalForAll(_msgSender(), account);
         }
 
         _burnBatch(account, ids, values);

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -254,7 +254,7 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
               this.token.safeTransferFrom(multiTokenHolder, recipient, firstTokenId, firstAmount, '0x', {
                 from: proxy,
               }),
-              'ERC1155InsufficientApprovalForAll',
+              'ERC1155MissingApprovalForAll',
               [proxy, multiTokenHolder],
             );
           });
@@ -609,7 +609,7 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
                 '0x',
                 { from: proxy },
               ),
-              'ERC1155InsufficientApprovalForAll',
+              'ERC1155MissingApprovalForAll',
               [proxy, multiTokenHolder],
             );
           });

--- a/test/token/ERC1155/extensions/ERC1155Burnable.test.js
+++ b/test/token/ERC1155/extensions/ERC1155Burnable.test.js
@@ -38,7 +38,7 @@ contract('ERC1155Burnable', function (accounts) {
     it("unapproved accounts cannot burn the holder's tokens", async function () {
       await expectRevertCustomError(
         this.token.burn(holder, tokenIds[0], amounts[0].subn(1), { from: other }),
-        'ERC1155InsufficientApprovalForAll',
+        'ERC1155MissingApprovalForAll',
         [other, holder],
       );
     });
@@ -63,7 +63,7 @@ contract('ERC1155Burnable', function (accounts) {
     it("unapproved accounts cannot burn the holder's tokens", async function () {
       await expectRevertCustomError(
         this.token.burnBatch(holder, tokenIds, [amounts[0].subn(1), amounts[1].subn(2)], { from: other }),
-        'ERC1155InsufficientApprovalForAll',
+        'ERC1155MissingApprovalForAll',
         [other, holder],
       );
     });


### PR DESCRIPTION
Implement error naming suggestion for 5.0 audit phase I.

Details to be published soon.

NOTE: Pending to update EIP-6093 accordingly