### PR TITLE
Better context on _spendAllowance NatSpec

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -356,7 +356,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
      * Does not update the allowance value in case of infinite allowance.
      * Revert if not enough allowance is available.
      *
-     * Won't emit an {Approval} event.
+     * Does not emit an {Approval} event.
      */
     function _spendAllowance(address owner, address spender, uint256 value) internal virtual {
         uint256 currentAllowance = allowance(owner, spender);

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -356,7 +356,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
      * Does not update the allowance value in case of infinite allowance.
      * Revert if not enough allowance is available.
      *
-     * Might emit an {Approval} event.
+     * Won't emit an {Approval} event.
      */
     function _spendAllowance(address owner, address spender, uint256 value) internal virtual {
         uint256 currentAllowance = allowance(owner, spender);


### PR DESCRIPTION
Changed "Might emit" to "Won't emit" in `_spendAllowance` function.

`_approve` will only handle events when the fourth argument (boolean) is `true`. 

Such a condition will never trigger as `_spendAllowance` will always call `_approve` passing a hardcoded `false` input.
