### PR TITLE
Use namespaced storage for upgradeable contracts

### DIFF
--- a/.changeset/wet-bears-heal.md
+++ b/.changeset/wet-bears-heal.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': major
+---
+
+Upgradeable contracts now use namespaced storage (EIP-7201).

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - uses: actions/cache@v3
       id: cache
       with:

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -299,8 +299,8 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
         bytes[] memory calldatas,
         string memory description,
         address proposer
-    ) internal virtual returns (uint256) {
-        uint256 proposalId = hashProposal(targets, values, calldatas, keccak256(bytes(description)));
+    ) internal virtual returns (uint256 proposalId) {
+        proposalId = hashProposal(targets, values, calldatas, keccak256(bytes(description)));
 
         if (targets.length != values.length || targets.length != calldatas.length || targets.length == 0) {
             revert GovernorInvalidProposalLength(targets.length, calldatas.length, values.length);
@@ -329,7 +329,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
             description
         );
 
-        return proposalId;
+        // Using a named return variable to avoid stack too deep errors
     }
 
     /**

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -27,13 +27,6 @@ import {IGovernor, IERC6372} from "./IGovernor.sol";
 abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC721Receiver, IERC1155Receiver {
     using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
 
-    bytes32 public constant BALLOT_TYPEHASH =
-        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
-    bytes32 public constant EXTENDED_BALLOT_TYPEHASH =
-        keccak256(
-            "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
-        );
-
     struct ProposalCore {
         address proposer;
         uint48 voteStart;
@@ -43,7 +36,14 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
         uint48 eta;
     }
 
+    bytes32 public constant BALLOT_TYPEHASH =
+        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
+    bytes32 public constant EXTENDED_BALLOT_TYPEHASH =
+        keccak256(
+            "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
+        );
     bytes32 private constant _ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
+
     string private _name;
 
     mapping(uint256 proposalId => ProposalCore) private _proposals;

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -27,6 +27,13 @@ import {IGovernor, IERC6372} from "./IGovernor.sol";
 abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC721Receiver, IERC1155Receiver {
     using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
 
+    bytes32 public constant BALLOT_TYPEHASH =
+        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
+    bytes32 public constant EXTENDED_BALLOT_TYPEHASH =
+        keccak256(
+            "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
+        );
+
     struct ProposalCore {
         address proposer;
         uint48 voteStart;
@@ -36,14 +43,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
         uint48 eta;
     }
 
-    bytes32 public constant BALLOT_TYPEHASH =
-        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
-    bytes32 public constant EXTENDED_BALLOT_TYPEHASH =
-        keccak256(
-            "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
-        );
     bytes32 private constant _ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
-
     string private _name;
 
     mapping(uint256 proposalId => ProposalCore) private _proposals;

--- a/contracts/governance/extensions/GovernorVotes.sol
+++ b/contracts/governance/extensions/GovernorVotes.sol
@@ -12,6 +12,7 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token, or since v4.5 an {ERC721Votes} token.
  */
 abstract contract GovernorVotes is Governor {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IERC5805 public immutable token;
 
     constructor(IVotes tokenAddress) {

--- a/contracts/governance/extensions/GovernorVotes.sol
+++ b/contracts/governance/extensions/GovernorVotes.sol
@@ -12,12 +12,17 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token, or since v4.5 an {ERC721Votes} token.
  */
 abstract contract GovernorVotes is Governor {
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    IERC5805 public immutable token;
+    IERC5805 private immutable _token;
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(IVotes tokenAddress) {
-        token = IERC5805(address(tokenAddress));
+        _token = IERC5805(address(tokenAddress));
+    }
+
+    /**
+     * @dev The token that voting power is sourced from.
+     */
+    function token() public view virtual returns (IERC5805) {
+        return _token;
     }
 
     /**
@@ -25,7 +30,7 @@ abstract contract GovernorVotes is Governor {
      * does not implement EIP-6372.
      */
     function clock() public view virtual override returns (uint48) {
-        try token.clock() returns (uint48 timepoint) {
+        try token().clock() returns (uint48 timepoint) {
             return timepoint;
         } catch {
             return SafeCast.toUint48(block.number);
@@ -37,7 +42,7 @@ abstract contract GovernorVotes is Governor {
      */
     // solhint-disable-next-line func-name-mixedcase
     function CLOCK_MODE() public view virtual override returns (string memory) {
-        try token.CLOCK_MODE() returns (string memory clockmode) {
+        try token().CLOCK_MODE() returns (string memory clockmode) {
             return clockmode;
         } catch {
             return "mode=blocknumber&from=default";
@@ -52,6 +57,6 @@ abstract contract GovernorVotes is Governor {
         uint256 timepoint,
         bytes memory /*params*/
     ) internal view virtual override returns (uint256) {
-        return token.getPastVotes(account, timepoint);
+        return token().getPastVotes(account, timepoint);
     }
 }

--- a/contracts/governance/extensions/GovernorVotes.sol
+++ b/contracts/governance/extensions/GovernorVotes.sol
@@ -12,8 +12,10 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token, or since v4.5 an {ERC721Votes} token.
  */
 abstract contract GovernorVotes is Governor {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IERC5805 public immutable token;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(IVotes tokenAddress) {
         token = IERC5805(address(tokenAddress));
     }

--- a/contracts/governance/extensions/GovernorVotes.sol
+++ b/contracts/governance/extensions/GovernorVotes.sol
@@ -12,7 +12,6 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * @dev Extension of {Governor} for voting weight extraction from an {ERC20Votes} token, or since v4.5 an {ERC721Votes} token.
  */
 abstract contract GovernorVotes is Governor {
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IERC5805 public immutable token;
 
     constructor(IVotes tokenAddress) {

--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -69,7 +69,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
      * @dev Returns the quorum for a timepoint, in terms of number of votes: `supply * numerator / denominator`.
      */
     function quorum(uint256 timepoint) public view virtual override returns (uint256) {
-        return (token.getPastTotalSupply(timepoint) * quorumNumerator(timepoint)) / quorumDenominator();
+        return (token().getPastTotalSupply(timepoint) * quorumNumerator(timepoint)) / quorumDenominator();
     }
 
     /**

--- a/contracts/mocks/StorageSlotMock.sol
+++ b/contracts/mocks/StorageSlotMock.sol
@@ -7,10 +7,6 @@ import {StorageSlot} from "../utils/StorageSlot.sol";
 contract StorageSlotMock {
     using StorageSlot for *;
 
-    mapping(uint256 key => string) public stringMap;
-
-    mapping(uint256 key => bytes) public bytesMap;
-
     function setBoolean(bytes32 slot, bool value) public {
         slot.getBooleanSlot().value = value;
     }
@@ -43,6 +39,8 @@ contract StorageSlotMock {
         return slot.getUint256Slot().value;
     }
 
+    mapping(uint256 key => string) public stringMap;
+
     function setString(bytes32 slot, string calldata value) public {
         slot.getStringSlot().value = value;
     }
@@ -58,6 +56,8 @@ contract StorageSlotMock {
     function getStringStorage(uint256 key) public view returns (string memory) {
         return stringMap[key].getStringSlot().value;
     }
+
+    mapping(uint256 key => bytes) public bytesMap;
 
     function setBytes(bytes32 slot, bytes calldata value) public {
         slot.getBytesSlot().value = value;

--- a/contracts/mocks/StorageSlotMock.sol
+++ b/contracts/mocks/StorageSlotMock.sol
@@ -7,6 +7,10 @@ import {StorageSlot} from "../utils/StorageSlot.sol";
 contract StorageSlotMock {
     using StorageSlot for *;
 
+    mapping(uint256 key => string) public stringMap;
+
+    mapping(uint256 key => bytes) public bytesMap;
+
     function setBoolean(bytes32 slot, bool value) public {
         slot.getBooleanSlot().value = value;
     }
@@ -39,8 +43,6 @@ contract StorageSlotMock {
         return slot.getUint256Slot().value;
     }
 
-    mapping(uint256 key => string) public stringMap;
-
     function setString(bytes32 slot, string calldata value) public {
         slot.getStringSlot().value = value;
     }
@@ -56,8 +58,6 @@ contract StorageSlotMock {
     function getStringStorage(uint256 key) public view returns (string memory) {
         return stringMap[key].getStringSlot().value;
     }
-
-    mapping(uint256 key => bytes) public bytesMap;
 
     function setBytes(bytes32 slot, bytes calldata value) public {
         slot.getBytesSlot().value = value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "semver": "^7.3.5",
         "solhint": "^3.3.6",
         "solhint-plugin-openzeppelin": "file:scripts/solhint-custom",
-        "solidity-ast": "^0.4.25",
+        "solidity-ast": "^0.4.50",
         "solidity-coverage": "^0.8.0",
         "solidity-docgen": "^0.6.0-beta.29",
         "undici": "^5.22.1",
@@ -3216,6 +3216,25 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.2.tgz",
+      "integrity": "sha512-p1YDNPNqA+P6cPX9ATsxg7DKir7gOmJ+jh5dEP3LlumMNYVC1F2Jgnyh6oI3n/qD9FeIkqR2jXfd73G68ImYUQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12569,10 +12588,13 @@
       }
     },
     "node_modules/solidity-ast": {
-      "version": "0.4.49",
-      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.49.tgz",
-      "integrity": "sha512-Pr5sCAj1SFqzwFZw1HPKSq0PehlQNdM8GwKyAVYh2DOn7/cCK8LUKD1HeHnKtTgBW7hi9h4nnnan7hpAg5RhWQ==",
-      "dev": true
+      "version": "0.4.50",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.50.tgz",
+      "integrity": "sha512-WpIhaUibbjcBY4bg8TO2UXFWl8PQPhtH1QtMYJUqFUGxx0rRiEFsVLV+ow8XiWEnSPeu4xPp1/K43P4esxuK1Q==",
+      "dev": true,
+      "dependencies": {
+        "array.prototype.findlast": "^1.2.2"
+      }
     },
     "node_modules/solidity-comments": {
       "version": "0.0.2",
@@ -17851,6 +17873,19 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.findlast": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.2.tgz",
+      "integrity": "sha512-p1YDNPNqA+P6cPX9ATsxg7DKir7gOmJ+jh5dEP3LlumMNYVC1F2Jgnyh6oI3n/qD9FeIkqR2jXfd73G68ImYUQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "array.prototype.flat": {
@@ -25144,10 +25179,13 @@
       "version": "file:scripts/solhint-custom"
     },
     "solidity-ast": {
-      "version": "0.4.49",
-      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.49.tgz",
-      "integrity": "sha512-Pr5sCAj1SFqzwFZw1HPKSq0PehlQNdM8GwKyAVYh2DOn7/cCK8LUKD1HeHnKtTgBW7hi9h4nnnan7hpAg5RhWQ==",
-      "dev": true
+      "version": "0.4.50",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.50.tgz",
+      "integrity": "sha512-WpIhaUibbjcBY4bg8TO2UXFWl8PQPhtH1QtMYJUqFUGxx0rRiEFsVLV+ow8XiWEnSPeu4xPp1/K43P4esxuK1Q==",
+      "dev": true,
+      "requires": {
+        "array.prototype.findlast": "^1.2.2"
+      }
     },
     "solidity-comments": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "semver": "^7.3.5",
     "solhint": "^3.3.6",
     "solhint-plugin-openzeppelin": "file:scripts/solhint-custom",
-    "solidity-ast": "^0.4.25",
+    "solidity-ast": "^0.4.50",
     "solidity-coverage": "^0.8.0",
     "solidity-docgen": "^0.6.0-beta.29",
     "undici": "^5.22.1",

--- a/scripts/upgradeable/transpile.sh
+++ b/scripts/upgradeable/transpile.sh
@@ -22,6 +22,8 @@ fi
 # -i: use included Initializable
 # -x: exclude proxy-related contracts with a few exceptions
 # -p: emit public initializer
+# -n: use namespaces
+# -N: exclude from namespaces transformation
 npx @openzeppelin/upgrade-safe-transpiler@latest -D \
   -b "$build_info" \
   -i contracts/proxy/utils/Initializable.sol \
@@ -32,7 +34,9 @@ npx @openzeppelin/upgrade-safe-transpiler@latest -D \
   -x '!contracts/proxy/ERC1967/ERC1967Utils.sol' \
   -x '!contracts/proxy/utils/UUPSUpgradeable.sol' \
   -x '!contracts/proxy/beacon/IBeacon.sol' \
-  -p 'contracts/**/presets/**/*'
+  -p 'contracts/**/presets/**/*' \
+  -n \
+  -N 'contracts/mocks/**/*'
 
 # delete compilation artifacts of vanilla code
 npm run clean

--- a/scripts/upgradeable/transpile.sh
+++ b/scripts/upgradeable/transpile.sh
@@ -24,7 +24,7 @@ fi
 # -p: emit public initializer
 # -n: use namespaces
 # -N: exclude from namespaces transformation
-npx @openzeppelin/upgrade-safe-transpiler@next -D \
+npx @openzeppelin/upgrade-safe-transpiler@latest -D \
   -b "$build_info" \
   -i contracts/proxy/utils/Initializable.sol \
   -x 'contracts-exposed/**/*' \

--- a/scripts/upgradeable/transpile.sh
+++ b/scripts/upgradeable/transpile.sh
@@ -24,7 +24,7 @@ fi
 # -p: emit public initializer
 # -n: use namespaces
 # -N: exclude from namespaces transformation
-npx @openzeppelin/upgrade-safe-transpiler@latest -D \
+npx @openzeppelin/upgrade-safe-transpiler@next -D \
   -b "$build_info" \
   -i contracts/proxy/utils/Initializable.sol \
   -x 'contracts-exposed/**/*' \


### PR DESCRIPTION
This PR configures the transpiler to use namespaces instead of gaps in the upgradeable code.

There are two changes to the code that I found necessary. In one case, the transpiled code resulted in a stack too deep compilation error, I assume because the `$` storage pointer takes up a place in the stack. In another case, I had to change a `public immutable` variable into a private variable, because immutables without an override get converted to storage variables and the namespace transformation enforces storage variables to be private. This implies that we can't use public immutables in the codebase in general.

The transpiler code can be found in https://github.com/OpenZeppelin/openzeppelin-transpiler/pull/127.

Fixes #2964 

