### PR TITLE
Remove Context from "Ownable" contract

### DIFF
--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.20;
 
-import {Context} from "../utils/Context.sol";
-
 /**
  * @dev Contract module which provides a basic access control mechanism, where
  * there is an account (an owner) that can be granted exclusive access to
@@ -17,7 +15,7 @@ import {Context} from "../utils/Context.sol";
  * `onlyOwner`, which can be applied to your functions to restrict their use to
  * the owner.
  */
-abstract contract Ownable is Context {
+abstract contract Ownable {
     address private _owner;
 
     /**
@@ -61,8 +59,8 @@ abstract contract Ownable is Context {
      * @dev Throws if the sender is not the owner.
      */
     function _checkOwner() internal view virtual {
-        if (owner() != _msgSender()) {
-            revert OwnableUnauthorizedAccount(_msgSender());
+        if (owner() != msg.sender) {
+            revert OwnableUnauthorizedAccount(msg.sender);
         }
     }
 

--- a/contracts/access/Ownable2Step.sol
+++ b/contracts/access/Ownable2Step.sol
@@ -56,7 +56,7 @@ abstract contract Ownable2Step is Ownable {
      * @dev The new owner accepts the ownership transfer.
      */
     function acceptOwnership() public virtual {
-        address sender = _msgSender();
+        address sender = msg.sender;
         if (pendingOwner() != sender) {
             revert OwnableUnauthorizedAccount(sender);
         }


### PR DESCRIPTION
By default, the "Ownable" and "Ownable2Step" contracts make use of "Context" to create the option for _msgSender() to be used for validating message senders.

However, for most "ownerOnly" types of functions, proper sender authorization is critical, and these should not be exposed by default to the potential risks or complications from an ERC2771 forwarder implementation.

This PR removes the Context from Ownable and Ownable2Step, and just uses msg.sender by default. Developers can override these functions as desired to use Context if they want, but it shouldn't be included by default.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
