### PR TITLE
Migrate finance tests to ethers.js

### DIFF
--- a/test/finance/VestingWallet.behavior.js
+++ b/test/finance/VestingWallet.behavior.js
@@ -1,10 +1,6 @@
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const { expect } = require('chai');
 
-function releasedEvent(token) {
-  return token ? 'ERC20Released' : 'EtherReleased';
-}
-
 function shouldBehaveLikeVesting() {
   it('check vesting schedule', async function () {
     for (const timestamp of this.schedule) {
@@ -21,7 +17,7 @@ function shouldBehaveLikeVesting() {
     {
       const tx = await this.mock.release(...this.args);
       await expect(tx)
-        .to.emit(this.mock, releasedEvent(this.token))
+        .to.emit(this.mock, this.releasedEvent)
         .withArgs(...this.argsVerify, 0);
 
       await this.checkRelease(tx, 0n);
@@ -32,8 +28,7 @@ function shouldBehaveLikeVesting() {
       const vested = this.vestingFn(timestamp);
 
       const tx = await this.mock.release(...this.args);
-      await expect(tx)
-        .to.emit(this.mock, releasedEvent(this.token))
+      await expect(tx).to.emit(this.mock, this.releasedEvent);
 
       await this.checkRelease(tx, vested - released);
       released = vested;

--- a/test/finance/VestingWallet.behavior.js
+++ b/test/finance/VestingWallet.behavior.js
@@ -7,28 +7,22 @@ function releasedEvent(token) {
 
 function shouldBehaveLikeVesting() {
   it('check vesting schedule', async function () {
-    const args = this.token ? [this.token.address] : [];
-
     for (const timestamp of this.schedule) {
       await time.increaseTo(timestamp);
       const vesting = this.vestingFn(timestamp);
 
-      expect(await this.mock.vestedAmount(...args, timestamp)).to.be.equal(vesting);
-      expect(await this.mock.releasable(...args)).to.be.equal(vesting);
+      expect(await this.mock.vestedAmount(...this.args, timestamp)).to.be.equal(vesting);
+      expect(await this.mock.releasable(...this.args)).to.be.equal(vesting);
     }
   });
 
   it('execute vesting schedule', async function () {
-    const args = this.token ? [this.token.address] : [];
-
     let released = 0n;
-    const before = await this.getBalance(this.beneficiary);
-
     {
-      const tx = await this.mock.release(...args);
+      const tx = await this.mock.release(...this.args);
       await expect(tx)
         .to.emit(this.mock, releasedEvent(this.token))
-        .withArgs(...args, 0);
+        .withArgs(...this.argsVerify, 0);
 
       await this.checkRelease(tx, 0n);
     }
@@ -37,7 +31,7 @@ function shouldBehaveLikeVesting() {
       await time.setNextBlockTimestamp(timestamp);
       const vested = this.vestingFn(timestamp);
 
-      const tx = await this.mock.release(...args);
+      const tx = await this.mock.release(...this.args);
       await expect(tx)
         .to.emit(this.mock, releasedEvent(this.token))
 
@@ -45,8 +39,6 @@ function shouldBehaveLikeVesting() {
       released = vested;
     }
   });
-
-  it('Rejects execution if transaction fails')
 }
 
 module.exports = {

--- a/test/finance/VestingWallet.behavior.js
+++ b/test/finance/VestingWallet.behavior.js
@@ -1,10 +1,10 @@
-const { time } = require('@nomicfoundation/hardhat-network-helpers');
 const { expect } = require('chai');
+const { bigint: time } = require('../helpers/time');
 
 function shouldBehaveLikeVesting() {
   it('check vesting schedule', async function () {
     for (const timestamp of this.schedule) {
-      await time.increaseTo(timestamp);
+      await time.forward.timestamp(timestamp);
       const vesting = this.vestingFn(timestamp);
 
       expect(await this.mock.vestedAmount(...this.args, timestamp)).to.be.equal(vesting);
@@ -24,7 +24,7 @@ function shouldBehaveLikeVesting() {
     }
 
     for (const timestamp of this.schedule) {
-      await time.setNextBlockTimestamp(timestamp);
+      await time.forward.timestamp(timestamp, false);
       const vested = this.vestingFn(timestamp);
 
       const tx = await this.mock.release(...this.args);

--- a/test/finance/VestingWallet.behavior.js
+++ b/test/finance/VestingWallet.behavior.js
@@ -1,57 +1,52 @@
 const { time } = require('@nomicfoundation/hardhat-network-helpers');
-const { expectEvent } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 
-function releasedEvent(token, amount) {
-  return token ? ['ERC20Released', { token: token.address, amount }] : ['EtherReleased', { amount }];
+function releasedEvent(token) {
+  return token ? 'ERC20Released' : 'EtherReleased';
 }
 
-function shouldBehaveLikeVesting(beneficiary) {
+function shouldBehaveLikeVesting() {
   it('check vesting schedule', async function () {
-    const [vestedAmount, releasable, ...args] = this.token
-      ? ['vestedAmount(address,uint64)', 'releasable(address)', this.token.address]
-      : ['vestedAmount(uint64)', 'releasable()'];
+    const args = this.token ? [this.token.address] : [];
 
     for (const timestamp of this.schedule) {
       await time.increaseTo(timestamp);
       const vesting = this.vestingFn(timestamp);
 
-      expect(await this.mock.methods[vestedAmount](...args, timestamp)).to.be.bignumber.equal(vesting);
-
-      expect(await this.mock.methods[releasable](...args)).to.be.bignumber.equal(vesting);
+      expect(await this.mock.vestedAmount(...args, timestamp)).to.be.equal(vesting);
+      expect(await this.mock.releasable(...args)).to.be.equal(vesting);
     }
   });
 
   it('execute vesting schedule', async function () {
-    const [release, ...args] = this.token ? ['release(address)', this.token.address] : ['release()'];
+    const args = this.token ? [this.token.address] : [];
 
-    let released = web3.utils.toBN(0);
-    const before = await this.getBalance(beneficiary);
+    let released = 0n;
+    const before = await this.getBalance(this.beneficiary);
 
     {
-      const receipt = await this.mock.methods[release](...args);
+      const tx = await this.mock.release(...args);
+      await expect(tx)
+        .to.emit(this.mock, releasedEvent(this.token))
+        .withArgs(...args, 0);
 
-      await expectEvent.inTransaction(receipt.tx, this.mock, ...releasedEvent(this.token, '0'));
-
-      await this.checkRelease(receipt, beneficiary, '0');
-
-      expect(await this.getBalance(beneficiary)).to.be.bignumber.equal(before);
+      await this.checkRelease(tx, 0n);
     }
 
     for (const timestamp of this.schedule) {
       await time.setNextBlockTimestamp(timestamp);
       const vested = this.vestingFn(timestamp);
 
-      const receipt = await this.mock.methods[release](...args);
-      await expectEvent.inTransaction(receipt.tx, this.mock, ...releasedEvent(this.token, vested.sub(released)));
+      const tx = await this.mock.release(...args);
+      await expect(tx)
+        .to.emit(this.mock, releasedEvent(this.token))
 
-      await this.checkRelease(receipt, beneficiary, vested.sub(released));
-
-      expect(await this.getBalance(beneficiary)).to.be.bignumber.equal(before.add(vested));
-
+      await this.checkRelease(tx, vested - released);
       released = vested;
     }
   });
+
+  it('Rejects execution if transaction fails')
 }
 
 module.exports = {

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -1,15 +1,8 @@
-const { constants, expectEvent } = require('@openzeppelin/test-helpers');
-const { web3 } = require('@openzeppelin/test-helpers/src/setup');
-const { expect } = require('chai');
-const { BNmin } = require('../helpers/math');
-const { expectRevertCustomError } = require('../helpers/customError');
-
 const { ethers } = require('hardhat');
+const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { bigint: time } = require('../helpers/time');
-
-const VestingWallet = artifacts.require('VestingWallet');
-const ERC20 = artifacts.require('$ERC20');
+const { min } = require('../helpers/math');
 
 const { shouldBehaveLikeVesting } = require('./VestingWallet.behavior');
 
@@ -23,12 +16,12 @@ async function fixture() {
   return { mock, amount, duration, start, sender, beneficiary, accounts };
 }
 
-contract('VestingWallet', function (accounts) {
+describe.only('VestingWallet', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
-  it.only('rejects zero address for beneficiary', async function () {
+  it('rejects zero address for beneficiary', async function () {
     const tx = ethers.deployContract('VestingWallet', [ethers.ZeroAddress, this.start, this.duration]);
     await expect(tx)
       .revertedWithCustomError(this.mock, 'OwnableInvalidOwner')
@@ -36,25 +29,32 @@ contract('VestingWallet', function (accounts) {
   });
 
   it('check vesting contract', async function () {
-    expect(await this.mock.owner()).to.be.equal(beneficiary);
-    expect(await this.mock.start()).to.be.bignumber.equal(this.start);
-    expect(await this.mock.duration()).to.be.bignumber.equal(duration);
-    expect(await this.mock.end()).to.be.bignumber.equal(this.start.add(duration));
+    expect(await this.mock.owner()).to.be.equal(this.beneficiary.address);
+    expect(await this.mock.start()).to.be.equal(this.start);
+    expect(await this.mock.duration()).to.be.equal(this.duration);
+    expect(await this.mock.end()).to.be.equal(this.start + this.duration);
   });
 
   describe('vesting schedule', function () {
     beforeEach(async function () {
       this.schedule = Array(64)
         .fill()
-        .map((_, i) => web3.utils.toBN(i).mul(duration).divn(60).add(this.start));
-      this.vestingFn = timestamp => BNmin(amount, amount.mul(timestamp.sub(this.start)).div(duration));
+        .map((_, i) => BigInt(i) * this.duration / 60n + this.start);
+      this.vestingFn = timestamp => min(this.amount, this.amount * (timestamp - this.start) / this.duration);
     });
 
-    describe('Eth vesting', function () {
+    describe.only('Eth vesting', function () {
+      before(async function () {
+        this.getBalance = signer => ethers.provider.getBalance(signer);
+        this.checkRelease = async (tx, amount) => expect(tx)
+          .to.changeEtherBalances([this.beneficiary.address], [amount]);
+        
+        this.releasedEvent = 'EtherReleased'
+        this.args = [];
+      });
+
       beforeEach(async function () {
-        await web3.eth.sendTransaction({ from: sender, to: this.mock.address, value: amount });
-        this.getBalance = account => web3.eth.getBalance(account).then(web3.utils.toBN);
-        this.checkRelease = () => {};
+        await this.sender.sendTransaction({to: this.mock, value: this.amount});
       });
 
       shouldBehaveLikeVesting();
@@ -64,10 +64,18 @@ contract('VestingWallet', function (accounts) {
       beforeEach(async function () {
         this.token = await ERC20.new('Name', 'Symbol');
         this.getBalance = account => this.token.balanceOf(account);
-        this.checkRelease = (receipt, to, value) =>
-          expectEvent.inTransaction(receipt.tx, this.token, 'Transfer', { from: this.mock.address, to, value });
-
+        this.checkRelease = async (tx, amount) => {
+          await expect(tx)
+            .to.emit(this.token, 'Transfer')
+            .withArgs(this.mock.target, this.beneficiary.address, amount);
+          await expect(tx)
+            .to.changeTokenBalances([this.mock, this.beneficiary], [-amount, amount]);
+        }
+        
         await this.token.$_mint(this.mock.address, amount);
+
+        this.releasedEvent = 'EtherReleased'
+        this.args = [];
       });
 
       shouldBehaveLikeVesting();

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -24,9 +24,7 @@ describe('VestingWallet', function () {
 
   it('rejects zero address for beneficiary', async function () {
     const tx = ethers.deployContract('VestingWallet', [ethers.ZeroAddress, this.start, this.duration]);
-    await expect(tx)
-      .revertedWithCustomError(this.mock, 'OwnableInvalidOwner')
-      .withArgs(ethers.ZeroAddress);
+    await expect(tx).revertedWithCustomError(this.mock, 'OwnableInvalidOwner').withArgs(ethers.ZeroAddress);
   });
 
   it('check vesting contract', async function () {
@@ -40,19 +38,18 @@ describe('VestingWallet', function () {
     beforeEach(async function () {
       this.schedule = Array(64)
         .fill()
-        .map((_, i) => BigInt(i) * this.duration / 60n + this.start);
-      this.vestingFn = timestamp => min(this.amount, this.amount * (timestamp - this.start) / this.duration);
+        .map((_, i) => (BigInt(i) * this.duration) / 60n + this.start);
+      this.vestingFn = timestamp => min(this.amount, (this.amount * (timestamp - this.start)) / this.duration);
     });
 
     describe('Eth vesting', function () {
       beforeEach(async function () {
-        await this.sender.sendTransaction({to: this.mock, value: this.amount});
+        await this.sender.sendTransaction({ to: this.mock, value: this.amount });
 
         this.getBalance = signer => ethers.provider.getBalance(signer);
-        this.checkRelease = async (tx, amount) => expect(tx)
-          .to.changeEtherBalances([this.beneficiary], [amount]);
-        
-        this.releasedEvent = 'EtherReleased'
+        this.checkRelease = async (tx, amount) => expect(tx).to.changeEtherBalances([this.beneficiary], [amount]);
+
+        this.releasedEvent = 'EtherReleased';
         this.args = [];
         this.argsVerify = [];
       });
@@ -65,16 +62,13 @@ describe('VestingWallet', function () {
         this.token = await ethers.deployContract('$ERC20', ['Name', 'Symbol']);
         this.getBalance = account => this.token.balanceOf(account);
         this.checkRelease = async (tx, amount) => {
-          await expect(tx)
-            .to.emit(this.token, 'Transfer')
-            .withArgs(this.mock.target, this.beneficiary.address, amount);
-          await expect(tx)
-            .to.changeTokenBalances(this.token, [this.mock, this.beneficiary], [-amount, amount]);
-        }
-        
+          await expect(tx).to.emit(this.token, 'Transfer').withArgs(this.mock.target, this.beneficiary.address, amount);
+          await expect(tx).to.changeTokenBalances(this.token, [this.mock, this.beneficiary], [-amount, amount]);
+        };
+
         await this.token.$_mint(this.mock, this.amount);
 
-        this.releasedEvent = 'ERC20Released'
+        this.releasedEvent = 'ERC20Released';
         this.args = [Typed.address(this.token.target)];
         this.argsVerify = [this.token.target];
       });

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -35,7 +35,7 @@ describe('VestingWallet', function () {
   });
 
   describe('vesting schedule', function () {
-    beforeEach(async function () {
+    beforeEach(function () {
       this.schedule = Array(64)
         .fill()
         .map((_, i) => (BigInt(i) * this.duration) / 60n + this.start);
@@ -47,7 +47,7 @@ describe('VestingWallet', function () {
         await this.sender.sendTransaction({ to: this.mock, value: this.amount });
 
         this.getBalance = signer => ethers.provider.getBalance(signer);
-        this.checkRelease = async (tx, amount) => expect(tx).to.changeEtherBalances([this.beneficiary], [amount]);
+        this.checkRelease = (tx, amount) => expect(tx).to.changeEtherBalances([this.beneficiary], [amount]);
 
         this.releasedEvent = 'EtherReleased';
         this.args = [];


### PR DESCRIPTION
This PR migrates VestingWallet tests to ethersjs v6


#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
