### PR TITLE
Remove retyped and renamed storage layout annotations

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -49,7 +49,6 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
     bytes32 private constant _ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
     string private _name;
 
-    /// @custom:oz-retyped-from mapping(uint256 => Governor.ProposalCore)
     mapping(uint256 => ProposalCore) private _proposals;
 
     // This queue keeps track of the governor operating on itself. Calls to functions protected by the

--- a/contracts/governance/extensions/GovernorPreventLateQuorum.sol
+++ b/contracts/governance/extensions/GovernorPreventLateQuorum.sol
@@ -20,7 +20,6 @@ import {Math} from "../../utils/math/Math.sol";
 abstract contract GovernorPreventLateQuorum is Governor {
     uint48 private _voteExtension;
 
-    /// @custom:oz-retyped-from mapping(uint256 => Timers.BlockNumber)
     mapping(uint256 => uint48) private _extendedDeadlines;
 
     /// @dev Emitted when a proposal deadline is pushed back due to reaching quorum late in its voting period.

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -25,7 +25,6 @@ import {Address} from "../../utils/Address.sol";
 abstract contract GovernorTimelockCompound is IGovernorTimelock, Governor {
     ICompoundTimelock private _timelock;
 
-    /// @custom:oz-retyped-from mapping(uint256 => GovernorTimelockCompound.ProposalTimelock)
     mapping(uint256 => uint256) private _proposalTimelocks;
 
     /**

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -16,7 +16,6 @@ import {Checkpoints} from "../../utils/structs/Checkpoints.sol";
 abstract contract GovernorVotesQuorumFraction is GovernorVotes {
     using Checkpoints for Checkpoints.Trace224;
 
-    /// @custom:oz-retyped-from Checkpoints.History
     Checkpoints.Trace224 private _quorumNumeratorHistory;
 
     event QuorumNumeratorUpdated(uint256 oldQuorumNumerator, uint256 newQuorumNumerator);

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -38,10 +38,8 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
 
     mapping(address => address) private _delegation;
 
-    /// @custom:oz-retyped-from mapping(address => Checkpoints.History)
     mapping(address => Checkpoints.Trace224) private _delegateCheckpoints;
 
-    /// @custom:oz-retyped-from Checkpoints.History
     Checkpoints.Trace224 private _totalCheckpoints;
 
     /**

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -58,7 +58,6 @@ import {Address} from "../../utils/Address.sol";
 abstract contract Initializable {
     /**
      * @dev Indicates that the contract has been initialized.
-     * @custom:oz-retyped-from bool
      */
     uint8 private _initialized;
 

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -105,32 +105,6 @@ index 27627f43..e42a66e8 100644
      }
  }
  ```
-diff --git a/contracts/finance/VestingWallet.sol b/contracts/finance/VestingWallet.sol
-index f776a7ca..d7a7e0b0 100644
---- a/contracts/finance/VestingWallet.sol
-+++ b/contracts/finance/VestingWallet.sol
-@@ -19,6 +19,8 @@ import {Context} from "../utils/Context.sol";
-  *
-  * By setting the duration to 0, one can configure this contract to behave like an asset timelock that hold tokens for
-  * a beneficiary until a specified time.
-+ *
-+ * @custom:storage-size 52
-  */
- contract VestingWallet is Context {
-     event EtherReleased(uint256 amount);
-diff --git a/contracts/governance/extensions/GovernorVotes.sol b/contracts/governance/extensions/GovernorVotes.sol
-index bb14d7fd..0785ebbd 100644
---- a/contracts/governance/extensions/GovernorVotes.sol
-+++ b/contracts/governance/extensions/GovernorVotes.sol
-@@ -12,6 +12,8 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
-  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token, or since v4.5 an {ERC721Votes} token.
-  *
-  * _Available since v4.3._
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract GovernorVotes is Governor {
-     IERC5805 public immutable token;
 diff --git a/contracts/package.json b/contracts/package.json
 index df141192..1cf90ad1 100644
 --- a/contracts/package.json
@@ -151,47 +125,8 @@ index df141192..1cf90ad1 100644
    },
    "keywords": [
      "solidity",
-diff --git a/contracts/token/ERC20/extensions/ERC20Capped.sol b/contracts/token/ERC20/extensions/ERC20Capped.sol
-index 98ec7144..4992115b 100644
---- a/contracts/token/ERC20/extensions/ERC20Capped.sol
-+++ b/contracts/token/ERC20/extensions/ERC20Capped.sol
-@@ -7,6 +7,8 @@ import {ERC20} from "../ERC20.sol";
- 
- /**
-  * @dev Extension of {ERC20} that adds a cap to the supply of tokens.
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract ERC20Capped is ERC20 {
-     uint256 private immutable _cap;
-diff --git a/contracts/token/ERC20/extensions/ERC20Permit.sol b/contracts/token/ERC20/extensions/ERC20Permit.sol
-index 8778f4ba..825d4e16 100644
---- a/contracts/token/ERC20/extensions/ERC20Permit.sol
-+++ b/contracts/token/ERC20/extensions/ERC20Permit.sol
-@@ -18,6 +18,8 @@ import {Nonces} from "../../../utils/Nonces.sol";
-  * need to send a transaction, and thus is not required to hold Ether at all.
-  *
-  * _Available since v3.4._
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {
-     // solhint-disable-next-line var-name-mixedcase
-diff --git a/contracts/token/ERC20/extensions/ERC20Wrapper.sol b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
-index 2cbff622..97f43d7a 100644
---- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
-+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
-@@ -14,6 +14,8 @@ import {SafeERC20} from "../utils/SafeERC20.sol";
-  * wrapping of an existing "basic" ERC20 into a governance token.
-  *
-  * _Available since v4.2._
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract ERC20Wrapper is ERC20 {
-     IERC20 private immutable _underlying;
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index d94e956a..86bb5713 100644
+index d94e956a..b2d3546f 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -202,12 +137,12 @@ index d94e956a..86bb5713 100644
  import {IERC5267} from "../../interfaces/IERC5267.sol";
  
  /**
-@@ -30,27 +29,19 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+@@ -29,28 +28,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+  * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
   *
   * _Available since v3.4._
-  *
+- *
 - * @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
-+ * @custom:storage-size 52
   */
  abstract contract EIP712 is IERC5267 {
 -    using ShortStrings for *;
@@ -235,7 +170,7 @@ index d94e956a..86bb5713 100644
  
      /**
       * @dev Initializes the domain separator and parameter caches.
-@@ -65,29 +56,23 @@ abstract contract EIP712 is IERC5267 {
+@@ -65,29 +54,23 @@ abstract contract EIP712 is IERC5267 {
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
@@ -273,7 +208,7 @@ index d94e956a..86bb5713 100644
      }
  
      /**
-@@ -128,6 +113,10 @@ abstract contract EIP712 is IERC5267 {
+@@ -128,6 +111,10 @@ abstract contract EIP712 is IERC5267 {
              uint256[] memory extensions
          )
      {
@@ -284,7 +219,7 @@ index d94e956a..86bb5713 100644
          return (
              hex"0f", // 01111
              _EIP712Name(),
-@@ -142,26 +131,62 @@ abstract contract EIP712 is IERC5267 {
+@@ -142,26 +129,62 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -221,7 +221,9 @@ index d94e956a..86bb5713 100644
 -    uint256 private immutable _cachedChainId;
 -    address private immutable _cachedThis;
 -
++    /// @custom:oz-renamed-from _HASHED_NAME
      bytes32 private immutable _hashedName;
++    /// @custom:oz-renamed-from _HASHED_VERSION
      bytes32 private immutable _hashedVersion;
  
 -    ShortString private immutable _name;

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -221,9 +221,7 @@ index d94e956a..86bb5713 100644
 -    uint256 private immutable _cachedChainId;
 -    address private immutable _cachedThis;
 -
-+    /// @custom:oz-renamed-from _HASHED_NAME
      bytes32 private immutable _hashedName;
-+    /// @custom:oz-renamed-from _HASHED_VERSION
      bytes32 private immutable _hashedVersion;
  
 -    ShortString private immutable _name;


### PR DESCRIPTION
Removes all `@custom:oz-retyped-from` and `@custom:oz-renamed-from` annotations for storage layout checks from OpenZeppelin Upgrades Plugins.

Also removes the `@custom:storage-size` annotations for the transpiler, all of them found in `upgradeable.patch`.

The changes to storage layout need to be documented in the changelog but the storage-size change is the least of changes given the upcoming change to namespaced storage.

Fixes LIB-932