### PR TITLE
Use immutable beacon address in BeaconProxy

### DIFF
--- a/.changeset/proud-seals-complain.md
+++ b/.changeset/proud-seals-complain.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Use immutable beacon address in BeaconProxy

--- a/.changeset/proud-seals-complain.md
+++ b/.changeset/proud-seals-complain.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-Use immutable beacon address in BeaconProxy
+`BeaconProxy`: Use an immutable variable to store the address of the beacon. It is no longer possible for a `BeaconProxy` to upgrade by changing to another beacon.

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -161,10 +161,13 @@ library ERC1967Utils {
     }
 
     /**
-     * @dev Perform beacon upgrade with additional setup call. Note: This upgrades the address of the beacon, it does
-     * not upgrade the implementation contained in the beacon (see {UpgradeableBeacon-_setImplementation} for that).
+     * @dev Change the beacon and trigger a setup call.
      *
      * Emits an {IERC1967-BeaconUpgraded} event.
+     *
+     * CAUTION: Invoking this function has no effect on an instance of {BeaconProxy} since v5, since
+     * it uses an immutable beacon without looking at the value of the ERC-1967 beacon slot for
+     * efficiency.
      */
     function upgradeBeaconToAndCall(address newBeacon, bytes memory data, bool forceCall) internal {
         _setBeacon(newBeacon);

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -138,6 +138,13 @@ library ERC1967Utils {
     bytes32 internal constant BEACON_SLOT = 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
 
     /**
+     * @dev Returns the current beacon.
+     */
+    function getBeacon() internal view returns (address) {
+        return StorageSlot.getAddressSlot(BEACON_SLOT).value;
+    }
+
+    /**
      * @dev Stores a new beacon in the EIP1967 beacon slot.
      */
     function _setBeacon(address newBeacon) private {

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -138,13 +138,6 @@ library ERC1967Utils {
     bytes32 internal constant BEACON_SLOT = 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
 
     /**
-     * @dev Returns the current beacon.
-     */
-    function getBeacon() internal view returns (address) {
-        return StorageSlot.getAddressSlot(BEACON_SLOT).value;
-    }
-
-    /**
      * @dev Stores a new beacon in the EIP1967 beacon slot.
      */
     function _setBeacon(address newBeacon) private {

--- a/contracts/proxy/beacon/BeaconProxy.sol
+++ b/contracts/proxy/beacon/BeaconProxy.sol
@@ -12,7 +12,7 @@ import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
  *
  * The beacon address is stored in storage slot `uint256(keccak256('eip1967.proxy.beacon')) - 1`, so that it doesn't
  * conflict with the storage layout of the implementation behind the proxy. It is also stored in an immutable variable
- * for gas efficiency when reading it.
+ * for gas efficiency when reading it internally.
  */
 contract BeaconProxy is Proxy {
     // An immutable address for the beacon to avoid unnecessary SLOADs before each delegate call.

--- a/contracts/proxy/beacon/BeaconProxy.sol
+++ b/contracts/proxy/beacon/BeaconProxy.sol
@@ -18,7 +18,6 @@ import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
  */
 contract BeaconProxy is Proxy {
     // An immutable address for the beacon to avoid unnecessary SLOADs before each delegate call.
-    // This is private to avoid generating a getter function that could clash with a function from the implementation.
     address private immutable _beacon;
 
     /**
@@ -41,6 +40,13 @@ contract BeaconProxy is Proxy {
      * @dev Returns the current implementation address of the associated beacon.
      */
     function _implementation() internal view virtual override returns (address) {
-        return IBeacon(_beacon).implementation();
+        return IBeacon(_getBeacon()).implementation();
+    }
+
+    /**
+     * @dev Returns the beacon.
+     */
+    function _getBeacon() internal view virtual returns (address) {
+        return _beacon;
     }
 }

--- a/contracts/proxy/beacon/BeaconProxy.sol
+++ b/contracts/proxy/beacon/BeaconProxy.sol
@@ -18,7 +18,7 @@ import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
  */
 contract BeaconProxy is Proxy {
     // An immutable address for the beacon to avoid unnecessary SLOADs before each delegate call.
-    // This must be private to avoid generating a getter function that could clash with a function from the implementation.
+    // This is private to avoid generating a getter function that could clash with a function from the implementation.
     address private immutable _beacon;
 
     /**

--- a/contracts/proxy/beacon/BeaconProxy.sol
+++ b/contracts/proxy/beacon/BeaconProxy.sol
@@ -11,8 +11,10 @@ import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
  * @dev This contract implements a proxy that gets the implementation address for each call from an {UpgradeableBeacon}.
  *
  * The beacon address is stored in storage slot `uint256(keccak256('eip1967.proxy.beacon')) - 1`, so that it doesn't
- * conflict with the storage layout of the implementation behind the proxy. It is also stored in an immutable variable
- * for gas efficiency when reading it internally.
+ * conflict with the storage layout of the implementation behind the proxy.
+ *
+ * CAUTION: The beacon address can only be set once during construction, and cannot be changed afterwards.
+ * You must ensure that you either control the beacon, or trust the beacon to not upgrade the implementation maliciously.
  */
 contract BeaconProxy is Proxy {
     // An immutable address for the beacon to avoid unnecessary SLOADs before each delegate call.


### PR DESCRIPTION
Fixes #2538

Uses an immutable variable to store the beacon's address in BeaconProxy, in addition to the beacon storage slot.  This avoids an extra SLOAD when retrieving the beacon address before each delegate call.

The immutable variable is used in `_implementation()` to read the beacon address before each delegate call.
The beacon slot is still written during construction, so that the beacon address can be read externally according to ERC-1967.  This beacon slot is required because the immutable variable must be private to avoid generating a getter function that could clash with a function from the implementation.

Rationale:
- Although there is an `upgradeBeaconToAndCall` internal function in ERC1967Utils which sets the beacon slot, that function is not exposed in BeaconProxy but is only called on construction.  Effectively, this means the beacon address is already not modifiable after the BeaconProxy is deployed.
- Therefore, there is no need to continue reading the beacon slot before every delegate call during the proxy's fallback function. We can use an immutable variable instead.

#### PR Checklist

- [x] Tests (not applicable as this only changes the proxy's internal implementation)
- [x] Documentation (updated comments)
- [x] Changeset entry (run `npx changeset add`)
