### PR TITLE
Remove Time.Delay *At functions

### DIFF
--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -373,6 +373,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
             // No setback here. Value can be reset by doing revoke + grant, effectively allowing the admin to perform
             // any change to the execution delay within the duration of the role admin delay.
             (_roles[roleId].members[account].delay, since) = _roles[roleId].members[account].delay.withUpdate(
+                Time.timestamp(),
                 executionDelay,
                 0
             );
@@ -444,7 +445,11 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
 
         uint48 effect;
-        (_roles[roleId].grantDelay, effect) = _roles[roleId].grantDelay.withUpdate(newDelay, minSetback());
+        (_roles[roleId].grantDelay, effect) = _roles[roleId].grantDelay.withUpdate(
+            Time.timestamp(),
+            newDelay,
+            minSetback()
+        );
 
         emit RoleGrantDelayChanged(roleId, newDelay, effect);
     }
@@ -499,7 +504,11 @@ contract AccessManager is Context, Multicall, IAccessManager {
      */
     function _setTargetAdminDelay(address target, uint32 newDelay) internal virtual {
         uint48 effect;
-        (_targets[target].adminDelay, effect) = _targets[target].adminDelay.withUpdate(newDelay, minSetback());
+        (_targets[target].adminDelay, effect) = _targets[target].adminDelay.withUpdate(
+            Time.timestamp(),
+            newDelay,
+            minSetback()
+        );
 
         emit TargetAdminDelayUpdated(target, newDelay, effect);
     }

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -444,10 +444,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         }
 
         uint48 effect;
-        (_roles[roleId].grantDelay, effect) = _roles[roleId].grantDelay.withUpdate(
-            newDelay,
-            minSetback()
-        );
+        (_roles[roleId].grantDelay, effect) = _roles[roleId].grantDelay.withUpdate(newDelay, minSetback());
 
         emit RoleGrantDelayChanged(roleId, newDelay, effect);
     }
@@ -502,10 +499,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
      */
     function _setTargetAdminDelay(address target, uint32 newDelay) internal virtual {
         uint48 effect;
-        (_targets[target].adminDelay, effect) = _targets[target].adminDelay.withUpdate(
-            newDelay,
-            minSetback()
-        );
+        (_targets[target].adminDelay, effect) = _targets[target].adminDelay.withUpdate(newDelay, minSetback());
 
         emit TargetAdminDelayUpdated(target, newDelay, effect);
     }

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -373,7 +373,6 @@ contract AccessManager is Context, Multicall, IAccessManager {
             // No setback here. Value can be reset by doing revoke + grant, effectively allowing the admin to perform
             // any change to the execution delay within the duration of the role admin delay.
             (_roles[roleId].members[account].delay, since) = _roles[roleId].members[account].delay.withUpdate(
-                Time.timestamp(),
                 executionDelay,
                 0
             );
@@ -446,7 +445,6 @@ contract AccessManager is Context, Multicall, IAccessManager {
 
         uint48 effect;
         (_roles[roleId].grantDelay, effect) = _roles[roleId].grantDelay.withUpdate(
-            Time.timestamp(),
             newDelay,
             minSetback()
         );
@@ -505,7 +503,6 @@ contract AccessManager is Context, Multicall, IAccessManager {
     function _setTargetAdminDelay(address target, uint32 newDelay) internal virtual {
         uint48 effect;
         (_targets[target].adminDelay, effect) = _targets[target].adminDelay.withUpdate(
-            Time.timestamp(),
             newDelay,
             minSetback()
         );

--- a/contracts/utils/types/Time.sol
+++ b/contracts/utils/types/Time.sol
@@ -103,10 +103,15 @@ library Time {
      * enforce the old delay at the moment of the update. Returns the updated Delay object and the timestamp when the
      * new delay becomes effective.
      */
-    function withUpdate(Delay self, uint32 newValue, uint32 minSetback) internal view returns (Delay, uint48) {
-        uint32 value = self.get();
+    function withUpdate(
+        Delay self,
+        uint48 clock,
+        uint32 newValue,
+        uint32 minSetback
+    ) internal pure returns (Delay, uint48) {
+        uint32 value = self.getAt(clock);
         uint32 setback = uint32(Math.max(minSetback, value > newValue ? value - newValue : 0));
-        uint48 effect = timestamp() + setback;
+        uint48 effect = clock + setback;
         return (pack(value, newValue, effect), effect);
     }
 

--- a/contracts/utils/types/Time.sol
+++ b/contracts/utils/types/Time.sol
@@ -54,8 +54,8 @@ library Time {
      * 0xAAAAAAAAAAAABBBBBBBBCCCCCCCC
      * ```
      *
-     * NOTE: The {get} and {update} function operate using timestamps. Block number based delays should use the
-     * {getAt} and {withUpdateAt} variants of these functions.
+     * NOTE: The {get} and {withUpdate} functions operate using timestamps. Block number based delays are not currently
+     * supported.
      */
     type Delay is uint112;
 

--- a/contracts/utils/types/Time.sol
+++ b/contracts/utils/types/Time.sol
@@ -70,7 +70,7 @@ library Time {
      * @dev Get the value at a given timepoint plus the pending value and effect timepoint if there is a scheduled
      * change after this timepoint. If the effect timepoint is 0, then the pending value should not be considered.
      */
-    function getFullAt(Delay self, uint48 timepoint) internal pure returns (uint32, uint32, uint48) {
+    function _getFullAt(Delay self, uint48 timepoint) private pure returns (uint32, uint32, uint48) {
         (uint32 valueBefore, uint32 valueAfter, uint48 effect) = self.unpack();
         return effect <= timepoint ? (valueAfter, 0, 0) : (valueBefore, valueAfter, effect);
     }
@@ -80,22 +80,15 @@ library Time {
      * effect timepoint is 0, then the pending value should not be considered.
      */
     function getFull(Delay self) internal view returns (uint32, uint32, uint48) {
-        return self.getFullAt(timestamp());
-    }
-
-    /**
-     * @dev Get the value the Delay will be at a given timepoint.
-     */
-    function getAt(Delay self, uint48 timepoint) internal pure returns (uint32) {
-        (uint32 delay, , ) = getFullAt(self, timepoint);
-        return delay;
+        return _getFullAt(self, timestamp());
     }
 
     /**
      * @dev Get the current value.
      */
     function get(Delay self) internal view returns (uint32) {
-        return self.getAt(timestamp());
+        (uint32 delay, , ) = self.getFull();
+        return delay;
     }
 
     /**
@@ -105,13 +98,12 @@ library Time {
      */
     function withUpdate(
         Delay self,
-        uint48 clock,
         uint32 newValue,
         uint32 minSetback
-    ) internal pure returns (Delay, uint48) {
-        uint32 value = self.getAt(clock);
+    ) internal view returns (Delay, uint48) {
+        uint32 value = self.get();
         uint32 setback = uint32(Math.max(minSetback, value > newValue ? value - newValue : 0));
-        uint48 effect = clock + setback;
+        uint48 effect = timestamp() + setback;
         return (pack(value, newValue, effect), effect);
     }
 

--- a/contracts/utils/types/Time.sol
+++ b/contracts/utils/types/Time.sol
@@ -96,11 +96,7 @@ library Time {
      * enforce the old delay at the moment of the update. Returns the updated Delay object and the timestamp when the
      * new delay becomes effective.
      */
-    function withUpdate(
-        Delay self,
-        uint32 newValue,
-        uint32 minSetback
-    ) internal view returns (Delay, uint48) {
+    function withUpdate(Delay self, uint32 newValue, uint32 minSetback) internal view returns (Delay, uint48) {
         uint32 value = self.get();
         uint32 setback = uint32(Math.max(minSetback, value > newValue ? value - newValue : 0));
         uint48 effect = timestamp() + setback;

--- a/test/utils/types/Time.test.js
+++ b/test/utils/types/Time.test.js
@@ -8,7 +8,7 @@ const Time = artifacts.require('$Time');
 
 const MAX_UINT32 = 1n << (32n - 1n);
 const MAX_UINT48 = 1n << (48n - 1n);
-const SOME_VALUES = [0n, 1n, 2n, 15n, 16n, 17n, 42n];
+const SOME_VALUES = [0n, 1n, 15n, 16n, 17n];
 
 const asUint = (value, size) => {
   if (typeof value != 'bigint') {
@@ -128,34 +128,35 @@ contract('Time', function () {
     });
 
     it('withUpdate', async function () {
-      const timepoint = await clock.timestamp().then(BigInt);
       const valueBefore = 24194n;
       const valueAfter = 4214143n;
       const newvalueAfter = 94716n;
 
-      for (const effect of effectSamplesForTimepoint(timepoint))
-        for (const minSetback of [...SOME_VALUES, MAX_UINT32]) {
-          const isPast = effect <= timepoint;
-          const expectedvalueBefore = isPast ? valueAfter : valueBefore;
-          const expectedSetback = max(minSetback, expectedvalueBefore - newvalueAfter, 0n);
+      for (const timepoint of [...SOME_VALUES, MAX_UINT48])
+        for (const effect of effectSamplesForTimepoint(timepoint))
+          for (const minSetback of [...SOME_VALUES, MAX_UINT32]) {
+            const isPast = effect <= timepoint;
+            const expectedvalueBefore = isPast ? valueAfter : valueBefore;
+            const expectedSetback = max(minSetback, expectedvalueBefore - newvalueAfter, 0n);
 
-          const result = await this.mock.$withUpdate(
-            packDelay({ valueBefore, valueAfter, effect }),
-            newvalueAfter,
-            minSetback,
-          );
+            const result = await this.mock.$withUpdate(
+              packDelay({ valueBefore, valueAfter, effect }),
+              timepoint,
+              newvalueAfter,
+              minSetback,
+            );
 
-          expect(result[0]).to.be.bignumber.equal(
-            String(
-              packDelay({
-                valueBefore: expectedvalueBefore,
-                valueAfter: newvalueAfter,
-                effect: timepoint + expectedSetback,
-              }),
-            ),
-          );
-          expect(result[1]).to.be.bignumber.equal(String(timepoint + expectedSetback));
-        }
+            expect(result[0]).to.be.bignumber.equal(
+              String(
+                packDelay({
+                  valueBefore: expectedvalueBefore,
+                  valueAfter: newvalueAfter,
+                  effect: timepoint + expectedSetback,
+                }),
+              ),
+            );
+            expect(result[1]).to.be.bignumber.equal(String(timepoint + expectedSetback));
+          }
     });
   });
 });


### PR DESCRIPTION
The `Time.Delay` library is partially generic for different clock types, but the important `withUpdate` function is hardcoded to work with timestamps and it's not as simple as the rest of the functions to make it work with block numbers. This PR removes the `*At` variants of functions to leave a timestamp-only interface for the time being.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes LIB-1047

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
