### PR TITLE
Remove outdated comments in AccessControl.sol

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -60,9 +60,6 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
      * @dev Modifier that checks that an account has a specific role. Reverts
      * with a standardized message including the required role.
      *
-     * The format of the revert reason is given by the following regular expression:
-     *
-     *  /^AccessControl: account (0x[0-9a-f]{40}) is missing role (0x[0-9a-f]{64})$/
      */
     modifier onlyRole(bytes32 role) {
         _checkRole(role);
@@ -86,8 +83,6 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
     /**
      * @dev Revert with a standard message if `_msgSender()` is missing `role`.
      * Overriding this function changes the behavior of the {onlyRole} modifier.
-     *
-     * Format of the revert message is described in {_checkRole}.
      */
     function _checkRole(bytes32 role) internal view virtual {
         _checkRole(role, _msgSender());
@@ -95,10 +90,6 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
 
     /**
      * @dev Revert with a standard message if `account` is missing `role`.
-     *
-     * The format of the revert reason is given by the following regular expression:
-     *
-     *  /^AccessControl: account (0x[0-9a-f]{40}) is missing role (0x[0-9a-f]{64})$/
      */
     function _checkRole(bytes32 role, address account) internal view virtual {
         if (!hasRole(role, account)) {


### PR DESCRIPTION
Fixes #4470 

Outdated comments for `onlyowner` modifier and `_checkrole` has been removed. 

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
