### PR TITLE
Rename ProposalCore.eta to etaSeconds

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -40,7 +40,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
         uint32 voteDuration;
         bool executed;
         bool canceled;
-        uint48 eta;
+        uint48 etaSeconds;
     }
 
     bytes32 private constant ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
@@ -205,7 +205,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      * @dev See {IGovernor-proposalEta}.
      */
     function proposalEta(uint256 proposalId) public view virtual returns (uint256) {
-        return _proposals[proposalId].eta;
+        return _proposals[proposalId].etaSeconds;
     }
 
     /**
@@ -352,11 +352,11 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
 
         _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Succeeded));
 
-        uint48 eta = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
+        uint48 etaSeconds = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
 
-        if (eta != 0) {
-            _proposals[proposalId].eta = eta;
-            emit ProposalQueued(proposalId, eta);
+        if (etaSeconds != 0) {
+            _proposals[proposalId].etaSeconds = etaSeconds;
+            emit ProposalQueued(proposalId, etaSeconds);
         } else {
             revert GovernorQueueNotImplemented();
         }
@@ -370,7 +370,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      *
      * This is empty by default, and must be overridden to implement queuing.
      *
-     * This function returns a timestamp that describes the expected eta for execution. If the returned value is 0
+     * This function returns a timestamp that describes the expected ETA for execution. If the returned value is 0
      * (which is the default value), the core will consider queueing did not succeed, and the public {queue} function
      * will revert.
      *

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -352,11 +352,11 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
 
         _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Succeeded));
 
-        uint48 etaSeconds = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
+        uint48 eta = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
 
-        if (etaSeconds != 0) {
-            _proposals[proposalId].etaSeconds = etaSeconds;
-            emit ProposalQueued(proposalId, etaSeconds);
+        if (eta != 0) {
+            _proposals[proposalId].etaSeconds = eta;
+            emit ProposalQueued(proposalId, eta);
         } else {
             revert GovernorQueueNotImplemented();
         }

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -352,11 +352,11 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
 
         _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Succeeded));
 
-        uint48 eta = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
+        uint48 etaSeconds = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
 
-        if (eta != 0) {
-            _proposals[proposalId].etaSeconds = eta;
-            emit ProposalQueued(proposalId, eta);
+        if (etaSeconds != 0) {
+            _proposals[proposalId].etaSeconds = etaSeconds;
+            emit ProposalQueued(proposalId, etaSeconds);
         } else {
             revert GovernorQueueNotImplemented();
         }

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -122,7 +122,7 @@ interface IGovernor is IERC165, IERC6372 {
     /**
      * @dev Emitted when a proposal is queued.
      */
-    event ProposalQueued(uint256 proposalId, uint256 eta);
+    event ProposalQueued(uint256 proposalId, uint256 etaSeconds);
 
     /**
      * @dev Emitted when a proposal is executed.

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -70,16 +70,18 @@ abstract contract GovernorTimelockCompound is Governor {
         bytes[] memory calldatas,
         bytes32 /*descriptionHash*/
     ) internal virtual override returns (uint48) {
-        uint48 eta = SafeCast.toUint48(block.timestamp + _timelock.delay());
+        uint48 etaSeconds = SafeCast.toUint48(block.timestamp + _timelock.delay());
 
         for (uint256 i = 0; i < targets.length; ++i) {
-            if (_timelock.queuedTransactions(keccak256(abi.encode(targets[i], values[i], "", calldatas[i], eta)))) {
+            if (
+                _timelock.queuedTransactions(keccak256(abi.encode(targets[i], values[i], "", calldatas[i], etaSeconds)))
+            ) {
                 revert GovernorAlreadyQueuedProposal(proposalId);
             }
-            _timelock.queueTransaction(targets[i], values[i], "", calldatas[i], eta);
+            _timelock.queueTransaction(targets[i], values[i], "", calldatas[i], etaSeconds);
         }
 
-        return eta;
+        return etaSeconds;
     }
 
     /**
@@ -93,13 +95,13 @@ abstract contract GovernorTimelockCompound is Governor {
         bytes[] memory calldatas,
         bytes32 /*descriptionHash*/
     ) internal virtual override {
-        uint256 eta = proposalEta(proposalId);
-        if (eta == 0) {
+        uint256 etaSeconds = proposalEta(proposalId);
+        if (etaSeconds == 0) {
             revert GovernorNotQueuedProposal(proposalId);
         }
         Address.sendValue(payable(_timelock), msg.value);
         for (uint256 i = 0; i < targets.length; ++i) {
-            _timelock.executeTransaction(targets[i], values[i], "", calldatas[i], eta);
+            _timelock.executeTransaction(targets[i], values[i], "", calldatas[i], etaSeconds);
         }
     }
 
@@ -115,11 +117,11 @@ abstract contract GovernorTimelockCompound is Governor {
     ) internal virtual override returns (uint256) {
         uint256 proposalId = super._cancel(targets, values, calldatas, descriptionHash);
 
-        uint256 eta = proposalEta(proposalId);
-        if (eta > 0) {
+        uint256 etaSeconds = proposalEta(proposalId);
+        if (etaSeconds > 0) {
             // do external call later
             for (uint256 i = 0; i < targets.length; ++i) {
-                _timelock.cancelTransaction(targets[i], values[i], "", calldatas[i], eta);
+                _timelock.cancelTransaction(targets[i], values[i], "", calldatas[i], etaSeconds);
             }
         }
 


### PR DESCRIPTION
The other members in the struct use the Governor clock, whereas the `eta` member specifically uses timestamps, so we rename the variable to reduce ambiguity.

Fixes LIB-1080