### PR TITLE
Refactor ERC721 to use _update pattern

### DIFF
--- a/.changeset/bright-tomatoes-sing.md
+++ b/.changeset/bright-tomatoes-sing.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': major
 ---
 
-`ERC20`, `ERC1155`: Deleted `_beforeTokenTransfer` and `_afterTokenTransfer` hooks, added a new internal `_update` function for customizations, and refactored all extensions using those hooks to use `_update` instead. ([#3838](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3838), [#3876](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3876))
+`ERC20`, `ERC721`, `ERC1155`: Deleted `_beforeTokenTransfer` and `_afterTokenTransfer` hooks, added a new internal `_update` function for customizations, and refactored all extensions using those hooks to use `_update` instead. ([#3838](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3838), [#4419](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4419), [#3876](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3876))

--- a/contracts/interfaces/draft-IERC6093.sol
+++ b/contracts/interfaces/draft-IERC6093.sol
@@ -69,11 +69,11 @@ interface IERC721Errors {
 
     /**
      * @dev Indicates an error related to the ownership over a particular token. Used in transfers.
-     * @param sender Address whose tokens are being transferred.
+     * @param claimedOwner Address whose tokens are being transferred.
      * @param tokenId Identifier number of a token.
-     * @param owner Address of the current owner of a token.
+     * @param actualOwner Address of the current owner of a token.
      */
-    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);
+    error ERC721IncorrectOwner(address claimedOwner, uint256 tokenId, address actualOwner);
 
     /**
      * @dev Indicates a failure with the token `sender`. Used in transfers.

--- a/contracts/mocks/token/ERC721ConsecutiveEnumerableMock.sol
+++ b/contracts/mocks/token/ERC721ConsecutiveEnumerableMock.sol
@@ -28,11 +28,15 @@ contract ERC721ConsecutiveEnumerableMock is ERC721Consecutive, ERC721Enumerable 
         return super._ownerOf(tokenId);
     }
 
-    function _update(address from, address to, uint256 tokenId) internal virtual override(ERC721Consecutive, ERC721Enumerable) {
+    function _update(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(ERC721Consecutive, ERC721Enumerable) {
         super._update(from, to, tokenId);
     }
 
-    function _updateBalance(address account, uint128 value) internal virtual override(ERC721, ERC721Enumerable) {
-        super._updateBalance(account, value);
+    function _increaseBalance(address account, uint128 value) internal virtual override(ERC721, ERC721Enumerable) {
+        super._increaseBalance(account, value);
     }
 }

--- a/contracts/mocks/token/ERC721ConsecutiveEnumerableMock.sol
+++ b/contracts/mocks/token/ERC721ConsecutiveEnumerableMock.sol
@@ -28,25 +28,11 @@ contract ERC721ConsecutiveEnumerableMock is ERC721Consecutive, ERC721Enumerable 
         return super._ownerOf(tokenId);
     }
 
-    function _mint(address to, uint256 tokenId) internal virtual override(ERC721, ERC721Consecutive) {
-        super._mint(to, tokenId);
+    function _update(address from, address to, uint256 tokenId) internal virtual override(ERC721Consecutive, ERC721Enumerable) {
+        super._update(from, to, tokenId);
     }
 
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 firstTokenId,
-        uint256 batchSize
-    ) internal virtual override(ERC721, ERC721Enumerable) {
-        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
-    }
-
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 firstTokenId,
-        uint256 batchSize
-    ) internal virtual override(ERC721, ERC721Consecutive) {
-        super._afterTokenTransfer(from, to, firstTokenId, batchSize);
+    function _updateBalance(address account, uint128 value) internal virtual override(ERC721, ERC721Enumerable) {
+        super._updateBalance(account, value);
     }
 }

--- a/contracts/mocks/token/ERC721ConsecutiveMock.sol
+++ b/contracts/mocks/token/ERC721ConsecutiveMock.sol
@@ -41,26 +41,19 @@ contract ERC721ConsecutiveMock is ERC721Consecutive, ERC721Pausable, ERC721Votes
         return super._ownerOf(tokenId);
     }
 
-    function _mint(address to, uint256 tokenId) internal virtual override(ERC721, ERC721Consecutive) {
-        super._mint(to, tokenId);
-    }
-
-    function _beforeTokenTransfer(
+    function _update(
         address from,
         address to,
-        uint256 firstTokenId,
-        uint256 batchSize
-    ) internal virtual override(ERC721, ERC721Pausable) {
-        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
+        uint256 tokenId
+    ) internal virtual override(ERC721Consecutive, ERC721Pausable, ERC721Votes) {
+        super._update(from, to, tokenId);
     }
 
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 firstTokenId,
-        uint256 batchSize
-    ) internal virtual override(ERC721, ERC721Votes, ERC721Consecutive) {
-        super._afterTokenTransfer(from, to, firstTokenId, batchSize);
+    function _updateBalance(
+        address account,
+        uint128 value
+    ) internal virtual override(ERC721, ERC721Votes) {
+        super._updateBalance(account, value);
     }
 }
 

--- a/contracts/mocks/token/ERC721ConsecutiveMock.sol
+++ b/contracts/mocks/token/ERC721ConsecutiveMock.sol
@@ -49,11 +49,8 @@ contract ERC721ConsecutiveMock is ERC721Consecutive, ERC721Pausable, ERC721Votes
         super._update(from, to, tokenId);
     }
 
-    function _updateBalance(
-        address account,
-        uint128 value
-    ) internal virtual override(ERC721, ERC721Votes) {
-        super._updateBalance(account, value);
+    function _increaseBalance(address account, uint128 value) internal virtual override(ERC721, ERC721Votes) {
+        super._increaseBalance(account, value);
     }
 }
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -198,7 +198,7 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
      * @dev Returns the owner of the `tokenId`. Returns `address(0)` if token doesn't exist.
      *
      * IMPORTANT: Any overrides to this function that add ownership of tokens not tracked by the
-     * core ERC721 logic MUST be matched with the use of {_updateBalance} to keep balances
+     * core ERC721 logic MUST be matched with the use of {_increaseBalance} to keep balances
      * consistent with ownership. The invariant to preserve is that for any address `a` the value returned by
      * `balanceOf(a)` must be equal to the number of tokens such that `_ownerOf(tokenId)` is `a`.
      */
@@ -370,9 +370,10 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
     }
 
     /**
-     * @dev Unsafe write access to the balances, used by extensions that "mint" tokens using an {ownerOf} override.
+     * @dev Increases the balance of `account` by `value`.
+     * Write access to the balances, used by extensions that "mint" tokens using an {ownerOf} override.
      */
-    function _updateBalance(address account, uint128 value) internal virtual {
+    function _increaseBalance(address account, uint128 value) internal virtual {
         unchecked {
             _balances[account] += value;
         }

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -359,7 +359,9 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
         }
 
         if (to != address(0)) {
-            _increaseBalance(to, 1);
+            unchecked {
+                _balances[to] += 1;
+            }
         }
 
         _owners[tokenId] = to;

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -359,9 +359,7 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
         }
 
         if (to != address(0)) {
-            unchecked {
-                _balances[to] += 1;
-            }
+            _increaseBalance(to, 1);
         }
 
         _owners[tokenId] = to;
@@ -370,8 +368,10 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
     }
 
     /**
-     * @dev Increases the balance of `account` by `value`.
-     * Write access to the balances, used by extensions that "mint" tokens using an {ownerOf} override.
+     * @dev Increases the balance of `account` by an arbitrary `value`.
+     *
+     * This function provides write access to the balances, which can be used by extensions that
+     * "mint" tokens using an {ownerOf} override.
      */
     function _increaseBalance(address account, uint128 value) internal virtual {
         unchecked {

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -199,7 +199,7 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
      *
      * IMPORTANT: Any overrides to this function that add ownership of tokens not tracked by the
      * core ERC721 logic MUST be matched with the use of {_updateBalance} to keep balances
-     * consistent with ownership. The invariant being that for any address `a` the value returned by
+     * consistent with ownership. The invariant to preserve is that for any address `a` the value returned by
      * `balanceOf(a)` must be equal to the number of tokens such that `_ownerOf(tokenId)` is `a`.
      */
     function _ownerOf(uint256 tokenId) internal view virtual returns (address) {

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -328,7 +328,7 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
     }
 
     /**
-     * @dev Updates the ownership of toke with id `tokenId` from `from` to `to`.
+     * @dev Updates the ownership of token with id `tokenId` from `from` to `to`.
      * It clears the approval for the token when is transferred.
      *
      * Requirements:

--- a/contracts/token/ERC721/extensions/ERC721Burnable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Burnable.sol
@@ -18,10 +18,8 @@ abstract contract ERC721Burnable is Context, ERC721 {
      *
      * - The caller must own `tokenId` or be an approved operator.
      */
-    function burn(uint256 tokenId) public virtual {
-        if (!_isApprovedOrOwner(_msgSender(), tokenId)) {
-            revert ERC721InsufficientApproval(_msgSender(), tokenId);
-        }
-        _burn(tokenId);
+    function burn(address from, uint256 tokenId) public virtual {
+        _checkApproved(from, _msgSender(), tokenId);
+        _burn(from, tokenId);
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721Consecutive.sol
+++ b/contracts/token/ERC721/extensions/ERC721Consecutive.sol
@@ -121,7 +121,7 @@ abstract contract ERC721Consecutive is IERC2309, ERC721 {
 
             // Preserve the invariant required by `_ownerOf`, given that the new sequentialOwnership
             // checkpoint is attributing ownership of `batchSize` new tokens to account `to`.
-            _updateBalance(to, batchSize);
+            _increaseBalance(to, batchSize);
 
             emit ConsecutiveTransfer(next, last, address(0), to);
         }

--- a/contracts/token/ERC721/extensions/ERC721Consecutive.sol
+++ b/contracts/token/ERC721/extensions/ERC721Consecutive.sol
@@ -134,7 +134,7 @@ abstract contract ERC721Consecutive is IERC2309, ERC721 {
      * during construction, and burning of tokens that have been sequentially minted are complete.
      */
     function _update(address from, address to, uint256 tokenId) internal virtual override {
-        if (to == address(0) && address(this).code.length == 0) {
+        if (from == address(0) && address(this).code.length == 0) {
             revert ERC721ForbiddenMint();
         }
 

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -76,11 +76,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     /**
      * @dev See {ERC721-_beforeTokenTransfer}.
      */
-    function _update(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual override {
+    function _update(address from, address to, uint256 tokenId) internal virtual override {
         if (from == address(0)) {
             _addTokenToAllTokensEnumeration(tokenId);
         } else if (from != to) {
@@ -168,10 +164,13 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
         _allTokens.pop();
     }
 
-    function _updateBalance(address account, uint128 value) internal virtual override {
+    /**
+     * @dev See {ERC721-_increaseBalance}.
+     */
+    function _increaseBalance(address account, uint128 value) internal virtual override {
         if (value > 0) {
             revert ERC721EnumerableForbiddenBatchMint();
         }
-        super._updateBalance(account, value);
+        super._increaseBalance(account, value);
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -77,6 +77,8 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      * @dev See {ERC721-_beforeTokenTransfer}.
      */
     function _update(address from, address to, uint256 tokenId) internal virtual override {
+        super._update(from, to, tokenId);
+
         if (from == address(0)) {
             _addTokenToAllTokensEnumeration(tokenId);
         } else if (from != to) {
@@ -87,8 +89,6 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
         } else if (to != from) {
             _addTokenToOwnerEnumeration(to, tokenId);
         }
-
-        super._update(from, to, tokenId);
     }
 
     /**
@@ -97,7 +97,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      * @param tokenId uint256 ID of the token to be added to the tokens list of the given address
      */
     function _addTokenToOwnerEnumeration(address to, uint256 tokenId) private {
-        uint256 length = balanceOf(to);
+        uint256 length = balanceOf(to) - 1; // Balance is already increased by super._update
         _ownedTokens[to][length] = tokenId;
         _ownedTokensIndex[tokenId] = length;
     }
@@ -123,7 +123,7 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
         // To prevent a gap in from's tokens array, we store the last token in the index of the token to delete, and
         // then delete the last slot (swap and pop).
 
-        uint256 lastTokenIndex = balanceOf(from) - 1;
+        uint256 lastTokenIndex = balanceOf(from); // Balance is already decreased by super._update
         uint256 tokenIndex = _ownedTokensIndex[tokenId];
 
         // When the token to delete is the last token, the swap operation is unnecessary

--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -76,21 +76,11 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     /**
      * @dev See {ERC721-_beforeTokenTransfer}.
      */
-    function _beforeTokenTransfer(
+    function _update(
         address from,
         address to,
-        uint256 firstTokenId,
-        uint256 batchSize
+        uint256 tokenId
     ) internal virtual override {
-        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
-
-        if (batchSize > 1) {
-            // Will only trigger during construction. Batch transferring (minting) is not available afterwards.
-            revert ERC721EnumerableForbiddenBatchMint();
-        }
-
-        uint256 tokenId = firstTokenId;
-
         if (from == address(0)) {
             _addTokenToAllTokensEnumeration(tokenId);
         } else if (from != to) {
@@ -101,6 +91,8 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
         } else if (to != from) {
             _addTokenToOwnerEnumeration(to, tokenId);
         }
+
+        super._update(from, to, tokenId);
     }
 
     /**
@@ -174,5 +166,12 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
         // This also deletes the contents at the last position of the array
         delete _allTokensIndex[tokenId];
         _allTokens.pop();
+    }
+
+    function _updateBalance(address account, uint128 value) internal virtual override {
+        if (value > 0) {
+            revert ERC721EnumerableForbiddenBatchMint();
+        }
+        super._updateBalance(account, value);
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721Pausable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Pausable.sol
@@ -27,11 +27,7 @@ abstract contract ERC721Pausable is ERC721, Pausable {
      *
      * - the contract must not be paused.
      */
-    function _update(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual override {
+    function _update(address from, address to, uint256 tokenId) internal virtual override {
         _requireNotPaused();
         super._update(from, to, tokenId);
     }

--- a/contracts/token/ERC721/extensions/ERC721Pausable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Pausable.sol
@@ -27,14 +27,12 @@ abstract contract ERC721Pausable is ERC721, Pausable {
      *
      * - the contract must not be paused.
      */
-    function _beforeTokenTransfer(
+    function _update(
         address from,
         address to,
-        uint256 firstTokenId,
-        uint256 batchSize
+        uint256 tokenId
     ) internal virtual override {
-        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
-
         _requireNotPaused();
+        super._update(from, to, tokenId);
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721Royalty.sol
+++ b/contracts/token/ERC721/extensions/ERC721Royalty.sol
@@ -29,10 +29,13 @@ abstract contract ERC721Royalty is ERC2981, ERC721 {
     }
 
     /**
-     * @dev See {ERC721-_burn}. This override additionally clears the royalty information for the token.
+     * @dev See {ERC721-_update}. This override additionally clears the royalty information for the token on burns.
      */
-    function _burn(uint256 tokenId) internal virtual override {
-        super._burn(tokenId);
-        _resetTokenRoyalty(tokenId);
+    function _update(address from, address to, uint256 tokenId) internal virtual override {
+        super._update(from, to, tokenId);
+
+        if (to == address(0)) {
+            _resetTokenRoyalty(tokenId);
+        }
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -64,15 +64,17 @@ abstract contract ERC721URIStorage is IERC4906, ERC721 {
     }
 
     /**
-     * @dev See {ERC721-_burn}. This override additionally checks to see if a
+     * @dev See {ERC721-_update}. This override additionally extends burns to see if a
      * token-specific URI was set for the token, and if so, it deletes the token URI from
      * the storage mapping.
      */
-    function _burn(uint256 tokenId) internal virtual override {
-        super._burn(tokenId);
+    function _update(address from, address to, uint256 tokenId) internal virtual override {
+        super._update(from, to, tokenId);
 
-        if (bytes(_tokenURIs[tokenId]).length != 0) {
-            delete _tokenURIs[tokenId];
+        if (to == address(0)) {
+            if (bytes(_tokenURIs[tokenId]).length != 0) {
+                delete _tokenURIs[tokenId];
+            }
         }
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721URIStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721URIStorage.sol
@@ -71,10 +71,8 @@ abstract contract ERC721URIStorage is IERC4906, ERC721 {
     function _update(address from, address to, uint256 tokenId) internal virtual override {
         super._update(from, to, tokenId);
 
-        if (to == address(0)) {
-            if (bytes(_tokenURIs[tokenId]).length != 0) {
-                delete _tokenURIs[tokenId];
-            }
+        if (to == address(0) && bytes(_tokenURIs[tokenId]).length != 0) {
+            delete _tokenURIs[tokenId];
         }
     }
 }

--- a/contracts/token/ERC721/extensions/ERC721Votes.sol
+++ b/contracts/token/ERC721/extensions/ERC721Votes.sol
@@ -22,14 +22,17 @@ abstract contract ERC721Votes is ERC721, Votes {
      *
      * Emits a {IVotes-DelegateVotesChanged} event.
      */
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 firstTokenId,
-        uint256 batchSize
-    ) internal virtual override {
-        _transferVotingUnits(from, to, batchSize);
-        super._afterTokenTransfer(from, to, firstTokenId, batchSize);
+    function _update(address from, address to, uint256 tokenId) internal virtual override {
+        super._update(from, to, tokenId);
+        _transferVotingUnits(from, to, 1);
+    }
+
+    /**
+     * @dev See {ERC721-_updateBalance}. We need that to account tokens that were minted in batch.
+     */
+    function _updateBalance(address account, uint128 value) internal virtual override {
+        super._updateBalance(account, value);
+        _transferVotingUnits(address(0), account, value);
     }
 
     /**

--- a/contracts/token/ERC721/extensions/ERC721Votes.sol
+++ b/contracts/token/ERC721/extensions/ERC721Votes.sol
@@ -28,10 +28,10 @@ abstract contract ERC721Votes is ERC721, Votes {
     }
 
     /**
-     * @dev See {ERC721-_updateBalance}. We need that to account tokens that were minted in batch.
+     * @dev See {ERC721-_increaseBalance}. We need that to account tokens that were minted in batch.
      */
-    function _updateBalance(address account, uint128 value) internal virtual override {
-        super._updateBalance(account, value);
+    function _increaseBalance(address account, uint128 value) internal virtual override {
+        super._increaseBalance(account, value);
         _transferVotingUnits(address(0), account, value);
     }
 

--- a/contracts/token/ERC721/extensions/ERC721Wrapper.sol
+++ b/contracts/token/ERC721/extensions/ERC721Wrapper.sol
@@ -52,10 +52,9 @@ abstract contract ERC721Wrapper is ERC721, IERC721Receiver {
         uint256 length = tokenIds.length;
         for (uint256 i = 0; i < length; ++i) {
             uint256 tokenId = tokenIds[i];
-            if (!_isApprovedOrOwner(_msgSender(), tokenId)) {
-                revert ERC721InsufficientApproval(_msgSender(), tokenId);
-            }
-            _burn(tokenId);
+            address owner = _ownerOf(tokenId);
+            _checkApproved(owner, _msgSender(), tokenId);
+            _burn(owner, tokenId);
             // Checks were already performed at this point, and there's no way to retake ownership or approval from
             // the wrapped tokenId after this point, so it's safe to remove the reentrancy check for the next line.
             // slither-disable-next-line reentrancy-no-eth

--- a/test/governance/utils/Votes.behavior.js
+++ b/test/governance/utils/Votes.behavior.js
@@ -269,16 +269,16 @@ function shouldBehaveLikeVotes(accounts, tokens, { mode = 'blocknumber', fungibl
         const t1 = await this.votes.$_mint(accounts[1], tokens[1]);
         await time.advanceBlock();
         // t2 = burn #1
-        const t2 = await this.votes.$_burn(...(fungible ? [accounts[1]] : []), tokens[1]);
+        const t2 = await this.votes.$_burn(accounts[1], tokens[1]);
         await time.advanceBlock();
         // t3 = mint #2
         const t3 = await this.votes.$_mint(accounts[1], tokens[2]);
         await time.advanceBlock();
         // t4 = burn #0
-        const t4 = await this.votes.$_burn(...(fungible ? [accounts[1]] : []), tokens[0]);
+        const t4 = await this.votes.$_burn(accounts[1], tokens[0]);
         await time.advanceBlock();
         // t5 = burn #2
-        const t5 = await this.votes.$_burn(...(fungible ? [accounts[1]] : []), tokens[2]);
+        const t5 = await this.votes.$_burn(accounts[1], tokens[2]);
         await time.advanceBlock();
 
         t0.timepoint = await clockFromReceipt[mode](t0.receipt);

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -705,7 +705,11 @@ function shouldBehaveLikeERC721(owner, newOwner, approved, anotherApproved, oper
       });
 
       it('reverts when adding a token id that already exists', async function () {
-        await expectRevertCustomError(this.token.$_mint(owner, firstTokenId), 'ERC721IncorrectOwner', [ZERO_ADDRESS, firstTokenId, owner]);
+        await expectRevertCustomError(this.token.$_mint(owner, firstTokenId), 'ERC721IncorrectOwner', [
+          ZERO_ADDRESS,
+          firstTokenId,
+          owner,
+        ]);
       });
     });
   });
@@ -738,7 +742,9 @@ function shouldBehaveLikeERC721(owner, newOwner, approved, anotherApproved, oper
         });
 
         it('reverts when burning a token id that has been deleted', async function () {
-          await expectRevertCustomError(this.token.$_burn(owner, firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);
+          await expectRevertCustomError(this.token.$_burn(owner, firstTokenId), 'ERC721NonexistentToken', [
+            firstTokenId,
+          ]);
         });
       });
     });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -705,14 +705,14 @@ function shouldBehaveLikeERC721(owner, newOwner, approved, anotherApproved, oper
       });
 
       it('reverts when adding a token id that already exists', async function () {
-        await expectRevertCustomError(this.token.$_mint(owner, firstTokenId), 'ERC721InvalidSender', [ZERO_ADDRESS]);
+        await expectRevertCustomError(this.token.$_mint(owner, firstTokenId), 'ERC721IncorrectOwner', [ZERO_ADDRESS, firstTokenId, owner]);
       });
     });
   });
 
   describe('_burn', function () {
     it('reverts when burning a non-existent token id', async function () {
-      await expectRevertCustomError(this.token.$_burn(nonExistentTokenId), 'ERC721NonexistentToken', [
+      await expectRevertCustomError(this.token.$_burn(owner, nonExistentTokenId), 'ERC721NonexistentToken', [
         nonExistentTokenId,
       ]);
     });
@@ -725,7 +725,7 @@ function shouldBehaveLikeERC721(owner, newOwner, approved, anotherApproved, oper
 
       context('with burnt token', function () {
         beforeEach(async function () {
-          this.receipt = await this.token.$_burn(firstTokenId);
+          this.receipt = await this.token.$_burn(owner, firstTokenId);
         });
 
         it('emits a Transfer event', function () {
@@ -738,7 +738,7 @@ function shouldBehaveLikeERC721(owner, newOwner, approved, anotherApproved, oper
         });
 
         it('reverts when burning a token id that has been deleted', async function () {
-          await expectRevertCustomError(this.token.$_burn(firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);
+          await expectRevertCustomError(this.token.$_burn(owner, firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);
         });
       });
     });
@@ -820,7 +820,7 @@ function shouldBehaveLikeERC721Enumerable(owner, newOwner, approved, anotherAppr
           const newTokenId = new BN(300);
           const anotherNewTokenId = new BN(400);
 
-          await this.token.$_burn(tokenId);
+          await this.token.$_burn(owner, tokenId);
           await this.token.$_mint(newOwner, newTokenId);
           await this.token.$_mint(newOwner, anotherNewTokenId);
 
@@ -860,7 +860,7 @@ function shouldBehaveLikeERC721Enumerable(owner, newOwner, approved, anotherAppr
 
   describe('_burn', function () {
     it('reverts when burning a non-existent token id', async function () {
-      await expectRevertCustomError(this.token.$_burn(firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);
+      await expectRevertCustomError(this.token.$_burn(owner, firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);
     });
 
     context('with minted tokens', function () {
@@ -871,7 +871,7 @@ function shouldBehaveLikeERC721Enumerable(owner, newOwner, approved, anotherAppr
 
       context('with burnt token', function () {
         beforeEach(async function () {
-          this.receipt = await this.token.$_burn(firstTokenId);
+          this.receipt = await this.token.$_burn(owner, firstTokenId);
         });
 
         it('removes that token from the token list of the owner', async function () {
@@ -883,7 +883,7 @@ function shouldBehaveLikeERC721Enumerable(owner, newOwner, approved, anotherAppr
         });
 
         it('burns all tokens', async function () {
-          await this.token.$_burn(secondTokenId, { from: owner });
+          await this.token.$_burn(owner, secondTokenId, { from: owner });
           expect(await this.token.totalSupply()).to.be.bignumber.equal('0');
           await expectRevertCustomError(this.token.tokenByIndex(0), 'ERC721OutOfBoundsIndex', [ZERO_ADDRESS, 0]);
         });

--- a/test/token/ERC721/extensions/ERC721Burnable.test.js
+++ b/test/token/ERC721/extensions/ERC721Burnable.test.js
@@ -63,18 +63,21 @@ contract('ERC721Burnable', function (accounts) {
 
       describe('when there is no previous approval burned', function () {
         it('reverts', async function () {
-          await expectRevertCustomError(this.token.burn(owner, tokenId, { from: another }), 'ERC721InsufficientApproval', [
-            another,
-            tokenId,
-          ]);
+          await expectRevertCustomError(
+            this.token.burn(owner, tokenId, { from: another }),
+            'ERC721InsufficientApproval',
+            [another, tokenId],
+          );
         });
       });
 
       describe('when the given token ID was not tracked by this contract', function () {
         it('reverts', async function () {
-          await expectRevertCustomError(this.token.burn(owner, unknownTokenId, { from: owner }), 'ERC721NonexistentToken', [
-            unknownTokenId,
-          ]);
+          await expectRevertCustomError(
+            this.token.burn(owner, unknownTokenId, { from: owner }),
+            'ERC721NonexistentToken',
+            [unknownTokenId],
+          );
         });
       });
     });

--- a/test/token/ERC721/extensions/ERC721Burnable.test.js
+++ b/test/token/ERC721/extensions/ERC721Burnable.test.js
@@ -31,7 +31,7 @@ contract('ERC721Burnable', function (accounts) {
 
       describe('when successful', function () {
         beforeEach(async function () {
-          receipt = await this.token.burn(tokenId, { from: owner });
+          receipt = await this.token.burn(owner, tokenId, { from: owner });
         });
 
         it('burns the given token ID and adjusts the balance of the owner', async function () {
@@ -51,7 +51,7 @@ contract('ERC721Burnable', function (accounts) {
       describe('when there is a previous approval burned', function () {
         beforeEach(async function () {
           await this.token.approve(approved, tokenId, { from: owner });
-          receipt = await this.token.burn(tokenId, { from: owner });
+          receipt = await this.token.burn(owner, tokenId, { from: owner });
         });
 
         context('getApproved', function () {
@@ -63,7 +63,7 @@ contract('ERC721Burnable', function (accounts) {
 
       describe('when there is no previous approval burned', function () {
         it('reverts', async function () {
-          await expectRevertCustomError(this.token.burn(tokenId, { from: another }), 'ERC721InsufficientApproval', [
+          await expectRevertCustomError(this.token.burn(owner, tokenId, { from: another }), 'ERC721InsufficientApproval', [
             another,
             tokenId,
           ]);
@@ -72,7 +72,7 @@ contract('ERC721Burnable', function (accounts) {
 
       describe('when the given token ID was not tracked by this contract', function () {
         it('reverts', async function () {
-          await expectRevertCustomError(this.token.burn(unknownTokenId, { from: owner }), 'ERC721NonexistentToken', [
+          await expectRevertCustomError(this.token.burn(owner, unknownTokenId, { from: owner }), 'ERC721NonexistentToken', [
             unknownTokenId,
           ]);
         });

--- a/test/token/ERC721/extensions/ERC721Consecutive.t.sol
+++ b/test/token/ERC721/extensions/ERC721Consecutive.t.sol
@@ -28,8 +28,8 @@ contract ERC721ConsecutiveTarget is StdUtils, ERC721Consecutive {
         }
     }
 
-    function burn(uint256 tokenId) public {
-        _burn(tokenId);
+    function burn(address from, uint256 tokenId) public {
+        _burn(from, tokenId);
     }
 
     function _firstConsecutiveId() internal view virtual override returns (uint96) {
@@ -96,7 +96,7 @@ contract ERC721ConsecutiveTest is Test {
 
         // burn a token in [0; supply[
         uint256 tokenId = bound(unboundedTokenId, startingTokenId, startingTokenId + supply - 1);
-        token.burn(tokenId);
+        token.burn(receiver, tokenId);
 
         // balance should have decreased
         assertEq(token.balanceOf(receiver), supply - 1);

--- a/test/token/ERC721/extensions/ERC721Consecutive.test.js
+++ b/test/token/ERC721/extensions/ERC721Consecutive.test.js
@@ -117,7 +117,11 @@ contract('ERC721Consecutive', function (accounts) {
 
           expect(await this.token.$_exists(tokenId)).to.be.equal(true);
 
-          await expectRevertCustomError(this.token.$_mint(user1, tokenId), 'ERC721InvalidSender', [ZERO_ADDRESS]);
+          await expectRevertCustomError(this.token.$_mint(user1, tokenId), 'ERC721IncorrectOwner', [
+            ZERO_ADDRESS,
+            tokenId,
+            await this.token.ownerOf(tokenId),
+          ]);
         });
       });
 
@@ -190,14 +194,6 @@ contract('ERC721Consecutive', function (accounts) {
         ERC721ConsecutiveMock.new(name, symbol, 0, [], [user1], ['5001']),
         'ERC721ExceededMaxBatchMint',
         [5000, 5001],
-      );
-    });
-
-    it('cannot use single minting during construction', async function () {
-      await expectRevertCustomError(
-        ERC721ConsecutiveNoConstructorMintMock.new(name, symbol),
-        'ERC721ForbiddenMint',
-        [],
       );
     });
 

--- a/test/token/ERC721/extensions/ERC721Consecutive.test.js
+++ b/test/token/ERC721/extensions/ERC721Consecutive.test.js
@@ -131,7 +131,7 @@ contract('ERC721Consecutive', function (accounts) {
         });
 
         it('tokens can be burned and re-minted #1', async function () {
-          expectEvent(await this.token.$_burn(tokenId, { from: user1 }), 'Transfer', {
+          expectEvent(await this.token.$_burn(user1, tokenId, { from: user1 }), 'Transfer', {
             from: user1,
             to: constants.ZERO_ADDRESS,
             tokenId,
@@ -161,7 +161,7 @@ contract('ERC721Consecutive', function (accounts) {
           expect(await this.token.ownerOf(tokenId), user1);
 
           // burn
-          expectEvent(await this.token.$_burn(tokenId, { from: user1 }), 'Transfer', {
+          expectEvent(await this.token.$_burn(user1, tokenId, { from: user1 }), 'Transfer', {
             from: user1,
             to: constants.ZERO_ADDRESS,
             tokenId,
@@ -179,17 +179,6 @@ contract('ERC721Consecutive', function (accounts) {
 
           expect(await this.token.$_exists(tokenId)).to.be.equal(true);
           expect(await this.token.ownerOf(tokenId), user2);
-        });
-
-        it('reverts burning batches of size != 1', async function () {
-          const tokenId = batches[0].amount + offset;
-          const receiver = batches[0].receiver;
-
-          await expectRevertCustomError(
-            this.token.$_afterTokenTransfer(receiver, ZERO_ADDRESS, tokenId, 2),
-            'ERC721ForbiddenBatchBurn',
-            [],
-          );
         });
       });
     });

--- a/test/token/ERC721/extensions/ERC721Pausable.test.js
+++ b/test/token/ERC721/extensions/ERC721Pausable.test.js
@@ -57,7 +57,7 @@ contract('ERC721Pausable', function (accounts) {
     });
 
     it('reverts when trying to burn', async function () {
-      await expectRevertCustomError(this.token.$_burn(firstTokenId), 'EnforcedPause', []);
+      await expectRevertCustomError(this.token.$_burn(owner, firstTokenId), 'EnforcedPause', []);
     });
 
     describe('getApproved', function () {

--- a/test/token/ERC721/extensions/ERC721Royalty.test.js
+++ b/test/token/ERC721/extensions/ERC721Royalty.test.js
@@ -29,7 +29,7 @@ contract('ERC721Royalty', function (accounts) {
     });
 
     it('removes royalty information after burn', async function () {
-      await this.token.$_burn(tokenId1);
+      await this.token.$_burn(account1, tokenId1);
       const tokenInfo = await this.token.royaltyInfo(tokenId1, salePrice);
 
       expect(tokenInfo[0]).to.be.equal(constants.ZERO_ADDRESS);

--- a/test/token/ERC721/extensions/ERC721URIStorage.test.js
+++ b/test/token/ERC721/extensions/ERC721URIStorage.test.js
@@ -84,7 +84,7 @@ contract('ERC721URIStorage', function (accounts) {
     });
 
     it('tokens without URI can be burnt ', async function () {
-      await this.token.$_burn(firstTokenId, { from: owner });
+      await this.token.$_burn(owner, firstTokenId, { from: owner });
 
       expect(await this.token.$_exists(firstTokenId)).to.equal(false);
       await expectRevertCustomError(this.token.tokenURI(firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);
@@ -93,7 +93,7 @@ contract('ERC721URIStorage', function (accounts) {
     it('tokens with URI can be burnt ', async function () {
       await this.token.$_setTokenURI(firstTokenId, sampleUri);
 
-      await this.token.$_burn(firstTokenId, { from: owner });
+      await this.token.$_burn(owner, firstTokenId, { from: owner });
 
       expect(await this.token.$_exists(firstTokenId)).to.equal(false);
       await expectRevertCustomError(this.token.tokenURI(firstTokenId), 'ERC721NonexistentToken', [firstTokenId]);


### PR DESCRIPTION
A simpler alternative to https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4377 using:

```solidity
function _update(address from, address to, uint256 tokenId) internal;
```

`_burn` now has a `from` argument.

Fixes LIB-628