### PR TITLE
Add internal functions inside modifiers

### DIFF
--- a/.changeset/swift-numbers-cry.md
+++ b/.changeset/swift-numbers-cry.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Governor`, `Initializable` and `UUPSUpgradeable`: Use internal functions in modifiers.

--- a/.changeset/swift-numbers-cry.md
+++ b/.changeset/swift-numbers-cry.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`Governor`, `Initializable` and `UUPSUpgradeable`: Use internal functions in modifiers.
+`Governor`, `Initializable`, and `UUPSUpgradeable`: Use internal functions in modifiers to optimize bytecode size.

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -221,7 +221,9 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
     }
 
     /**
-     * @dev Throws if the executor is not the owner.
+     * @dev Reverts if the `msg.sender` is not the executor. In case the executor is not this contract
+     * itself, the function reverts if `msg.data` is not whitelisted as a result of an {execute}
+     * operation. See {onlyGovernance}.
      */
     function _checkGovernance() internal virtual {
         if (_executor() != _msgSender()) {

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -66,14 +66,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      * governance protocol (since v4.6).
      */
     modifier onlyGovernance() {
-        if (_executor() != _msgSender()) {
-            revert GovernorOnlyExecutor(_msgSender());
-        }
-        if (_executor() != address(this)) {
-            bytes32 msgDataHash = keccak256(_msgData());
-            // loop until popping the expected operation - throw if deque is empty (operation not authorized)
-            while (_governanceCall.popFront() != msgDataHash) {}
-        }
+        _checkGovernance();
         _;
     }
 
@@ -225,6 +218,20 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      */
     function proposalProposer(uint256 proposalId) public view virtual override returns (address) {
         return _proposals[proposalId].proposer;
+    }
+
+    /**
+     * @dev Throws if the executor is not the owner.
+     */
+    function _checkGovernance() internal virtual {
+        if (_executor() != _msgSender()) {
+            revert GovernorOnlyExecutor(_msgSender());
+        }
+        if (_executor() != address(this)) {
+            bytes32 msgDataHash = keccak256(_msgData());
+            // loop until popping the expected operation - throw if deque is empty (operation not authorized)
+            while (_governanceCall.popFront() != msgDataHash) {}
+        }
     }
 
     /**

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -143,7 +143,7 @@ abstract contract Initializable {
     }
 
     /**
-     * @dev Throws if not Initializing.
+     * @dev Reverts if the contract is not in an initializing state. See {onlyInitializing}.
      */
     function _checkInitializing() internal view virtual {
         if (!_initializing) {

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -138,10 +138,17 @@ abstract contract Initializable {
      * {initializer} and {reinitializer} modifiers, directly or indirectly.
      */
     modifier onlyInitializing() {
+        _checkInitializing();
+        _;
+    }
+
+    /**
+     * @dev Throws if not Initializing.
+     */
+    function _checkInitializing() internal view virtual {
         if (!_initializing) {
             revert NotInitializing();
         }
-        _;
     }
 
     /**

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -103,7 +103,8 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
     }
 
     /**
-     * @dev Throws if called through a delegate call
+     * @dev Reverts if the execution is performed via delegatecall.
+     * See {notDelegated}.
      */
     function _checkNotDelegated() internal view virtual {
         if (address(this) != __self) {

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -89,8 +89,9 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
     }
 
     /**
-     * @dev Throws if the execution is not being performed through a delegatecall call
-     * Throws if not called through an active proxy
+     * @dev Reverts if the execution is not performed via delegatecall or the execution
+     * context is not of a proxy with an ERC1967-compliant implementation pointing to self.
+     * See {_onlyProxy}.
      */
     function _checkProxy() internal view virtual {
         if (


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

Fixes #4466 

Some modifiers could use internal functions to reduce code size impact

`_checkGovernance`, `_checkProxy `, `_checkNotDelegated ` and `_checkInitializing ` internal functions has been added.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
