### PR TITLE
Remove duplicated SLOAD in Arrays.findUpperBound

### DIFF
--- a/.changeset/fluffy-countries-buy.md
+++ b/.changeset/fluffy-countries-buy.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Arrays`: Optimize `findUpperBound` by removing redundant SLOAD.

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -22,12 +22,12 @@ library Arrays {
      * repeated elements.
      */
     function findUpperBound(uint256[] storage array, uint256 element) internal view returns (uint256) {
+        uint256 low = 0;
         uint256 high = array.length;
+
         if (high == 0) {
             return 0;
         }
-
-        uint256 low = 0;
 
         while (low < high) {
             uint256 mid = Math.average(low, high);

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -22,12 +22,12 @@ library Arrays {
      * repeated elements.
      */
     function findUpperBound(uint256[] storage array, uint256 element) internal view returns (uint256) {
-        if (array.length == 0) {
+        uint256 high = array.length;
+        if (high == 0) {
             return 0;
         }
 
         uint256 low = 0;
-        uint256 high = array.length;
 
         while (low < high) {
             uint256 mid = Math.average(low, high);


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Reading a variable in storage costs more gas than reading a variable in memory. 
Replacing load of ```array.length``` with load of local variable ```high``` can save gas.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
