### PR TITLE
Improve custom error helper when there is no match

### DIFF
--- a/test/helpers/customError.js
+++ b/test/helpers/customError.js
@@ -13,13 +13,10 @@ async function expectRevertCustomError(promise, expectedErrorName, args) {
       // VM Exception while processing transaction:
       // reverted with custom error 'InvalidAccountNonce("0x70997970C51812dc3A010C7d01b50e0d17dc79C8", 0)'
 
-      // We trim out anything inside the single quotes as comma-separated values
-      const [, error] = message.match(/'(.*)'/);
-
-      // Attempt to parse as an error
-      const match = error.match(/(?<name>\w+)\((?<args>.*)\)/);
+      // Attempt to parse as a custom error
+      const match = message.match(/custom error '(?<name>\w+)\((?<args>.*)\)'/);
       if (!match) {
-        expect.fail(`Couldn't parse "${error}" as a custom error`);
+        expect.fail(`Could not parse as custom error. ${message}`);
       }
       // Extract the error name and parameters
       const errorName = match.groups.name;


### PR DESCRIPTION
When the `expectRevertCustomError` helper doesn't find a custom error it fails by attempting to destructure the `null` return value of the `match` function and results in "TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))" which is really disconcerting when it shows up. This PR makes the original error text show up.

Side note: I've also slightly changed the matching logic to look for `custom error` in the message to make it more specific.