### PR TITLE
Use the inherited EIP712 name in the Governor contract

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -44,7 +44,6 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
     }
 
     bytes32 private constant ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
-    string private _name;
 
     mapping(uint256 proposalId => ProposalCore) private _proposals;
 
@@ -72,9 +71,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
     /**
      * @dev Sets the value for {name} and {version}
      */
-    constructor(string memory name_) EIP712(name_, version()) {
-        _name = name_;
-    }
+    constructor(string memory name_) EIP712(name_, version()) {}
 
     /**
      * @dev Function to receive ETH that will be handled by the governor (disabled if executor is a third party contract)
@@ -99,7 +96,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      * @dev See {IGovernor-name}.
      */
     function name() public view virtual returns (string memory) {
-        return _name;
+        return _EIP712Name();
     }
 
     /**


### PR DESCRIPTION
The Governor contract includes a {_name} state variable, but the parent EIP712 contract already uses and stores the exact same value. This is unnecessary duplicate storage.

This PR removes the duplicate {_name} state variable from the Governor, and in the Governor's public "name()" function, returns the result of the internal EIP712 function for retrieving the {_name} value.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
