### PR TITLE
Add override guidelines

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -137,7 +137,7 @@ In addition to the official Solidity Style Guide we have a number of other conve
 
   * Custom error names should not be declared twice along the library to avoid duplicated identifier declarations when inheriting from multiple contracts.
 
-* It is important to follow a few rules around the use of Solidity overrides to avoid introducing unintended consequences due to the interaction with multiple inheritance:
+* Solidity function overrides should follow the rules listed below in order to avoid introducing unintended consequences due to the interaction with multiple inheritance:
 
     1. When overriding a function `foo`, always invoke `super.foo`, and pass the same arguments that were received.
     2. Never use `super` outside of an override, or for a function other than the one being overridden.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -136,3 +136,8 @@ In addition to the official Solidity Style Guide we have a number of other conve
     4. Declare the error in an extension if the error only happens in such extension or child contracts.
 
   * Custom error names should not be declared twice along the library to avoid duplicated identifier declarations when inheriting from multiple contracts.
+
+* It is important to follow a few rules around the use of Solidity overrides to avoid introducing unintended consequences due to the interaction with multiple inheritance:
+
+    1. When overriding a function `foo`, always invoke `super.foo`, and pass the same arguments that were received.
+    2. Never use `super` for a function other than the one being overridden.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -140,4 +140,4 @@ In addition to the official Solidity Style Guide we have a number of other conve
 * It is important to follow a few rules around the use of Solidity overrides to avoid introducing unintended consequences due to the interaction with multiple inheritance:
 
     1. When overriding a function `foo`, always invoke `super.foo`, and pass the same arguments that were received.
-    2. Never use `super` for a function other than the one being overridden.
+    2. Never use `super` outside of an override, or for a function other than the one being overridden.


### PR DESCRIPTION
The idea is to establish guidelines to avoid common errors around multiple inheritance. These guidelines are quite strict, and we have to review if we're following them, and implement a rule to check it automatically.

Fixes LIB-897