### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -147,16 +147,12 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           path: ${{ steps.pack.outputs.tarball }}
-      - name: Tag
-        run: npx changeset tag
       - name: Publish
         run: bash scripts/release/workflow/publish.sh
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TARBALL: ${{ steps.pack.outputs.tarball }}
           TAG: ${{ steps.pack.outputs.tag }}
-      - name: Push tags
-        run: git push --tags
       - name: Create Github Release
         uses: actions/github-script@v6
         env:

--- a/scripts/release/workflow/github-release.js
+++ b/scripts/release/workflow/github-release.js
@@ -9,6 +9,7 @@ module.exports = async ({ github, context }) => {
     owner: context.repo.owner,
     repo: context.repo.repo,
     tag_name: `v${version}`,
+    target_commitish: github.ref_name,
     body: extractSection(changelog, version),
     prerelease: process.env.PRERELEASE === 'true',
   });


### PR DESCRIPTION
We're having an issue with automated releases where the tag that gets created in the process is not correctly assigned to the release commit (even though the rest of the release is all done correctly). We believe this is because `npx changeset tag; git push --tags` is either not creating the tag or not pushing it correctly, causing the subsequent `createRelease` API call in `github-release.js` to create the tag in the default branch. This PR removes the manual tagging and relies on `createRelease` by specifying the `target_commitish` option ([docs here](https://octokit.github.io/rest.js/v18#repos-create-release)).