### PR TITLE
Update recommended remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OpenZeppelin Contracts features a [stable API](https://docs.openzeppelin.com/con
 $ forge install OpenZeppelin/openzeppelin-contracts
 ```
 
-Add `@openzeppelin/=lib/openzeppelin-contracts/` in `remappings.txt.` 
+Add `@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/` in `remappings.txt.` 
 
 ### Usage
 


### PR DESCRIPTION
Change recommend Foundry remapping to
```
@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
```
This maps directly to the npm package which is packaged from the `contracts` directory of this repository.

This also prevents the entry from taking precedence over the the upgradeable contracts repository's remapping which would be
```
@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
```