### PR TITLE
Remove unnecessary explicit assignment override

### DIFF
--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -17,7 +17,7 @@ import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
  * The {_authorizeUpgrade} function must be overridden to include access restriction to the upgrade mechanism.
  */
 abstract contract UUPSUpgradeable is IERC1822Proxiable {
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address private immutable __self = address(this);
 
     /**

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -29,7 +29,7 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
  * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
  *
- * @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+ * @custom:oz-upgrades-unsafe-allow state-variable-immutable
  */
 abstract contract EIP712 is IERC5267 {
     using ShortStrings for *;

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -142,7 +142,7 @@ index 36f076e5..90c1db78 100644
   * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
   * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
 - *
-- * @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+- * @custom:oz-upgrades-unsafe-allow state-variable-immutable
   */
  abstract contract EIP712 is IERC5267 {
 -    using ShortStrings for *;


### PR DESCRIPTION
Since [@openzeppelin/upgrades-core@1.27.2](https://github.com/OpenZeppelin/openzeppelin-upgrades/releases/tag/%40openzeppelin%2Fupgrades-core%401.27.2) and [@openzeppelin/upgrade-safe-transpiler@0.3.25](https://github.com/OpenZeppelin/openzeppelin-transpiler/blob/master/CHANGELOG.md#0325-2023-07-05), the `state-variable-immutable` override implies `state-variable-assignment` so it isn't needed any more.