### PR TITLE
Remove slither hardcoded version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,7 +100,6 @@ jobs:
       - uses: crytic/slither-action@v0.3.0
         with:
           node-version: 18.15
-          slither-version: 0.9.3
 
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #4397

After #4346 we fixed the version of slither to 0.9.3 because the `unchecked-lowlevel` rule was triggering false positives (see https://github.com/crytic/slither/issues/2008). [Slither 0.9.6](https://github.com/crytic/slither/releases/tag/0.9.6) was just released and includes a fix to the false positives, so we're enabling the latest version again.
