### PR TITLE
Improve ERC4626 fees example

### DIFF
--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -72,19 +72,19 @@ abstract contract ERC4626Fees is ERC4626 {
     // === Fee configuration === ///
 
     function _entryFeeBasePoint() internal view virtual returns (uint256) {
-        return 0; // i.e. 1_000 for 1%
+        return 0; // replace with e.g. 1_000 for 1%
     }
 
     function _exitFeeBasePoint() internal view virtual returns (uint256) {
-        return 0; // i.e. 1_000 for 1%
+        return 0; // replace with e.g. 1_000 for 1%
     }
 
     function _entryFeeRecipient() internal view virtual returns (address) {
-        return address(0); // i.e. treasury
+        return address(0); // replace with e.g. a treasury address
     }
 
     function _exitFeeRecipient() internal view virtual returns (address) {
-        return address(0); // i.e. treasury
+        return address(0); // replace with e.g. a treasury address
     }
 
     // === Fee operations === ///

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -89,12 +89,12 @@ abstract contract ERC4626Fees is ERC4626 {
 
     // === Fee operations === ///
 
-    /// @dev Calculates fee on `assets` not including fees. Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
+    /// @dev Calculates the fees that should be added to an amount `assets` that does not already include fees. Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
     function _feeOnRaw(uint256 assets, uint256 feePCM) private pure returns (uint256) {
         return assets.mulDiv(feePCM, _PCM_SCALE, Math.Rounding.Ceil);
     }
 
-    /// @dev Calculates fee on `assets` already including fees. Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
+    /// @dev Calculates the fee part of an amount `assets` that already includes fees. Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
     function _feeOnTotal(uint256 assets, uint256 feePCM) private pure returns (uint256) {
         return assets.mulDiv(feePCM, feePCM + _PCM_SCALE, Math.Rounding.Ceil);
     }

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -91,19 +91,11 @@ abstract contract ERC4626Fees is ERC4626 {
 
     /// @dev Calculates fee on `assets` not including fees. Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
     function _feeOnRaw(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
-<<<<<<< Updated upstream
-        return assets.mulDiv(feeBasePoint, 1e5, Math.Rounding.Ceil);
-=======
-        return assets.mulDiv(feeBasePoint, _PCM_SCALE, Math.Rounding.Up);
->>>>>>> Stashed changes
+        return assets.mulDiv(feeBasePoint, _PCM_SCALE, Math.Rounding.Ceil);
     }
 
     /// @dev Calculates fee on `assets` already including fees. Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
     function _feeOnTotal(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
-<<<<<<< Updated upstream
-        return assets.mulDiv(feeBasePoint, feeBasePoint + 1e5, Math.Rounding.Ceil);
-=======
-        return assets.mulDiv(feeBasePoint, feeBasePoint + _PCM_SCALE, Math.Rounding.Up);
->>>>>>> Stashed changes
+        return assets.mulDiv(feeBasePoint, feeBasePoint + _PCM_SCALE, Math.Rounding.Ceil);
     }
 }

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -7,41 +7,41 @@ import {ERC4626} from "../../token/ERC20/extensions/ERC4626.sol";
 import {SafeERC20} from "../../token/ERC20/utils/SafeERC20.sol";
 import {Math} from "../../utils/math/Math.sol";
 
-/// @dev ERC4626 vault with entry/exit fees expressed in https://en.wikipedia.org/wiki/Per_cent_mille[PCM].
+/// @dev ERC4626 vault with entry/exit fees expressed in https://en.wikipedia.org/wiki/Basis_point[base point (bp)].
 abstract contract ERC4626Fees is ERC4626 {
     using Math for uint256;
 
-    uint256 private constant _PCM_SCALE = 1e5;
+    uint256 private constant _BASE_POINT_SCALE = 1e4;
 
     // === Overrides === ///
 
     /// @dev Preview taking an entry fee on deposit. See {IERC4626-previewDeposit}.
     function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
-        uint256 fee = _feeOnTotal(assets, _entryFeePCM());
+        uint256 fee = _feeOnTotal(assets, _entryFeeBasePoint());
         return super.previewDeposit(assets - fee);
     }
 
     /// @dev Preview adding an entry fee on mint. See {IERC4626-previewMint}.
     function previewMint(uint256 shares) public view virtual override returns (uint256) {
         uint256 assets = super.previewMint(shares);
-        return assets + _feeOnRaw(assets, _entryFeePCM());
+        return assets + _feeOnRaw(assets, _entryFeeBasePoint());
     }
 
     /// @dev Preview adding an exit fee on withdraw. See {IERC4626-previewWithdraw}.
     function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
-        uint256 fee = _feeOnRaw(assets, _exitFeePCM());
+        uint256 fee = _feeOnRaw(assets, _exitFeeBasePoint());
         return super.previewWithdraw(assets + fee);
     }
 
     /// @dev Preview taking an exit fee on redeem. See {IERC4626-previewRedeem}.
     function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
         uint256 assets = super.previewRedeem(shares);
-        return assets - _feeOnTotal(assets, _exitFeePCM());
+        return assets - _feeOnTotal(assets, _exitFeeBasePoint());
     }
 
     /// @dev Send entry fee to {_entryFeeRecipient}. See {IERC4626-_deposit}.
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal virtual override {
-        uint256 fee = _feeOnTotal(assets, _entryFeePCM());
+        uint256 fee = _feeOnTotal(assets, _entryFeeBasePoint());
         address recipient = _entryFeeRecipient();
 
         super._deposit(caller, receiver, assets, shares);
@@ -59,7 +59,7 @@ abstract contract ERC4626Fees is ERC4626 {
         uint256 assets,
         uint256 shares
     ) internal virtual override {
-        uint256 fee = _feeOnRaw(assets, _exitFeePCM());
+        uint256 fee = _feeOnRaw(assets, _exitFeeBasePoint());
         address recipient = _exitFeeRecipient();
 
         super._withdraw(caller, receiver, owner, assets, shares);
@@ -71,11 +71,11 @@ abstract contract ERC4626Fees is ERC4626 {
 
     // === Fee configuration === ///
 
-    function _entryFeePCM() internal view virtual returns (uint256) {
+    function _entryFeeBasePoint() internal view virtual returns (uint256) {
         return 0; // i.e. 1_000 for 1%
     }
 
-    function _exitFeePCM() internal view virtual returns (uint256) {
+    function _exitFeeBasePoint() internal view virtual returns (uint256) {
         return 0; // i.e. 1_000 for 1%
     }
 
@@ -90,12 +90,11 @@ abstract contract ERC4626Fees is ERC4626 {
     // === Fee operations === ///
 
     /// @dev Calculates the fees that should be added to an amount `assets` that does not already include fees. Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
-    function _feeOnRaw(uint256 assets, uint256 feePCM) private pure returns (uint256) {
-        return assets.mulDiv(feePCM, _PCM_SCALE, Math.Rounding.Ceil);
+    function _feeOnRaw(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
+        return assets.mulDiv(feeBasePoint, _BASE_POINT_SCALE, Math.Rounding.Ceil);
     }
 
     /// @dev Calculates the fee part of an amount `assets` that already includes fees. Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
-    function _feeOnTotal(uint256 assets, uint256 feePCM) private pure returns (uint256) {
-        return assets.mulDiv(feePCM, feePCM + _PCM_SCALE, Math.Rounding.Ceil);
-    }
+    function _feeOnTotal(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
+        return assets.mulDiv(feeBasePoint, feeBasePoint + _BASE_POINT_SCALE, Math.Rounding.Ceil);
 }

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -89,12 +89,15 @@ abstract contract ERC4626Fees is ERC4626 {
 
     // === Fee operations === ///
 
-    /// @dev Calculates the fees that should be added to an amount `assets` that does not already include fees. Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
+    /// @dev Calculates the fees that should be added to an amount `assets` that does not already include fees.
+    /// Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
     function _feeOnRaw(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
         return assets.mulDiv(feeBasePoint, _BASE_POINT_SCALE, Math.Rounding.Ceil);
     }
 
-    /// @dev Calculates the fee part of an amount `assets` that already includes fees. Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
+    /// @dev Calculates the fee part of an amount `assets` that already includes fees.
+    /// Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
     function _feeOnTotal(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
         return assets.mulDiv(feeBasePoint, feeBasePoint + _BASE_POINT_SCALE, Math.Rounding.Ceil);
+    }
 }

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -11,7 +11,7 @@ import {Math} from "../../utils/math/Math.sol";
 abstract contract ERC4626Fees is ERC4626 {
     using Math for uint256;
 
-    uint256 private constant _BASE_POINT_SCALE = 1e4;
+    uint256 private constant _BASIS_POINT_SCALE = 1e4;
 
     // === Overrides === ///
 
@@ -92,12 +92,12 @@ abstract contract ERC4626Fees is ERC4626 {
     /// @dev Calculates the fees that should be added to an amount `assets` that does not already include fees.
     /// Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
     function _feeOnRaw(uint256 assets, uint256 feeBasisPoints) private pure returns (uint256) {
-        return assets.mulDiv(feeBasisPoints, _BASE_POINT_SCALE, Math.Rounding.Ceil);
+        return assets.mulDiv(feeBasisPoints, _BASIS_POINT_SCALE, Math.Rounding.Ceil);
     }
 
     /// @dev Calculates the fee part of an amount `assets` that already includes fees.
     /// Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
     function _feeOnTotal(uint256 assets, uint256 feeBasisPoints) private pure returns (uint256) {
-        return assets.mulDiv(feeBasisPoints, feeBasisPoints + _BASE_POINT_SCALE, Math.Rounding.Ceil);
+        return assets.mulDiv(feeBasisPoints, feeBasisPoints + _BASIS_POINT_SCALE, Math.Rounding.Ceil);
     }
 }

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -7,7 +7,7 @@ import {ERC4626} from "../../token/ERC20/extensions/ERC4626.sol";
 import {SafeERC20} from "../../token/ERC20/utils/SafeERC20.sol";
 import {Math} from "../../utils/math/Math.sol";
 
-/// @dev ERC4626 vault with entry/exit fees expressed in https://en.wikipedia.org/wiki/Basis_point[base point (bp)].
+/// @dev ERC4626 vault with entry/exit fees expressed in https://en.wikipedia.org/wiki/Basis_point[basis point (bp)].
 abstract contract ERC4626Fees is ERC4626 {
     using Math for uint256;
 
@@ -17,31 +17,31 @@ abstract contract ERC4626Fees is ERC4626 {
 
     /// @dev Preview taking an entry fee on deposit. See {IERC4626-previewDeposit}.
     function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
-        uint256 fee = _feeOnTotal(assets, _entryFeeBasePoint());
+        uint256 fee = _feeOnTotal(assets, _entryFeeBasisPoints());
         return super.previewDeposit(assets - fee);
     }
 
     /// @dev Preview adding an entry fee on mint. See {IERC4626-previewMint}.
     function previewMint(uint256 shares) public view virtual override returns (uint256) {
         uint256 assets = super.previewMint(shares);
-        return assets + _feeOnRaw(assets, _entryFeeBasePoint());
+        return assets + _feeOnRaw(assets, _entryFeeBasisPoints());
     }
 
     /// @dev Preview adding an exit fee on withdraw. See {IERC4626-previewWithdraw}.
     function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
-        uint256 fee = _feeOnRaw(assets, _exitFeeBasePoint());
+        uint256 fee = _feeOnRaw(assets, _exitFeeBasisPoints());
         return super.previewWithdraw(assets + fee);
     }
 
     /// @dev Preview taking an exit fee on redeem. See {IERC4626-previewRedeem}.
     function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
         uint256 assets = super.previewRedeem(shares);
-        return assets - _feeOnTotal(assets, _exitFeeBasePoint());
+        return assets - _feeOnTotal(assets, _exitFeeBasisPoints());
     }
 
     /// @dev Send entry fee to {_entryFeeRecipient}. See {IERC4626-_deposit}.
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal virtual override {
-        uint256 fee = _feeOnTotal(assets, _entryFeeBasePoint());
+        uint256 fee = _feeOnTotal(assets, _entryFeeBasisPoints());
         address recipient = _entryFeeRecipient();
 
         super._deposit(caller, receiver, assets, shares);
@@ -59,7 +59,7 @@ abstract contract ERC4626Fees is ERC4626 {
         uint256 assets,
         uint256 shares
     ) internal virtual override {
-        uint256 fee = _feeOnRaw(assets, _exitFeeBasePoint());
+        uint256 fee = _feeOnRaw(assets, _exitFeeBasisPoints());
         address recipient = _exitFeeRecipient();
 
         super._withdraw(caller, receiver, owner, assets, shares);
@@ -71,11 +71,11 @@ abstract contract ERC4626Fees is ERC4626 {
 
     // === Fee configuration === ///
 
-    function _entryFeeBasePoint() internal view virtual returns (uint256) {
+    function _entryFeeBasisPoints() internal view virtual returns (uint256) {
         return 0; // replace with e.g. 1_000 for 1%
     }
 
-    function _exitFeeBasePoint() internal view virtual returns (uint256) {
+    function _exitFeeBasisPoints() internal view virtual returns (uint256) {
         return 0; // replace with e.g. 1_000 for 1%
     }
 
@@ -91,13 +91,13 @@ abstract contract ERC4626Fees is ERC4626 {
 
     /// @dev Calculates the fees that should be added to an amount `assets` that does not already include fees.
     /// Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
-    function _feeOnRaw(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
-        return assets.mulDiv(feeBasePoint, _BASE_POINT_SCALE, Math.Rounding.Ceil);
+    function _feeOnRaw(uint256 assets, uint256 feeBasisPoints) private pure returns (uint256) {
+        return assets.mulDiv(feeBasisPoints, _BASE_POINT_SCALE, Math.Rounding.Ceil);
     }
 
     /// @dev Calculates the fee part of an amount `assets` that already includes fees.
     /// Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
-    function _feeOnTotal(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
-        return assets.mulDiv(feeBasePoint, feeBasePoint + _BASE_POINT_SCALE, Math.Rounding.Ceil);
+    function _feeOnTotal(uint256 assets, uint256 feeBasisPoints) private pure returns (uint256) {
+        return assets.mulDiv(feeBasisPoints, feeBasisPoints + _BASE_POINT_SCALE, Math.Rounding.Ceil);
     }
 }

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -90,12 +90,12 @@ abstract contract ERC4626Fees is ERC4626 {
     // === Fee operations === ///
 
     /// @dev Calculates fee on `assets` not including fees. Used in {IERC4626-mint} and {IERC4626-withdraw} operations.
-    function _feeOnRaw(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
-        return assets.mulDiv(feeBasePoint, _PCM_SCALE, Math.Rounding.Ceil);
+    function _feeOnRaw(uint256 assets, uint256 feePCM) private pure returns (uint256) {
+        return assets.mulDiv(feePCM, _PCM_SCALE, Math.Rounding.Ceil);
     }
 
     /// @dev Calculates fee on `assets` already including fees. Used in {IERC4626-deposit} and {IERC4626-redeem} operations.
-    function _feeOnTotal(uint256 assets, uint256 feeBasePoint) private pure returns (uint256) {
-        return assets.mulDiv(feeBasePoint, feeBasePoint + _PCM_SCALE, Math.Rounding.Ceil);
+    function _feeOnTotal(uint256 assets, uint256 feePCM) private pure returns (uint256) {
+        return assets.mulDiv(feePCM, feePCM + _PCM_SCALE, Math.Rounding.Ceil);
     }
 }

--- a/contracts/mocks/token/ERC4646FeesMock.sol
+++ b/contracts/mocks/token/ERC4646FeesMock.sol
@@ -5,33 +5,33 @@ pragma solidity ^0.8.19;
 import {ERC4626Fees} from "../docs/ERC4626Fees.sol";
 
 abstract contract ERC4626FeesMock is ERC4626Fees {
-    uint256 private immutable _entryFeeBasePointValue;
+    uint256 private immutable _entryFeeBasisPointValue;
     address private immutable _entryFeeRecipientValue;
-    uint256 private immutable _exitFeeBasePointValue;
+    uint256 private immutable _exitFeeBasisPointValue;
     address private immutable _exitFeeRecipientValue;
 
     constructor(
-        uint256 entryFeeBasePoint,
+        uint256 entryFeeBasisPoints,
         address entryFeeRecipient,
-        uint256 exitFeeBasePoint,
+        uint256 exitFeeBasisPoints,
         address exitFeeRecipient
     ) {
-        _entryFeeBasePointValue = entryFeeBasePoint;
+        _entryFeeBasisPointValue = entryFeeBasisPoints;
         _entryFeeRecipientValue = entryFeeRecipient;
-        _exitFeeBasePointValue = exitFeeBasePoint;
+        _exitFeeBasisPointValue = exitFeeBasisPoints;
         _exitFeeRecipientValue = exitFeeRecipient;
     }
 
-    function _entryFeeBasePoint() internal view virtual override returns (uint256) {
-        return _entryFeeBasePointValue;
+    function _entryFeeBasisPoints() internal view virtual override returns (uint256) {
+        return _entryFeeBasisPointValue;
     }
 
     function _entryFeeRecipient() internal view virtual override returns (address) {
         return _entryFeeRecipientValue;
     }
 
-    function _exitFeeBasePoint() internal view virtual override returns (uint256) {
-        return _exitFeeBasePointValue;
+    function _exitFeeBasisPoints() internal view virtual override returns (uint256) {
+        return _exitFeeBasisPointValue;
     }
 
     function _exitFeeRecipient() internal view virtual override returns (address) {

--- a/contracts/mocks/token/ERC4646FeesMock.sol
+++ b/contracts/mocks/token/ERC4646FeesMock.sol
@@ -5,9 +5,9 @@ pragma solidity ^0.8.19;
 import {ERC4626Fees} from "../docs/ERC4626Fees.sol";
 
 abstract contract ERC4626FeesMock is ERC4626Fees {
-    uint256 private immutable _entryFeeBasePointValue;
+    uint256 private immutable _entryFeePCMValue;
     address private immutable _entryFeeRecipientValue;
-    uint256 private immutable _exitFeeBasePointValue;
+    uint256 private immutable _exitFeePCMValue;
     address private immutable _exitFeeRecipientValue;
 
     constructor(
@@ -16,22 +16,22 @@ abstract contract ERC4626FeesMock is ERC4626Fees {
         uint256 exitFeeBasePoint,
         address exitFeeRecipient
     ) {
-        _entryFeeBasePointValue = entryFeeBasePoint;
+        _entryFeePCMValue = entryFeeBasePoint;
         _entryFeeRecipientValue = entryFeeRecipient;
-        _exitFeeBasePointValue = exitFeeBasePoint;
+        _exitFeePCMValue = exitFeeBasePoint;
         _exitFeeRecipientValue = exitFeeRecipient;
     }
 
-    function _entryFeeBasePoint() internal view virtual override returns (uint256) {
-        return _entryFeeBasePointValue;
+    function _entryFeePCM() internal view virtual override returns (uint256) {
+        return _entryFeePCMValue;
     }
 
     function _entryFeeRecipient() internal view virtual override returns (address) {
         return _entryFeeRecipientValue;
     }
 
-    function _exitFeeBasePoint() internal view virtual override returns (uint256) {
-        return _exitFeeBasePointValue;
+    function _exitFeePCM() internal view virtual override returns (uint256) {
+        return _exitFeePCMValue;
     }
 
     function _exitFeeRecipient() internal view virtual override returns (address) {

--- a/contracts/mocks/token/ERC4646FeesMock.sol
+++ b/contracts/mocks/token/ERC4646FeesMock.sol
@@ -5,28 +5,33 @@ pragma solidity ^0.8.19;
 import {ERC4626Fees} from "../docs/ERC4626Fees.sol";
 
 abstract contract ERC4626FeesMock is ERC4626Fees {
-    uint256 private immutable _entryFeePCMValue;
+    uint256 private immutable _entryFeeBasePointValue;
     address private immutable _entryFeeRecipientValue;
-    uint256 private immutable _exitFeePCMValue;
+    uint256 private immutable _exitFeeBasePointValue;
     address private immutable _exitFeeRecipientValue;
 
-    constructor(uint256 entryFeePCM, address entryFeeRecipient, uint256 exitFeePCM, address exitFeeRecipient) {
-        _entryFeePCMValue = entryFeePCM;
+    constructor(
+        uint256 entryFeeBasePoint,
+        address entryFeeRecipient,
+        uint256 exitFeeBasePoint,
+        address exitFeeRecipient
+    ) {
+        _entryFeeBasePointValue = entryFeeBasePoint;
         _entryFeeRecipientValue = entryFeeRecipient;
-        _exitFeePCMValue = exitFeePCM;
+        _exitFeeBasePointValue = exitFeeBasePoint;
         _exitFeeRecipientValue = exitFeeRecipient;
     }
 
-    function _entryFeePCM() internal view virtual override returns (uint256) {
-        return _entryFeePCMValue;
+    function _entryFeeBasePoint() internal view virtual override returns (uint256) {
+        return _entryFeeBasePointValue;
     }
 
     function _entryFeeRecipient() internal view virtual override returns (address) {
         return _entryFeeRecipientValue;
     }
 
-    function _exitFeePCM() internal view virtual override returns (uint256) {
-        return _exitFeePCMValue;
+    function _exitFeeBasePoint() internal view virtual override returns (uint256) {
+        return _exitFeeBasePointValue;
     }
 
     function _exitFeeRecipient() internal view virtual override returns (address) {

--- a/contracts/mocks/token/ERC4646FeesMock.sol
+++ b/contracts/mocks/token/ERC4646FeesMock.sol
@@ -10,12 +10,7 @@ abstract contract ERC4626FeesMock is ERC4626Fees {
     uint256 private immutable _exitFeePCMValue;
     address private immutable _exitFeeRecipientValue;
 
-    constructor(
-        uint256 entryFeePCM,
-        address entryFeeRecipient,
-        uint256 exitFeePCM,
-        address exitFeeRecipient
-    ) {
+    constructor(uint256 entryFeePCM, address entryFeeRecipient, uint256 exitFeePCM, address exitFeeRecipient) {
         _entryFeePCMValue = entryFeePCM;
         _entryFeeRecipientValue = entryFeeRecipient;
         _exitFeePCMValue = exitFeePCM;

--- a/contracts/mocks/token/ERC4646FeesMock.sol
+++ b/contracts/mocks/token/ERC4646FeesMock.sol
@@ -11,14 +11,14 @@ abstract contract ERC4626FeesMock is ERC4626Fees {
     address private immutable _exitFeeRecipientValue;
 
     constructor(
-        uint256 entryFeeBasePoint,
+        uint256 entryFeePCM,
         address entryFeeRecipient,
-        uint256 exitFeeBasePoint,
+        uint256 exitFeePCM,
         address exitFeeRecipient
     ) {
-        _entryFeePCMValue = entryFeeBasePoint;
+        _entryFeePCMValue = entryFeePCM;
         _entryFeeRecipientValue = entryFeeRecipient;
-        _exitFeePCMValue = exitFeeBasePoint;
+        _exitFeePCMValue = exitFeePCM;
         _exitFeeRecipientValue = exitFeeRecipient;
     }
 

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -737,9 +737,9 @@ contract('ERC4626', function (accounts) {
   }
 
   describe('ERC4626Fees', function () {
-    const feeBasePoint = web3.utils.toBN(5e3);
+    const feeBasisPoints = web3.utils.toBN(5e3);
     const valueWithoutFees = web3.utils.toBN(10000);
-    const fees = valueWithoutFees.mul(feeBasePoint).divn(1e5);
+    const fees = valueWithoutFees.mul(feeBasisPoints).divn(1e5);
     const valueWithFees = valueWithoutFees.add(fees);
 
     describe('input fees', function () {
@@ -749,7 +749,7 @@ contract('ERC4626', function (accounts) {
           name + ' Vault',
           symbol + 'V',
           this.token.address,
-          feeBasePoint,
+          feeBasisPoints,
           other,
           0,
           constants.ZERO_ADDRESS,

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -737,9 +737,9 @@ contract('ERC4626', function (accounts) {
   }
 
   describe('ERC4626Fees', function () {
-    const feeBasePoint = web3.utils.toBN(5e3);
+    const feePCM = web3.utils.toBN(5e3);
     const valueWithoutFees = web3.utils.toBN(10000);
-    const fees = valueWithoutFees.mul(feeBasePoint).divn(1e5);
+    const fees = valueWithoutFees.mul(feePCM).divn(1e5);
     const valueWithFees = valueWithoutFees.add(fees);
 
     describe('input fees', function () {
@@ -749,7 +749,7 @@ contract('ERC4626', function (accounts) {
           name + ' Vault',
           symbol + 'V',
           this.token.address,
-          feeBasePoint,
+          feePCM,
           other,
           0,
           constants.ZERO_ADDRESS,

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -739,7 +739,7 @@ contract('ERC4626', function (accounts) {
   describe('ERC4626Fees', function () {
     const feeBasisPoints = web3.utils.toBN(5e3);
     const valueWithoutFees = web3.utils.toBN(10000);
-    const fees = valueWithoutFees.mul(feeBasisPoints).divn(1e5);
+    const fees = valueWithoutFees.mul(feeBasisPoints).divn(1e4);
     const valueWithFees = valueWithoutFees.add(fees);
 
     describe('input fees', function () {

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -737,9 +737,9 @@ contract('ERC4626', function (accounts) {
   }
 
   describe('ERC4626Fees', function () {
-    const feePCM = web3.utils.toBN(5e3);
+    const feeBasePoint = web3.utils.toBN(5e3);
     const valueWithoutFees = web3.utils.toBN(10000);
-    const fees = valueWithoutFees.mul(feePCM).divn(1e5);
+    const fees = valueWithoutFees.mul(feeBasePoint).divn(1e5);
     const valueWithFees = valueWithoutFees.add(fees);
 
     describe('input fees', function () {
@@ -749,7 +749,7 @@ contract('ERC4626', function (accounts) {
           name + ' Vault',
           symbol + 'V',
           this.token.address,
-          feePCM,
+          feeBasePoint,
           other,
           0,
           constants.ZERO_ADDRESS,


### PR DESCRIPTION
This PR improves the documentation of the ERC4626Fees example in the docs with better documentation and better specifying the units used in the contract.

See this [forum thread](https://forum.openzeppelin.com/t/please-explain-erc4626fees-math/37141/3).