### PR TITLE
Optimize muldiv

### DIFF
--- a/.changeset/pink-suns-mix.md
+++ b/.changeset/pink-suns-mix.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+optimization of stack operations in mulDiv (Math.sol)

--- a/.changeset/pink-suns-mix.md
+++ b/.changeset/pink-suns-mix.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-optimization of stack operations in mulDiv (Math.sol)
+`Math`: Optimized stack operations in `mulDiv`.

--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -162,8 +162,7 @@ library Math {
             // Factor powers of two out of denominator and compute largest power of two divisor of denominator. Always >= 1.
             // See https://cs.stackexchange.com/q/138556/92363.
 
-            // Does not overflow because the denominator cannot be zero at this stage in the function.
-            uint256 twos = denominator & (~denominator + 1);
+            uint256 twos = denominator & (0 - denominator);
             assembly {
                 // Divide denominator by twos.
                 denominator := div(denominator, twos)

--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -124,11 +124,10 @@ library Math {
             // 512-bit multiply [prod1 prod0] = x * y. Compute the product mod 2^256 and mod 2^256 - 1, then use
             // use the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256
             // variables such that product = prod1 * 2^256 + prod0.
-            uint256 prod0; // Least significant 256 bits of the product
+            uint256 prod0 = x * y; // Least significant 256 bits of the product
             uint256 prod1; // Most significant 256 bits of the product
             assembly {
                 let mm := mulmod(x, y, not(0))
-                prod0 := mul(x, y)
                 prod1 := sub(sub(mm, prod0), lt(mm, prod0))
             }
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This pull request contains two small changes to the mulDiv function to slightly optimize gas.

#### Reduce stack operations in mulDiv
The product of x and y to obtain the least significant bits of the result is moved above, to the place where the variable prod0 is declared.

https://github.com/vladyan18/openzeppelin-contracts/blob/e54956d8453f04f59491511df8d353dbaab98202/contracts/utils/math/Math.sol#L127
```solidity
uint256 prod0 = x * y; // Least significant 256 bits of the product
uint256 prod1; // Most significant 256 bits of the product
assembly {
  let mm := mulmod(x, y, not(0))
  prod1 := sub(sub(mm, prod0), lt(mm, prod0))
}
```

**Rationale**: with compiler optimization enabled, the old implementation led to unnecessary initialization of the variable by zero. As a result, this initialization also added unnecessary stack operations below in the code. Since this code is in an unchecked block, calculating the product in assembly does not provide gas savings by itself.

Gas tests, small inputs. Optimizer 200 runs, 0.8.20
**Gas before**: 198
**Gas after**: 190 (-4%)

#### Simplify twos calculation in mulDiv

An easier method was used to factor powers of two out of denominator due to which the number of necessary operations is reduced by one.

https://github.com/vladyan18/openzeppelin-contracts/blob/e54956d8453f04f59491511df8d353dbaab98202/contracts/utils/math/Math.sol#L165
```solidity
uint256 twos = denominator & (0 - denominator);
```
**Rationale**: the previous implementation uses a unary negation operation and ends up needing more operations to get the same result. The proposed line gives the same result inside an unchecked block with fewer operations.

Gas tests, big inputs. Optimizer 200 runs, 0.8.20
**Gas before**: 497
**Gas after**: 494 (-0.6%)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)

_Probably new tests and documentation are not required for this pull request._
