### PR TITLE
Remove changesets already included in CHANGELOG

### DIFF
--- a/.changeset/dull-ghosts-sip.md
+++ b/.changeset/dull-ghosts-sip.md
@@ -1,6 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`AccessManager`, `AccessManaged`, `GovernorTimelockAccess`: Ensure that calldata shorter than 4 bytes is not padded to 4 bytes.
-pr: #4624

--- a/.changeset/grumpy-poets-rush.md
+++ b/.changeset/grumpy-poets-rush.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': major
----
-
-Upgradeable Contracts: No longer transpile interfaces, libraries, and stateless contracts.

--- a/.changeset/purple-squids-attend.md
+++ b/.changeset/purple-squids-attend.md
@@ -1,6 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`AccessManager`: Use named return parameters in functions that return multiple values.
-pr: #4624

--- a/.changeset/rude-weeks-beg.md
+++ b/.changeset/rude-weeks-beg.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`ERC2771Context` and `Context`: Introduce a `_contextPrefixLength()` getter, used to trim extra information appended to `msg.data`.

--- a/.changeset/strong-points-invent.md
+++ b/.changeset/strong-points-invent.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`Multicall`: Make aware of non-canonical context (i.e. `msg.sender` is not `_msgSender()`), allowing compatibility with `ERC2771Context`.

--- a/.changeset/thirty-drinks-happen.md
+++ b/.changeset/thirty-drinks-happen.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': major
----
-
-`AccessManager`: Make `schedule` and `execute` more conservative when delay is 0.


### PR DESCRIPTION
After the 5.0.0 and 5.0.1 releases, we got a few changesets left without removal. The reason for this is that when merging the release branch back to master some changesets may have been modified and no longer match with the original file.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
