### PR TITLE
Fix typos in the tests

### DIFF
--- a/test/governance/extensions/GovernorWithParams.test.js
+++ b/test/governance/extensions/GovernorWithParams.test.js
@@ -147,7 +147,7 @@ contract('GovernorWithParams', function (accounts) {
             ethSigUtil.signTypedMessage(privateKey, { data: await this.data(contract, message) });
         });
 
-        it('suports EOA signatures', async function () {
+        it('supports EOA signatures', async function () {
           await this.token.delegate(this.voterBySig.address, { from: voter2 });
 
           const weight = web3.utils.toBN(web3.utils.toWei('7')).sub(rawParams.uintParam);

--- a/test/helpers/governance.js
+++ b/test/helpers/governance.js
@@ -81,7 +81,7 @@ class GovernorHelper {
           ...concatOpts(proposal.shortProposal, opts),
         );
       default:
-        throw new Error(`unsuported visibility "${visibility}"`);
+        throw new Error(`unsupported visibility "${visibility}"`);
     }
   }
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `test/governance/extensions/GovernorWithParams.test.js`
1 typo in `test/helpers/governance.js`


Best!