### PR TITLE
Move `ECDSA` message hash methods to its own `MessageHashUtils` library

### DIFF
--- a/.changeset/hot-dingos-kiss.md
+++ b/.changeset/hot-dingos-kiss.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': major
+---
+
+`MessageHashUtils`: Add a new library for creating message digest to be used along with ECDSA signing or recovery. These functions are moved from the `ECDSA` library.

--- a/.changeset/hot-dingos-kiss.md
+++ b/.changeset/hot-dingos-kiss.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': major
 ---
 
-`MessageHashUtils`: Add a new library for creating message digest to be used along with ECDSA signing or recovery. These functions are moved from the `ECDSA` library.
+`MessageHashUtils`: Add a new library for creating message digest to be used along with signing or recovery such as  ECDSA or ERC-1271. These functions are moved from the `ECDSA` library.

--- a/contracts/utils/README.adoc
+++ b/contracts/utils/README.adoc
@@ -34,6 +34,8 @@ Finally, {Create2} contains all necessary utilities to safely use the https://bl
 
 {{ECDSA}}
 
+{{MessageHashUtils}}
+
 {{SignatureChecker}}
 
 {{MerkleProof}}

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.19;
 
-import {Strings} from "../Strings.sol";
-
 /**
  * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
  *
@@ -34,18 +32,6 @@ library ECDSA {
      */
     error ECDSAInvalidSignatureS(bytes32 s);
 
-    function _throwError(RecoverError error, bytes32 errorArg) private pure {
-        if (error == RecoverError.NoError) {
-            return; // no error: do nothing
-        } else if (error == RecoverError.InvalidSignature) {
-            revert ECDSAInvalidSignature();
-        } else if (error == RecoverError.InvalidSignatureLength) {
-            revert ECDSAInvalidSignatureLength(uint256(errorArg));
-        } else if (error == RecoverError.InvalidSignatureS) {
-            revert ECDSAInvalidSignatureS(errorArg);
-        }
-    }
-
     /**
      * @dev Returns the address that signed a hashed message (`hash`) with
      * `signature` or error string. This address can then be used for verification purposes.
@@ -58,7 +44,7 @@ library ECDSA {
      * verification to be secure: it is possible to craft signatures that
      * recover to arbitrary addresses for non-hashed data. A safe way to ensure
      * this is by receiving a hash of the original message (which may otherwise
-     * be too long), and then calling {toEthSignedMessageHash} on it.
+     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.
      *
      * Documentation for signature generation:
      * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]
@@ -97,7 +83,7 @@ library ECDSA {
      * verification to be secure: it is possible to craft signatures that
      * recover to arbitrary addresses for non-hashed data. A safe way to ensure
      * this is by receiving a hash of the original message (which may otherwise
-     * be too long), and then calling {toEthSignedMessageHash} on it.
+     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.
      */
     function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
         (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);
@@ -177,63 +163,17 @@ library ECDSA {
     }
 
     /**
-     * @dev Returns an Ethereum Signed Message, created from a `hash`. This
-     * produces hash corresponding to the one signed with the
-     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]
-     * JSON-RPC method as part of EIP-191.
-     *
-     * See {recover}.
+     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.
      */
-    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32 message) {
-        // 32 is the length in bytes of hash,
-        // enforced by the type signature above
-        /// @solidity memory-safe-assembly
-        assembly {
-            mstore(0x00, "\x19Ethereum Signed Message:\n32")
-            mstore(0x1c, hash)
-            message := keccak256(0x00, 0x3c)
+    function _throwError(RecoverError error, bytes32 errorArg) private pure {
+        if (error == RecoverError.NoError) {
+            return; // no error: do nothing
+        } else if (error == RecoverError.InvalidSignature) {
+            revert ECDSAInvalidSignature();
+        } else if (error == RecoverError.InvalidSignatureLength) {
+            revert ECDSAInvalidSignatureLength(uint256(errorArg));
+        } else if (error == RecoverError.InvalidSignatureS) {
+            revert ECDSAInvalidSignatureS(errorArg);
         }
-    }
-
-    /**
-     * @dev Returns an Ethereum Signed Message, created from `s`. This
-     * produces hash corresponding to the one signed with the
-     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]
-     * JSON-RPC method as part of EIP-191.
-     *
-     * See {recover}.
-     */
-    function toEthSignedMessageHash(bytes memory s) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", Strings.toString(s.length), s));
-    }
-
-    /**
-     * @dev Returns an Ethereum Signed Typed Data, created from a
-     * `domainSeparator` and a `structHash`. This produces hash corresponding
-     * to the one signed with the
-     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`]
-     * JSON-RPC method as part of EIP-712.
-     *
-     * See {recover}.
-     */
-    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 data) {
-        /// @solidity memory-safe-assembly
-        assembly {
-            let ptr := mload(0x40)
-            mstore(ptr, hex"19_01")
-            mstore(add(ptr, 0x02), domainSeparator)
-            mstore(add(ptr, 0x22), structHash)
-            data := keccak256(ptr, 0x42)
-        }
-    }
-
-    /**
-     * @dev Returns an Ethereum Signed Data with intended validator, created from a
-     * `validator` and `data` according to the version 0 of EIP-191.
-     *
-     * See {recover}.
-     */
-    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(hex"19_00", validator, data));
     }
 }

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -3,16 +3,17 @@
 
 pragma solidity ^0.8.19;
 
-import {ECDSA} from "./ECDSA.sol";
+import {MessageHashUtils} from "./MessageHashUtils.sol";
 import {ShortStrings, ShortString} from "../ShortStrings.sol";
 import {IERC5267} from "../../interfaces/IERC5267.sol";
 
 /**
  * @dev https://eips.ethereum.org/EIPS/eip-712[EIP 712] is a standard for hashing and signing of typed structured data.
  *
- * The encoding specified in the EIP is very generic, and such a generic implementation in Solidity is not feasible,
- * thus this contract does not implement the encoding itself. Protocols need to implement the type-specific encoding
- * they need in their contracts using a combination of `abi.encode` and `keccak256`.
+ * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose
+ * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract
+ * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to
+ * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.
  *
  * This contract implements the EIP 712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding
  * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA
@@ -25,7 +26,7 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
  *
  * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain
- * separator of the implementation contract. This will cause the `_domainSeparatorV4` function to always rebuild the
+ * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
  * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
  *
  * _Available since v3.4._
@@ -106,7 +107,7 @@ abstract contract EIP712 is IERC5267 {
      * ```
      */
     function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {
-        return ECDSA.toTypedDataHash(_domainSeparatorV4(), structHash);
+        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);
     }
 
     /**

--- a/contracts/utils/cryptography/MessageHashUtils.sol
+++ b/contracts/utils/cryptography/MessageHashUtils.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+import {Strings} from "../Strings.sol";
+
+/**
+ * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.
+ *
+ * The library provides methods for generating a hash of a message that conforms to the
+ * https://eips.ethereum.org/EIPS/eip-191[EIP 191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]
+ * specifications.
+ */
+library MessageHashUtils {
+    /**
+     * @dev Returns the keccak256 digest of an EIP-191 signed data with version
+     * `0x45` (`personal_sign` messages).
+     *
+     * The digest is calculated by prefixing a bytes32 `messageHash` with
+     * `"\x19Ethereum Signed Message:\n32"` and hashing the result. It corresponds with the
+     * hash signed when using the https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`] JSON-RPC method.
+     *
+     * NOTE: The `hash` parameter is intended to be the result of hashing a raw message with
+     * keccak256, althoguh any bytes32 value can be safely used because the final digest will
+     * be re-hashed.
+     *
+     * See {ECDSA-recover}.
+     */
+    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, "\x19Ethereum Signed Message:\n32") // 32 is the bytes-length of messageHash
+            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix
+            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)
+        }
+    }
+
+    /**
+     * @dev Returns the keccak256 digest of an EIP-191 signed data with version
+     * `0x45` (`personal_sign` messages).
+     *
+     * The digest is calculated by prefixing an arbitrary `message` with
+     * `"\x19Ethereum Signed Message:\n" + len(message)` and hashing the result. It corresponds with the
+     * hash signed when using the https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`] JSON-RPC method.
+     *
+     * See {ECDSA-recover}.
+     */
+    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32 digest) {
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", Strings.toString(message.length), message));
+    }
+
+    /**
+     * @dev Returns the keccak256 digest of an EIP-191 signed data with version
+     * `0x00` (data with intended validator).
+     *
+     * The digest is calculated by prefixing an arbitrary `data` with `"\x19\x00"` and the intended
+     * `validator` address. Then hashing the result.
+     *
+     * See {ECDSA-recover}.
+     */
+    function toDataWithIntendedValidatorHash(
+        address validator,
+        bytes memory data
+    ) internal pure returns (bytes32 digest) {
+        return keccak256(abi.encodePacked(hex"19_00", validator, data));
+    }
+
+    /**
+     * @dev Returns the keccak256 digest of an EIP-712 typed data (EIP-191 version `0x01`).
+     *
+     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with
+     * `\x19\x01` and hashing the result. It corresponds to the hash signed by the
+     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.
+     *
+     * See {ECDSA-recover}.
+     */
+    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, hex"19_01")
+            mstore(add(ptr, 0x02), domainSeparator)
+            mstore(add(ptr, 0x22), structHash)
+            digest := keccak256(ptr, 0x42)
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -23,7 +23,7 @@ function _verify(bytes32 data, bytes memory signature, address account) internal
 }
 ----
 
-WARNING: Getting signature verification right is not trivial: make sure you fully read and understand xref:api:utils.adoc#MessageHashUtils[`MessageHashUtils`]'s and xref:api:utils.adoc#ECDSA[`ECDSA`]'s documentations.
+WARNING: Getting signature verification right is not trivial: make sure you fully read and understand xref:api:utils.adoc#MessageHashUtils[`MessageHashUtils`]'s and xref:api:utils.adoc#ECDSA[`ECDSA`]'s documentation.
 
 === Verifying Merkle Proofs
 

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -9,11 +9,12 @@ The OpenZeppelin Contracts provide a ton of useful utilities that you can use in
 
 xref:api:utils.adoc#ECDSA[`ECDSA`] provides functions for recovering and managing Ethereum account ECDSA signatures. These are often generated via https://web3js.readthedocs.io/en/v1.7.3/web3-eth.html#sign[`web3.eth.sign`], and are a 65 byte array (of type `bytes` in Solidity) arranged the following way: `[[v (1)], [r (32)], [s (32)]]`.
 
-The data signer can be recovered with xref:api:utils.adoc#ECDSA-recover-bytes32-bytes-[`ECDSA.recover`], and its address compared to verify the signature. Most wallets will hash the data to sign and add the prefix '\x19Ethereum Signed Message:\n', so when attempting to recover the signer of an Ethereum signed message hash, you'll want to use xref:api:utils.adoc#ECDSA-toEthSignedMessageHash-bytes32-[`toEthSignedMessageHash`].
+The data signer can be recovered with xref:api:utils.adoc#ECDSA-recover-bytes32-bytes-[`ECDSA.recover`], and its address compared to verify the signature. Most wallets will hash the data to sign and add the prefix '\x19Ethereum Signed Message:\n', so when attempting to recover the signer of an Ethereum signed message hash, you'll want to use xref:api:utils.adoc#MessageHashUtils-toEthSignedMessageHash-bytes32-[`toEthSignedMessageHash`].
 
 [source,solidity]
 ----
 using ECDSA for bytes32;
+using MessageHashUtils for bytes32;
 
 function _verify(bytes32 data, bytes memory signature, address account) internal pure returns (bool) {
     return data
@@ -22,7 +23,7 @@ function _verify(bytes32 data, bytes memory signature, address account) internal
 }
 ----
 
-WARNING: Getting signature verification right is not trivial: make sure you fully read and understand xref:api:utils.adoc#ECDSA[`ECDSA`]'s documentation.
+WARNING: Getting signature verification right is not trivial: make sure you fully read and understand xref:api:utils.adoc#MessageHashUtils[`MessageHashUtils`]'s and xref:api:utils.adoc#ECDSA[`ECDSA`]'s documentations.
 
 === Verifying Merkle Proofs
 

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -126,20 +126,20 @@ index df141192..1cf90ad1 100644
    "keywords": [
      "solidity",
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index ff34e814..a9d08d5c 100644
+index 36f076e5..90c1db78 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
  pragma solidity ^0.8.19;
  
- import {ECDSA} from "./ECDSA.sol";
+ import {MessageHashUtils} from "./MessageHashUtils.sol";
 -import {ShortStrings, ShortString} from "../ShortStrings.sol";
  import {IERC5267} from "../../interfaces/IERC5267.sol";
  
  /**
-@@ -27,28 +26,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+@@ -28,28 +27,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
   * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain
-  * separator of the implementation contract. This will cause the `_domainSeparatorV4` function to always rebuild the
+  * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
   * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
 - *
 - * @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
@@ -170,7 +170,7 @@ index ff34e814..a9d08d5c 100644
  
      /**
       * @dev Initializes the domain separator and parameter caches.
-@@ -63,29 +52,23 @@ abstract contract EIP712 is IERC5267 {
+@@ -64,29 +53,23 @@ abstract contract EIP712 is IERC5267 {
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
@@ -208,7 +208,7 @@ index ff34e814..a9d08d5c 100644
      }
  
      /**
-@@ -124,6 +107,10 @@ abstract contract EIP712 is IERC5267 {
+@@ -125,6 +108,10 @@ abstract contract EIP712 is IERC5267 {
              uint256[] memory extensions
          )
      {
@@ -219,7 +219,7 @@ index ff34e814..a9d08d5c 100644
          return (
              hex"0f", // 01111
              _EIP712Name(),
-@@ -138,22 +125,62 @@ abstract contract EIP712 is IERC5267 {
+@@ -139,22 +126,62 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -1,406 +1,71 @@
-diff --git a/.github/ISSUE_TEMPLATE/bug_report.md b/.github/ISSUE_TEMPLATE/bug_report.md
-deleted file mode 100644
-index 2797a088..00000000
---- a/.github/ISSUE_TEMPLATE/bug_report.md
-+++ /dev/null
-@@ -1,21 +0,0 @@
-----
--name: Bug report
--about: Report a bug in OpenZeppelin Contracts
--
-----
--
--<!-- Briefly describe the issue you're experiencing. Tell us what you were trying to do and what happened instead. -->
--
--<!-- Remember, this is not a place to ask for help debugging code. For that, we welcome you in the OpenZeppelin Community Forum: https://forum.openzeppelin.com/. -->
--
--**💻 Environment**
--
--<!-- Tell us what version of OpenZeppelin Contracts you're using, and how you're using it: Truffle, Remix, etc. -->
--
--**📝 Details**
--
--<!-- Describe the problem you have been experiencing in more detail. Include as much information as you think is relevant. Keep in mind that transactions can fail for many reasons; context is key here. -->
--
--**🔢 Code to reproduce bug**
--
--<!-- We will be able to better help if you provide a minimal example that triggers the bug. -->
-diff --git a/.github/ISSUE_TEMPLATE/config.yml b/.github/ISSUE_TEMPLATE/config.yml
-index 4018cef2..d343a53d 100644
---- a/.github/ISSUE_TEMPLATE/config.yml
-+++ b/.github/ISSUE_TEMPLATE/config.yml
-@@ -1,4 +1,8 @@
-+blank_issues_enabled: false
- contact_links:
-+  - name: Bug Reports & Feature Requests
-+    url: https://github.com/OpenZeppelin/openzeppelin-contracts/issues/new/choose
-+    about: Visit the OpenZeppelin Contracts repository
-   - name: Questions & Support Requests
-     url: https://forum.openzeppelin.com/c/support/contracts/18
-     about: Ask in the OpenZeppelin Forum
-diff --git a/.github/ISSUE_TEMPLATE/feature_request.md b/.github/ISSUE_TEMPLATE/feature_request.md
-deleted file mode 100644
-index ff596b0c..00000000
---- a/.github/ISSUE_TEMPLATE/feature_request.md
-+++ /dev/null
-@@ -1,14 +0,0 @@
-----
--name: Feature request
--about: Suggest an idea for OpenZeppelin Contracts
--
-----
--
--**🧐 Motivation**
--<!-- Is your feature request related to a specific problem? Is it just a crazy idea? Tell us about it! -->
--
--**📝 Details**
--<!-- Please describe your feature request in detail. -->
--
--<!-- Make sure that you have reviewed the OpenZeppelin Contracts Contributor Guidelines. -->
--<!-- https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md -->
-diff --git a/README.md b/README.md
-index 27627f43..e42a66e8 100644
---- a/README.md
-+++ b/README.md
-@@ -19,6 +19,9 @@
- 
- :building_construction: **Want to scale your decentralized application?** Check out [OpenZeppelin Defender](https://openzeppelin.com/defender) — a secure platform for automating and monitoring your operations.
- 
-+> **Note**
-+> You are looking at the upgradeable variant of OpenZeppelin Contracts. Be sure to review the documentation on [Using OpenZeppelin Contracts with Upgrades](https://docs.openzeppelin.com/contracts/4.x/upgradeable).
-+
- ## Overview
- 
- ### Installation
-@@ -26,7 +29,7 @@
- #### Hardhat, Truffle (npm)
- 
- ```
--$ npm install @openzeppelin/contracts
-+$ npm install @openzeppelin/contracts-upgradeable
- ```
- 
- OpenZeppelin Contracts features a [stable API](https://docs.openzeppelin.com/contracts/releases-stability#api-stability), which means that your contracts won't break unexpectedly when upgrading to a newer minor version.
-@@ -38,7 +41,7 @@ OpenZeppelin Contracts features a [stable API](https://docs.openzeppelin.com/con
- > **Warning** Foundry installs the latest version initially, but subsequent `forge update` commands will use the `master` branch.
- 
- ```
--$ forge install OpenZeppelin/openzeppelin-contracts
-+$ forge install OpenZeppelin/openzeppelin-contracts-upgradeable
- ```
- 
- ### Usage
-@@ -48,10 +51,11 @@ Once installed, you can use the contracts in the library by importing them:
- ```solidity
- pragma solidity ^0.8.19;
- 
--import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-+import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
- 
--contract MyCollectible is ERC721 {
--    constructor() ERC721("MyCollectible", "MCO") {
-+contract MyCollectible is ERC721Upgradeable {
-+    function initialize() initializer public {
-+        __ERC721_init("MyCollectible", "MCO");
-     }
- }
- ```
-diff --git a/contracts/finance/VestingWallet.sol b/contracts/finance/VestingWallet.sol
-index f776a7ca..d7a7e0b0 100644
---- a/contracts/finance/VestingWallet.sol
-+++ b/contracts/finance/VestingWallet.sol
-@@ -19,6 +19,8 @@ import {Context} from "../utils/Context.sol";
-  *
-  * By setting the duration to 0, one can configure this contract to behave like an asset timelock that hold tokens for
-  * a beneficiary until a specified time.
-+ *
-+ * @custom:storage-size 52
-  */
- contract VestingWallet is Context {
-     event EtherReleased(uint256 amount);
-diff --git a/contracts/governance/extensions/GovernorVotes.sol b/contracts/governance/extensions/GovernorVotes.sol
-index bb14d7fd..0785ebbd 100644
---- a/contracts/governance/extensions/GovernorVotes.sol
-+++ b/contracts/governance/extensions/GovernorVotes.sol
-@@ -12,6 +12,8 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
-  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token, or since v4.5 an {ERC721Votes} token.
-  *
-  * _Available since v4.3._
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract GovernorVotes is Governor {
-     IERC5805 public immutable token;
-diff --git a/contracts/package.json b/contracts/package.json
-index df141192..1cf90ad1 100644
---- a/contracts/package.json
-+++ b/contracts/package.json
-@@ -1,5 +1,5 @@
- {
--  "name": "@openzeppelin/contracts",
-+  "name": "@openzeppelin/contracts-upgradeable",
-   "description": "Secure Smart Contract library for Solidity",
-   "version": "4.9.2",
-   "files": [
-@@ -13,7 +13,7 @@
-   },
-   "repository": {
-     "type": "git",
--    "url": "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
-+    "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git"
-   },
-   "keywords": [
-     "solidity",
-diff --git a/contracts/token/ERC20/extensions/ERC20Capped.sol b/contracts/token/ERC20/extensions/ERC20Capped.sol
-index 98ec7144..4992115b 100644
---- a/contracts/token/ERC20/extensions/ERC20Capped.sol
-+++ b/contracts/token/ERC20/extensions/ERC20Capped.sol
-@@ -7,6 +7,8 @@ import {ERC20} from "../ERC20.sol";
- 
- /**
-  * @dev Extension of {ERC20} that adds a cap to the supply of tokens.
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract ERC20Capped is ERC20 {
-     uint256 private immutable _cap;
-diff --git a/contracts/token/ERC20/extensions/ERC20Permit.sol b/contracts/token/ERC20/extensions/ERC20Permit.sol
-index 8778f4ba..825d4e16 100644
---- a/contracts/token/ERC20/extensions/ERC20Permit.sol
-+++ b/contracts/token/ERC20/extensions/ERC20Permit.sol
-@@ -18,6 +18,8 @@ import {Nonces} from "../../../utils/Nonces.sol";
-  * need to send a transaction, and thus is not required to hold Ether at all.
-  *
-  * _Available since v3.4._
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {
-     // solhint-disable-next-line var-name-mixedcase
-diff --git a/contracts/token/ERC20/extensions/ERC20Wrapper.sol b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
-index 2cbff622..97f43d7a 100644
---- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
-+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
-@@ -14,6 +14,8 @@ import {SafeERC20} from "../utils/SafeERC20.sol";
-  * wrapping of an existing "basic" ERC20 into a governance token.
-  *
-  * _Available since v4.2._
-+ *
-+ * @custom:storage-size 51
-  */
- abstract contract ERC20Wrapper is ERC20 {
-     IERC20 private immutable _underlying;
-diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index d94e956a..86bb5713 100644
---- a/contracts/utils/cryptography/EIP712.sol
-+++ b/contracts/utils/cryptography/EIP712.sol
-@@ -4,7 +4,6 @@
- pragma solidity ^0.8.19;
- 
- import {ECDSA} from "./ECDSA.sol";
--import {ShortStrings, ShortString} from "../ShortStrings.sol";
- import {IERC5267} from "../../interfaces/IERC5267.sol";
- 
- /**
-@@ -30,27 +29,19 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
-  *
-  * _Available since v3.4._
-  *
-- * @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
-+ * @custom:storage-size 52
-  */
- abstract contract EIP712 is IERC5267 {
--    using ShortStrings for *;
--
-     bytes32 private constant _TYPE_HASH =
-         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
- 
--    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
--    // invalidate the cached domain separator if the chain id changes.
--    bytes32 private immutable _cachedDomainSeparator;
--    uint256 private immutable _cachedChainId;
--    address private immutable _cachedThis;
--
-+    /// @custom:oz-renamed-from _HASHED_NAME
-     bytes32 private immutable _hashedName;
-+    /// @custom:oz-renamed-from _HASHED_VERSION
-     bytes32 private immutable _hashedVersion;
- 
--    ShortString private immutable _name;
--    ShortString private immutable _version;
--    string private _nameFallback;
--    string private _versionFallback;
-+    string private _name;
-+    string private _version;
- 
-     /**
-      * @dev Initializes the domain separator and parameter caches.
-@@ -65,29 +56,23 @@ abstract contract EIP712 is IERC5267 {
-      * contract upgrade].
-      */
-     constructor(string memory name, string memory version) {
--        _name = name.toShortStringWithFallback(_nameFallback);
--        _version = version.toShortStringWithFallback(_versionFallback);
--        _hashedName = keccak256(bytes(name));
--        _hashedVersion = keccak256(bytes(version));
--
--        _cachedChainId = block.chainid;
--        _cachedDomainSeparator = _buildDomainSeparator();
--        _cachedThis = address(this);
-+        _name = name;
-+        _version = version;
-+
-+        // Reset prior values in storage if upgrading
-+        _hashedName = 0;
-+        _hashedVersion = 0;
-     }
- 
-     /**
-      * @dev Returns the domain separator for the current chain.
-      */
-     function _domainSeparatorV4() internal view returns (bytes32) {
--        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {
--            return _cachedDomainSeparator;
--        } else {
--            return _buildDomainSeparator();
--        }
-+        return _buildDomainSeparator();
-     }
- 
-     function _buildDomainSeparator() private view returns (bytes32) {
--        return keccak256(abi.encode(_TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));
-+        return keccak256(abi.encode(_TYPE_HASH, _EIP712NameHash(), _EIP712VersionHash(), block.chainid, address(this)));
-     }
- 
-     /**
-@@ -128,6 +113,10 @@ abstract contract EIP712 is IERC5267 {
-             uint256[] memory extensions
-         )
-     {
-+        // If the hashed name and version in storage are non-zero, the contract hasn't been properly initialized
-+        // and the EIP712 domain is not reliable, as it will be missing name and version.
-+        require(_hashedName == 0 && _hashedVersion == 0, "EIP712: Uninitialized");
-+
-         return (
-             hex"0f", // 01111
-             _EIP712Name(),
-@@ -142,26 +131,62 @@ abstract contract EIP712 is IERC5267 {
-     /**
-      * @dev The name parameter for the EIP712 domain.
-      *
--     * NOTE: By default this function reads _name which is an immutable value.
--     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
--     *
--     * _Available since v5.0._
-+     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
-+     * are a concern.
-      */
--    // solhint-disable-next-line func-name-mixedcase
--    function _EIP712Name() internal view returns (string memory) {
--        return _name.toStringWithFallback(_nameFallback);
-+    function _EIP712Name() internal view virtual returns (string memory) {
-+        return _name;
-     }
- 
-     /**
-      * @dev The version parameter for the EIP712 domain.
-      *
--     * NOTE: By default this function reads _version which is an immutable value.
--     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
-+     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
-+     * are a concern.
-+     */
-+    function _EIP712Version() internal view virtual returns (string memory) {
-+        return _version;
-+    }
-+
-+    /**
-+     * @dev The hash of the name parameter for the EIP712 domain.
-+     *
-+     * NOTE: In previous versions this function was virtual. In this version you should override `_EIP712Name` instead.
-+     */
-+    function _EIP712NameHash() internal view returns (bytes32) {
-+        string memory name = _EIP712Name();
-+        if (bytes(name).length > 0) {
-+            return keccak256(bytes(name));
-+        } else {
-+            // If the name is empty, the contract may have been upgraded without initializing the new storage.
-+            // We return the name hash in storage if non-zero, otherwise we assume the name is empty by design.
-+            bytes32 hashedName = _hashedName;
-+            if (hashedName != 0) {
-+                return hashedName;
-+            } else {
-+                return keccak256("");
-+            }
-+        }
-+    }
-+
-+    /**
-+     * @dev The hash of the version parameter for the EIP712 domain.
-      *
--     * _Available since v5.0._
-+     * NOTE: In previous versions this function was virtual. In this version you should override `_EIP712Version` instead.
-      */
--    // solhint-disable-next-line func-name-mixedcase
--    function _EIP712Version() internal view returns (string memory) {
--        return _version.toStringWithFallback(_versionFallback);
-+    function _EIP712VersionHash() internal view returns (bytes32) {
-+        string memory version = _EIP712Version();
-+        if (bytes(version).length > 0) {
-+            return keccak256(bytes(version));
-+        } else {
-+            // If the version is empty, the contract may have been upgraded without initializing the new storage.
-+            // We return the version hash in storage if non-zero, otherwise we assume the version is empty by design.
-+            bytes32 hashedVersion = _hashedVersion;
-+            if (hashedVersion != 0) {
-+                return hashedVersion;
-+            } else {
-+                return keccak256("");
-+            }
-+        }
-     }
- }
-diff --git a/package.json b/package.json
-index 9eae6732..b3a56366 100644
---- a/package.json
-+++ b/package.json
-@@ -33,7 +33,7 @@
-   },
-   "repository": {
-     "type": "git",
--    "url": "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
-+    "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git"
-   },
-   "keywords": [
-     "solidity",
-diff --git a/test/utils/cryptography/EIP712.test.js b/test/utils/cryptography/EIP712.test.js
-index 7ea535b7..32e3a370 100644
---- a/test/utils/cryptography/EIP712.test.js
-+++ b/test/utils/cryptography/EIP712.test.js
-@@ -47,26 +47,6 @@ contract('EIP712', function (accounts) {
-           const rebuildDomain = await getDomain(this.eip712);
-           expect(mapValues(rebuildDomain, String)).to.be.deep.equal(mapValues(this.domain, String));
-         });
--
--        if (shortOrLong === 'short') {
--          // Long strings are in storage, and the proxy will not be properly initialized unless
--          // the upgradeable contract variant is used and the initializer is invoked.
--
--          it('adjusts when behind proxy', async function () {
--            const factory = await Clones.new();
--            const cloneReceipt = await factory.$clone(this.eip712.address);
--            const cloneAddress = cloneReceipt.logs.find(({ event }) => event === 'return$clone').args.instance;
--            const clone = new EIP712Verifier(cloneAddress);
--
--            const cloneDomain = { ...this.domain, verifyingContract: clone.address };
--
--            const reportedDomain = await getDomain(clone);
--            expect(mapValues(reportedDomain, String)).to.be.deep.equal(mapValues(cloneDomain, String));
--
--            const expectedSeparator = await domainSeparator(cloneDomain);
--            expect(await clone.$_domainSeparatorV4()).to.equal(expectedSeparator);
--          });
--        }
-       });
- 
-       it('hash digest', async function () {
+diff --git a/scripts/upgradeable/upgradeable.patch b/scripts/upgradeable/upgradeable.patch
+index 466d1d1c..2f5e169f 100644
+--- a/scripts/upgradeable/upgradeable.patch
++++ b/scripts/upgradeable/upgradeable.patch
+@@ -152,7 +152,7 @@ index df141192..1cf90ad1 100644
+    "keywords": [
+      "solidity",
+ diff --git a/contracts/token/ERC20/extensions/ERC20Capped.sol b/contracts/token/ERC20/extensions/ERC20Capped.sol
+-index 98ec7144..4992115b 100644
++index 943d0164..248ebc0d 100644
+ --- a/contracts/token/ERC20/extensions/ERC20Capped.sol
+ +++ b/contracts/token/ERC20/extensions/ERC20Capped.sol
+ @@ -7,6 +7,8 @@ import {ERC20} from "../ERC20.sol";
+@@ -178,7 +178,7 @@ index 8778f4ba..825d4e16 100644
+  abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {
+      // solhint-disable-next-line var-name-mixedcase
+ diff --git a/contracts/token/ERC20/extensions/ERC20Wrapper.sol b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+-index 2cbff622..97f43d7a 100644
++index c9e33d00..ecc1c218 100644
+ --- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+ +++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+ @@ -14,6 +14,8 @@ import {SafeERC20} from "../utils/SafeERC20.sol";
+@@ -191,18 +191,18 @@ index 2cbff622..97f43d7a 100644
+  abstract contract ERC20Wrapper is ERC20 {
+      IERC20 private immutable _underlying;
+ diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
+-index d94e956a..86bb5713 100644
++index 7160f96c..1fd020ad 100644
+ --- a/contracts/utils/cryptography/EIP712.sol
+ +++ b/contracts/utils/cryptography/EIP712.sol
+ @@ -4,7 +4,6 @@
+  pragma solidity ^0.8.19;
+  
+- import {ECDSA} from "./ECDSA.sol";
++ import {MessageHashUtils} from "./MessageHashUtils.sol";
+ -import {ShortStrings, ShortString} from "../ShortStrings.sol";
+  import {IERC5267} from "../../interfaces/IERC5267.sol";
+  
+  /**
+-@@ -30,27 +29,19 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
++@@ -31,27 +30,19 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+   *
+   * _Available since v3.4._
+   *
+@@ -235,7 +235,7 @@ index d94e956a..86bb5713 100644
+  
+      /**
+       * @dev Initializes the domain separator and parameter caches.
+-@@ -65,29 +56,23 @@ abstract contract EIP712 is IERC5267 {
++@@ -66,29 +57,23 @@ abstract contract EIP712 is IERC5267 {
+       * contract upgrade].
+       */
+      constructor(string memory name, string memory version) {
+@@ -273,7 +273,7 @@ index d94e956a..86bb5713 100644
+      }
+  
+      /**
+-@@ -128,6 +113,10 @@ abstract contract EIP712 is IERC5267 {
++@@ -129,6 +114,10 @@ abstract contract EIP712 is IERC5267 {
+              uint256[] memory extensions
+          )
+      {
+@@ -284,7 +284,7 @@ index d94e956a..86bb5713 100644
+          return (
+              hex"0f", // 01111
+              _EIP712Name(),
+-@@ -142,26 +131,62 @@ abstract contract EIP712 is IERC5267 {
++@@ -143,26 +132,62 @@ abstract contract EIP712 is IERC5267 {
+      /**
+       * @dev The name parameter for the EIP712 domain.
+       *

--- a/test/utils/cryptography/ECDSA.test.js
+++ b/test/utils/cryptography/ECDSA.test.js
@@ -1,6 +1,6 @@
 require('@openzeppelin/test-helpers');
 const { expectRevertCustomError } = require('../../helpers/customError');
-const { toEthSignedMessageHash, toDataWithIntendedValidatorHash } = require('../../helpers/sign');
+const { toEthSignedMessageHash } = require('../../helpers/sign');
 
 const { expect } = require('chai');
 
@@ -9,7 +9,6 @@ const ECDSA = artifacts.require('$ECDSA');
 const TEST_MESSAGE = web3.utils.sha3('OpenZeppelin');
 const WRONG_MESSAGE = web3.utils.sha3('Nope');
 const NON_HASH_MESSAGE = '0x' + Buffer.from('abcd').toString('hex');
-const RANDOM_ADDRESS = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
 
 function to2098Format(signature) {
   const long = web3.utils.hexToBytes(signature);
@@ -241,28 +240,6 @@ contract('ECDSA', function (accounts) {
         [s],
       );
       expect(() => to2098Format(highSSignature)).to.throw("invalid signature 's' value");
-    });
-  });
-
-  context('toEthSignedMessageHash', function () {
-    it('prefixes bytes32 data correctly', async function () {
-      expect(await this.ecdsa.methods['$toEthSignedMessageHash(bytes32)'](TEST_MESSAGE)).to.equal(
-        toEthSignedMessageHash(TEST_MESSAGE),
-      );
-    });
-
-    it('prefixes dynamic length data correctly', async function () {
-      expect(await this.ecdsa.methods['$toEthSignedMessageHash(bytes)'](NON_HASH_MESSAGE)).to.equal(
-        toEthSignedMessageHash(NON_HASH_MESSAGE),
-      );
-    });
-  });
-
-  context('toDataWithIntendedValidatorHash', function () {
-    it('returns the hash correctly', async function () {
-      expect(
-        await this.ecdsa.methods['$toDataWithIntendedValidatorHash(address,bytes)'](RANDOM_ADDRESS, NON_HASH_MESSAGE),
-      ).to.equal(toDataWithIntendedValidatorHash(RANDOM_ADDRESS, NON_HASH_MESSAGE));
     });
   });
 });

--- a/test/utils/cryptography/MessageHashUtils.test.js
+++ b/test/utils/cryptography/MessageHashUtils.test.js
@@ -1,7 +1,6 @@
 require('@openzeppelin/test-helpers');
 const { toEthSignedMessageHash, toDataWithIntendedValidatorHash } = require('../../helpers/sign');
 const { domainSeparator, hashTypedData } = require('../../helpers/eip712');
-const { getChainId } = require('../../helpers/chainid');
 
 const { expect } = require('chai');
 
@@ -24,9 +23,8 @@ contract('MessageHashUtils', function () {
     });
 
     it('prefixes dynamic length data correctly', async function () {
-      const message = '0x' + Buffer.from('abcd').toString('hex');
-      expect(await this.messageHashUtils.methods['$toEthSignedMessageHash(bytes)'](message)).to.equal(
-        toEthSignedMessageHash(message),
+      expect(await this.messageHashUtils.methods['$toEthSignedMessageHash(bytes)'](this.message)).to.equal(
+        toEthSignedMessageHash(this.message),
       );
     });
   });
@@ -44,7 +42,7 @@ contract('MessageHashUtils', function () {
       const domain = {
         name: 'Test',
         version: 1,
-        chainId: await getChainId(),
+        chainId: 1,
         verifyingContract: this.verifyingAddress,
       };
       const structhash = web3.utils.randomHex(32);

--- a/test/utils/cryptography/MessageHashUtils.test.js
+++ b/test/utils/cryptography/MessageHashUtils.test.js
@@ -1,0 +1,57 @@
+require('@openzeppelin/test-helpers');
+const { toEthSignedMessageHash, toDataWithIntendedValidatorHash } = require('../../helpers/sign');
+const { domainSeparator, hashTypedData } = require('../../helpers/eip712');
+const { getChainId } = require('../../helpers/chainid');
+
+const { expect } = require('chai');
+
+const MessageHashUtils = artifacts.require('$MessageHashUtils');
+
+contract('MessageHashUtils', function () {
+  beforeEach(async function () {
+    this.messageHashUtils = await MessageHashUtils.new();
+
+    this.message = '0x' + Buffer.from('abcd').toString('hex');
+    this.messageHash = web3.utils.sha3(this.message);
+    this.verifyingAddress = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
+  });
+
+  context('toEthSignedMessageHash', function () {
+    it('prefixes bytes32 data correctly', async function () {
+      expect(await this.messageHashUtils.methods['$toEthSignedMessageHash(bytes32)'](this.messageHash)).to.equal(
+        toEthSignedMessageHash(this.messageHash),
+      );
+    });
+
+    it('prefixes dynamic length data correctly', async function () {
+      const message = '0x' + Buffer.from('abcd').toString('hex');
+      expect(await this.messageHashUtils.methods['$toEthSignedMessageHash(bytes)'](message)).to.equal(
+        toEthSignedMessageHash(message),
+      );
+    });
+  });
+
+  context('toDataWithIntendedValidatorHash', function () {
+    it('returns the digest correctly', async function () {
+      expect(
+        await this.messageHashUtils.$toDataWithIntendedValidatorHash(this.verifyingAddress, this.message),
+      ).to.equal(toDataWithIntendedValidatorHash(this.verifyingAddress, this.message));
+    });
+  });
+
+  context('toTypedDataHash', function () {
+    it('returns the digest correctly', async function () {
+      const domain = {
+        name: 'Test',
+        version: 1,
+        chainId: await getChainId(),
+        verifyingContract: this.verifyingAddress,
+      };
+      const structhash = web3.utils.randomHex(32);
+      const expectedDomainSeparator = await domainSeparator(domain);
+      expect(await this.messageHashUtils.$toTypedDataHash(expectedDomainSeparator, structhash)).to.equal(
+        hashTypedData(domain, structhash),
+      );
+    });
+  });
+});


### PR DESCRIPTION
As part of #4318, we agreed that the `ECDSA` library can just focus on `recovery` methods, whereas a new library for ECDSA message hashes would be a suitable place for adding support to new message schemes.

It includes some updates to the documentation.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
