### PR TITLE
Make ERC2771Context return original sender address if `msg.data.length <= 20`

### DIFF
--- a/.changeset/unlucky-beans-obey.md
+++ b/.changeset/unlucky-beans-obey.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC2771Context`: Return the forwarder address whenever `msg.data.length` is not appended with the request signer address (i.e. length is less than 20 bytes).
+`ERC2771Context`: Return the forwarder address whenever the `msg.data` or calls sent by a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes).

--- a/.changeset/unlucky-beans-obey.md
+++ b/.changeset/unlucky-beans-obey.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC2771Context`: Return the forwarder address whenever the `msg.data` of a call originating from a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes).
+`ERC2771Context`: Return the forwarder address whenever the `msg.data` of a call originating from a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes), as specified by ERC-2771.

--- a/.changeset/unlucky-beans-obey.md
+++ b/.changeset/unlucky-beans-obey.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC2771Context`: Return the forwarder address whenever the `msg.data` or calls sent by a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes).
+`ERC2771Context`: Return the forwarder address whenever the `msg.data` of a calls originating from a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes).

--- a/.changeset/unlucky-beans-obey.md
+++ b/.changeset/unlucky-beans-obey.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC2771Context`: Returns the forwarder address whenever `msg.data.length` is not appended with an address (i.e. length is less than 20 bytes).

--- a/.changeset/unlucky-beans-obey.md
+++ b/.changeset/unlucky-beans-obey.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC2771Context`: Returns the forwarder address whenever `msg.data.length` is not appended with an address (i.e. length is less than 20 bytes).
+`ERC2771Context`: Return the forwarder address whenever `msg.data.length` is not appended with the request signer address (i.e. length is less than 20 bytes).

--- a/.changeset/unlucky-beans-obey.md
+++ b/.changeset/unlucky-beans-obey.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC2771Context`: Return the forwarder address whenever the `msg.data` of a calls originating from a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes).
+`ERC2771Context`: Return the forwarder address whenever the `msg.data` of a call originating from a trusted forwarder is not long enough to contain the request signer address (i.e. `msg.data.length` is less than 20 bytes).

--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -22,7 +22,7 @@ abstract contract ERC2771Context is Context {
     }
 
     function _msgSender() internal view virtual override returns (address sender) {
-        if (isTrustedForwarder(msg.sender)) {
+        if (isTrustedForwarder(msg.sender) && msg.data.length >= 20) {
             // The assembly code is more direct than the Solidity version using `abi.decode`.
             /// @solidity memory-safe-assembly
             assembly {

--- a/test/metatx/ERC2771Context.test.js
+++ b/test/metatx/ERC2771Context.test.js
@@ -81,13 +81,13 @@ contract('ERC2771Context', function (accounts) {
         const { tx } = await this.forwarder.execute(req);
         await expectEvent.inTransaction(tx, ERC2771ContextMock, 'Sender', { sender: this.sender });
       });
-      
+
       it('returns the original sender when calldata length is less than 20 bytes (address length)', async function () {
         // The forwarder doesn't produce calls with calldata length less than 20 bytes
         const recipient = await ERC2771ContextMock.new(anotherAccount);
-        
+
         const { tx } = await recipient.msgSender({ from: anotherAccount });
-        
+
         await expectEvent.inTransaction(tx, ERC2771ContextMock, 'Sender', { sender: anotherAccount });
       });
     });

--- a/test/metatx/ERC2771Context.test.js
+++ b/test/metatx/ERC2771Context.test.js
@@ -86,9 +86,9 @@ contract('ERC2771Context', function (accounts) {
         // The forwarder doesn't produce calls with calldata length less than 20 bytes
         const recipient = await ERC2771ContextMock.new(anotherAccount);
 
-        const { tx } = await recipient.msgSender({ from: anotherAccount });
+        const { receipt } = await recipient.msgSender({ from: anotherAccount });
 
-        await expectEvent.inTransaction(tx, ERC2771ContextMock, 'Sender', { sender: anotherAccount });
+        await expectEvent(receipt, 'Sender', { sender: anotherAccount });
       });
     });
 

--- a/test/metatx/ERC2771Context.test.js
+++ b/test/metatx/ERC2771Context.test.js
@@ -12,6 +12,8 @@ const ContextMockCaller = artifacts.require('ContextMockCaller');
 const { shouldBehaveLikeRegularContext } = require('../utils/Context.behavior');
 
 contract('ERC2771Context', function (accounts) {
+  const [, anotherAccount] = accounts;
+
   const MAX_UINT48 = web3.utils.toBN(1).shln(48).subn(1).toString();
 
   beforeEach(async function () {
@@ -78,6 +80,15 @@ contract('ERC2771Context', function (accounts) {
 
         const { tx } = await this.forwarder.execute(req);
         await expectEvent.inTransaction(tx, ERC2771ContextMock, 'Sender', { sender: this.sender });
+      });
+      
+      it('returns the original sender when calldata length is less than 20 bytes (address length)', async function () {
+        // The forwarder doesn't produce calls with calldata length less than 20 bytes
+        const recipient = await ERC2771ContextMock.new(anotherAccount);
+        
+        const { tx } = await recipient.msgSender({ from: anotherAccount });
+        
+        await expectEvent.inTransaction(tx, ERC2771ContextMock, 'Sender', { sender: anotherAccount });
       });
     });
 


### PR DESCRIPTION
Fixes an audit finding. Report will be published soon.

The current implementation of the ERC2771Forwarder doesn't check that the `msg.data` has a length of at least the ERC2771 suffixed address, nullifying the result and producing the `address(0)` whenever accessing an out-of-bounds `calldata` location (i.e. calldata with size 19).

This PR checks for the correct length and falls back to the original sender.