### PR TITLE
Update docs for Ownable2Step

### DIFF
--- a/contracts/access/Ownable2Step.sol
+++ b/contracts/access/Ownable2Step.sol
@@ -10,6 +10,12 @@ import {Ownable} from "./Ownable.sol";
  * there is an account (an owner) that can be granted exclusive access to
  * specific functions.
  *
+ * This extension of the {Ownable} contract includes a two-step mechanism to transfer
+ * ownership, where the new owner must call {acceptOwnership} in order to replace the
+ * old one. This can help prevent common mistakes, such as transfers of ownership to
+ * incorrect accounts, or to contracts that are unable to interact with the 
+ * permission system.
+ *
  * The initial owner is specified at deployment time in the constructor for `Ownable`. This
  * can later be changed with {transferOwnership} and {acceptOwnership}.
  *


### PR DESCRIPTION
Going through the docs I noticed there's no explanation of what `Ownable2Step` is or why it exists, it's just _there_. I added a brief paragraph going over the motivation.