### PR TITLE
Add suggested remappings in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,8 @@ OpenZeppelin Contracts features a [stable API](https://docs.openzeppelin.com/con
 ```
 $ forge install OpenZeppelin/openzeppelin-contracts
 ```
-Note: Only while working with Foundry  
 
-Head to foundry.toml and add the below line
-```
-remappings = ["@openzeppelin/=lib/openzeppelin-contracts/"]
-```
+Add `@openzeppelin/=lib/openzeppelin-contracts/` in `remappings.txt.` 
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ OpenZeppelin Contracts features a [stable API](https://docs.openzeppelin.com/con
 ```
 $ forge install OpenZeppelin/openzeppelin-contracts
 ```
+Note: Only while working with Foundry  
+
+Head to foundry.toml and add the below line
+```
+remappings = ["@openzeppelin/=lib/openzeppelin-contracts/"]
+```
 
 ### Usage
 


### PR DESCRIPTION
Added directions to remappings while working with foundry in README.md.

Fixes #4439 

Added below lines to give directions about remappings

-----------
Note: Only while working with Foundry

Head to foundry.toml and add below line
```
remappings = ["@openzeppelin/=lib/openzeppelin-contracts/"]
```
--------------

