### PR TITLE
Add named return parameters and `_checkSelector` function to AccessManager

### DIFF
--- a/contracts/access/manager/AccessManaged.sol
+++ b/contracts/access/manager/AccessManaged.sol
@@ -99,14 +99,15 @@ abstract contract AccessManaged is Context, IAccessManaged {
     }
 
     /**
-     * @dev Reverts if the caller is not allowed to call the function identified by a selector.
+     * @dev Reverts if the caller is not allowed to call the function identified by a selector. Panics if the calldata
+     * is less than 4 bytes long.
      */
     function _checkCanCall(address caller, bytes calldata data) internal virtual {
         (bool immediate, uint32 delay) = AuthorityUtils.canCallWithDelay(
             authority(),
             caller,
             address(this),
-            bytes4(data)
+            bytes4(data[0:4])
         );
         if (!immediate) {
             if (delay > 0) {

--- a/contracts/access/manager/AccessManaged.sol
+++ b/contracts/access/manager/AccessManaged.sol
@@ -41,17 +41,15 @@ abstract contract AccessManaged is Context, IAccessManaged {
      * function at the bottom of the call stack, and not the function where the modifier is visible in the source code.
      * ====
      *
-     * [NOTE]
+     * [WARNING]
      * ====
-     * Selector collisions are mitigated by scoping permissions per contract, but some edge cases must be considered:
+     * Avoid adding this modifier to the https://docs.soliditylang.org/en/v0.8.20/contracts.html#receive-ether-function[`receive()`]
+     * function or the https://docs.soliditylang.org/en/v0.8.20/contracts.html#fallback-function[`fallback()`]. These
+     * functions are the only execution paths where a function selector cannot be unambiguosly determined from the calldata
+     * since the selector defaults to `0x00000000` in the `receive()` function and similary in the `fallback()` function
+     * if no calldata is provided. (See {_checkCanCall}).
      *
-     * * If the https://docs.soliditylang.org/en/v0.8.20/contracts.html#receive-ether-function[`receive()`] function
-     * is restricted, any other function with a `0x00000000` selector will share permissions with `receive()`.
-     * * Similarly, if there's no `receive()` function but a `fallback()` instead, the fallback might be called with
-     * empty `calldata`, sharing the `0x00000000` selector permissions as well.
-     * * For any other selector, if the restricted function is set on an upgradeable contract, an upgrade may remove
-     * the restricted function and replace it with a new method whose selector replaces the last one, keeping the
-     * previous permissions.
+     * The `receive()` function will always panic whereas the `fallback()` may panic depending on the calldata length. 
      * ====
      */
     modifier restricted() {

--- a/contracts/access/manager/AccessManaged.sol
+++ b/contracts/access/manager/AccessManaged.sol
@@ -49,7 +49,7 @@ abstract contract AccessManaged is Context, IAccessManaged {
      * since the selector defaults to `0x00000000` in the `receive()` function and similary in the `fallback()` function
      * if no calldata is provided. (See {_checkCanCall}).
      *
-     * The `receive()` function will always panic whereas the `fallback()` may panic depending on the calldata length. 
+     * The `receive()` function will always panic whereas the `fallback()` may panic depending on the calldata length.
      * ====
      */
     modifier restricted() {

--- a/contracts/access/manager/AccessManaged.sol
+++ b/contracts/access/manager/AccessManaged.sol
@@ -46,7 +46,7 @@ abstract contract AccessManaged is Context, IAccessManaged {
      * Avoid adding this modifier to the https://docs.soliditylang.org/en/v0.8.20/contracts.html#receive-ether-function[`receive()`]
      * function or the https://docs.soliditylang.org/en/v0.8.20/contracts.html#fallback-function[`fallback()`]. These
      * functions are the only execution paths where a function selector cannot be unambiguosly determined from the calldata
-     * since the selector defaults to `0x00000000` in the `receive()` function and similary in the `fallback()` function
+     * since the selector defaults to `0x00000000` in the `receive()` function and similarly in the `fallback()` function
      * if no calldata is provided. (See {_checkCanCall}).
      *
      * The `receive()` function will always panic whereas the `fallback()` may panic depending on the calldata length.

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -450,6 +450,10 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * Emits a {RoleGrantDelayChanged} event
      */
     function _setGrantDelay(uint64 roleId, uint32 newDelay) internal virtual {
+        if (roleId == PUBLIC_ROLE) {
+            revert AccessManagerLockedRole(roleId);
+        }
+
         uint48 effect;
         (_roles[roleId].grantDelay, effect) = _roles[roleId].grantDelay.withUpdate(newDelay, minSetback());
 

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -143,9 +143,8 @@ contract AccessManager is Context, Multicall, IAccessManager {
             return (_isExecuting(target, selector), 0);
         } else {
             uint64 roleId = getTargetFunctionRole(target, selector);
-            bool inRole;
-            (inRole, delay) = hasRole(roleId, caller);
-            return inRole ? (delay == 0, delay) : (false, 0);
+            (bool isMember, uint32 currentDelay) = hasRole(roleId, caller);
+            return isMember ? (currentDelay == 0, currentDelay) : (false, 0);
         }
     }
 

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -130,7 +130,11 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * is backward compatible. Some contracts may thus ignore the second return argument. In that case they will fail
      * to identify the indirect workflow, and will consider calls that require a delay to be forbidden.
      */
-    function canCall(address caller, address target, bytes4 selector) public view virtual returns (bool immediate, uint32 delay) {
+    function canCall(
+        address caller,
+        address target,
+        bytes4 selector
+    ) public view virtual returns (bool immediate, uint32 delay) {
         if (isTargetClosed(target)) {
             return (false, 0);
         } else if (caller == address(this)) {
@@ -221,10 +225,13 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * [2] Pending execution delay for the account.
      * [3] Timestamp at which the pending execution delay will become active. 0 means no delay update is scheduled.
      */
-    function getAccess(uint64 roleId, address account) public view virtual returns (uint48 since, uint32 currentDelay, uint32 pendingDelay, uint48 effect) {
+    function getAccess(
+        uint64 roleId,
+        address account
+    ) public view virtual returns (uint48 since, uint32 currentDelay, uint32 pendingDelay, uint48 effect) {
         Access storage access = _roles[roleId].members[account];
 
-         since = access.since;
+        since = access.since;
         (currentDelay, pendingDelay, effect) = access.delay.getFull();
 
         return (since, currentDelay, pendingDelay, effect);
@@ -234,7 +241,10 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * @dev Check if a given account currently had the permission level corresponding to a given role. Note that this
      * permission might be associated with a delay. {getAccess} can provide more details.
      */
-    function hasRole(uint64 roleId, address account) public view virtual returns (bool isMember, uint32 executionDelay) {
+    function hasRole(
+        uint64 roleId,
+        address account
+    ) public view virtual returns (bool isMember, uint32 executionDelay) {
         if (roleId == PUBLIC_ROLE) {
             return (true, 0);
         } else {
@@ -776,7 +786,9 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * - uint64: which role is this operation restricted to
      * - uint32: minimum delay to enforce for that operation (on top of the admin's execution delay)
      */
-    function _getAdminRestrictions(bytes calldata data) private view returns (bool restricted, uint64 roleAdminId, uint32 executionDelay) {
+    function _getAdminRestrictions(
+        bytes calldata data
+    ) private view returns (bool restricted, uint64 roleAdminId, uint32 executionDelay) {
         bytes4 selector = _checkSelector(data);
 
         if (data.length < 4) {
@@ -827,7 +839,11 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * If immediate is true, the delay can be disregarded and the operation can be immediately executed.
      * If immediate is false, the operation can be executed if and only if delay is greater than 0.
      */
-    function _canCallExtended(address caller, address target, bytes calldata data) private view returns (bool immediate, uint32 delay) {
+    function _canCallExtended(
+        address caller,
+        address target,
+        bytes calldata data
+    ) private view returns (bool immediate, uint32 delay) {
         if (target == address(this)) {
             return _canCallSelf(caller, data);
         } else {

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -789,11 +789,11 @@ contract AccessManager is Context, Multicall, IAccessManager {
     function _getAdminRestrictions(
         bytes calldata data
     ) private view returns (bool restricted, uint64 roleAdminId, uint32 executionDelay) {
-        bytes4 selector = _checkSelector(data);
-
         if (data.length < 4) {
             return (false, 0, 0);
         }
+
+        bytes4 selector = _checkSelector(data);
 
         // Restricted to ADMIN with no delay beside any execution delay the caller may have
         if (
@@ -847,8 +847,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         if (target == address(this)) {
             return _canCallSelf(caller, data);
         } else {
-            bytes4 selector = _checkSelector(data);
-            return canCall(caller, target, selector);
+            return data.length < 4 ? (false, 0) : canCall(caller, target, _checkSelector(data));
         }
     }
 
@@ -856,6 +855,10 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * @dev A version of {canCall} that checks for admin restrictions in this contract.
      */
     function _canCallSelf(address caller, bytes calldata data) private view returns (bool immediate, uint32 delay) {
+        if (data.length < 4) {
+            return (false, 0);
+        }
+
         if (caller == address(this)) {
             // Caller is AccessManager, this means the call was sent through {execute} and it already checked
             // permissions. We verify that the call "identifier", which is set during {execute}, is correct.

--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -191,6 +191,9 @@ abstract contract GovernorTimelockAccess is Governor {
         plan.length = SafeCast.toUint16(targets.length);
 
         for (uint256 i = 0; i < targets.length; ++i) {
+            if (calldatas[i].length < 4) {
+                continue;
+            }
             address target = targets[i];
             bytes4 selector = bytes4(calldatas[i]);
             (bool immediate, uint32 delay) = AuthorityUtils.canCallWithDelay(

--- a/contracts/mocks/AccessManagedTarget.sol
+++ b/contracts/mocks/AccessManagedTarget.sol
@@ -7,6 +7,7 @@ import {AccessManaged} from "../access/manager/AccessManaged.sol";
 abstract contract AccessManagedTarget is AccessManaged {
     event CalledRestricted(address caller);
     event CalledUnrestricted(address caller);
+    event CalledFallback(address caller);
 
     function fnRestricted() public restricted {
         emit CalledRestricted(msg.sender);
@@ -14,5 +15,9 @@ abstract contract AccessManagedTarget is AccessManaged {
 
     function fnUnrestricted() public {
         emit CalledUnrestricted(msg.sender);
+    }
+
+    fallback() external {
+        emit CalledFallback(msg.sender);
     }
 }

--- a/test/governance/extensions/GovernorTimelockAccess.test.js
+++ b/test/governance/extensions/GovernorTimelockAccess.test.js
@@ -84,6 +84,18 @@ contract('GovernorTimelockAccess', function (accounts) {
           this.unrestricted.operation.target,
           this.unrestricted.operation.data,
         );
+
+        this.fallback = {};
+        this.fallback.operation = {
+          target: this.receiver.address,
+          value: '0',
+          data: '0x1234',
+        };
+        this.fallback.operationId = hashOperation(
+          this.mock.address,
+          this.fallback.operation.target,
+          this.fallback.operation.data,
+        );
       });
 
       it('accepts ether transfers', async function () {
@@ -180,7 +192,7 @@ contract('GovernorTimelockAccess', function (accounts) {
         await this.manager.grantRole(roleId, this.mock.address, managerDelay, { from: admin });
 
         this.proposal = await this.helper.setProposal(
-          [this.restricted.operation, this.unrestricted.operation],
+          [this.restricted.operation, this.unrestricted.operation, this.fallback.operation],
           'descr',
         );
 
@@ -209,6 +221,7 @@ contract('GovernorTimelockAccess', function (accounts) {
         });
         await expectEvent.inTransaction(txExecute.tx, this.receiver, 'CalledRestricted');
         await expectEvent.inTransaction(txExecute.tx, this.receiver, 'CalledUnrestricted');
+        await expectEvent.inTransaction(txExecute.tx, this.receiver, 'CalledFallback');
       });
 
       describe('cancel', function () {


### PR DESCRIPTION
Improvements after #4613

The `_checkSelector` function is added to keep consistency of the way the calldata selector is consumed.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests in #4613 
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
