### PR TITLE
Fix warning format in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note**
+> [!NOTE]
 > Version 5.0 is currently in release candidate period. Bug bounty rewards are boosted 50% until the release.  
 > [See more details on Immunefi.](https://immunefi.com/bounty/openzeppelin/)
 
@@ -35,9 +35,11 @@ $ npm install @openzeppelin/contracts
 
 #### Foundry (git)
 
-> **Warning** When installing via git, it is a common error to use the `master` branch. This is a development branch that should be avoided in favor of tagged releases. The release process involves security measures that the `master` branch does not guarantee.
+> [!WARNING]
+> When installing via git, it is a common error to use the `master` branch. This is a development branch that should be avoided in favor of tagged releases. The release process involves security measures that the `master` branch does not guarantee.
 
-> **Warning** Foundry installs the latest version initially, but subsequent `forge update` commands will use the `master` branch.
+> [!WARNING]
+> Foundry installs the latest version initially, but subsequent `forge update` commands will use the `master` branch.
 
 ```
 $ forge install OpenZeppelin/openzeppelin-contracts


### PR DESCRIPTION
Looks like this:

![image](https://github.com/OpenZeppelin/openzeppelin-contracts/assets/481465/9dc15b8a-fea0-4c3d-8217-0dee34efd1fd)


Should look like this:

![image](https://github.com/OpenZeppelin/openzeppelin-contracts/assets/481465/18529726-8d67-446b-9b9e-10a9c7b93b67)
