### PR TITLE
Improve GovernorTimelockAccess

### DIFF
--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -720,7 +720,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
     /**
      * @dev Hashing function for delayed operations
      */
-    function hashOperation(address caller, address target, bytes calldata data) public pure returns (bytes32) {
+    function hashOperation(address caller, address target, bytes calldata data) public view virtual returns (bytes32) {
         return keccak256(abi.encode(caller, target, data));
     }
 

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -581,7 +581,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
 
         // If caller is authorised, schedule operation
-        operationId = _hashOperation(caller, target, data);
+        operationId = hashOperation(caller, target, data);
 
         // Cannot reschedule unless the operation has expired
         uint48 prevTimepoint = _schedules[operationId].timepoint;
@@ -624,7 +624,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
 
         // If caller is authorised, check operation was scheduled early enough
-        bytes32 operationId = _hashOperation(caller, target, data);
+        bytes32 operationId = hashOperation(caller, target, data);
         uint32 nonce;
 
         if (setback != 0) {
@@ -658,7 +658,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         if (IAccessManaged(target).isConsumingScheduledOp() != IAccessManaged.isConsumingScheduledOp.selector) {
             revert AccessManagerUnauthorizedConsume(target);
         }
-        _consumeScheduledOp(_hashOperation(caller, target, data));
+        _consumeScheduledOp(hashOperation(caller, target, data));
     }
 
     /**
@@ -698,7 +698,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         address msgsender = _msgSender();
         bytes4 selector = bytes4(data[0:4]);
 
-        bytes32 operationId = _hashOperation(caller, target, data);
+        bytes32 operationId = hashOperation(caller, target, data);
         if (_schedules[operationId].timepoint == 0) {
             revert AccessManagerNotScheduled(operationId);
         } else if (caller != msgsender) {
@@ -720,7 +720,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
     /**
      * @dev Hashing function for delayed operations
      */
-    function _hashOperation(address caller, address target, bytes calldata data) private pure returns (bytes32) {
+    function hashOperation(address caller, address target, bytes calldata data) public pure returns (bytes32) {
         return keccak256(abi.encode(caller, target, data));
     }
 
@@ -755,7 +755,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
                 (, uint64 requiredRole, ) = _getAdminRestrictions(_msgData());
                 revert AccessManagerUnauthorizedAccount(caller, requiredRole);
             } else {
-                _consumeScheduledOp(_hashOperation(caller, address(this), _msgData()));
+                _consumeScheduledOp(hashOperation(caller, address(this), _msgData()));
             }
         }
     }

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -57,6 +57,8 @@ interface IAccessManager {
         bytes4 selector
     ) external view returns (bool allowed, uint32 delay);
 
+    function hashOperation(address caller, address target, bytes calldata data) external view returns (bytes32);
+
     function expiration() external view returns (uint32);
 
     function isTargetClosed(address target) external view returns (bool);

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -234,7 +234,7 @@ abstract contract GovernorTimelockAccess is Governor {
             for (uint256 i = 0; i < targets.length; ++i) {
                 (, bool withDelay, uint32 nonce) = _getManagerData(plan, i);
                 if (withDelay) {
-                    bytes32 operationId = keccak256(abi.encode(address(this), targets[i], calldatas[i]));
+                    bytes32 operationId = _manager.hashOperation(address(this), targets[i], calldatas[i]);
                     if (nonce == _manager.getNonce(operationId)) {
                         // Attempt to cancel considering the operation could have been cancelled and rescheduled already
                         try _manager.cancel(address(this), targets[i], calldatas[i]) returns (uint32) {} catch {}

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -129,8 +129,7 @@ abstract contract GovernorTimelockAccess is Governor {
         bool ignored
     ) public virtual onlyGovernance {
         for (uint256 i = 0; i < selectors.length; ++i) {
-            bytes4 selector = selectors[i];
-            _setAccessManagerIgnored(target, selector, ignored);
+            _setAccessManagerIgnored(target, selectors[i], ignored);
         }
     }
 

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -197,7 +197,7 @@ abstract contract GovernorTimelockAccess is Governor {
             (bool immediate, uint32 delay) = AuthorityUtils.canCallWithDelay(
                 address(_manager),
                 address(this),
-                targets[i],
+                target,
                 selector
             );
             if ((immediate || delay > 0) && !isAccessManagerIgnored(target, selector)) {

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -295,9 +295,11 @@ abstract contract GovernorTimelockAccess is Governor {
                     // already have been cancelled and rescheduled. We don't want to cancel unless it is exactly the
                     // instance that we previously scheduled.
                     if (nonce == _manager.getNonce(operationId)) {
-                        // Cancel might fail if the operation was cancelled by guardians previously.
-                        // We allow the function call to fail for any reason to avoid encoding assumptions about
-                        // specific errors.
+                        // It is important that all calls have an opportunity to be cancelled. We chose to ignore
+                        // potential failures of some of the cancel operations to give the other operations a chance to
+                        // be properly cancelled. In particular cancel might fail if the operation was already cancelled
+                        // by guardians previously. We don't match on the revert reason to avoid encoding assumptions
+                        // about specific errors.
                         try _manager.cancel(address(this), targets[i], calldatas[i]) {} catch {}
                     }
                 }

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -134,7 +134,12 @@ abstract contract GovernorTimelockAccess is Governor {
         plan.length = SafeCast.toUint16(targets.length);
 
         for (uint256 i = 0; i < targets.length; ++i) {
-            (bool immediate, uint32 delay) = AuthorityUtils.canCallWithDelay(address(_manager), address(this), targets[i], bytes4(calldatas[i]));
+            (bool immediate, uint32 delay) = AuthorityUtils.canCallWithDelay(
+                address(_manager),
+                address(this),
+                targets[i],
+                bytes4(calldatas[i])
+            );
             if (immediate || delay > 0) {
                 _setManagerData(plan, i, 0);
             }

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -295,7 +295,9 @@ abstract contract GovernorTimelockAccess is Governor {
                     // already have been cancelled and rescheduled. We don't want to cancel unless it is exactly the
                     // instance that we previously scheduled.
                     if (nonce == _manager.getNonce(operationId)) {
-                        // Attempt to cancel but allow to fail for any reason
+                        // Cancel might fail if the operation was cancelled by guardians previously.
+                        // We allow the function call to fail for any reason to avoid encoding assumptions about
+                        // specific errors.
                         try _manager.cancel(address(this), targets[i], calldatas[i]) {} catch {}
                     }
                 }

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -52,7 +52,7 @@ abstract contract GovernorTimelockAccess is Governor {
     // The meaning of the "toggle" set to true depends on the target contract.
     // If target == address(this), the manager is ignored by default, and a true toggle means it won't be ignored.
     // For all other target contracts, the manager is used by default, and a true toggle means it will be ignored.
-    mapping(address target => mapping (bytes4 selector => bool)) private _ignoreToggle;
+    mapping(address target => mapping(bytes4 selector => bool)) private _ignoreToggle;
 
     mapping(uint256 proposalId => ExecutionPlan) private _executionPlan;
 
@@ -123,7 +123,11 @@ abstract contract GovernorTimelockAccess is Governor {
      * @dev Configure whether restrictions from the associated {AccessManager} are ignored for a target function.
      * See Security Considerations above.
      */
-    function setAccessManagerIgnored(address target, bytes4[] calldata selectors, bool ignored) public virtual onlyGovernance {
+    function setAccessManagerIgnored(
+        address target,
+        bytes4[] calldata selectors,
+        bool ignored
+    ) public virtual onlyGovernance {
         for (uint256 i = 0; i < selectors.length; ++i) {
             bytes4 selector = selectors[i];
             _setAccessManagerIgnored(target, selector, ignored);

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -293,7 +293,7 @@ abstract contract GovernorTimelockAccess is Governor {
                 if (withDelay) {
                     bytes32 operationId = _manager.hashOperation(address(this), targets[i], calldatas[i]);
                     // Check first if the current operation nonce is the one that we observed previously. It could
-                    // aready have been cancelled and rescheduled. We don't want to cancel unless it is exactly the
+                    // already have been cancelled and rescheduled. We don't want to cancel unless it is exactly the
                     // instance that we previously scheduled.
                     if (nonce == _manager.getNonce(operationId)) {
                         // Attempt to cancel but allow to fail for any reason

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -255,11 +255,14 @@ abstract contract GovernorTimelockAccess is Governor {
     ) private view returns (bool controlled, bool withDelay, uint32 nonce) {
         (uint256 bucket, uint256 subindex) = _getManagerDataIndices(index);
         uint32 value = plan.managerData[bucket][subindex];
-        return (value > 0, value > 1, value > 1 ? value - 2 : 0);
+        unchecked {
+            return (value > 0, value > 1, value > 1 ? value - 2 : 0);
+        }
     }
 
     /**
-     * @dev Marks an operation at an index as delayed by the manager, and sets its scheduling nonce.
+     * @dev Marks an operation at an index as permissioned by the manager, potentially delayed, and
+     * when delayed sets its scheduling nonce.
      */
     function _setManagerData(ExecutionPlan storage plan, uint256 index, bool withDelay, uint32 nonce) private {
         (uint256 bucket, uint256 subindex) = _getManagerDataIndices(index);

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -97,17 +97,18 @@ abstract contract GovernorTimelockAccess is Governor {
      * delayed since queuing, and an array indicating which of the proposal actions will be executed indirectly through
      * the associated {AccessManager}.
      */
-    function proposalExecutionPlan(uint256 proposalId) public view returns (uint32, bool[2][] memory) {
+    function proposalExecutionPlan(uint256 proposalId) public view returns (uint32 delay, bool[] memory indirect, bool[] memory withDelay) {
         ExecutionPlan storage plan = _executionPlan[proposalId];
 
-        uint32 delay = plan.delay;
         uint32 length = plan.length;
-        bool[2][] memory indirect = new bool[2][](length);
+        delay = plan.delay;
+        indirect = new bool[](length);
+        withDelay = new bool[](length);
         for (uint256 i = 0; i < length; ++i) {
-            (indirect[i][0], indirect[i][1], ) = _getManagerData(plan, i);
+            (indirect[i], withDelay[i], ) = _getManagerData(plan, i);
         }
 
-        return (delay, indirect);
+        return (delay, indirect, withDelay);
     }
 
     /**

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -94,8 +94,9 @@ abstract contract GovernorTimelockAccess is Governor {
 
     /**
      * @dev Public accessor to check the execution plan, including the number of seconds that the proposal will be
-     * delayed since queuing, and an array indicating which of the proposal actions will be executed indirectly through
-     * the associated {AccessManager}.
+     * delayed since queuing, an array indicating which of the proposal actions will be executed indirectly through
+     * the associated {AccessManager}, and another indicating which will be scheduled in {queue}. Note that
+     * those that must be scheduled are cancellable by `AccessManager` guardians.
      */
     function proposalExecutionPlan(
         uint256 proposalId

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -140,8 +140,12 @@ abstract contract GovernorTimelockAccess is Governor {
                 targets[i],
                 bytes4(calldatas[i])
             );
+            // After proposal, the values are:
+            // - 0: for calls that do not go through the AccessManager
+            // - 1: for calls that go through the AccessManager without scheduling
+            // - 2: for calls that go through the AccessManager with scheduling
             if (immediate || delay > 0) {
-                _setManagerData(plan, i, 0);
+                _setManagerData(plan, i, immediate ? 1 : 2);
             }
             // downcast is safe because both arguments are uint32
             neededDelay = uint32(Math.max(delay, neededDelay));
@@ -169,10 +173,14 @@ abstract contract GovernorTimelockAccess is Governor {
         uint48 eta = Time.timestamp() + plan.delay;
 
         for (uint256 i = 0; i < targets.length; ++i) {
-            (bool delayed, ) = _getManagerData(plan, i);
-            if (delayed) {
+            // After queuing, the values stored are:
+            // - 0: for calls that do not go through the AccessManager (same as before)
+            // - 1: for calls that go through the AccessManager without scheduling (same as before)
+            // - *: nonce + 2, where the nonce was obtained when scheduling the call
+            uint32 value = _getManagerData(plan, i);
+            if (value > 1) {
                 (, uint32 nonce) = _manager.schedule(targets[i], calldatas[i], eta);
-                _setManagerData(plan, i, nonce);
+                _setManagerData(plan, i, nonce + 2);
             }
         }
 
@@ -197,10 +205,14 @@ abstract contract GovernorTimelockAccess is Governor {
         ExecutionPlan storage plan = _executionPlan[proposalId];
 
         for (uint256 i = 0; i < targets.length; ++i) {
-            (bool delayed, uint32 nonce) = _getManagerData(plan, i);
-            if (delayed) {
+            // At this stage (we are after queuing), the values stored are:
+            // - 0: for calls that do not go through the AccessManager
+            // - 1: for calls that go through the AccessManager without scheduling
+            // - *: nonce + 2, where the nonce was obtained when scheduling the call
+            uint32 value = _getManagerData(plan, i);
+            if (value > 0) {
                 uint32 executedNonce = _manager.execute{value: values[i]}(targets[i], calldatas[i]);
-                if (executedNonce != nonce) {
+                if (value > 1 && executedNonce != value - 2) {
                     revert GovernorMismatchedNonce(proposalId, nonce, executedNonce);
                 }
             } else {
@@ -228,8 +240,9 @@ abstract contract GovernorTimelockAccess is Governor {
         // If the proposal has been scheduled it will have an ETA and we have to externally cancel
         if (eta != 0) {
             for (uint256 i = 0; i < targets.length; ++i) {
-                (bool delayed, uint32 nonce) = _getManagerData(plan, i);
-                if (delayed) {
+                uint32 value = _getManagerData(plan, i);
+                if (value > 1) {
+                    uint32 nonce = value - 2;
                     // Attempt to cancel considering the operation could have been cancelled and rescheduled already
                     try _manager.cancel(address(this), targets[i], calldatas[i]) returns (uint32 canceledNonce) {
                         if (canceledNonce != nonce) {
@@ -246,20 +259,17 @@ abstract contract GovernorTimelockAccess is Governor {
     /**
      * @dev Returns whether the operation at an index is delayed by the manager, and its scheduling nonce once queued.
      */
-    function _getManagerData(ExecutionPlan storage plan, uint256 index) private view returns (bool, uint32) {
+    function _getManagerData(ExecutionPlan storage plan, uint256 index) private view returns (uint32) {
         (uint256 bucket, uint256 subindex) = _getManagerDataIndices(index);
-        uint32 nonce = plan.managerData[bucket][subindex];
-        unchecked {
-            return nonce > 0 ? (true, nonce - 1) : (false, 0);
-        }
+        return plan.managerData[bucket][subindex];
     }
 
     /**
      * @dev Marks an operation at an index as delayed by the manager, and sets its scheduling nonce.
      */
-    function _setManagerData(ExecutionPlan storage plan, uint256 index, uint32 nonce) private {
+    function _setManagerData(ExecutionPlan storage plan, uint256 index, uint32 value) private {
         (uint256 bucket, uint256 subindex) = _getManagerDataIndices(index);
-        plan.managerData[bucket][subindex] = nonce + 1;
+        plan.managerData[bucket][subindex] = value;
     }
 
     /**

--- a/test/governance/extensions/GovernorTimelockAccess.test.js
+++ b/test/governance/extensions/GovernorTimelockAccess.test.js
@@ -297,7 +297,9 @@ contract('GovernorTimelockAccess', function (accounts) {
 
       describe('ignore AccessManager', function () {
         it('defaults', async function () {
-          expect(await this.mock.isAccessManagerIgnored(this.receiver.address, this.restricted.selector)).to.equal(false);
+          expect(await this.mock.isAccessManagerIgnored(this.receiver.address, this.restricted.selector)).to.equal(
+            false,
+          );
           expect(await this.mock.isAccessManagerIgnored(this.mock.address, '0x12341234')).to.equal(true);
         });
 
@@ -314,20 +316,28 @@ contract('GovernorTimelockAccess', function (accounts) {
         });
 
         it('external setter', async function () {
-          const setAccessManagerIgnored = (...args) => this.mock.contract.methods.setAccessManagerIgnored(...args).encodeABI();
+          const setAccessManagerIgnored = (...args) =>
+            this.mock.contract.methods.setAccessManagerIgnored(...args).encodeABI();
 
-          await this.helper.setProposal([
-            {
-              target: this.mock.address,
-              data: setAccessManagerIgnored(this.receiver.address, [this.restricted.selector, this.unrestricted.selector], true),
-              value: '0',
-            },
-            {
-              target: this.mock.address,
-              data: setAccessManagerIgnored(this.mock.address, ['0x12341234', '0x67896789'], false),
-              value: '0',
-            },
-          ], 'descr');
+          await this.helper.setProposal(
+            [
+              {
+                target: this.mock.address,
+                data: setAccessManagerIgnored(
+                  this.receiver.address,
+                  [this.restricted.selector, this.unrestricted.selector],
+                  true,
+                ),
+                value: '0',
+              },
+              {
+                target: this.mock.address,
+                data: setAccessManagerIgnored(this.mock.address, ['0x12341234', '0x67896789'], false),
+                value: '0',
+              },
+            ],
+            'descr',
+          );
 
           await this.helper.propose();
           await this.helper.waitForSnapshot();
@@ -337,8 +347,12 @@ contract('GovernorTimelockAccess', function (accounts) {
 
           expectEvent(tx, 'AccessManagerIgnoredSet');
 
-          expect(await this.mock.isAccessManagerIgnored(this.receiver.address, this.restricted.selector)).to.equal(true);
-          expect(await this.mock.isAccessManagerIgnored(this.receiver.address, this.unrestricted.selector)).to.equal(true);
+          expect(await this.mock.isAccessManagerIgnored(this.receiver.address, this.restricted.selector)).to.equal(
+            true,
+          );
+          expect(await this.mock.isAccessManagerIgnored(this.receiver.address, this.unrestricted.selector)).to.equal(
+            true,
+          );
 
           expect(await this.mock.isAccessManagerIgnored(this.mock.address, '0x12341234')).to.equal(false);
           expect(await this.mock.isAccessManagerIgnored(this.mock.address, '0x67896789')).to.equal(false);

--- a/test/governance/extensions/GovernorTimelockAccess.test.js
+++ b/test/governance/extensions/GovernorTimelockAccess.test.js
@@ -215,7 +215,9 @@ contract('GovernorTimelockAccess', function (accounts) {
         const roleId = '1';
 
         beforeEach(async function () {
-          await this.manager.setTargetFunctionRole(this.receiver.address, [this.restricted.selector], roleId, { from: admin });
+          await this.manager.setTargetFunctionRole(this.receiver.address, [this.restricted.selector], roleId, {
+            from: admin,
+          });
           await this.manager.grantRole(roleId, this.mock.address, delay, { from: admin });
         });
 
@@ -244,16 +246,16 @@ contract('GovernorTimelockAccess', function (accounts) {
         });
 
         it('cancel calls already canceled by guardian', async function () {
-          const operationA = { target: this.receiver.address, data: this.restricted.selector + '00'};
-          const operationB = { target: this.receiver.address, data: this.restricted.selector + '01'};
-          const operationC = { target: this.receiver.address, data: this.restricted.selector + '02'};
+          const operationA = { target: this.receiver.address, data: this.restricted.selector + '00' };
+          const operationB = { target: this.receiver.address, data: this.restricted.selector + '01' };
+          const operationC = { target: this.receiver.address, data: this.restricted.selector + '02' };
           const operationAId = hashOperation(this.mock.address, operationA.target, operationA.data);
           const operationBId = hashOperation(this.mock.address, operationB.target, operationB.data);
 
           const proposal1 = new GovernorHelper(this.mock, mode);
           const proposal2 = new GovernorHelper(this.mock, mode);
-          proposal1.setProposal([ operationA, operationB ], 'proposal A+B');
-          proposal2.setProposal([ operationA, operationC ], 'proposal A+C');
+          proposal1.setProposal([operationA, operationB], 'proposal A+B');
+          proposal2.setProposal([operationA, operationC], 'proposal A+C');
 
           for (const p of [proposal1, proposal2]) {
             await p.propose();
@@ -266,18 +268,18 @@ contract('GovernorTimelockAccess', function (accounts) {
           await proposal1.queue();
 
           // Cannot queue the second proposal: operation A already scheduled with delay
-          await expectRevertCustomError(proposal2.queue(), 'AccessManagerAlreadyScheduled', [ operationAId ]);
+          await expectRevertCustomError(proposal2.queue(), 'AccessManagerAlreadyScheduled', [operationAId]);
 
           // Admin cancels operation B on the manager
           await this.manager.cancel(this.mock.address, operationB.target, operationB.data, { from: admin });
 
           // Still cannot queue the second proposal: operation A already scheduled with delay
-          await expectRevertCustomError(proposal2.queue(), 'AccessManagerAlreadyScheduled', [ operationAId ]);
+          await expectRevertCustomError(proposal2.queue(), 'AccessManagerAlreadyScheduled', [operationAId]);
 
           await proposal1.waitForEta();
 
           // Cannot execute first proposal: operation B has been canceled
-          await expectRevertCustomError(proposal1.execute(), 'AccessManagerNotScheduled', [ operationBId ]);
+          await expectRevertCustomError(proposal1.execute(), 'AccessManagerNotScheduled', [operationBId]);
 
           // Cancel the first proposal to release operation A
           await proposal1.cancel('internal');
@@ -288,7 +290,7 @@ contract('GovernorTimelockAccess', function (accounts) {
           await proposal2.waitForEta();
 
           // Can execute second proposal
-          await proposal2.execute()
+          await proposal2.execute();
         });
       });
     });


### PR DESCRIPTION
1. Ensure that `_cancel` works correctly even when an operation has already been cancelled at the manager level, and even when it has been rescheduled after that.
2. Ensure that calls are executed through the AccessManager even if it authorizes the call without a delay. This is to make sure that we support operations on legacy contracts (e.g. Ownable) that are under control of (e.g. owned by) the `AccessManager`.
3. Add a mechanism to ignore restrictions claimed  by the AccessManager to mitigate a denial of service on functions that should be called directly.

Fixes LIB-1066
Fixes LIB-1065 (part of)
