### PR TITLE
#fixes Some modifiers could use internal functions to reduce code size impact 

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -65,17 +65,19 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      * for example, additional timelock proposers are not able to change governance parameters without going through the
      * governance protocol (since v4.6).
      */
-    modifier onlyGovernance() {
-        if (_executor() != _msgSender()) {
-            revert GovernorOnlyExecutor(_msgSender());
-        }
-        if (_executor() != address(this)) {
-            bytes32 msgDataHash = keccak256(_msgData());
-            // loop until popping the expected operation - throw if deque is empty (operation not authorized)
-            while (_governanceCall.popFront() != msgDataHash) {}
-        }
-        _;
-    }
+
+     
+    // modifier onlyGovernance() {
+    //     if (_executor() != _msgSender()) {
+    //         revert GovernorOnlyExecutor(_msgSender());
+    //     }
+    //     if (_executor() != address(this)) {
+    //         bytes32 msgDataHash = keccak256(_msgData());
+    //         // loop until popping the expected operation - throw if deque is empty (operation not authorized)
+    //         while (_governanceCall.popFront() != msgDataHash) {}
+    //     }
+    //     _;
+    // }
 
    // Internal function to check governance
 function _checkGovernance() internal  {

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -145,6 +145,18 @@ abstract contract Initializable {
     }
 
     /**
+     * @dev Returns true if this contract has been initialized.
+
+     */
+
+function _checkInitializing() internal view   {
+        if (!_initializing) {
+            revert NotInitializing();
+        }
+    }
+
+
+    /**
      * @dev Locks the contract, preventing any future reinitialization. This cannot be part of an initializer call.
      * Calling this in the constructor of a contract will prevent that contract from being initialized or reinitialized
      * to any version. It is recommended to use this to lock implementation contracts that are designed to be called
@@ -172,7 +184,7 @@ abstract contract Initializable {
     /**
      * @dev Returns `true` if the contract is currently initializing. See {onlyInitializing}.
      */
-    function _isInitializing() internal view returns (bool) {
+    function _isInitializing() internal view returns (bool) {  
         return _initializing;
     }
 }

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -47,26 +47,44 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
      * function through ERC1167 minimal proxies (clones) would not normally pass this test, but is not guaranteed to
      * fail.
      */
-    modifier onlyProxy() {
-        if (
-            address(this) == __self || // Must be called through delegatecall
-            ERC1967Utils.getImplementation() != __self // Must be called through an active proxy
-        ) {
-            revert UUPSUnauthorizedCallContext();
-        }
-        _;
+    // modifier onlyProxy() {
+    //     if (
+    //         address(this) == __self || // Must be called through delegatecall
+    //         ERC1967Utils.getImplementation() != __self // Must be called through an active proxy
+    //     ) {
+    //         revert UUPSUnauthorizedCallContext();
+    //     }
+    //     _;
+    // }
+    // Internal function to check if the contract is being called through a proxy
+function _checkProxy(address self) internal  {
+    if (
+        address(this) == self || // Must be called through delegatecall
+        ERC1967Utils.getImplementation() != self // Must be called through an active proxy
+    ) {
+        revert UUPSUnauthorizedCallContext();
     }
+}
+
+
 
     /**
      * @dev Check that the execution is not being performed through a delegate call. This allows a function to be
      * callable on the implementing contract but not through proxies.
      */
-    modifier notDelegated() {
+    // modifier notDelegated() {
+    //     if (address(this) != __self) {
+    //         // Must not be called through delegatecall
+    //         revert UUPSUnauthorizedCallContext();
+    //     }
+    //     _;
+    // }
+
+    function _checkNotDelegated() internal  {
         if (address(this) != __self) {
             // Must not be called through delegatecall
             revert UUPSUnauthorizedCallContext();
         }
-        _;
     }
 
     /**
@@ -77,7 +95,8 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
      * bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this
      * function revert if invoked through a proxy. This is guaranteed by the `notDelegated` modifier.
      */
-    function proxiableUUID() external view virtual notDelegated returns (bytes32) {
+    function proxiableUUID() external view virtual  returns (bytes32) {
+        _checkNotDelegated();
         return ERC1967Utils.IMPLEMENTATION_SLOT;
     }
 
@@ -91,7 +110,8 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable {
      *
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
-    function upgradeToAndCall(address newImplementation, bytes memory data) public payable virtual onlyProxy {
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable virtual {
+        _checkProxy(__self);
         _authorizeUpgrade(newImplementation);
         _upgradeToAndCallUUPS(newImplementation, data);
     }


### PR DESCRIPTION


Fixes #4466 
Replaced the [onlyGovernance](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/Governor.sol#L68) code with an internal function called _checkGovernance (alternatively _checkExecutor) doing the same check.

Replaced the [onlyProxy](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/UUPSUpgradeable.sol#L50) code with an internal function called _checkProxy with the same check and the [notDelegated](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/UUPSUpgradeable.sol#L64) code with a _checkNotDelegated internal function


Replaced the [onlyInitializing](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/Initializable.sol#L140) code with an internal function called _checkInitializing)






