### PR TITLE
Add back IGovernor to docs

### DIFF
--- a/contracts/governance/README.adoc
+++ b/contracts/governance/README.adoc
@@ -52,6 +52,8 @@ NOTE: Functions of the `Governor` contract do not include access control. If you
 
 === Core
 
+{{IGovernor}}
+
 {{Governor}}
 
 === Modules


### PR DESCRIPTION
In #4358 this was removed from the docs, but it should remain given that all over the Govenor docs it says "See IGovernor.xyz".

Perhaps we can take this opportunity to review how we want the documentation to read though, because this is not a nice reading experience. It feels like the docs should be there when you read the Governor interface, without needing to go through indirections. Should we change things in some way?