### PR TITLE
Reset Hardhat Network before each test suite

### DIFF
--- a/hardhat/env-contract.js
+++ b/hardhat/env-contract.js
@@ -4,10 +4,8 @@ extendEnvironment(env => {
   env.contract = function (name, body) {
     const { takeSnapshot } = require('@nomicfoundation/hardhat-network-helpers');
 
-    // remove the default account from the accounts list used in tests, in order
-    // to protect tests against accidentally passing due to the contract
-    // deployer being used subsequently as function caller
     contract(name, accounts => {
+      // reset the state of the chain in between contract test suites
       let snapshot;
 
       before(async function () {
@@ -18,6 +16,9 @@ extendEnvironment(env => {
         await snapshot.restore();
       });
 
+      // remove the default account from the accounts list used in tests, in order
+      // to protect tests against accidentally passing due to the contract
+      // deployer being used subsequently as function caller
       body(accounts.slice(1));
     });
   };

--- a/hardhat/env-contract.js
+++ b/hardhat/env-contract.js
@@ -2,9 +2,23 @@ extendEnvironment(env => {
   const { contract } = env;
 
   env.contract = function (name, body) {
+    const { takeSnapshot } = require('@nomicfoundation/hardhat-network-helpers');
+
     // remove the default account from the accounts list used in tests, in order
     // to protect tests against accidentally passing due to the contract
     // deployer being used subsequently as function caller
-    contract(name, accounts => body(accounts.slice(1)));
+    contract(name, accounts => {
+      let snapshot;
+
+      before(async function () {
+        snapshot = await takeSnapshot();
+      });
+
+      after(async function () {
+        await snapshot.restore();
+      });
+
+      body(accounts.slice(1));
+    });
   };
 });


### PR DESCRIPTION
Prevents issues from growing the block timestamp too much.