### PR TITLE
Add Governor note for state changes between proposal creation and execution

### DIFF
--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -318,10 +318,10 @@ interface IGovernor is IERC165, IERC6372 {
      *
      * Emits a {ProposalCreated} event.
      *
-     * NOTE: The state of the Governor and `targets` may change since proposal creation until its execution. For example,
-     * the balance of this contract may change or its access control permissions may be modified, possibly compromising
-     * the proposal's ability to execute successfully (e.g. the governor doesn't have enough value to cover a proposal 
-     * with multiple transfers).
+     * NOTE: The state of the Governor and `targets` may change since the proposal creation until its execution.
+     * For example, the balance of this contract could be updated or its access control permissions may be modified,
+     * possibly compromising the proposal's ability to execute successfully (e.g. the governor doesn't have enough
+     * value to cover a proposal with multiple transfers).
      */
     function propose(
         address[] memory targets,

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -317,6 +317,11 @@ interface IGovernor is IERC165, IERC6372 {
      * duration specified by {IGovernor-votingPeriod}.
      *
      * Emits a {ProposalCreated} event.
+     *
+     * NOTE: The state of the Governor and `targets` may change since proposal creation until its execution. For example,
+     * the balance of this contract may change or its access control permissions may be modified, possibly compromising
+     * the proposal's ability to execute successfully (e.g. the governor doesn't have enough value to cover a proposal 
+     * with multiple transfers).
      */
     function propose(
         address[] memory targets,

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -319,6 +319,7 @@ interface IGovernor is IERC165, IERC6372 {
      * Emits a {ProposalCreated} event.
      *
      * NOTE: The state of the Governor and `targets` may change between the proposal creation and its execution.
+     * This may be the result of third party actions on the targeted contracts, or other governor proposals.
      * For example, the balance of this contract could be updated or its access control permissions may be modified,
      * possibly compromising the proposal's ability to execute successfully (e.g. the governor doesn't have enough
      * value to cover a proposal with multiple transfers).

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -318,7 +318,7 @@ interface IGovernor is IERC165, IERC6372 {
      *
      * Emits a {ProposalCreated} event.
      *
-     * NOTE: The state of the Governor and `targets` may change since the proposal creation until its execution.
+     * NOTE: The state of the Governor and `targets` may change between the proposal creation and its execution.
      * For example, the balance of this contract could be updated or its access control permissions may be modified,
      * possibly compromising the proposal's ability to execute successfully (e.g. the governor doesn't have enough
      * value to cover a proposal with multiple transfers).


### PR DESCRIPTION
The Governor doesn't check that a proposal is executable at the moment of calling `propose` or `execute`. While this makes sense because the execution requirements can be modified since proposal creation until execution, it's worth noting that such changes may have effects on those proposals that may not be obvious.

A concrete example would be a proposal that transfers a total of 3 ETH among 3 targets. In this case, the proposal will depend on the Governor having 3 ETH on its balance, but a faster proposal may use the funds of the Governor, blocking the execution of the 3rd proposal.

Although, it's not an issue since the proposal can still be executed since the `execute` function is payable, we're adding a note to take in consideration any potential state change between the proposal creation and the proposal execution

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
