### PR TITLE
Fix function documentation in Nonces

### DIFF
--- a/contracts/utils/Nonces.sol
+++ b/contracts/utils/Nonces.sol
@@ -13,7 +13,7 @@ abstract contract Nonces {
     mapping(address account => uint256) private _nonces;
 
     /**
-     * @dev Returns an the next unused nonce for an address.
+     * @dev Returns the current nonce for an address.
      */
     function nonces(address owner) public view virtual returns (uint256) {
         return _nonces[owner];

--- a/contracts/utils/Nonces.sol
+++ b/contracts/utils/Nonces.sol
@@ -13,7 +13,7 @@ abstract contract Nonces {
     mapping(address account => uint256) private _nonces;
 
     /**
-     * @dev Returns the current nonce for an address.
+     * @dev Returns the next unused nonce for an address.
      */
     function nonces(address owner) public view virtual returns (uint256) {
         return _nonces[owner];


### PR DESCRIPTION
The description of the function nonce(address) had a description not matching its true behavior. 

Current behavior: 
Return the next nonce of an address

Expect behavior:
Return the current nonce of an address