### PR TITLE
Making ERC721 mint virtual

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -281,7 +281,7 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
      *
      * Emits a {Transfer} event.
      */
-    function _mint(address to, uint256 tokenId) internal {
+    function _mint(address to, uint256 tokenId) internal virtual {
         if (to == address(0)) {
             revert ERC721InvalidReceiver(address(0));
         }


### PR DESCRIPTION
Hey everyone!

We had a small issue at Mean, where we wanted to set up an abstract contract that would implement ERC721, but add some extra features to it. One of the things we wanted to do, was automatically assign an incremental id to tokens during mints, so that supply + mint ids are tracked directly by our abstract contract.

The thing is that since `_mint` is not virtual, we can't prevent people from using it directly and avoiding our logic. I'm curious as to why `_mint` isn't virtual in the first place, but since `_safeMint` is. Per guidelines:
> Functions should be declared virtual, with few exceptions listed below...

Anyways, this is a way to ask if there is a reason why `_mint` isn't virtual ,and if there isn't, we are making the change here

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
