### PR TITLE
Add Access Manager explorer note in the docs

### DIFF
--- a/docs/modules/ROOT/pages/access-control.adoc
+++ b/docs/modules/ROOT/pages/access-control.adoc
@@ -159,7 +159,7 @@ For a call to be authorized, the caller must bear the role that is assigned to t
 
 image::access-manager-functions.svg[AccessManager functions]
 
-IMPORTANT: For a visual role explorer, the https://access-manager.openzeppelin.com/[Access Manager explorer] can be used for exploring the roles and permissions of a deployed AccessManager.
+IMPORTANT: For a visual role explorer, the https://access-manager.openzeppelin.com/[AccessManager explorer] can be used for exploring the roles and permissions of a deployed AccessManager. Connecting a wallet is supported to detect and display the roles granted and functions that are available to it.
 
 === Using `AccessManager`
 

--- a/docs/modules/ROOT/pages/access-control.adoc
+++ b/docs/modules/ROOT/pages/access-control.adoc
@@ -159,6 +159,8 @@ For a call to be authorized, the caller must bear the role that is assigned to t
 
 image::access-manager-functions.svg[AccessManager functions]
 
+IMPORTANT: For a visual role explorer, the https://access-manager.openzeppelin.com/[Access Manager explorer] can be used for exploring the roles and permissions of a deployed AccessManager.
+
 === Using `AccessManager`
 
 OpenZeppelin Contracts provides xref:api:access.adoc#AccessManager[`AccessManager`] for managing roles across any number of contracts. The `AccessManager` itself is a contract that can be deployed and used out of the box. It sets an initial admin in the constructor who will be allowed to perform management operations.


### PR DESCRIPTION
Added a note referencing the [Access Manager explorer](https://access-manager.openzeppelin.com/). Following our announcement plans.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
