### PR TITLE
Update ERC20.sol: Make _balances internal

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -36,7 +36,7 @@ import {IERC20Errors} from "../../interfaces/draft-IERC6093.sol";
  * allowances. See {IERC20-approve}.
  */
 abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
-    mapping(address account => uint256) private _balances;
+    mapping(address account => uint256) internal _balances;
 
     mapping(address account => mapping(address spender => uint256)) private _allowances;
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes *N.A.* 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

I have a very niche use case where I need to completely overwrite the `_update` function to change the value of the `Transfer` event that is emitted, because all the balances are scaled. Here's what I would like my code to look like:

```solidity
    // Override view functions to produce the illusion of token multiplication
    function totalSupply() public view override returns (uint256) {
        return super.totalSupply() * tokenMultiplyer / DENOMINATOR;
    }

    function balanceOf(address account) public view override returns (uint256) {
        return super.balanceOf(account) * tokenMultiplyer / DENOMINATOR;
    }

    // Covers all mints, burns, and transfers
    function _update(
        address from,
        address to,
        uint256 value
    ) internal override {
        // Scale back token multiplication effect
        uint256 ogValue = value;
        value *= DENOMINATOR / tokenMultiplyer;

        // Original _update
        if (from == address(0)) {
            // Overflow check required: The rest of the code assumes that totalSupply never overflows
            _totalSupply += value;
        } else {
            uint256 fromBalance = _balances[from];
            if (fromBalance < value) {
                revert ERC20InsufficientBalance(from, fromBalance, value);
            }
            unchecked {
                // Overflow not possible: value <= fromBalance <= totalSupply.
                _balances[from] = fromBalance - value;
            }
        }

        if (to == address(0)) {
            unchecked {
                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.
                _totalSupply -= value;
            }
        } else {
            unchecked {
                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.
                _balances[to] += value;
            }
        }

        // Make sure original value is the one used
        emit Transfer(from, to, ogValue);
    }
```

However, I can't do this because _balances is private, not internal. This PR fixes this, so that `_update` overrides that modify the `Transfer` event are actually possible.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests (*N.A.*)
- [x] Documentation (*N.A.*)
- [x] Changeset entry (run `npx changeset add`) (*N.A.*)
