### PR TITLE
Remove redundant memory usage in ERC2981 royaltyInfo

### DIFF
--- a/.changeset/perfect-coins-accept.md
+++ b/.changeset/perfect-coins-accept.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-`ERC2981`: Optimized memory usage in `royaltyInfo`

--- a/.changeset/perfect-coins-accept.md
+++ b/.changeset/perfect-coins-accept.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC2981`: Optimized memory usage in `royaltyInfo`

--- a/contracts/token/common/ERC2981.sol
+++ b/contracts/token/common/ERC2981.sol
@@ -59,15 +59,18 @@ abstract contract ERC2981 is IERC2981, ERC165 {
      * @inheritdoc IERC2981
      */
     function royaltyInfo(uint256 tokenId, uint256 salePrice) public view virtual returns (address, uint256) {
-        RoyaltyInfo memory royalty = _tokenRoyaltyInfo[tokenId];
+        RoyaltyInfo storage _royaltyInfo = _tokenRoyaltyInfo[tokenId];
+        address royaltyReceiver = _royaltyInfo.receiver;
+        uint96 royaltyFraction = _royaltyInfo.royaltyFraction;
 
-        if (royalty.receiver == address(0)) {
-            royalty = _defaultRoyaltyInfo;
+        if (royaltyReceiver == address(0)) {
+            royaltyReceiver = _defaultRoyaltyInfo.receiver;
+            royaltyFraction = _defaultRoyaltyInfo.royaltyFraction;
         }
 
-        uint256 royaltyAmount = (salePrice * royalty.royaltyFraction) / _feeDenominator();
+        uint256 royaltyAmount = (salePrice * royaltyFraction) / _feeDenominator();
 
-        return (royalty.receiver, royaltyAmount);
+        return (royaltyReceiver, royaltyAmount);
     }
 
     /**


### PR DESCRIPTION
Same change as in #4495 

There is no actual need to use memory for this structure:

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/9e3f4d60c581010c4a3979480e07cc7752f124cc/contracts/token/common/ERC2981.sol#L62

- [X] Tests
- [X] Documentation
- [X] Changeset entry (run `npx changeset add`)
