### PR TITLE
Add a boolean to AccessManager.GrantGroup

### DIFF
--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -378,7 +378,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
             _groups[groupId].members[account] = Access({since: since, delay: executionDelay.toDelay()});
         }
 
-        emit GroupGranted(groupId, account, executionDelay, since, inGroup);
+        emit GroupGranted(groupId, account, executionDelay, since, !inGroup);
         return !inGroup;
     }
 

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -378,7 +378,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
             _groups[groupId].members[account] = Access({since: since, delay: executionDelay.toDelay()});
         }
 
-        emit GroupGranted(groupId, account, executionDelay, since);
+        emit GroupGranted(groupId, account, executionDelay, since, inGroup);
         return !inGroup;
     }
 

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -29,7 +29,7 @@ interface IAccessManager {
     event OperationCanceled(bytes32 indexed operationId, uint32 indexed nonce);
 
     event GroupLabel(uint64 indexed groupId, string label);
-    event GroupGranted(uint64 indexed groupId, address indexed account, uint32 delay, uint48 since, bool isUpdate);
+    event GroupGranted(uint64 indexed groupId, address indexed account, uint32 delay, uint48 since, bool newMember);
     event GroupRevoked(uint64 indexed groupId, address indexed account);
     event GroupAdminChanged(uint64 indexed groupId, uint64 indexed admin);
     event GroupGuardianChanged(uint64 indexed groupId, uint64 indexed guardian);

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -29,7 +29,7 @@ interface IAccessManager {
     event OperationCanceled(bytes32 indexed operationId, uint32 indexed nonce);
 
     event GroupLabel(uint64 indexed groupId, string label);
-    event GroupGranted(uint64 indexed groupId, address indexed account, uint32 delay, uint48 since);
+    event GroupGranted(uint64 indexed groupId, address indexed account, uint32 delay, uint48 since, bool isUpdate);
     event GroupRevoked(uint64 indexed groupId, address indexed account);
     event GroupAdminChanged(uint64 indexed groupId, uint64 indexed admin);
     event GroupGuardianChanged(uint64 indexed groupId, uint64 indexed guardian);

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -106,7 +106,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp,
             delay: '0',
-            isUpdate: false,
+            newMember: true,
           });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([true, '0']);
@@ -128,7 +128,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp,
             delay: executeDelay,
-            isUpdate: false,
+            newMember: true,
           });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([
@@ -178,7 +178,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp.add(grantDelay),
             delay: '0',
-            isUpdate: false,
+            newMember: true,
           });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([false, '0']);
@@ -198,7 +198,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp.add(grantDelay),
             delay: '0',
-            isUpdate: false,
+            newMember: true,
           });
 
           await time.increase(grantDelay);
@@ -376,7 +376,7 @@ contract('AccessManager', function (accounts) {
           account: member,
           since: timestamp,
           delay: newDelay,
-          isUpdate: true,
+          newMember: false,
         });
 
         // immediate effect
@@ -407,7 +407,7 @@ contract('AccessManager', function (accounts) {
           account: member,
           since: timestamp.add(oldDelay).sub(newDelay),
           delay: newDelay,
-          isUpdate: true,
+          newMember: false,
         });
 
         // delayed effect
@@ -428,7 +428,7 @@ contract('AccessManager', function (accounts) {
           account: other,
           since: timestamp,
           delay: executeDelay,
-          isUpdate: true,
+          newMember: false,
         });
       });
     });

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -101,7 +101,13 @@ contract('AccessManager', function (accounts) {
 
           const { receipt } = await this.manager.grantGroup(GROUPS.SOME, user, 0, { from: manager });
           const timestamp = await clockFromReceipt.timestamp(receipt).then(web3.utils.toBN);
-          expectEvent(receipt, 'GroupGranted', { groupId: GROUPS.SOME, account: user, since: timestamp, delay: '0', isUpdate: false });
+          expectEvent(receipt, 'GroupGranted', {
+            groupId: GROUPS.SOME,
+            account: user,
+            since: timestamp,
+            delay: '0',
+            isUpdate: false,
+          });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([true, '0']);
 

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -101,7 +101,7 @@ contract('AccessManager', function (accounts) {
 
           const { receipt } = await this.manager.grantGroup(GROUPS.SOME, user, 0, { from: manager });
           const timestamp = await clockFromReceipt.timestamp(receipt).then(web3.utils.toBN);
-          expectEvent(receipt, 'GroupGranted', { groupId: GROUPS.SOME, account: user, since: timestamp, delay: '0' });
+          expectEvent(receipt, 'GroupGranted', { groupId: GROUPS.SOME, account: user, since: timestamp, delay: '0', isUpdate: false });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([true, '0']);
 
@@ -122,6 +122,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp,
             delay: executeDelay,
+            isUpdate: false,
           });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([
@@ -163,7 +164,7 @@ contract('AccessManager', function (accounts) {
           await this.manager.$_setGrantDelay(GROUPS.SOME, grantDelay);
         });
 
-        it('granted group is not active immediatly', async function () {
+        it('granted group is not active immediately', async function () {
           const { receipt } = await this.manager.grantGroup(GROUPS.SOME, user, 0, { from: manager });
           const timestamp = await clockFromReceipt.timestamp(receipt).then(web3.utils.toBN);
           expectEvent(receipt, 'GroupGranted', {
@@ -171,6 +172,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp.add(grantDelay),
             delay: '0',
+            isUpdate: false,
           });
 
           expect(await this.manager.hasGroup(GROUPS.SOME, user).then(formatAccess)).to.be.deep.equal([false, '0']);
@@ -190,6 +192,7 @@ contract('AccessManager', function (accounts) {
             account: user,
             since: timestamp.add(grantDelay),
             delay: '0',
+            isUpdate: false,
           });
 
           await time.increase(grantDelay);
@@ -367,6 +370,7 @@ contract('AccessManager', function (accounts) {
           account: member,
           since: timestamp,
           delay: newDelay,
+          isUpdate: true,
         });
 
         // immediate effect
@@ -397,6 +401,7 @@ contract('AccessManager', function (accounts) {
           account: member,
           since: timestamp.add(oldDelay).sub(newDelay),
           delay: newDelay,
+          isUpdate: true,
         });
 
         // delayed effect
@@ -417,6 +422,7 @@ contract('AccessManager', function (accounts) {
           account: other,
           since: timestamp,
           delay: executeDelay,
+          isUpdate: true,
         });
       });
     });


### PR DESCRIPTION
This will help distinguish granting membership (where this since is the effect at which the membership and execution delay both takes effect) from updates to the execution delay.

Fixes LIB-1051

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
