### PR TITLE
Avoid overflow on empty multiproof

### DIFF
--- a/.changeset/large-humans-remain.md
+++ b/.changeset/large-humans-remain.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`MerkleProof`: Use custom error to report invalid multiproof instead of reverting with overflow panic.

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -118,7 +118,7 @@ library MerkleProof {
         uint256 totalHashes = proofFlags.length;
 
         // Check proof validity.
-        if (leavesLen + proofLen - 1 != totalHashes) {
+        if (leavesLen + proofLen != totalHashes + 1) {
             revert MerkleProofInvalidMultiproof();
         }
 
@@ -174,7 +174,7 @@ library MerkleProof {
         uint256 totalHashes = proofFlags.length;
 
         // Check proof validity.
-        if (leavesLen + proofLen - 1 != totalHashes) {
+        if (leavesLen + proofLen != totalHashes + 1) {
             revert MerkleProofInvalidMultiproof();
         }
 


### PR DESCRIPTION
If `leavesLen + proofLen` is 0, the function will revert with overflow instead of the `MerkleProofInvalidMultiproof` error.