### PR TITLE
Add compile step in `checks.yml`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Compile contracts # TODO: Remove after migrating tests to ethers
+        run: npm run compile
       - name: Run tests and generate gas report
         run: npm run test
       - name: Check linearisation of the inheritance graph


### PR DESCRIPTION
The tests in #4657 not passing due to Hardhat error decoding. The good news is that `Ownable` and `Ownable2Step` are passing, meaning that the ethers migration should solve the decoding issues (possibly also for #4349).

In the meantime, the tests pass locally if `npm run compile` is run after an `npm run clean`.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
