### PR TITLE
Avoid `returndatacopy` in ERC2771Forwarder by calling via assembly

### DIFF
--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -7,6 +7,12 @@ import {Context} from "../utils/Context.sol";
 
 /**
  * @dev Context variant with ERC2771 support.
+ *
+ * WARNING: Avoid using this pattern in contracts that rely in a specific calldata length as they'll
+ * be affected by any forwarder whose `msg.data` is suffixed with the `from` address according to the ERC2771
+ * specification adding the address size in bytes (20) to the calldata size. An example of an unexpected
+ * behavior could be an unintended fallback (or another function) invocation while trying to invoke the `receive`
+ * function only accessible if `msg.data.length == 0`.
  */
 abstract contract ERC2771Context is Context {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -26,9 +26,11 @@ import {Address} from "../utils/Address.sol";
  * transactions in the mempool. In these cases the recommendation is to distribute the load among
  * multiple accounts.
  *
- * NOTE: The `receive()` function is not available with ERC2771 because it requires `msg.data` to
- * always have the `from` address at the end of the calldata, whereas the `receive()` function only
- * works when data is empty.
+ * WARNING: Any forwarded call to a contract relying on a specific calldata length will be affected
+ * this forwarder since the ERC2771 specification requires `msg.data` to always be suffixed with the
+ * `from` address, making the minimum calldata length received within the subcall is 20 for the address
+ * size in bytes. An example of this is the `receive` function, which can be accessed only when the
+ * calldata is nonempty.
  *
  * ==== Security Considerations
  *

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -27,10 +27,10 @@ import {Address} from "../utils/Address.sol";
  * multiple accounts.
  *
  * WARNING: Any forwarded call to a contract relying on a specific calldata length will be affected
- * this forwarder since the ERC2771 specification requires `msg.data` to always be suffixed with the
- * `from` address, making the minimum calldata length received within the subcall is 20 for the address
- * size in bytes. An example of this is the `receive` function, which can be accessed only when the
- * calldata is nonempty.
+ * by this forwarder since the ERC2771 specification requires `msg.data` to always be suffixed with the
+ * `from` address, adding the address size in bytes (20) to the calldata size. An example of an unexpected
+ * behavior could be an unintended fallback (or another function) invocation while trying to invoke the `receive`
+ * function, which can be accessed only if `msg.data.length == 0`.
  *
  * ==== Security Considerations
  *

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -26,6 +26,10 @@ import {Address} from "../utils/Address.sol";
  * transactions in the mempool. In these cases the recommendation is to distribute the load among
  * multiple accounts.
  *
+ * NOTE: The `receive()` function is not available with ERC2771 because it requires `msg.data` to
+ * always have the `from` address at the end of the calldata, whereas the `receive()` function only
+ * works when data is empty.
+ *
  * ==== Security Considerations
  *
  * If a relayer submits a forward request, it should be willing to pay up to 100% of the gas amount

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -26,12 +26,6 @@ import {Address} from "../utils/Address.sol";
  * transactions in the mempool. In these cases the recommendation is to distribute the load among
  * multiple accounts.
  *
- * WARNING: Any forwarded call to a contract relying on a specific calldata length will be affected
- * by this forwarder since the ERC2771 specification requires `msg.data` to always be suffixed with the
- * `from` address, adding the address size in bytes (20) to the calldata size. An example of an unexpected
- * behavior could be an unintended fallback (or another function) invocation while trying to invoke the `receive`
- * function, which can be accessed only if `msg.data.length == 0`.
- *
  * ==== Security Considerations
  *
  * If a relayer submits a forward request, it should be willing to pay up to 100% of the gas amount

--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -41,7 +41,7 @@ contract('ERC2771Forwarder', function (accounts) {
     this.alice.address = web3.utils.toChecksumAddress(this.alice.getAddressString());
 
     this.timestamp = await time.latest();
-    this.receiver = await CallReceiverMock.new(this.forwarder.address, { value: 1e18 });
+    this.receiver = await CallReceiverMock.new();
     this.request = {
       from: this.alice.address,
       to: this.receiver.address,

--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -230,14 +230,28 @@ contract('ERC2771Forwarder', function (accounts) {
     });
 
     it('bubbles out of gas forced by the relayer', async function () {
-      // A malicious relayer would provide a gas limit that is too low to execute the request.
+      // If there's an incentive behind executing requests, a malicious relayer could grief
+      // the forwarder by executing requests and providing a top-level call gas limit that
+      // is too low to succesfully finish the request after the 63/64 rule.
+
+      // We set the baseline to the gas limit consumed by a successful request if it was executed
+      // normally. Note this includes the 21000 buffer that also the relayer will be charged to
+      // start a request execution.
       const estimate = await this.estimateRequest(this.request);
-      const gasAvailable = estimate + 2_000; // Add some gas to let the first-level transaction pass
+
+      // Because the relayer call consumes gas until the `CALL` opcode, the gas left after failing
+      // the subcall is not be enough to finish the top level call (after testing), so we add a
+      // moderated buffer.
+      const gasAvailable = estimate + 2_000;
+
+      // The subcall out of gas should be caught by the contract and then bubbled up consuming
+      // the available gas with an `invalid` opcode.
       await expectRevert.outOfGas(this.forwarder.execute(this.requestData, { gas: gasAvailable }));
 
       const { transactions } = await web3.eth.getBlock('latest');
       const { gasUsed } = await web3.eth.getTransactionReceipt(transactions[0]);
 
+      // We assert that indeed the gas was totally consumed.
       expect(gasUsed).to.be.equal(gasAvailable);
     });
   });
@@ -478,8 +492,18 @@ contract('ERC2771Forwarder', function (accounts) {
       });
 
       it('bubbles out of gas forced by the relayer', async function () {
-        // A malicious relayer would provide a gas limit that is too low to execute the request.
-        const gasAvailable = (await this.gasUntil(this.requestDatas, this.idx)) + 10_000; // Add some gas to let the first-level transaction pass
+        // Similarly to the single execute, a malicious relayer could grief requests.
+
+        // We estimate until the selected request as if they were executed normally
+        const estimate = await this.gasUntil(this.requestDatas, this.idx);
+
+        // We add a Buffer to account for all the gas that's used before the selected call.
+        // Note is slightly bigger because the selected request is not the index 0 and it affects
+        // the buffer needed.
+        const gasAvailable = estimate + 10_000;
+
+        // The subcall out of gas should be caught by the contract and then bubbled up consuming
+        // the available gas with an `invalid` opcode.
         await expectRevert.outOfGas(
           this.forwarder.executeBatch(this.requestDatas, constants.ZERO_ADDRESS, { gas: gasAvailable }),
         );
@@ -487,6 +511,7 @@ contract('ERC2771Forwarder', function (accounts) {
         const { transactions } = await web3.eth.getBlock('latest');
         const { gasUsed } = await web3.eth.getTransactionReceipt(transactions[0]);
 
+        // We assert that indeed the gas was totally consumed.
         expect(gasUsed).to.be.equal(gasAvailable);
       });
     });

--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -232,7 +232,7 @@ contract('ERC2771Forwarder', function (accounts) {
     it('bubbles out of gas forced by the relayer', async function () {
       // If there's an incentive behind executing requests, a malicious relayer could grief
       // the forwarder by executing requests and providing a top-level call gas limit that
-      // is too low to succesfully finish the request after the 63/64 rule.
+      // is too low to successfully finish the request after the 63/64 rule.
 
       // We set the baseline to the gas limit consumed by a successful request if it was executed
       // normally. Note this includes the 21000 buffer that also the relayer will be charged to

--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -240,7 +240,7 @@ contract('ERC2771Forwarder', function (accounts) {
       const estimate = await this.estimateRequest(this.request);
 
       // Because the relayer call consumes gas until the `CALL` opcode, the gas left after failing
-      // the subcall is not be enough to finish the top level call (after testing), so we add a
+      // the subcall won't enough to finish the top level call (after testing), so we add a
       // moderated buffer.
       const gasAvailable = estimate + 2_000;
 


### PR DESCRIPTION
As reported in https://github.com/ethereum/solidity/issues/12306, the `returndatacopy` is allocating memory after every call although we're purposely ignoring the `returndata` in forwarded requests. Therefore, calling with assembly will allow to avoid this unnecessary `returndatacopy` and reduce gas costs.

Moreover, the tests were improved to check for correctly checking gas bubbling up and a relayer griefing attack.

Also, a note was added about the availability of ERC2771 when trying to call the `receive` function.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
