### PR TITLE
update Governor mappings from private to internal

### DIFF
--- a/.changeset/young-bats-eat.md
+++ b/.changeset/young-bats-eat.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+update Governor mappings from private to internal

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -47,13 +47,13 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
     bytes32 private constant _ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
     string private _name;
 
-    mapping(uint256 => ProposalCore) private _proposals;
+    mapping(uint256 => ProposalCore) internal _proposals;
 
     // This queue keeps track of the governor operating on itself. Calls to functions protected by the
     // {onlyGovernance} modifier needs to be whitelisted in this queue. Whitelisting is set in {_beforeExecute},
     // consumed by the {onlyGovernance} modifier and eventually reset in {_afterExecute}. This ensures that the
     // execution of {onlyGovernance} protected calls can only be achieved through successful proposals.
-    DoubleEndedQueue.Bytes32Deque private _governanceCall;
+    DoubleEndedQueue.Bytes32Deque internal _governanceCall;
 
     /**
      * @dev Restricts a function so it can only be executed through governance proposals. For example, governance


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->

### Description 

Changes the `_proposals` and `_governanceCall` mappings to internal from private.

<!-- Include any context necessary for understanding the PR's purpose. -->

### Rationale

For many of the useful overrides that you'd want to make on the Governor, accessing this state is essential. For example, it is impractical to override `propose()` if you do not have access to the storage for proposals.

This leads to inefficient and dangerous workarounds that could otherwise be avoided by making this storage internal.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [X] Tests
- [X] Documentation
- [X] Changeset entry (run `npx changeset add`)
