### PR TITLE
Refactor restriction mechanism in AccessManager to enable enforce executionDelay

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check proceduraly generated contracts are up-to-date
         run: npm run test:generation
       - name: Compare gas costs
-        if: github.base_ref == 'master'
         uses: ./.github/actions/gas-compare
+        if: github.base_ref == 'master'
         with:
           token: ${{ github.token }}
 
@@ -64,6 +64,7 @@ jobs:
         run: npm run test:inheritance
       - name: Check storage layout
         uses: ./.github/actions/storage-layout
+        if: github.base_ref == 'master'
         with:
           token: ${{ github.token }}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Check proceduraly generated contracts are up-to-date
         run: npm run test:generation
       - name: Compare gas costs
+        if: github.base_ref == 'master'
         uses: ./.github/actions/gas-compare
         with:
           token: ${{ github.token }}

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -96,15 +96,15 @@ contract AccessManager is Context, Multicall, IAccessManager {
     bytes32 private _relayIdentifier;
 
     /**
-     * @dev check that the caller is authorized to perform the operation, following the restrictions encoded in
-     * {_getRestrictions}.
+     * @dev Check that the caller is authorized to perform the operation, following the restrictions encoded in
+     * {_getAdminRestrictions}.
      */
     modifier onlyAuthorized() {
         address caller = _msgSender();
         (bool allowed, uint32 delay) = _canCallExtended(caller, address(this), _msgData());
         if (!allowed) {
             if (delay == 0) {
-                (, uint64 requiredGroup, ) = _getRestrictions(_msgData());
+                (, uint64 requiredGroup, ) = _getAdminRestrictions(_msgData());
                 revert AccessManagerUnauthorizedAccount(caller, requiredGroup);
             } else {
                 _consumeScheduledOp(_hashOperation(caller, address(this), _msgData()));
@@ -746,7 +746,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
     }
 
     // =================================================== HELPERS ====================================================
-    function _getRestrictions(bytes calldata data) private view returns (bool, uint64, uint32) {
+    function _getAdminRestrictions(bytes calldata data) private view returns (bool, uint64, uint32) {
         bytes4 selector = bytes4(data);
 
         if (selector == this.updateAuthority.selector || selector == this.setContractFamily.selector) {
@@ -786,7 +786,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
 
     function _canCallExtended(address caller, address target, bytes calldata data) private view returns (bool, uint32) {
         if (target == address(this)) {
-            (bool enabled, uint64 groupId, uint32 operationDelay) = _getRestrictions(data);
+            (bool enabled, uint64 groupId, uint32 operationDelay) = _getAdminRestrictions(data);
             if (!enabled) {
                 return (false, 0);
             }

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -809,6 +809,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
     }
 
+    // =================================================== HELPERS ====================================================
     function _isExpired(uint48 timepoint) private view returns (bool) {
         return timepoint + expiration() <= Time.timestamp();
     }

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -104,7 +104,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         (bool allowed, uint32 delay) = _canCallExtended(caller, address(this), _msgData());
         if (!allowed) {
             if (delay == 0) {
-                (,uint64 requiredGroup,) = _getRestrictions(_msgData());
+                (, uint64 requiredGroup, ) = _getRestrictions(_msgData());
                 revert AccessManagerUnauthorizedAccount(caller, requiredGroup);
             } else {
                 _consumeScheduledOp(_hashOperation(caller, address(this), _msgData()));
@@ -146,9 +146,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         } else {
             uint64 groupId = getFamilyFunctionGroup(familyId, selector);
             (bool inGroup, uint32 currentDelay) = hasGroup(groupId, caller);
-            return inGroup
-                ? (currentDelay == 0, currentDelay)
-                : (false, 0);
+            return inGroup ? (currentDelay == 0, currentDelay) : (false, 0);
         }
     }
 
@@ -253,7 +251,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupLabel} event.
      */
-    function labelGroup(uint64 groupId, string calldata label) public virtual onlyAuthorized() {
+    function labelGroup(uint64 groupId, string calldata label) public virtual onlyAuthorized {
         if (groupId == ADMIN_GROUP || groupId == PUBLIC_GROUP) {
             revert AccessManagerLockedGroup(groupId);
         }
@@ -273,11 +271,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupGranted} event
      */
-    function grantGroup(
-        uint64 groupId,
-        address account,
-        uint32 executionDelay
-    ) public virtual onlyAuthorized() {
+    function grantGroup(uint64 groupId, address account, uint32 executionDelay) public virtual onlyAuthorized {
         _grantGroup(groupId, account, getGroupGrantDelay(groupId), executionDelay);
     }
 
@@ -290,7 +284,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupRevoked} event
      */
-    function revokeGroup(uint64 groupId, address account) public virtual onlyAuthorized() {
+    function revokeGroup(uint64 groupId, address account) public virtual onlyAuthorized {
         _revokeGroup(groupId, account);
     }
 
@@ -322,11 +316,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupExecutionDelayUpdated} event
      */
-    function setExecuteDelay(
-        uint64 groupId,
-        address account,
-        uint32 newDelay
-    ) public virtual onlyAuthorized() {
+    function setExecuteDelay(uint64 groupId, address account, uint32 newDelay) public virtual onlyAuthorized {
         _setExecuteDelay(groupId, account, newDelay);
     }
 
@@ -339,7 +329,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupAdminChanged} event
      */
-    function setGroupAdmin(uint64 groupId, uint64 admin) public virtual onlyAuthorized() {
+    function setGroupAdmin(uint64 groupId, uint64 admin) public virtual onlyAuthorized {
         _setGroupAdmin(groupId, admin);
     }
 
@@ -352,7 +342,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupGuardianChanged} event
      */
-    function setGroupGuardian(uint64 groupId, uint64 guardian) public virtual onlyAuthorized() {
+    function setGroupGuardian(uint64 groupId, uint64 guardian) public virtual onlyAuthorized {
         _setGroupGuardian(groupId, guardian);
     }
 
@@ -365,7 +355,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {GroupGrantDelayChanged} event
      */
-    function setGrantDelay(uint64 groupId, uint32 newDelay) public virtual onlyAuthorized() {
+    function setGrantDelay(uint64 groupId, uint32 newDelay) public virtual onlyAuthorized {
         _setGrantDelay(groupId, newDelay);
     }
 
@@ -485,7 +475,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         uint64 familyId,
         bytes4[] calldata selectors,
         uint64 groupId
-    ) public virtual onlyAuthorized() {
+    ) public virtual onlyAuthorized {
         for (uint256 i = 0; i < selectors.length; ++i) {
             _setFamilyFunctionGroup(familyId, selectors[i], groupId);
         }
@@ -511,7 +501,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {FunctionAllowedGroupUpdated} event per selector
      */
-    function setFamilyAdminDelay(uint64 familyId, uint32 newDelay) public virtual onlyAuthorized() {
+    function setFamilyAdminDelay(uint64 familyId, uint32 newDelay) public virtual onlyAuthorized {
         _setFamilyAdminDelay(familyId, newDelay);
     }
 
@@ -547,10 +537,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {ContractFamilyUpdated} event.
      */
-    function setContractFamily(
-        address target,
-        uint64 familyId
-    ) public virtual onlyAuthorized() {
+    function setContractFamily(address target, uint64 familyId) public virtual onlyAuthorized {
         _setContractFamily(target, familyId);
     }
 
@@ -573,7 +560,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits a {ContractClosed} event.
      */
-    function setContractClosed(address target, bool closed) public virtual onlyAuthorized() {
+    function setContractClosed(address target, bool closed) public virtual onlyAuthorized {
         _setContractClosed(target, closed);
     }
 
@@ -721,10 +708,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
             // calls can only be canceled by the account that scheduled them, a global admin, or by a guardian of the required group.
             (uint64 familyId, ) = getContractFamily(target);
             (bool isAdmin, ) = hasGroup(ADMIN_GROUP, msgsender);
-            (bool isGuardian, ) = hasGroup(
-                getGroupGuardian(getFamilyFunctionGroup(familyId, selector)),
-                msgsender
-            );
+            (bool isGuardian, ) = hasGroup(getGroupGuardian(getFamilyFunctionGroup(familyId, selector)), msgsender);
             if (!isAdmin && !isGuardian) {
                 revert AccessManagerCannotCancel(msgsender, caller, target, selector);
             }
@@ -757,10 +741,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * - the caller must be a global admin
      */
-    function updateAuthority(
-        address target,
-        address newAuthority
-    ) public virtual onlyAuthorized() {
+    function updateAuthority(address target, address newAuthority) public virtual onlyAuthorized {
         IAccessManaged(target).setAuthority(newAuthority);
     }
 
@@ -768,18 +749,13 @@ contract AccessManager is Context, Multicall, IAccessManager {
     function _getRestrictions(bytes calldata data) private view returns (bool, uint64, uint32) {
         bytes4 selector = bytes4(data);
 
-        if (
-            selector == this.updateAuthority.selector ||
-            selector == this.setContractFamily.selector
-        ) {
+        if (selector == this.updateAuthority.selector || selector == this.setContractFamily.selector) {
             // First argument is a target. Restricted to ADMIN with the family delay corresponding to the target's family
             address target = abi.decode(data[0x04:0x24], (address));
             (uint64 familyId, ) = getContractFamily(target);
             uint32 delay = getFamilyAdminDelay(familyId);
             return (true, ADMIN_GROUP, delay);
-        } else if (
-            selector == this.setFamilyFunctionGroup.selector
-        ) {
+        } else if (selector == this.setFamilyFunctionGroup.selector) {
             // First argument is a family. Restricted to ADMIN with the family delay corresponding to the family
             uint64 familyId = abi.decode(data[0x04:0x24], (uint64));
             uint32 delay = getFamilyAdminDelay(familyId);
@@ -792,14 +768,14 @@ contract AccessManager is Context, Multicall, IAccessManager {
             selector == this.setFamilyAdminDelay.selector ||
             selector == this.setContractClosed.selector
         ) {
-            // Restricted to ADMIN with no delay decide any execution delay the caller may have
+            // Restricted to ADMIN with no delay becide any execution delay the caller may have
             return (true, ADMIN_GROUP, 0);
         } else if (
             selector == this.grantGroup.selector ||
             selector == this.revokeGroup.selector ||
             selector == this.setExecuteDelay.selector
         ) {
-            // First argument is a groupId. Restricted to that group's admin with no delay decide any execution delay the caller may have.
+            // First argument is a groupId. Restricted to that group's admin with no delay becide any execution delay the caller may have.
             uint64 groupId = abi.decode(data[0x04:0x24], (uint64));
             uint64 groupAdminId = getGroupAdmin(groupId);
             return (true, groupAdminId, 0);

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -737,6 +737,9 @@ contract AccessManager is Context, Multicall, IAccessManager {
     }
 
     // ================================================= ADMIN LOGIC ==================================================
+    /**
+     * @dev Check if the current call is authorized according to admin logic.
+     */
     function _checkAuthorized() private {
         address caller = _msgSender();
         (bool allowed, uint32 delay) = _canCallExtended(caller, address(this), _msgData());
@@ -750,6 +753,9 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
     }
 
+    /**
+     * @dev Get the admin restrictions of a given function call based on the function and arguments involved.
+     */
     function _getAdminRestrictions(bytes calldata data) private view returns (bool, uint64, uint32) {
         bytes4 selector = bytes4(data);
 
@@ -772,14 +778,14 @@ contract AccessManager is Context, Multicall, IAccessManager {
             selector == this.setFamilyAdminDelay.selector ||
             selector == this.setContractClosed.selector
         ) {
-            // Restricted to ADMIN with no delay becide any execution delay the caller may have
+            // Restricted to ADMIN with no delay beside any execution delay the caller may have
             return (true, ADMIN_GROUP, 0);
         } else if (
             selector == this.grantGroup.selector ||
             selector == this.revokeGroup.selector ||
             selector == this.setExecuteDelay.selector
         ) {
-            // First argument is a groupId. Restricted to that group's admin with no delay becide any execution delay the caller may have.
+            // First argument is a groupId. Restricted to that group's admin with no delay beside any execution delay the caller may have.
             uint64 groupId = abi.decode(data[0x04:0x24], (uint64));
             uint64 groupAdminId = getGroupAdmin(groupId);
             return (true, groupAdminId, 0);
@@ -788,6 +794,10 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
     }
 
+    // =================================================== HELPERS ====================================================
+    /**
+     * @dev An extended version of {canCall} for internal use that considers restrictions for admin functions.
+     */
     function _canCallExtended(address caller, address target, bytes calldata data) private view returns (bool, uint32) {
         if (target == address(this)) {
             (bool enabled, uint64 groupId, uint32 operationDelay) = _getAdminRestrictions(data);
@@ -809,7 +819,9 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
     }
 
-    // =================================================== HELPERS ====================================================
+    /**
+     * @dev Returns true if a schedule timepoint is past its expiration deadline.
+     */
     function _isExpired(uint48 timepoint) private view returns (bool) {
         return timepoint + expiration() <= Time.timestamp();
     }

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -617,6 +617,9 @@ contract AccessManager is Context, Multicall, IAccessManager {
      *
      * Emits an {OperationExecuted} event only if the call was scheduled and delayed.
      */
+    // Reentrancy is not an issue because permissions are checked on msg.sender. Additionally,
+    // _consumeScheduledOp guarantees a scheduled operation is only executed once.
+    // slither-disable-next-line reentrancy-no-eth
     function relay(address target, bytes calldata data) public payable virtual {
         address caller = _msgSender();
 


### PR DESCRIPTION
#### Description

This proposal removes the `onlyGroup` and `withFamilyDelay` modifier in favor of a single `onlyAuthorized` modifier. This modifier reuses the existing `_canCallExtended` mechanism. Unlike external contract with are restricted using family, function in the `AccessManager` are retricted to a groupId, and have a minimum delay (the family delay) that is applied on top of any execution delay that the caller may have.

This means that:
- ADMIN that have an execution delay need to schedule any admin operation such as setGroupAdmin
- If the ADMIN as an execution delay and tries to call a function that has a family delay (such as `updateAuthority`), then the maximum of the two values is used
- When calling `_grantGroup` (or `_revokeGroup`) any execution delay (on the groups admin, which may not be the ADMIN_GROUP) is applied
- All restrictions are encoded in the `_getRestrictions` function. There is no longer any risk of the modifiers not matching the _canCallExtended return values

This changes result in a more rigorious applications of the executions delay. A side effect is also that any call to a restricted function can be performed directly (without going through relay) if the operation was scheduled properly

#### Usecase enabled by this change

If you think that you could ever lose (brick) the main admin, that has no delay, you could setup a recovery account that is admin with an execution delay. This would act as an Argent's guardian:
- In case the main admin key is lost, the recovery can take over, which a delay
- If the recovery tries to do anything while the main key is still live, the main admin can cancel any operations that the recovery has initiated.

This is possible because all the function that require being an ADMIN will enforce the delay (which is not the case prior to this PR)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
