### PR TITLE
Improve ERC4626 virtual offset notes

### DIFF
--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -27,14 +27,14 @@ import {Math} from "../../../utils/math/Math.sol";
  * verifying the amount received is as expected, using a wrapper that performs these checks such as
  * https://github.com/fei-protocol/ERC4626#erc4626router-and-base[ERC4626Router].
  *
- * Since v4.9, this implementation uses virtual assets and shares to mitigate that risk. The `_decimalsOffset()`
- * corresponds to an offset in the decimal representation between the underlying asset's decimals and the vault
- * decimals. This offset also determines the rate of virtual shares to virtual assets in the vault, which itself
- * determines the initial exchange rate. While not fully preventing the attack, analysis shows that the default offset
- * (0) makes it non-profitable, as a result of the value being captured by the virtual shares (out of the attacker's
- * donation) matching the attacker's expected gains. With a larger offset, the attack becomes orders of magnitude more
- * expensive than it is profitable. More details about the underlying math can be found
- * xref:erc4626.adoc#inflation-attack[here].
+ * Since v4.9, this implementation introduces configurable virtual assets and shares to help developers mitigate that risk.
+ * The `_decimalsOffset()` corresponds to an offset in the decimal representation between the underlying asset's decimals 
+ * and the vault decimals. This offset also determines the rate of virtual shares to virtual assets in the vault, which 
+ * itself determines the initial exchange rate. While not fully preventing the attack, analysis shows that the default 
+ * offset (0) makes it non-profitable even if an attacker is able to capture value from multiple user deposits, as a result
+ * of the value being captured by the virtual shares (out of the attacker's donation) matching the attacker's expected gains.
+ * With a larger offset, the attack becomes orders of magnitude more expensive than it is profitable. More details about the
+ * underlying math can be found xref:erc4626.adoc#inflation-attack[here].
  *
  * The drawback of this approach is that the virtual shares do capture (a very small) part of the value being accrued
  * to the vault. Also, if the vault experiences losses, the users try to exit the vault, the virtual shares and assets

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -28,9 +28,9 @@ import {Math} from "../../../utils/math/Math.sol";
  * https://github.com/fei-protocol/ERC4626#erc4626router-and-base[ERC4626Router].
  *
  * Since v4.9, this implementation introduces configurable virtual assets and shares to help developers mitigate that risk.
- * The `_decimalsOffset()` corresponds to an offset in the decimal representation between the underlying asset's decimals 
- * and the vault decimals. This offset also determines the rate of virtual shares to virtual assets in the vault, which 
- * itself determines the initial exchange rate. While not fully preventing the attack, analysis shows that the default 
+ * The `_decimalsOffset()` corresponds to an offset in the decimal representation between the underlying asset's decimals
+ * and the vault decimals. This offset also determines the rate of virtual shares to virtual assets in the vault, which
+ * itself determines the initial exchange rate. While not fully preventing the attack, analysis shows that the default
  * offset (0) makes it non-profitable even if an attacker is able to capture value from multiple user deposits, as a result
  * of the value being captured by the virtual shares (out of the attacker's donation) matching the attacker's expected gains.
  * With a larger offset, the attack becomes orders of magnitude more expensive than it is profitable. More details about the


### PR DESCRIPTION
After an ERC4626 analysis report from Certik indicating the possibility of extending the profitability of an inflation attack, we agreed that the current documentation may give the sense to the reader that an attack is not profitable every time. However, there's the case in which an attacker can get minimal (if not negligible) returns from the rounding error captured by the vault if such an attacker is the holder of the majority of shares.

Rewording for clarity.

Linking [this simulation](https://www.desmos.com/calculator/uhundurngt?lang=es) where the rounding error, deposit rate, withdraw rate, amount deposited, and offset are modeled for comprehension.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
