### PR TITLE
Update remappings.txt for upgradeable contracts and set up submodule

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,3 +15,7 @@ runs:
       run: npm ci
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Copy non-upgradeable contracts as dependency
-        run:
-          cp -rnT contracts node_modules/@openzeppelin/contracts
+        run: |
+          mkdir -p lib/openzeppelin-contracts
+          cp -rnT contracts lib/openzeppelin-contracts/contracts
       - name: Transpile to upgradeable
         run: bash scripts/upgradeable/transpile.sh
       - name: Run tests

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,6 +79,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Run tests
         run: forge test -vv
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,10 +78,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
       - name: Run tests
         run: forge test -vv
 

--- a/.github/workflows/upgradeable.yml
+++ b/.github/workflows/upgradeable.yml
@@ -18,10 +18,12 @@ jobs:
           token: ${{ secrets.GH_TOKEN_UPGRADEABLE }}
       - name: Fetch current non-upgradeable branch
         run: |
-          git fetch "https://github.com/${{ github.repository }}.git" "$REF"
+          git fetch "$REMOTE" master # Fetch default branch first for patch to apply cleanly
+          git fetch "$REMOTE" "$REF"
           git checkout FETCH_HEAD
         env:
           REF: ${{ github.ref }}
+          REMOTE: https://github.com/${{ github.repository }}.git
       - name: Set up environment
         uses: ./.github/actions/setup
       - run: bash scripts/git-user-config.sh

--- a/.github/workflows/upgradeable.yml
+++ b/.github/workflows/upgradeable.yml
@@ -29,4 +29,6 @@ jobs:
       - run: bash scripts/git-user-config.sh
       - name: Transpile to upgradeable
         run: bash scripts/upgradeable/transpile-onto.sh ${{ github.ref_name }} origin/${{ github.ref_name }}
+        env:
+          REMOTE: https://github.com/${{ github.repository }}.git
       - run: git push origin ${{ github.ref_name }}

--- a/.github/workflows/upgradeable.yml
+++ b/.github/workflows/upgradeable.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release-v*
-      - partial-submodules
 
 jobs:
   transpile:

--- a/.github/workflows/upgradeable.yml
+++ b/.github/workflows/upgradeable.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release-v*
+      - partial-submodules
 
 jobs:
   transpile:

--- a/.github/workflows/upgradeable.yml
+++ b/.github/workflows/upgradeable.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Transpile to upgradeable
         run: bash scripts/upgradeable/transpile-onto.sh ${{ github.ref_name }} origin/${{ github.ref_name }}
         env:
-          REMOTE: https://github.com/${{ github.repository }}.git
+          SUBMODULE_REMOTE: https://github.com/${{ github.repository }}.git
       - run: git push origin ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ contracts-exposed
 
 # Foundry
 /out
+/cache_forge
 
 # Certora
 .certora*

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -15,8 +15,6 @@ import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
  * `UUPSUpgradeable` with a custom implementation of upgrades.
  *
  * The {_authorizeUpgrade} function must be overridden to include access restriction to the upgrade mechanism.
- *
- * @custom:stateless
  */
 abstract contract UUPSUpgradeable is IERC1822Proxiable {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable

--- a/contracts/token/ERC1155/utils/ERC1155Holder.sol
+++ b/contracts/token/ERC1155/utils/ERC1155Holder.sol
@@ -11,8 +11,6 @@ import {IERC1155Receiver} from "../IERC1155Receiver.sol";
  *
  * IMPORTANT: When inheriting this contract, you must include a way to use the received tokens, otherwise they will be
  * stuck.
- *
- * @custom:stateless
  */
 abstract contract ERC1155Holder is ERC165, IERC1155Receiver {
     /**

--- a/contracts/token/ERC721/utils/ERC721Holder.sol
+++ b/contracts/token/ERC721/utils/ERC721Holder.sol
@@ -11,8 +11,6 @@ import {IERC721Receiver} from "../IERC721Receiver.sol";
  * Accepts all token transfers.
  * Make sure the contract is able to use its token with {IERC721-safeTransferFrom}, {IERC721-approve} or
  * {IERC721-setApprovalForAll}.
- *
- * @custom:stateless
  */
 abstract contract ERC721Holder is IERC721Receiver {
     /**

--- a/contracts/utils/Context.sol
+++ b/contracts/utils/Context.sol
@@ -12,8 +12,6 @@ pragma solidity ^0.8.20;
  * is concerned).
  *
  * This contract is only required for intermediate, library-like contracts.
- *
- * @custom:stateless
  */
 abstract contract Context {
     function _msgSender() internal view virtual returns (address) {

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -7,8 +7,6 @@ import {Address} from "./Address.sol";
 
 /**
  * @dev Provides a function to batch together multiple calls in a single external call.
- *
- * @custom:stateless
  */
 abstract contract Multicall {
     /**

--- a/contracts/utils/introspection/ERC165.sol
+++ b/contracts/utils/introspection/ERC165.sol
@@ -16,8 +16,6 @@ import {IERC165} from "./IERC165.sol";
  *     return interfaceId == type(MyInterface).interfaceId || super.supportsInterface(interfaceId);
  * }
  * ```
- *
- * @custom:stateless
  */
 abstract contract ERC165 is IERC165 {
     /**

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,10 @@
+[profile.default]
+src = 'contracts'
+out = 'out'
+libs = ['node_modules', 'lib']
+test = 'test'
+cache_path  = 'cache_forge'
+
 [fuzz]
 runs = 10000
 max_test_rejects = 150000

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -49,6 +49,7 @@ const argv = require('yargs/yargs')()
   }).argv;
 
 require('@nomiclabs/hardhat-truffle5');
+require('@nomicfoundation/hardhat-foundry');
 require('hardhat-ignore-warnings');
 require('hardhat-exposed');
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -39,6 +39,11 @@ const argv = require('yargs/yargs')()
       type: 'boolean',
       default: false,
     },
+    foundry: {
+      alias: 'hasFoundry',
+      type: 'boolean',
+      default: hasFoundry(),
+    },
     compiler: {
       alias: 'compileVersion',
       type: 'string',
@@ -53,12 +58,8 @@ const argv = require('yargs/yargs')()
 require('@nomiclabs/hardhat-truffle5');
 require('hardhat-ignore-warnings');
 require('hardhat-exposed');
-
 require('solidity-docgen');
-
-if (hasFoundry()) {
-  require('@nomicfoundation/hardhat-foundry');
-}
+argv.foundry && require('@nomicfoundation/hardhat-foundry');
 
 for (const f of fs.readdirSync(path.join(__dirname, 'hardhat'))) {
   require(path.join(__dirname, 'hardhat', f));

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -8,6 +8,8 @@
 
 const fs = require('fs');
 const path = require('path');
+const proc = require('child_process');
+
 const argv = require('yargs/yargs')()
   .env('')
   .options({
@@ -49,11 +51,14 @@ const argv = require('yargs/yargs')()
   }).argv;
 
 require('@nomiclabs/hardhat-truffle5');
-require('@nomicfoundation/hardhat-foundry');
 require('hardhat-ignore-warnings');
 require('hardhat-exposed');
 
 require('solidity-docgen');
+
+if (hasFoundry()) {
+  require('@nomicfoundation/hardhat-foundry');
+}
 
 for (const f of fs.readdirSync(path.join(__dirname, 'hardhat'))) {
   require(path.join(__dirname, 'hardhat', f));
@@ -114,4 +119,8 @@ if (argv.gas) {
 if (argv.coverage) {
   require('solidity-coverage');
   module.exports.networks.hardhat.initialBaseFeePerGas = 0;
+}
+
+function hasFoundry() {
+  return proc.spawnSync('forge', ['-V'], { stdio: 'ignore' }).error === undefined;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nomiclabs/hardhat-web3": "^2.0.0",
         "@openzeppelin/docs-utils": "^0.1.4",
         "@openzeppelin/test-helpers": "^0.5.13",
-        "@openzeppelin/upgrade-safe-transpiler": "^0.3.30",
+        "@openzeppelin/upgrade-safe-transpiler": "^0.3.31",
         "@openzeppelin/upgrades-core": "^1.20.6",
         "array.prototype.at": "^1.1.1",
         "chai": "^4.2.0",
@@ -2422,9 +2422,9 @@
       }
     },
     "node_modules/@openzeppelin/upgrade-safe-transpiler": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrade-safe-transpiler/-/upgrade-safe-transpiler-0.3.30.tgz",
-      "integrity": "sha512-nkJ4r+W+FUp0eAvE18uHh/smwD1NS3KLAGJ59+Vgmx3VlCvCDNaS0rTJ1FpwxDYD3J0Whx0ZVtHz2ySq4YsnNQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrade-safe-transpiler/-/upgrade-safe-transpiler-0.3.31.tgz",
+      "integrity": "sha512-K2gK3KS+7lWMJcxUIQrJbuG9qYYPWmp/4WYdKFnByYDGa8gdomYnlnGD1bUxGrp9v0d4oF3CVgBJ+sbENLgtng==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@changesets/cli": "^2.26.0",
         "@changesets/pre": "^1.0.14",
         "@changesets/read": "^0.5.9",
+        "@nomicfoundation/hardhat-foundry": "^1.1.1",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.3",
         "@nomiclabs/hardhat-truffle5": "^2.0.5",
         "@nomiclabs/hardhat-web3": "^2.0.0",
@@ -2010,6 +2011,18 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-foundry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-foundry/-/hardhat-foundry-1.1.1.tgz",
+      "integrity": "sha512-cXGCBHAiXas9Pg9MhMOpBVQCkWRYoRFG7GJJAph+sdQsfd22iRs5U5Vs9XmpGEQd1yEvYISQZMeE68Nxj65iUQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.17.2"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nomiclabs/hardhat-web3": "^2.0.0",
         "@openzeppelin/docs-utils": "^0.1.4",
         "@openzeppelin/test-helpers": "^0.5.13",
-        "@openzeppelin/upgrade-safe-transpiler": "^0.3.31",
+        "@openzeppelin/upgrade-safe-transpiler": "^0.3.32",
         "@openzeppelin/upgrades-core": "^1.20.6",
         "array.prototype.at": "^1.1.1",
         "chai": "^4.2.0",
@@ -2422,9 +2422,9 @@
       }
     },
     "node_modules/@openzeppelin/upgrade-safe-transpiler": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrade-safe-transpiler/-/upgrade-safe-transpiler-0.3.31.tgz",
-      "integrity": "sha512-K2gK3KS+7lWMJcxUIQrJbuG9qYYPWmp/4WYdKFnByYDGa8gdomYnlnGD1bUxGrp9v0d4oF3CVgBJ+sbENLgtng==",
+      "version": "0.3.32",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrade-safe-transpiler/-/upgrade-safe-transpiler-0.3.32.tgz",
+      "integrity": "sha512-ypgj6MXXcDG0dOuMwENXt0H4atCtCsPgpDgWZYewb2egfUCMpj6d2GO4pcNZgdn1zYsmUHfm5ZA/Nga/8qkdKA==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "glob": "^10.3.5",
         "graphlib": "^2.1.8",
         "hardhat": "^2.9.1",
-        "hardhat-exposed": "^0.3.12-1",
+        "hardhat-exposed": "^0.3.13",
         "hardhat-gas-reporter": "^1.0.4",
         "hardhat-ignore-warnings": "^0.2.0",
         "keccak256": "^1.0.2",
@@ -8663,9 +8663,9 @@
       }
     },
     "node_modules/hardhat-exposed": {
-      "version": "0.3.12-1",
-      "resolved": "https://registry.npmjs.org/hardhat-exposed/-/hardhat-exposed-0.3.12-1.tgz",
-      "integrity": "sha512-hDhh+wC6usu/OPT4v6hi+JdBxZJDgi6gVAw/45ApY7rgODCqpan7+8GuVwOtu0YK/9wPN9Y065MzAVFqJtylgA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/hardhat-exposed/-/hardhat-exposed-0.3.13.tgz",
+      "integrity": "sha512-hY2qCYSi2wD2ChZ0WP0oEPS4zlZ2vGaLOVXvfosGcy6mNeQ+pWsxTge35tTumCHwCzk/dYxLZq+KW0Z5t08yDA==",
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@openzeppelin/docs-utils": "^0.1.4",
     "@openzeppelin/test-helpers": "^0.5.13",
-    "@openzeppelin/upgrade-safe-transpiler": "^0.3.30",
+    "@openzeppelin/upgrade-safe-transpiler": "^0.3.31",
     "@openzeppelin/upgrades-core": "^1.20.6",
     "array.prototype.at": "^1.1.1",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "glob": "^10.3.5",
     "graphlib": "^2.1.8",
     "hardhat": "^2.9.1",
-    "hardhat-exposed": "^0.3.12-1",
+    "hardhat-exposed": "^0.3.13",
     "hardhat-gas-reporter": "^1.0.4",
     "hardhat-ignore-warnings": "^0.2.0",
     "keccak256": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@changesets/cli": "^2.26.0",
     "@changesets/pre": "^1.0.14",
     "@changesets/read": "^0.5.9",
+    "@nomicfoundation/hardhat-foundry": "^1.1.1",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.3",
     "@nomiclabs/hardhat-truffle5": "^2.0.5",
     "@nomiclabs/hardhat-web3": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@openzeppelin/docs-utils": "^0.1.4",
     "@openzeppelin/test-helpers": "^0.5.13",
-    "@openzeppelin/upgrade-safe-transpiler": "^0.3.31",
+    "@openzeppelin/upgrade-safe-transpiler": "^0.3.32",
     "@openzeppelin/upgrades-core": "^1.20.6",
     "array.prototype.at": "^1.1.1",
     "chai": "^4.2.0",

--- a/scripts/upgradeable/transpile-onto.sh
+++ b/scripts/upgradeable/transpile-onto.sh
@@ -41,9 +41,9 @@ if git diff --quiet --cached; then
   exit
 fi
 
-if [[ -v REMOTE ]]; then
+if [[ -v SUBMODULE_REMOTE ]]; then
   lib=lib/openzeppelin-contracts
-  git submodule add -b "${base#origin/}" "$REMOTE" "$lib"
+  git submodule add -b "${base#origin/}" "$SUBMODULE_REMOTE" "$lib"
   git -C "$lib" checkout "$commit"
   git add "$lib"
 fi

--- a/scripts/upgradeable/transpile-onto.sh
+++ b/scripts/upgradeable/transpile-onto.sh
@@ -15,7 +15,7 @@ base="${2-}"
 bash scripts/upgradeable/transpile.sh
 
 commit="$(git rev-parse --short HEAD)"
-branch="$(git rev-parse --abbrev-ref HEAD)"
+start_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 git add contracts
 
@@ -43,10 +43,12 @@ fi
 
 if [[ -v REMOTE ]]; then
   lib=lib/openzeppelin-contracts
-  git submodule add -b "$branch" "$REMOTE" "$lib"
+  git submodule add -b "${base#origin/}" "$REMOTE" "$lib"
   git -C "$lib" checkout "$commit"
   git add "$lib"
 fi
 
 git commit -m "Transpile $commit"
-git checkout "$branch"
+
+# return to original branch
+git checkout "$start_branch"

--- a/scripts/upgradeable/transpile-onto.sh
+++ b/scripts/upgradeable/transpile-onto.sh
@@ -36,9 +36,17 @@ else
   fi
 fi
 
-# commit if there are changes to commit
-if ! git diff --quiet --cached; then
-  git commit -m "Transpile $commit"
+# abort if there are no changes to commit at this point
+if git diff --quiet --cached; then
+  exit
 fi
 
+if [[ -v REMOTE ]]; then
+  lib=lib/openzeppelin-contracts
+  git submodule add -b "$branch" "$REMOTE" "$lib"
+  git -C "$lib" checkout "$commit"
+  git add "$lib"
+fi
+
+git commit -m "Transpile $commit"
 git checkout "$branch"

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -319,6 +319,14 @@ index 3a1617c09..97e59c2d9 100644
    },
    "keywords": [
      "solidity",
+diff --git a/remappings.txt b/remappings.txt
+index 304d1386a..a1cd63bee 100644
+--- a/remappings.txt
++++ b/remappings.txt
+@@ -1 +1,2 @@
+-@openzeppelin/contracts/=contracts/
++@openzeppelin/contracts-upgradeable/=contracts/
++@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 diff --git a/test/utils/cryptography/EIP712.test.js b/test/utils/cryptography/EIP712.test.js
 index faf01f1a3..b25171a56 100644
 --- a/test/utils/cryptography/EIP712.test.js


### PR DESCRIPTION
Following #4628, this PR sets up the vanilla contracts in a submodule and updates remappings.txt accordingly.

In order for Hardhat to respect remappings.txt, we need the `hardhat-foundry` plugin to be installed, which needs the `forge` executable in scope.

Find the result for this PR here: https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/tree/partial-submodules