### PR TITLE
Refactor abs without logical branching

### DIFF
--- a/.changeset/popular-carpets-search.md
+++ b/.changeset/popular-carpets-search.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`SignedMath`: Refactor `abs` without logical branching

--- a/contracts/utils/math/SignedMath.sol
+++ b/contracts/utils/math/SignedMath.sol
@@ -36,8 +36,9 @@ library SignedMath {
      */
     function abs(int256 n) internal pure returns (uint256) {
         unchecked {
-            // must be unchecked in order to support `n = type(int256).min`
-            return uint256(n >= 0 ? n : -n);
+            // Formula from the "Bit Twiddling Hacks" by Sean Eron Anderson
+            int256 mask = n >> 255;
+            return uint256((n + mask) ^ mask);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

The calculation of the absolute value of a signed number has been replaced with a version without logical branching. 
Based on [**open-source** formula from "Bit Twiddling Hacks" by By Sean Eron Anderson](https://graphics.stanford.edu/~seander/bithacks.html#IntegerAbs).

```solidity
/**
 * @dev Returns the absolute unsigned value of a signed value.
 */
function abs(int256 n) internal pure returns (uint256) {
  unchecked {
    // Formula from the "Bit Twiddling Hacks" by Sean Eron Anderson
    int256 mask = n >> 255;
    return uint256((n + mask) ^ mask);
  }
}
```

**Rationale:** logical branching requires the use of additional rather expensive opcodes. The proposed version is cheaper. In addition, it seems that a small pure function without logical branching can often be placed by the compiler optimizer directly into the place it is used, which will further reduce the overhead.

#### Gas checks

Optimizer 200 runs, solidity 0.8.20

The results are highly dependent on compilation settings and surrounding code. The most conservative difference obtained is:

Old version, positive number (100): 70
Old version, negative number (-100): 85

New version, positive number (100): 48
New version, negative number (-100): 48

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [X] Tests
- [X] Documentation
- [X] Changeset entry (run `npx changeset add`)
