### PR TITLE
Optimize Clones bytecode

### DIFF
--- a/.changeset/seven-wolves-report.md
+++ b/.changeset/seven-wolves-report.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`Clones`: Reduced clone bytecode size by 1 byte. ([#4417](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4417))

--- a/.changeset/seven-wolves-report.md
+++ b/.changeset/seven-wolves-report.md
@@ -1,5 +1,5 @@
 ---
-'openzeppelin-solidity': patch
+'openzeppelin-solidity': major
 ---
 
 `Clones`: Reduced clone bytecode size by 1 byte. ([#4417](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4417))

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.8.19;
  *
  * Bytecode implementation is a bit different from EIP 1167, due to optimizations suggested by 0age in
  * https://medium.com/coinmonks/the-more-minimal-proxy-5756ae08ee48[The More-Minimal Proxy].
- * 
+ *
  * _Available since v3.4._
  */
 library Clones {

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -14,6 +14,9 @@ pragma solidity ^0.8.19;
  * (salted deterministic deployment). It also includes functions to predict the addresses of clones deployed using the
  * deterministic method.
  *
+ * Bytecode implementation is a bit different from EIP 1167, due to optimizations suggested by 0age in
+ * https://medium.com/coinmonks/the-more-minimal-proxy-5756ae08ee48[The More-Minimal Proxy].
+ * 
  * _Available since v3.4._
  */
 library Clones {
@@ -30,12 +33,11 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
-            instance := create(0, 0x09, 0x37)
+            // Packs the first 1 byte of the `implementation` address with the bytecode before the address.
+            mstore(0x00, or(byte(12, implementation), 0x3d602c80600a3d3981f33d3d3d3d363d3d37363d7300))
+            // Packs the remaining 19 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(0x68, implementation), 0x5af43d3d93803e602a57fd5bf3))
+            instance := create(0, 0x0a, 0x36)
         }
         if (instance == address(0)) {
             revert ERC1167FailedCreateClone();
@@ -52,12 +54,11 @@ library Clones {
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
-            instance := create2(0, 0x09, 0x37, salt)
+            // Packs the first 1 byte of the `implementation` address with the bytecode before the address.
+            mstore(0x00, or(byte(12, implementation), 0x3d602c80600a3d3981f33d3d3d3d363d3d37363d7300))
+            // Packs the remaining 19 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(0x68, implementation), 0x5af43d3d93803e602a57fd5bf3))
+            instance := create2(0, 0x0a, 0x36, salt)
         }
         if (instance == address(0)) {
             revert ERC1167FailedCreateClone();
@@ -75,13 +76,13 @@ library Clones {
         /// @solidity memory-safe-assembly
         assembly {
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x38), deployer)
-            mstore(add(ptr, 0x24), 0x5af43d82803e903d91602b57fd5bf3ff)
+            mstore(add(ptr, 0x36), deployer)
+            mstore(add(ptr, 0x22), 0x5af43d3d93803e602a57fd5bf3ff)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73)
-            mstore(add(ptr, 0x58), salt)
-            mstore(add(ptr, 0x78), keccak256(add(ptr, 0x0c), 0x37))
-            predicted := keccak256(add(ptr, 0x43), 0x55)
+            mstore(ptr, 0x3d602c80600a3d3981f33d3d3d3d363d3d37363d73)
+            mstore(add(ptr, 0x56), salt)
+            mstore(add(ptr, 0x76), keccak256(add(ptr, 0x0b), 0x36))
+            predicted := keccak256(add(ptr, 0x41), 0x55)
         }
     }
 

--- a/test/proxy/Clones.test.js
+++ b/test/proxy/Clones.test.js
@@ -48,9 +48,9 @@ contract('Clones', function (accounts) {
       const predicted = await factory.$predictDeterministicAddress(implementation, salt);
 
       const creationCode = [
-        '0x3d602d80600a3d3981f3363d3d373d3d3d363d73',
+        '0x3d602c80600a3d3981f33d3d3d3d363d3d37363d73',
         implementation.replace(/0x/, '').toLowerCase(),
-        '5af43d82803e903d91602b57fd5bf3',
+        '5af43d3d93803e602a57fd5bf3',
       ].join('');
 
       expect(computeCreate2Address(salt, creationCode, factory.address)).to.be.equal(predicted);


### PR DESCRIPTION
This PR applies optimizations suggested by 0age in [The More-Minimal Proxy](https://medium.com/coinmonks/the-more-minimal-proxy-5756ae08ee48) post.

### Backwards compatibility notes

This PR changes the bytecode of the minimal proxy which leads to different behaviour of `predictDeterministicAddress`. Upgradable contracts that are using current version of the `predictDeterministicAddress` will be affected by this breaking change in case of upgrading to a new version.

### Effective changes

- clone bytecode size is reduced by 1 byte
- deployment gas cost is reduced by 206 gas
- clone runtime cost is reduced by 4 gas

### Gas before

```
·-------------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                       Solc version: 0.8.20                        ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
····································································|···························|·············|······························
|  Methods                                                                                                                                  │
·························|··········································|·············|·············|·············|···············|··············
|  Contract              ·  Method                                  ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·························|··········································|·············|·············|·············|···············|··············
|  $Clones               ·  $clone(address)                         ·          -  ·          -  ·      64073  ·           14  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $Clones               ·  $cloneDeterministic(address,bytes32)    ·          -  ·          -  ·      64650  ·           16  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializeNonPayable()                  ·          -  ·          -  ·      46008  ·            4  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializeNonPayableWithValue(uint256)  ·          -  ·          -  ·      46226  ·            4  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializePayable()                     ·          -  ·          -  ·      46005  ·            8  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializePayableWithValue(uint256)     ·          -  ·          -  ·      46268  ·            8  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  Deployments                                                      ·                                         ·  % of limit   ·             │
····································································|·············|·············|·············|···············|··············
|  $Clones                                                          ·          -  ·          -  ·     266824  ·        2.7 %  ·          -  │
····································································|·············|·············|·············|···············|··············
|  DummyImplementation                                              ·          -  ·          -  ·     451677  ·        4.5 %  ·          -  │
·-------------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

### Gas after

```
·-------------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                       Solc version: 0.8.20                        ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
····································································|···························|·············|······························
|  Methods                                                                                                                                  │
·························|··········································|·············|·············|·············|···············|··············
|  Contract              ·  Method                                  ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·························|··········································|·············|·············|·············|···············|··············
|  $Clones               ·  $clone(address)                         ·          -  ·          -  ·      63867  ·           14  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $Clones               ·  $cloneDeterministic(address,bytes32)    ·          -  ·          -  ·      64444  ·           16  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializeNonPayable()                  ·          -  ·          -  ·      46004  ·            4  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializeNonPayableWithValue(uint256)  ·          -  ·          -  ·      46222  ·            4  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializePayable()                     ·          -  ·          -  ·      46001  ·            8  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  $DummyImplementation  ·  initializePayableWithValue(uint256)     ·          -  ·          -  ·      46264  ·            8  ·          -  │
·························|··········································|·············|·············|·············|···············|··············
|  Deployments                                                      ·                                         ·  % of limit   ·             │
····································································|·············|·············|·············|···············|··············
|  $Clones                                                          ·          -  ·          -  ·     264484  ·        2.6 %  ·          -  │
····································································|·············|·············|·············|···············|··············
|  DummyImplementation                                              ·          -  ·          -  ·     451677  ·        4.5 %  ·          -  │
·-------------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
