### PR TITLE
Add `view` modifier to `proxyAdmin` in TransparentUpgradeableProxy

### DIFF
--- a/.changeset/eleven-planets-relax.md
+++ b/.changeset/eleven-planets-relax.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`TransparentUpgradeableProxy`: Make internal `_proxyAdmin()` getter to have `view` visibility.

--- a/.changeset/eleven-planets-relax.md
+++ b/.changeset/eleven-planets-relax.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`TransparentUpgradeableProxy`: Make internal `_proxyAdmin()` getter to have `view` visibility.
+`TransparentUpgradeableProxy`: Make internal `_proxyAdmin()` getter have `view` visibility.

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -83,7 +83,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
      * @dev Returns the admin of this proxy.
      */
-    function _proxyAdmin() internal virtual returns (address) {
+    function _proxyAdmin() internal virtual view returns (address) {
         return _admin;
     }
 

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -50,7 +50,7 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  * IMPORTANT: This contract avoids unnecessary storage reads by setting the admin only during construction as an
  * immutable variable, preventing any changes thereafter. However, the admin slot defined in ERC-1967 can still be
  * overwritten by the implementation logic pointed to by this proxy. In such cases, the contract may end up in an
- * undesirable state where the admin slot is different from the actual admin. Relying in the value of the admin slot
+ * undesirable state where the admin slot is different from the actual admin. Relying on the value of the admin slot
  * is generally fine if the implementation is trusted.
  *
  * WARNING: It is not recommended to extend this contract to add additional external functions. If you do so, the

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -83,7 +83,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
     /**
      * @dev Returns the admin of this proxy.
      */
-    function _proxyAdmin() internal virtual view returns (address) {
+    function _proxyAdmin() internal view virtual returns (address) {
         return _admin;
     }
 


### PR DESCRIPTION
After implementing an [audit recommendation](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4502/commits/c2e835edcc97c3506ad4604ee321f69b9cc198a7) to allow anyone to select their proxy admin if they decide to override it, the `_proxyAdmin()` getter remained non `view`.

This is technically breaking but I don't see anyone complaining about that.  The breaking change is that state updates are no longer allowed within an overriden`_proxyAdmin()`.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
