### PR TITLE
Update SupportsInterface.behavior.js

### DIFF
--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -896,7 +896,7 @@ function shouldBehaveLikeERC1155([minter, firstTokenHolder, secondTokenHolder, m
       });
     });
 
-    shouldSupportInterfaces(['ERC165', 'ERC1155']);
+    shouldSupportInterfaces(['ERC165', 'ERC1155', 'ERC1155MetadataURI']);
   });
 }
 

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -26,6 +26,7 @@ const INTERFACES = {
     'safeTransferFrom(address,address,uint256,uint256,bytes)',
     'safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)',
   ],
+  ERC1155MetadataURI: ['uri(uint256)'],
   ERC1155Receiver: [
     'onERC1155Received(address,address,uint256,uint256,bytes)',
     'onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)',


### PR DESCRIPTION
Add Interface for ERC1155MetadataURI, so ERC1155 contracts can be fully checked (OZ ERC1155 supportsInterface() call will return true for both ERC1155 and ERC1155MetadataURI)

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

Added ERC1155MetadataURI interface definition, so that tests can be run using ERC1155MetadataURI key.
My company maintains its own version of this definition here: https://github.com/NFTCulture/nftc-contracts/blob/main/src/utils/introspection/OZ_Interfaces.ts

We use use that definition in our own typescript tests. We tested our own implementation of shouldSupportInterfaces (https://github.com/NFTCulture/nftc-contracts/blob/main/src/utils/introspection/test/behaviors/SupportsInterfaces.ts) and an ERC1155 contract derived from OZ ERC1155, and the tests pass as expected.

Since we do not use the javascript library and most of the implementation, we did not write JS tests in OZ library for this specific thing.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
