### PR TITLE
Fix accuracy of docs for ERC20._burn

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -287,7 +287,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     }
 
     /**
-     * @dev Destroys a `value` amount of tokens from `account`, by lowering the total supply.
+     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.
      * Relies on the `_update` mechanism.
      *
      * Emits a {Transfer} event with `to` set to the zero address.

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -287,7 +287,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     }
 
     /**
-     * @dev Destroys a `value` amount of tokens from `account`, by transferring it to address(0).
+     * @dev Destroys a `value` amount of tokens from `account`, by lowering the total supply.
      * Relies on the `_update` mechanism.
      *
      * Emits a {Transfer} event with `to` set to the zero address.


### PR DESCRIPTION
Current descriptions:
The description mentions the destination of the tokens to the 0 address, but this is the behavior of an old version of OpenZeppelin ERC20.

Expected description: 
Tokens aren't sent anymore to the `address(0)` when using `_burn`. Instead, the total supply is lowered and the burnt amount is removed from the account balance.
