### PR TITLE
Add note in ERC20Wrapper about rebasing tokens

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -12,6 +12,9 @@ import {SafeERC20} from "../utils/SafeERC20.sol";
  * Users can deposit and withdraw "underlying tokens" and receive a matching number of "wrapped tokens". This is useful
  * in conjunction with other modules. For example, combining this wrapping mechanism with {ERC20Votes} will allow the
  * wrapping of an existing "basic" ERC-20 into a governance token.
+ *
+ * NOTE: Any mechanism in which the underlying token changes the {balanceOf} of an account without an explicit transfer
+ * will desynchronize the wrapper's supply and its balance. See {_recover} for recovering value accrued to the wrapper.
  */
 abstract contract ERC20Wrapper is ERC20 {
     IERC20 private immutable _underlying;
@@ -75,8 +78,8 @@ abstract contract ERC20Wrapper is ERC20 {
     }
 
     /**
-     * @dev Mint wrapped token to cover any underlyingTokens that would have been transferred by mistake. Internal
-     * function that can be exposed with access control if desired.
+     * @dev Mint wrapped token to cover any underlyingTokens that would have been transferred by mistake or acquired from
+     * rebasing mechanisms. Internal function that can be exposed with access control if desired.
      */
     function _recover(address account) internal virtual returns (uint256) {
         uint256 value = _underlying.balanceOf(address(this)) - totalSupply();

--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -14,7 +14,7 @@ import {SafeERC20} from "../utils/SafeERC20.sol";
  * wrapping of an existing "basic" ERC-20 into a governance token.
  *
  * NOTE: Any mechanism in which the underlying token changes the {balanceOf} of an account without an explicit transfer
- * will desynchronize the wrapper's supply and its balance. See {_recover} for recovering value accrued to the wrapper.
+ * may desynchronize the wrapper's supply and its balance. See {_recover} for recovering value accrued to the wrapper.
  */
 abstract contract ERC20Wrapper is ERC20 {
     IERC20 private immutable _underlying;

--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -13,8 +13,10 @@ import {SafeERC20} from "../utils/SafeERC20.sol";
  * in conjunction with other modules. For example, combining this wrapping mechanism with {ERC20Votes} will allow the
  * wrapping of an existing "basic" ERC-20 into a governance token.
  *
- * NOTE: Any mechanism in which the underlying token changes the {balanceOf} of an account without an explicit transfer
- * may desynchronize the wrapper's supply and its balance. See {_recover} for recovering value accrued to the wrapper.
+ * WARNING: Any mechanism in which the underlying token changes the {balanceOf} of an account without an explicit transfer
+ * may desynchronize this contract's supply and its underlying balance. Please exercise caution when wrapping tokens that
+ * may undercollateralize the wrapper (i.e. wrapper's total supply is higher than its underlying balance). See {_recover}
+ * for recovering value accrued to the wrapper.
  */
 abstract contract ERC20Wrapper is ERC20 {
     IERC20 private immutable _underlying;


### PR DESCRIPTION
The ERC20Wrapper contract doesn't include any mention of rebasing tokens. Although there's no way of abstracting the fee mechanism to the wrapper, it can also be a use case to wrap fee-on-transfer tokens. Regardless, it makes sense to add a small note mentioning such cases should be considered.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
