### PR TITLE
Use bytes.concat in MessageHashUtils

### DIFF
--- a/.changeset/flat-bottles-wonder.md
+++ b/.changeset/flat-bottles-wonder.md
@@ -2,4 +2,6 @@
 'openzeppelin-solidity': minor
 ---
 
-Replace some uses of `abi.encodePacked` with clearer alternatives (e.g. `bytes.concat`, `string.concat`).
+Replace some uses of `abi.encodePacked` with clearer alternatives (e.g. `bytes.concat`, `string.concat`). (#4504)[https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4504]
+
+pr: #4296

--- a/contracts/utils/cryptography/MessageHashUtils.sol
+++ b/contracts/utils/cryptography/MessageHashUtils.sol
@@ -46,7 +46,8 @@ library MessageHashUtils {
      * See {ECDSA-recover}.
      */
     function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32 digest) {
-        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", Strings.toString(message.length), message));
+        return
+            keccak256(bytes.concat("\x19Ethereum Signed Message:\n", bytes(Strings.toString(message.length)), message));
     }
 
     /**


### PR DESCRIPTION
We can use bytes.concat instead of abi.encodePacked here which is clearer.

Updating an existing changeset to mention this PR too.

In `toDataWithIntendedValidatorHash` we keep `abi.encodePacked` because one of the arguments is an address.