### PR TITLE
Change _approve argument name in ERC721 

### DIFF
--- a/.changeset/loud-coins-love.md
+++ b/.changeset/loud-coins-love.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Uses operator as name argument to stay consistent with other functions

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -108,8 +108,8 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
     /**
      * @dev See {IERC721-approve}.
      */
-    function approve(address to, uint256 tokenId) public virtual {
-        _approve(to, tokenId, _msgSender());
+    function approve(address operator, uint256 tokenId) public virtual {
+        _approve(operator, tokenId, _msgSender());
     }
 
     /**
@@ -396,7 +396,7 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
      *
      * Emits an {Approval} event.
      */
-    function _approve(address to, uint256 tokenId, address auth) internal virtual returns (address) {
+    function _approve(address operator, uint256 tokenId, address auth) internal virtual returns (address) {
         address owner = ownerOf(tokenId);
 
         // We do not use _isAuthorized because single-token approvals should not be able to call approve
@@ -404,8 +404,8 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
             revert ERC721InvalidApprover(auth);
         }
 
-        _tokenApprovals[tokenId] = to;
-        emit Approval(owner, to, tokenId);
+        _tokenApprovals[tokenId] = operator;
+        emit Approval(owner, operator, tokenId);
 
         return owner;
     }

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -17,7 +17,7 @@ interface IERC721 is IERC165 {
     /**
      * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
      */
-    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed operator, uint256 indexed tokenId);
 
     /**
      * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -507,7 +507,6 @@ function shouldBehaveLikeERC721(owner, newOwner, operator, other) {
         itEmitsApprovalEvent(address);
       };
 
-
       context('when clearing approval', function () {
         context('when there was no prior approval', function () {
           beforeEach(async function () {

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -96,7 +96,7 @@ function shouldBehaveLikeERC721(owner, newOwner, operator, other) {
         });
 
         it('adjusts owners tokens by index', async function () {
-          if (!this.token.tokenOfOwnerByIndex) return;
+          if (!this.token.tokenOfOwnerByIndex) this.skip();
 
           expect(await this.token.tokenOfOwnerByIndex(this.toWhom, 0)).to.be.bignumber.equal(tokenId);
 
@@ -160,7 +160,8 @@ function shouldBehaveLikeERC721(owner, newOwner, operator, other) {
           });
 
           it('keeps same tokens by index', async function () {
-            if (!this.token.tokenOfOwnerByIndex) return;
+            if (!this.token.tokenOfOwnerByIndex) this.skip();
+
             const tokensListed = await Promise.all([0, 1].map(i => this.token.tokenOfOwnerByIndex(owner, i)));
             expect(tokensListed.map(t => t.toNumber())).to.have.members([
               firstTokenId.toNumber(),


### PR DESCRIPTION
Fixes #4457

Uses the 'operator' as argument to stay consistent with other functions

#### PR Checklist

- [X] Tests
- [ ] Documentation
- [X] Changeset entry (run `npx changeset add`)
