### PR TITLE
Remove superfluous receive() function from Proxy.sol

### DIFF
--- a/.changeset/eight-peaches-guess.md
+++ b/.changeset/eight-peaches-guess.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Proxy`: Removed redundant `receive` function.

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -69,14 +69,6 @@ abstract contract Proxy {
     }
 
     /**
-     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
-     * is empty.
-     */
-    receive() external payable virtual {
-        _fallback();
-    }
-
-    /**
      * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
      * call, or as part of the Solidity `fallback` or `receive` functions.
      *


### PR DESCRIPTION
[Following this discussion in the forum](https://forum.openzeppelin.com/t/proxy-sol-fallback/36951/7)

In the past, when declaring a `fallback()`, solidity would trigger a warning if no `receive()` is implemented. That is apparently no longer the case.

In the case of Proxy, the `receive` function is not necessary. Any call, with or without data, with or without value, will be catched by `fallback() fallback`.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests (nothing changes)
- [x] Changeset entry (run `npx changeset add`)
