### PR TITLE
Make isConsumingScheduleOp return bytes4 to mitigate clashes

### DIFF
--- a/contracts/access/manager/AccessManaged.sol
+++ b/contracts/access/manager/AccessManaged.sol
@@ -85,8 +85,8 @@ abstract contract AccessManaged is Context, IAccessManaged {
      * being consumed. Prevents denial of service for delayed restricted calls in the case that the contract performs
      * attacker controlled calls.
      */
-    function isConsumingScheduledOp() public view returns (bool) {
-        return _consumingSchedule;
+    function isConsumingScheduledOp() public view returns (bytes4) {
+        return _consumingSchedule ? this.isConsumingScheduledOp.selector : bytes4(0);
     }
 
     /**

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -748,7 +748,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
             (bool isAdmin, ) = hasGroup(ADMIN_GROUP, msgsender);
             (bool isGuardian, ) = hasGroup(getGroupGuardian(getClassFunctionGroup(classId, selector)), msgsender);
             if (!isAdmin && !isGuardian) {
-                revert AccessManagerCannotCancel(msgsender, caller, target, selector);
+                revert AccessManagerUnauthorizedCancel(msgsender, caller, target, selector);
             }
         }
 

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -696,7 +696,9 @@ contract AccessManager is Context, Multicall, IAccessManager {
      */
     function consumeScheduledOp(address caller, bytes calldata data) public virtual {
         address target = _msgSender();
-        require(IAccessManaged(target).isConsumingScheduledOp());
+        if (IAccessManaged(target).isConsumingScheduledOp() != IAccessManaged.isConsumingScheduledOp.selector) {
+            revert AccessManagerNotConsumingScheduledOp(target);
+        }
         _consumeScheduledOp(_hashOperation(caller, target, data));
     }
 

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -697,7 +697,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
     function consumeScheduledOp(address caller, bytes calldata data) public virtual {
         address target = _msgSender();
         if (IAccessManaged(target).isConsumingScheduledOp() != IAccessManaged.isConsumingScheduledOp.selector) {
-            revert AccessManagerNotConsumingScheduledOp(target);
+            revert AccessManagerUnauthorizedConsume(target);
         }
         _consumeScheduledOp(_hashOperation(caller, target, data));
     }

--- a/contracts/access/manager/IAccessManaged.sol
+++ b/contracts/access/manager/IAccessManaged.sol
@@ -13,5 +13,5 @@ interface IAccessManaged {
 
     function setAuthority(address) external;
 
-    function isConsumingScheduledOp() external view returns (bool);
+    function isConsumingScheduledOp() external view returns (bytes4);
 }

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -51,8 +51,8 @@ interface IAccessManager {
     error AccessManagerBadConfirmation();
     error AccessManagerUnauthorizedAccount(address msgsender, uint64 groupId);
     error AccessManagerUnauthorizedCall(address caller, address target, bytes4 selector);
+    error AccessManagerUnauthorizedConsume(address target);
     error AccessManagerCannotCancel(address msgsender, address caller, address target, bytes4 selector);
-    error AccessManagerNotConsumingScheduledOp(address msgsender);
 
     function canCall(
         address caller,

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -52,7 +52,7 @@ interface IAccessManager {
     error AccessManagerUnauthorizedAccount(address msgsender, uint64 groupId);
     error AccessManagerUnauthorizedCall(address caller, address target, bytes4 selector);
     error AccessManagerUnauthorizedConsume(address target);
-    error AccessManagerCannotCancel(address msgsender, address caller, address target, bytes4 selector);
+    error AccessManagerUnauthorizedCancel(address msgsender, address caller, address target, bytes4 selector);
 
     function canCall(
         address caller,

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -52,6 +52,7 @@ interface IAccessManager {
     error AccessManagerUnauthorizedAccount(address msgsender, uint64 groupId);
     error AccessManagerUnauthorizedCall(address caller, address target, bytes4 selector);
     error AccessManagerCannotCancel(address msgsender, address caller, address target, bytes4 selector);
+    error AccessManagerNotConsumingScheduledOp(address msgsender);
 
     function canCall(
         address caller,

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -933,7 +933,7 @@ contract('AccessManager', function (accounts) {
 
         expect(await this.manager.getSchedule(this.opId)).to.not.be.bignumber.equal('0');
 
-        await expectRevertCustomError(this.cancel({ from: other }), 'AccessManagerCannotCancel', [
+        await expectRevertCustomError(this.cancel({ from: other }), 'AccessManagerUnauthorizedCancel', [
           other,
           user,
           ...this.call,


### PR DESCRIPTION
1. Return bytes4 out of caution in case the selector for `isConsumingScheduleOp` clashes with another function in the contract (which may be `Ownable` and not have that getter from `AccessManaged`).
2. Use a custom error.

Fixes LIB-1056

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
