### PR TITLE
Revert memory pointer to storage pointer

### DIFF
--- a/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesQuorumFraction.sol
@@ -49,7 +49,7 @@ abstract contract GovernorVotesQuorumFraction is GovernorVotes {
         uint256 length = _quorumNumeratorHistory._checkpoints.length;
 
         // Optimistic search, check the latest checkpoint
-        Checkpoints.Checkpoint208 memory latest = _quorumNumeratorHistory._checkpoints[length - 1];
+        Checkpoints.Checkpoint208 storage latest = _quorumNumeratorHistory._checkpoints[length - 1];
         uint48 latestKey = latest._key;
         uint208 latestValue = latest._value;
         if (latestKey <= timepoint) {


### PR DESCRIPTION
Reverts a partially incorrect merge done in #4539. Note that the change to storage pointer was introduced in https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4512 for gas efficiency.

Raised by @vladyan18