### PR TITLE
Separate typehash into multiple lines

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -30,10 +30,22 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
     using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
 
     bytes32 public constant BALLOT_TYPEHASH =
-        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
+        keccak256(
+            "Ballot("
+            "uint256 proposalId,"
+            "uint8 support,"
+            "address voter,"
+            "uint256 nonce)"
+        );
     bytes32 public constant EXTENDED_BALLOT_TYPEHASH =
         keccak256(
-            "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
+            "ExtendedBallot("
+            "uint256 proposalId,"
+            "uint8 support,"
+            "address voter,"
+            "uint256 nonce,"
+            "string reason,"
+            "bytes params)"
         );
 
     // solhint-disable var-name-mixedcase

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -28,9 +28,20 @@ import {IGovernor, IERC6372} from "./IGovernor.sol";
 abstract contract Governor is Context, ERC165, EIP712, IGovernor, IERC721Receiver, IERC1155Receiver {
     using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
 
-    bytes32 public constant BALLOT_TYPEHASH = keccak256("Ballot(uint256 proposalId,uint8 support)");
+    bytes32 public constant BALLOT_TYPEHASH =
+        keccak256(
+            "Ballot("
+            "uint256 proposalId,"
+            "uint8 support)"
+        );
     bytes32 public constant EXTENDED_BALLOT_TYPEHASH =
-        keccak256("ExtendedBallot(uint256 proposalId,uint8 support,string reason,bytes params)");
+        keccak256(
+            "ExtendedBallot("
+            "uint256 proposalId,"
+            "uint8 support,"
+            "string reason,"
+            "bytes params)"
+        );
 
     // solhint-disable var-name-mixedcase
     struct ProposalCore {

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -34,7 +34,12 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
     using Checkpoints for Checkpoints.Trace224;
 
     bytes32 private constant _DELEGATION_TYPEHASH =
-        keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+        keccak256(
+            "Delegation("
+            "address delegatee,"
+            "uint256 nonce,"
+            "uint256 expiry)"
+        );
 
     mapping(address => address) private _delegation;
 

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -55,7 +55,14 @@ contract ERC2771Forwarder is EIP712, Nonces {
 
     bytes32 private constant _FORWARD_REQUEST_TYPEHASH =
         keccak256(
-            "ForwardRequest(address from,address to,uint256 value,uint256 gas,uint256 nonce,uint48 deadline,bytes data)"
+            "ForwardRequest("
+            "address from,"
+            "address to,"
+            "uint256 value,"
+            "uint256 gas,"
+            "uint256 nonce,"
+            "uint48 deadline,"
+            "bytes data)"
         );
 
     /**

--- a/contracts/mocks/token/ERC20VotesLegacyMock.sol
+++ b/contracts/mocks/token/ERC20VotesLegacyMock.sol
@@ -18,7 +18,12 @@ abstract contract ERC20VotesLegacyMock is IVotes, ERC20Permit {
     }
 
     bytes32 private constant _DELEGATION_TYPEHASH =
-        keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+        keccak256(
+            "Delegation("
+            "address delegatee,"
+            "uint256 nonce,"
+            "uint256 expiry)"
+        );
 
     mapping(address => address) private _delegates;
     mapping(address => Checkpoint[]) private _checkpoints;

--- a/contracts/token/ERC20/extensions/ERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/ERC20Permit.sol
@@ -22,7 +22,14 @@ import {Nonces} from "../../../utils/Nonces.sol";
 abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {
     // solhint-disable-next-line var-name-mixedcase
     bytes32 private constant _PERMIT_TYPEHASH =
-        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+        keccak256(
+            "Permit("
+            "address owner,"
+            "address spender,"
+            "uint256 value,"
+            "uint256 nonce,"
+            "uint256 deadline)"
+        );
 
     /**
      * @dev Permit deadline has expired.

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -36,7 +36,13 @@ abstract contract EIP712 is IERC5267 {
     using ShortStrings for *;
 
     bytes32 private constant _TYPE_HASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        keccak256(
+            "EIP712Domain("
+            "string name,"
+            "string version,"
+            "uint256 chainId,"
+            "address verifyingContract)"
+        );
 
     // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
     // invalidate the cached domain separator if the chain id changes.


### PR DESCRIPTION
This PR splits the type hash domains into multiple lines. This approach is more beneficial because it makes reading and updating the type hash easier and less error prone.

This is possible because the Solidity compiler allows splitting of string literals: https://docs.soliditylang.org/en/latest/types.html#string-literals-and-types
