### PR TITLE
Erc721 cleanup

### DIFF
--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -10,7 +10,6 @@ const firstTokenId = 5042n;
 const secondTokenId = 79217n;
 const nonExistentTokenId = 13n;
 const fourthTokenId = 4n;
-const baseURI = 'https://api.example.com/v1/';
 
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
@@ -935,31 +934,6 @@ function shouldBehaveLikeERC721Metadata(name, symbol) {
         await expect(this.token.tokenURI(nonExistentTokenId))
           .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
           .withArgs(nonExistentTokenId);
-      });
-
-      describe('base URI', function () {
-        beforeEach(function () {
-          if (!this.token.interface.hasFunction('setBaseURI')) {
-            this.skip();
-          }
-        });
-
-        it('base URI can be set', async function () {
-          await this.token.setBaseURI(baseURI);
-          expect(await this.token.baseURI()).to.equal(baseURI);
-        });
-
-        it('base URI is added as a prefix to the token URI', async function () {
-          await this.token.setBaseURI(baseURI);
-          expect(await this.token.tokenURI(firstTokenId)).to.equal(baseURI + firstTokenId.toString());
-        });
-
-        it('token URI can be changed by changing the base URI', async function () {
-          await this.token.setBaseURI(baseURI);
-          const newBaseURI = 'https://api.example.com/v2/';
-          await this.token.setBaseURI(newBaseURI);
-          expect(await this.token.tokenURI(firstTokenId)).to.equal(newBaseURI + firstTokenId.toString());
-        });
       });
     });
   });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -13,7 +13,7 @@ const fourthTokenId = 4n;
 
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
-function shouldBehaveLikeERC721() {
+function shouldBehaveLikeERC721(extraTxTests) {
   shouldSupportInterfaces(['ERC165', 'ERC721']);
 
   describe('with minted tokens', function () {
@@ -79,12 +79,7 @@ function shouldBehaveLikeERC721() {
           await expect(this.tx).to.changeTokenBalance(this.token, this.owner, -1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          if (!this.token.tokenOfOwnerByIndex) this.skip();
-
-          expect(await this.token.tokenOfOwnerByIndex(this.to, 0n)).to.equal(tokenId);
-          expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.not.equal(tokenId);
-        });
+        extraTxTests?.different(tokenId);
       };
 
       // opts:
@@ -155,13 +150,7 @@ function shouldBehaveLikeERC721() {
             await expect(this.tx).to.changeTokenBalance(this.token, this.owner, 0);
           });
 
-          it('keeps same tokens by index', async function () {
-            if (!this.token.tokenOfOwnerByIndex) this.skip();
-
-            expect(await Promise.all([0n, 1n].map(i => this.token.tokenOfOwnerByIndex(this.owner, i)))).to.have.members(
-              [firstTokenId, secondTokenId],
-            );
-          });
+          extraTxTests?.same([firstTokenId, secondTokenId]);
         });
 
         if (opts.unrestricted)

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -169,7 +169,7 @@ function shouldBehaveLikeERC721() {
             beforeEach(async function () {
               this.tx = await this.token
                 .connect(this.other)
-                [fragment](this.owner, this.other, tokenId, ...(opts.extra ?? []));
+                [fragment](this.owner, this.to, tokenId, ...(opts.extra ?? []));
             });
 
             transferWasSuccessful();

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -78,7 +78,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
           await expect(this.tx).to.changeTokenBalance(this.token, this.owner, -1);
         });
 
-        extraTxTests?.different(tokenId);
+        if (extraTxTests?.transferWasSuccessful) extraTxTests?.transferWasSuccessful(tokenId);
       };
 
       // opts:
@@ -141,7 +141,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
             await expect(this.tx).to.changeTokenBalance(this.token, this.owner, 0);
           });
 
-          extraTxTests?.same([firstTokenId, secondTokenId]);
+          if (extraTxTests?.toOwner) extraTxTests?.toOwner([firstTokenId, secondTokenId]);
         });
 
         if (opts.unrestricted)

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -615,7 +615,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
           await expect(this.token.$_safeMint(ethers.ZeroAddress, firstTokenId))
             .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
             .withArgs(ethers.ZeroAddress);
-        })
+        });
       });
     });
   });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -40,22 +40,14 @@ function shouldBehaveLikeERC721() {
     });
 
     describe('ownerOf', function () {
-      describe('when the given token ID was tracked by this token', function () {
-        const tokenId = firstTokenId;
-
-        it('returns the owner of the given token ID', async function () {
-          expect(await this.token.ownerOf(tokenId)).to.equal(this.owner);
-        });
+      it('when the given token ID was tracked by this token', async function () {
+        expect(await this.token.ownerOf(firstTokenId)).to.equal(this.owner);
       });
 
-      describe('when the given token ID was not tracked by this token', function () {
-        const tokenId = nonExistentTokenId;
-
-        it('reverts', async function () {
-          await expect(this.token.ownerOf(tokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-            .withArgs(tokenId);
-        });
+      it('when the given token ID was not tracked by this token', async function () {
+        await expect(this.token.ownerOf(nonExistentTokenId))
+          .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+          .withArgs(nonExistentTokenId);
       });
     });
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -645,29 +645,24 @@ function shouldBehaveLikeERC721() {
       beforeEach(async function () {
         await this.token.$_mint(this.owner, firstTokenId);
         await this.token.$_mint(this.owner, secondTokenId);
+        this.tx = await this.token.$_burn(firstTokenId);
       });
 
-      describe('with burnt token', function () {
-        beforeEach(async function () {
-          this.tx = await this.token.$_burn(firstTokenId);
-        });
+      it('emits a Transfer event', async function () {
+        await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, ethers.ZeroAddress, firstTokenId);
+      });
 
-        it('emits a Transfer event', async function () {
-          await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, ethers.ZeroAddress, firstTokenId);
-        });
+      it('deletes the token', async function () {
+        expect(await this.token.balanceOf(this.owner)).to.equal(1n);
+        await expect(this.token.ownerOf(firstTokenId))
+          .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+          .withArgs(firstTokenId);
+      });
 
-        it('deletes the token', async function () {
-          expect(await this.token.balanceOf(this.owner)).to.equal(1n);
-          await expect(this.token.ownerOf(firstTokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-            .withArgs(firstTokenId);
-        });
-
-        it('reverts when burning a token id that has been deleted', async function () {
-          await expect(this.token.$_burn(firstTokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-            .withArgs(firstTokenId);
-        });
+      it('reverts when burning a token id that has been deleted', async function () {
+        await expect(this.token.$_burn(firstTokenId))
+          .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+          .withArgs(firstTokenId);
       });
     });
   });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -13,6 +13,11 @@ const nonExistentTokenId = 13n;
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
 function shouldBehaveLikeERC721(extraTxTests) {
+  beforeEach(async function () {
+    const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
+    Object.assign(this, { owner, newOwner, approved, operator, other });
+  });
+
   shouldSupportInterfaces(['ERC165', 'ERC721']);
 
   describe('with minted tokens', function () {
@@ -655,6 +660,11 @@ function shouldBehaveLikeERC721(extraTxTests) {
 }
 
 function shouldBehaveLikeERC721Enumerable() {
+  beforeEach(async function () {
+    const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
+    Object.assign(this, { owner, newOwner, approved, operator, other });
+  });
+
   shouldSupportInterfaces(['ERC721Enumerable']);
 
   describe('with minted tokens', function () {

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -24,24 +24,18 @@ function shouldBehaveLikeERC721() {
     });
 
     describe('balanceOf', function () {
-      describe('when the given address owns some tokens', function () {
-        it('returns the amount of tokens owned by the given address', async function () {
-          expect(await this.token.balanceOf(this.owner)).to.equal(2n);
-        });
+      it('when the given address owns some tokens', async function () {
+        expect(await this.token.balanceOf(this.owner)).to.equal(2n);
       });
 
-      describe('when the given address does not own any tokens', function () {
-        it('returns 0', async function () {
-          expect(await this.token.balanceOf(this.other)).to.equal(0n);
-        });
+      it('when the given address does not own any tokens', async function () {
+        expect(await this.token.balanceOf(this.other)).to.equal(0n);
       });
 
-      describe('when querying the zero address', function () {
-        it('throws', async function () {
-          await expect(this.token.balanceOf(ethers.ZeroAddress))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOwner')
-            .withArgs(ethers.ZeroAddress);
-        });
+      it('when querying the zero address', async function () {
+        await expect(this.token.balanceOf(ethers.ZeroAddress))
+          .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOwner')
+          .withArgs(ethers.ZeroAddress);
       });
     });
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -14,11 +14,6 @@ const fourthTokenId = 4n;
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
 function shouldBehaveLikeERC721() {
-  beforeEach(async function () {
-    const [owner, newOwner, approved, operator, other] = this.accounts;
-    Object.assign(this, { owner, newOwner, approved, operator, other });
-  });
-
   shouldSupportInterfaces(['ERC165', 'ERC721']);
 
   describe('with minted tokens', function () {
@@ -748,11 +743,6 @@ function shouldBehaveLikeERC721() {
 }
 
 function shouldBehaveLikeERC721Enumerable() {
-  beforeEach(async function () {
-    const [owner, newOwner, approved, operator, other] = this.accounts;
-    Object.assign(this, { owner, newOwner, approved, operator, other });
-  });
-
   shouldSupportInterfaces(['ERC721Enumerable']);
 
   describe('with minted tokens', function () {

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -78,7 +78,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
           await expect(this.tx).to.changeTokenBalance(this.token, this.owner, -1);
         });
 
-        if (extraTxTests?.transferWasSuccessful) extraTxTests?.transferWasSuccessful(tokenId);
+        if (extraTxTests?.transferWasSuccessful) extraTxTests.transferWasSuccessful(tokenId);
       };
 
       // opts:
@@ -141,7 +141,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
             await expect(this.tx).to.changeTokenBalance(this.token, this.owner, 0);
           });
 
-          if (extraTxTests?.toOwner) extraTxTests?.toOwner([firstTokenId, secondTokenId]);
+          if (extraTxTests?.toOwner) extraTxTests.toOwner([firstTokenId, secondTokenId]);
         });
 
         if (opts.unrestricted)

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -82,7 +82,6 @@ function shouldBehaveLikeERC721() {
         it('adjusts owners tokens by index', async function () {
           if (!this.token.tokenOfOwnerByIndex) return;
 
-          await this.tx();
           expect(await this.token.tokenOfOwnerByIndex(this.to, 0n)).to.equal(tokenId);
           expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.not.equal(tokenId);
         });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -13,496 +13,762 @@ const nonExistentTokenId = 13n;
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
 function shouldBehaveLikeERC721(extraTxTests) {
-  beforeEach(async function () {
-    const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
-    Object.assign(this, { owner, newOwner, approved, operator, other });
-  });
-
-  shouldSupportInterfaces(['ERC165', 'ERC721']);
-
-  describe('with minted tokens', function () {
+  describe('ERC712 behavior', function () {
     beforeEach(async function () {
-      await this.token.$_mint(this.owner, firstTokenId);
-      await this.token.$_mint(this.owner, secondTokenId);
-      this.to = this.other;
+      const [owner, approved, operator, other] = await ethers.getSigners();
+      Object.assign(this, { owner, approved, operator, other });
     });
 
-    describe('balanceOf', function () {
-      it('when the given address owns some tokens', async function () {
-        expect(await this.token.balanceOf(this.owner)).to.equal(2n);
-      });
+    shouldSupportInterfaces(['ERC165', 'ERC721']);
 
-      it('when the given address does not own any tokens', async function () {
-        expect(await this.token.balanceOf(this.other)).to.equal(0n);
-      });
-
-      it('when querying the zero address', async function () {
-        await expect(this.token.balanceOf(ethers.ZeroAddress))
-          .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOwner')
-          .withArgs(ethers.ZeroAddress);
-      });
-    });
-
-    describe('ownerOf', function () {
-      it('when the given token ID was tracked by this token', async function () {
-        expect(await this.token.ownerOf(firstTokenId)).to.equal(this.owner);
-      });
-
-      it('when the given token ID was not tracked by this token', async function () {
-        await expect(this.token.ownerOf(nonExistentTokenId))
-          .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-          .withArgs(nonExistentTokenId);
-      });
-    });
-
-    describe('transfers', function () {
-      const tokenId = firstTokenId;
-      const data = '0x42';
-
+    describe('with minted tokens', function () {
       beforeEach(async function () {
-        await this.token.connect(this.owner).approve(this.approved, tokenId);
-        await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+        await this.token.$_mint(this.owner, firstTokenId);
+        await this.token.$_mint(this.owner, secondTokenId);
+        this.to = this.other;
       });
 
-      const transferWasSuccessful = () => {
-        it('transfers the ownership of the given token ID to the given address', async function () {
-          expect(await this.token.ownerOf(tokenId)).to.equal(this.to);
+      describe('balanceOf', function () {
+        it('returns the amount of tokens owned by the given address when the given address owns some tokens', async function () {
+          expect(await this.token.balanceOf(this.owner)).to.equal(2n);
         });
 
-        it('emits a Transfer event', async function () {
-          await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, this.to, tokenId);
+        it('returns 0 when the given address does not own any tokens', async function () {
+          expect(await this.token.balanceOf(this.other)).to.equal(0n);
         });
 
-        it('clears the approval for the token ID with no event', async function () {
-          await expect(this.tx).to.not.emit(this.token, 'Approval');
+        it('reverts when querying the zero address', async function () {
+          await expect(this.token.balanceOf(ethers.ZeroAddress))
+            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOwner')
+            .withArgs(ethers.ZeroAddress);
+        });
+      });
 
-          expect(await this.token.getApproved(tokenId)).to.equal(ethers.ZeroAddress);
+      describe('ownerOf', function () {
+        it('returns the owner of the given token ID when the given token ID was tracked by this token', async function () {
+          expect(await this.token.ownerOf(firstTokenId)).to.equal(this.owner);
         });
 
-        it('adjusts owners balances', async function () {
-          await expect(this.tx).to.changeTokenBalance(this.token, this.owner, -1);
+        it('reverts when the given token ID was not tracked by this token', async function () {
+          await expect(this.token.ownerOf(nonExistentTokenId))
+            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+            .withArgs(nonExistentTokenId);
+        });
+      });
+
+      describe('transfers', function () {
+        const tokenId = firstTokenId;
+        const data = '0x42';
+
+        beforeEach(async function () {
+          await this.token.connect(this.owner).approve(this.approved, tokenId);
+          await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
         });
 
-        if (extraTxTests?.transferWasSuccessful) extraTxTests.transferWasSuccessful(tokenId);
-      };
-
-      // opts:
-      //  - extra: extra arguments
-      //  - unrestricted: operator does not need to be allowed
-      const shouldTransferTokensByUsers = function (fragment, opts = {}) {
-        const extra = opts.extra ?? [];
-
-        describe('when called by the owner', function () {
-          beforeEach(async function () {
-            this.tx = await this.token.connect(this.owner)[fragment](this.owner, this.to, tokenId, ...extra);
+        const transferWasSuccessful = () => {
+          it('transfers the ownership of the given token ID to the given address', async function () {
+            expect(await this.token.ownerOf(tokenId)).to.equal(this.to);
           });
 
-          transferWasSuccessful();
-        });
-
-        describe('when called by the approved individual', function () {
-          beforeEach(async function () {
-            this.tx = await this.token.connect(this.approved)[fragment](this.owner, this.to, tokenId, ...extra);
+          it('emits a Transfer event', async function () {
+            await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, this.to, tokenId);
           });
 
-          transferWasSuccessful();
-        });
+          it('clears the approval for the token ID with no event', async function () {
+            await expect(this.tx).to.not.emit(this.token, 'Approval');
 
-        describe('when called by the operator', function () {
-          beforeEach(async function () {
-            this.tx = await this.token.connect(this.operator)[fragment](this.owner, this.to, tokenId, ...extra);
-          });
-
-          transferWasSuccessful();
-        });
-
-        describe('when called by the owner without an approved user', function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).approve(ethers.ZeroAddress, tokenId);
-            this.tx = await this.token.connect(this.operator)[fragment](this.owner, this.to, tokenId, ...extra);
-          });
-
-          transferWasSuccessful();
-        });
-
-        describe('when sent to the owner', function () {
-          beforeEach(async function () {
-            this.tx = await this.token.connect(this.owner)[fragment](this.owner, this.owner, tokenId, ...extra);
-          });
-
-          it('keeps ownership of the token', async function () {
-            expect(await this.token.ownerOf(tokenId)).to.equal(this.owner);
-          });
-
-          it('clears the approval for the token ID', async function () {
             expect(await this.token.getApproved(tokenId)).to.equal(ethers.ZeroAddress);
           });
 
-          it('emits only a transfer event', async function () {
-            await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, this.owner, tokenId);
+          it('adjusts owners balances', async function () {
+            await expect(this.tx).to.changeTokenBalance(this.token, this.owner, -1);
           });
 
-          it('keeps the owner balance', async function () {
-            await expect(this.tx).to.changeTokenBalance(this.token, this.owner, 0);
-          });
+          if (extraTxTests?.transferWasSuccessful) extraTxTests.transferWasSuccessful(tokenId);
+        };
 
-          if (extraTxTests?.toOwner) extraTxTests.toOwner([firstTokenId, secondTokenId]);
-        });
+        // opts:
+        //  - extra: extra transfer arguments
+        //  - unrestricted: operator does not need to be allowed
+        const shouldTransferTokensByUsers = function (fragment, opts = {}) {
+          const extra = opts.extra ?? [];
 
-        if (opts.unrestricted)
-          describe('when the sender is not authorized for the token ', function () {
+          describe('when called by the owner', function () {
             beforeEach(async function () {
-              this.tx = await this.token.connect(this.other)[fragment](this.owner, this.to, tokenId, ...extra);
+              this.tx = await this.token.connect(this.owner)[fragment](this.owner, this.to, tokenId, ...extra);
             });
 
             transferWasSuccessful();
           });
 
-        describe('reverts', function () {
-          it('when the address of the previous owner is incorrect', async function () {
-            await expect(this.token.connect(this.owner)[fragment](this.other, this.other, tokenId, ...extra))
-              .to.be.revertedWithCustomError(this.token, 'ERC721IncorrectOwner')
-              .withArgs(this.other, tokenId, this.owner);
-          });
-
-          if (!opts.unrestricted)
-            it('when the sender is not authorized for the token id', async function () {
-              await expect(this.token.connect(this.other)[fragment](this.owner, this.other, tokenId, ...extra))
-                .to.be.revertedWithCustomError(this.token, 'ERC721InsufficientApproval')
-                .withArgs(this.other, tokenId);
+          describe('when called by the approved individual', function () {
+            beforeEach(async function () {
+              this.tx = await this.token.connect(this.approved)[fragment](this.owner, this.to, tokenId, ...extra);
             });
 
+            transferWasSuccessful();
+          });
+
+          describe('when called by the operator', function () {
+            beforeEach(async function () {
+              this.tx = await this.token.connect(this.operator)[fragment](this.owner, this.to, tokenId, ...extra);
+            });
+
+            transferWasSuccessful();
+          });
+
+          describe('when called by the owner without an approved user', function () {
+            beforeEach(async function () {
+              await this.token.connect(this.owner).approve(ethers.ZeroAddress, tokenId);
+              this.tx = await this.token.connect(this.operator)[fragment](this.owner, this.to, tokenId, ...extra);
+            });
+
+            transferWasSuccessful();
+          });
+
+          describe('when sent to the owner', function () {
+            beforeEach(async function () {
+              this.tx = await this.token.connect(this.owner)[fragment](this.owner, this.owner, tokenId, ...extra);
+            });
+
+            it('keeps ownership of the token', async function () {
+              expect(await this.token.ownerOf(tokenId)).to.equal(this.owner);
+            });
+
+            it('clears the approval for the token ID', async function () {
+              expect(await this.token.getApproved(tokenId)).to.equal(ethers.ZeroAddress);
+            });
+
+            it('emits only a transfer event', async function () {
+              await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, this.owner, tokenId);
+            });
+
+            it('keeps the owner balance', async function () {
+              await expect(this.tx).to.changeTokenBalance(this.token, this.owner, 0);
+            });
+
+            if (extraTxTests?.toOwner) extraTxTests.toOwner([firstTokenId, secondTokenId]);
+          });
+
+          if (opts.unrestricted)
+            describe('when the sender is not authorized for the token ', function () {
+              beforeEach(async function () {
+                this.tx = await this.token.connect(this.other)[fragment](this.owner, this.to, tokenId, ...extra);
+              });
+
+              transferWasSuccessful();
+            });
+
+          describe('reverts', function () {
+            it('when the address of the previous owner is incorrect', async function () {
+              await expect(this.token.connect(this.owner)[fragment](this.other, this.other, tokenId, ...extra))
+                .to.be.revertedWithCustomError(this.token, 'ERC721IncorrectOwner')
+                .withArgs(this.other, tokenId, this.owner);
+            });
+
+            if (!opts.unrestricted)
+              it('when the sender is not authorized for the token id', async function () {
+                await expect(this.token.connect(this.other)[fragment](this.owner, this.other, tokenId, ...extra))
+                  .to.be.revertedWithCustomError(this.token, 'ERC721InsufficientApproval')
+                  .withArgs(this.other, tokenId);
+              });
+
+            it('when the given token ID does not exist', async function () {
+              await expect(
+                this.token.connect(this.owner)[fragment](this.owner, this.other, nonExistentTokenId, ...extra),
+              )
+                .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+                .withArgs(nonExistentTokenId);
+            });
+
+            it('when the address to transfer the token to is the zero address', async function () {
+              await expect(this.token.connect(this.owner)[fragment](this.owner, ethers.ZeroAddress, tokenId, ...extra))
+                .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+                .withArgs(ethers.ZeroAddress);
+            });
+          });
+        };
+
+        // opts:
+        // - extra: extra transfer arguments
+        // - unrestricted: operator does not need to be allowed
+        const shouldTransferSafely = function (fragment, data, opts = {}) {
+          const extra = opts.extra ?? [];
+
+          // sanity
+          it('function exists', async function () {
+            expect(this.token.interface.hasFunction(fragment)).to.be.true;
+          });
+
+          describe('to a user account', function () {
+            shouldTransferTokensByUsers(fragment, opts);
+          });
+
+          describe('to a valid receiver contract', function () {
+            beforeEach(async function () {
+              this.to = await ethers.deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, RevertType.None]);
+            });
+
+            shouldTransferTokensByUsers(fragment, opts);
+
+            it('calls onERC721Received', async function () {
+              await expect(this.token.connect(this.owner)[fragment](this.owner, this.to, tokenId, ...extra))
+                .to.emit(this.to, 'Received')
+                .withArgs(this.owner, this.owner, tokenId, data, anyValue);
+            });
+
+            it('calls onERC721Received from approved', async function () {
+              await expect(this.token.connect(this.approved)[fragment](this.owner, this.to, tokenId, ...extra))
+                .to.emit(this.to, 'Received')
+                .withArgs(this.approved, this.owner, tokenId, data, anyValue);
+            });
+
+            it('with an invalid token id', async function () {
+              await expect(
+                this.token.connect(this.approved)[fragment](this.owner, this.to, nonExistentTokenId, ...extra),
+              )
+                .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+                .withArgs(nonExistentTokenId);
+            });
+          });
+        };
+
+        for (const { fnName, opts } of [
+          { fnName: 'transferFrom', opts: {} },
+          { fnName: '$_transfer', opts: { unrestricted: true } },
+        ]) {
+          describe(`via ${fnName}`, function () {
+            shouldTransferTokensByUsers(fnName, opts);
+          });
+        }
+
+        for (const { fnName, opts } of [
+          { fnName: 'safeTransferFrom', opts: {} },
+          { fnName: '$_safeTransfer', opts: { unrestricted: true } },
+        ]) {
+          describe(`via ${fnName}`, function () {
+            describe('with data', function () {
+              shouldTransferSafely(fnName, data, { ...opts, extra: [ethers.Typed.bytes(data)] });
+            });
+
+            describe('without data', function () {
+              shouldTransferSafely(fnName, '0x', opts);
+            });
+
+            describe('reverts', function () {
+              it('to a receiver contract returning unexpected value', async function () {
+                const invalidReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+                  '0xdeadbeef',
+                  RevertType.None,
+                ]);
+
+                await expect(this.token.connect(this.owner)[fnName](this.owner, invalidReceiver, tokenId))
+                  .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+                  .withArgs(invalidReceiver);
+              });
+
+              it('to a receiver contract that reverts with message', async function () {
+                const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+                  RECEIVER_MAGIC_VALUE,
+                  RevertType.RevertWithMessage,
+                ]);
+
+                await expect(
+                  this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId),
+                ).to.be.revertedWith('ERC721ReceiverMock: reverting');
+              });
+
+              it('to a receiver contract that reverts without message', async function () {
+                const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+                  RECEIVER_MAGIC_VALUE,
+                  RevertType.RevertWithoutMessage,
+                ]);
+
+                await expect(this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId))
+                  .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+                  .withArgs(revertingReceiver);
+              });
+
+              it('to a receiver contract that reverts with custom error', async function () {
+                const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+                  RECEIVER_MAGIC_VALUE,
+                  RevertType.RevertWithCustomError,
+                ]);
+
+                await expect(this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId))
+                  .to.be.revertedWithCustomError(revertingReceiver, 'CustomError')
+                  .withArgs(RECEIVER_MAGIC_VALUE);
+              });
+
+              it('to a receiver contract that panics', async function () {
+                const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+                  RECEIVER_MAGIC_VALUE,
+                  RevertType.Panic,
+                ]);
+
+                await expect(
+                  this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId),
+                ).to.be.revertedWithPanic(PANIC_CODES.DIVISION_BY_ZERO);
+              });
+
+              it('to a contract that does not implement the required function', async function () {
+                const nonReceiver = await ethers.deployContract('CallReceiverMock');
+
+                await expect(this.token.connect(this.owner)[fnName](this.owner, nonReceiver, tokenId))
+                  .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+                  .withArgs(nonReceiver);
+              });
+            });
+          });
+        }
+      });
+
+      describe('approve', function () {
+        const tokenId = firstTokenId;
+
+        const itClearsApproval = function () {
+          it('clears approval for the token', async function () {
+            expect(await this.token.getApproved(tokenId)).to.equal(ethers.ZeroAddress);
+          });
+
+          it('emits an approval event', async function () {
+            await expect(this.tx).to.emit(this.token, 'Approval').withArgs(this.owner, ethers.ZeroAddress, tokenId);
+          });
+        };
+
+        const itApproves = function () {
+          it('sets the approval for the target address', async function () {
+            expect(await this.token.getApproved(tokenId)).to.equal(this.approved);
+          });
+
+          it('emits an approval event', async function () {
+            await expect(this.tx).to.emit(this.token, 'Approval').withArgs(this.owner, this.approved, tokenId);
+          });
+        };
+
+        describe('when clearing approval', function () {
+          describe('when there was no prior approval', function () {
+            beforeEach(async function () {
+              this.tx = await this.token.connect(this.owner).approve(ethers.ZeroAddress, tokenId);
+            });
+
+            itClearsApproval();
+          });
+
+          describe('when there was a prior approval', function () {
+            beforeEach(async function () {
+              await this.token.connect(this.owner).approve(this.other, tokenId);
+              this.tx = await this.token.connect(this.owner).approve(ethers.ZeroAddress, tokenId);
+            });
+
+            itClearsApproval();
+          });
+        });
+
+        describe('when approving a non-zero address', function () {
+          describe('when there was no prior approval', function () {
+            beforeEach(async function () {
+              this.tx = await this.token.connect(this.owner).approve(this.approved, tokenId);
+            });
+
+            itApproves();
+          });
+
+          describe('when there was a prior approval to the same address', function () {
+            beforeEach(async function () {
+              await this.token.connect(this.owner).approve(this.approved, tokenId);
+              this.tx = await this.token.connect(this.owner).approve(this.approved, tokenId);
+            });
+
+            itApproves();
+          });
+
+          describe('when there was a prior approval to a different address', function () {
+            beforeEach(async function () {
+              await this.token.connect(this.owner).approve(this.other, tokenId);
+              this.tx = await this.token.connect(this.owner).approve(this.approved, tokenId);
+            });
+
+            itApproves();
+          });
+        });
+
+        describe('when the sender is an operator', function () {
+          beforeEach(async function () {
+            await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+
+            this.tx = await this.token.connect(this.operator).approve(this.approved, tokenId);
+          });
+
+          itApproves();
+        });
+
+        describe('reverts', function () {
+          it('when the sender does not own the given token ID', async function () {
+            await expect(this.token.connect(this.other).approve(this.approved, tokenId))
+              .to.be.revertedWithCustomError(this.token, 'ERC721InvalidApprover')
+              .withArgs(this.other);
+          });
+
+          it('when the sender is approved for the given token ID', async function () {
+            await this.token.connect(this.owner).approve(this.approved, tokenId);
+
+            await expect(this.token.connect(this.approved).approve(this.other, tokenId))
+              .to.be.revertedWithCustomError(this.token, 'ERC721InvalidApprover')
+              .withArgs(this.approved);
+          });
+
           it('when the given token ID does not exist', async function () {
-            await expect(this.token.connect(this.owner)[fragment](this.owner, this.other, nonExistentTokenId, ...extra))
+            await expect(this.token.connect(this.operator).approve(this.approved, nonExistentTokenId))
               .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
               .withArgs(nonExistentTokenId);
           });
+        });
+      });
 
-          it('when the address to transfer the token to is the zero address', async function () {
-            await expect(this.token.connect(this.owner)[fragment](this.owner, ethers.ZeroAddress, tokenId, ...extra))
+      describe('setApprovalForAll', function () {
+        describe('when the operator willing to approve is not the owner', function () {
+          describe('when there is no operator approval set by the sender', function () {
+            it('approves the operator', async function () {
+              await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+
+              expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
+            });
+
+            it('emits an approval event', async function () {
+              await expect(this.token.connect(this.owner).setApprovalForAll(this.operator, true))
+                .to.emit(this.token, 'ApprovalForAll')
+                .withArgs(this.owner, this.operator, true);
+            });
+          });
+
+          describe('when the operator was set as not approved', function () {
+            beforeEach(async function () {
+              await this.token.connect(this.owner).setApprovalForAll(this.operator, false);
+              this.tx = await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+            });
+
+            it('approves the operator', async function () {
+              expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
+            });
+
+            it('emits an approval event', async function () {
+              await expect(this.tx).to.emit(this.token, 'ApprovalForAll').withArgs(this.owner, this.operator, true);
+            });
+
+            it('can unset the operator approval', async function () {
+              await this.token.connect(this.owner).setApprovalForAll(this.operator, false);
+
+              expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.false;
+            });
+          });
+
+          describe('when the operator was already approved', function () {
+            beforeEach(async function () {
+              await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+              this.tx = this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+            });
+
+            it('keeps the approval to the given address', async function () {
+              expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
+            });
+
+            it('emits an approval event', async function () {
+              await expect(this.tx).to.emit(this.token, 'ApprovalForAll').withArgs(this.owner, this.operator, true);
+            });
+          });
+        });
+
+        it('when the operator is address zero', async function () {
+          await expect(this.token.connect(this.owner).setApprovalForAll(ethers.ZeroAddress, true))
+            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOperator')
+            .withArgs(ethers.ZeroAddress);
+        });
+      });
+
+      describe('getApproved', function () {
+        it('when token is not minted', async function () {
+          await expect(this.token.getApproved(nonExistentTokenId))
+            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+            .withArgs(nonExistentTokenId);
+        });
+
+        describe('when token has been minted ', async function () {
+          it('should return the zero address', async function () {
+            expect(await this.token.getApproved(firstTokenId)).to.equal(ethers.ZeroAddress);
+          });
+
+          it('when account has been approved', async function () {
+            await this.token.connect(this.owner).approve(this.approved, firstTokenId);
+            expect(await this.token.getApproved(firstTokenId)).to.equal(this.approved);
+          });
+        });
+      });
+    });
+
+    describe('mint', function () {
+      describe('_mint', function () {
+        it('reverts with a null destination address', async function () {
+          await expect(this.token.$_mint(ethers.ZeroAddress, firstTokenId))
+            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+            .withArgs(ethers.ZeroAddress);
+        });
+
+        describe('with minted token', async function () {
+          beforeEach(async function () {
+            this.tx = await this.token.$_mint(this.owner, firstTokenId);
+          });
+
+          it('emits a Transfer event', async function () {
+            await expect(this.tx)
+              .to.emit(this.token, 'Transfer')
+              .withArgs(ethers.ZeroAddress, this.owner, firstTokenId);
+          });
+
+          it('creates the token', async function () {
+            expect(await this.token.balanceOf(this.owner)).to.equal(1n);
+            expect(await this.token.ownerOf(firstTokenId)).to.equal(this.owner);
+          });
+
+          it('reverts when adding a token id that already exists', async function () {
+            await expect(this.token.$_mint(this.owner, firstTokenId))
+              .to.be.revertedWithCustomError(this.token, 'ERC721InvalidSender')
+              .withArgs(ethers.ZeroAddress);
+          });
+        });
+      });
+
+      describe('_safeMint', function () {
+        const tokenId = firstTokenId;
+        const data = '0x42';
+
+        it('executes when to is not a contract', async function () {
+          await this.token.$_safeMint(this.owner, tokenId);
+        });
+
+        it('calls onERC721Received — with data', async function () {
+          const receiver = await ethers.deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, RevertType.None]);
+
+          await expect(await this.token.$_safeMint(receiver, tokenId, ethers.Typed.bytes(data)))
+            .to.emit(receiver, 'Received')
+            .withArgs(anyValue, ethers.ZeroAddress, tokenId, data, anyValue);
+        });
+
+        it('calls onERC721Received — without data', async function () {
+          const receiver = await ethers.deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, RevertType.None]);
+
+          await expect(await this.token.$_safeMint(receiver, tokenId))
+            .to.emit(receiver, 'Received')
+            .withArgs(anyValue, ethers.ZeroAddress, tokenId, '0x', anyValue);
+        });
+
+        describe('reverts', function () {
+          it('to a receiver contract returning unexpected value', async function () {
+            const invalidReceiver = await ethers.deployContract('ERC721ReceiverMock', ['0xdeadbeef', RevertType.None]);
+
+            await expect(this.token.$_safeMint(invalidReceiver, tokenId))
+              .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+              .withArgs(invalidReceiver);
+          });
+
+          it('to a receiver contract that reverts with message', async function () {
+            const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+              RECEIVER_MAGIC_VALUE,
+              RevertType.RevertWithMessage,
+            ]);
+
+            await expect(this.token.$_safeMint(revertingReceiver, tokenId)).to.be.revertedWith(
+              'ERC721ReceiverMock: reverting',
+            );
+          });
+
+          it('to a receiver contract that reverts without message', async function () {
+            const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+              RECEIVER_MAGIC_VALUE,
+              RevertType.RevertWithoutMessage,
+            ]);
+
+            await expect(this.token.$_safeMint(revertingReceiver, tokenId))
+              .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+              .withArgs(revertingReceiver);
+          });
+
+          it('to a receiver contract that reverts with custom error', async function () {
+            const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+              RECEIVER_MAGIC_VALUE,
+              RevertType.RevertWithCustomError,
+            ]);
+
+            await expect(this.token.$_safeMint(revertingReceiver, tokenId))
+              .to.be.revertedWithCustomError(revertingReceiver, 'CustomError')
+              .withArgs(RECEIVER_MAGIC_VALUE);
+          });
+
+          it('to a receiver contract that panics', async function () {
+            const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
+              RECEIVER_MAGIC_VALUE,
+              RevertType.Panic,
+            ]);
+
+            await expect(this.token.$_safeMint(revertingReceiver, tokenId)).to.be.revertedWithPanic(
+              PANIC_CODES.DIVISION_BY_ZERO,
+            );
+          });
+
+          it('to a contract that does not implement the required function', async function () {
+            const nonReceiver = await ethers.deployContract('CallReceiverMock');
+
+            await expect(this.token.$_safeMint(nonReceiver, tokenId))
+              .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
+              .withArgs(nonReceiver);
+          });
+
+          it('to zero address', async function () {
+            await expect(this.token.$_safeMint(ethers.ZeroAddress, firstTokenId))
               .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
               .withArgs(ethers.ZeroAddress);
           });
         });
-      };
-
-      // opts:
-      // - extra: extra arguments
-      // - unrestricted: operator does not need to be allowed
-      const shouldTransferSafely = function (fragment, data, opts = {}) {
-        const extra = opts.extra ?? [];
-
-        // sanity
-        it('function exists', async function () {
-          expect(this.token.interface.hasFunction(fragment)).to.be.true;
-        });
-
-        describe('to a user account', function () {
-          shouldTransferTokensByUsers(fragment, opts);
-        });
-
-        describe('to a valid receiver contract', function () {
-          beforeEach(async function () {
-            this.to = await ethers.deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, RevertType.None]);
-          });
-
-          shouldTransferTokensByUsers(fragment, opts);
-
-          it('calls onERC721Received', async function () {
-            await expect(this.token.connect(this.owner)[fragment](this.owner, this.to, tokenId, ...extra))
-              .to.emit(this.to, 'Received')
-              .withArgs(this.owner, this.owner, tokenId, data, anyValue);
-          });
-
-          it('calls onERC721Received from approved', async function () {
-            await expect(this.token.connect(this.approved)[fragment](this.owner, this.to, tokenId, ...extra))
-              .to.emit(this.to, 'Received')
-              .withArgs(this.approved, this.owner, tokenId, data, anyValue);
-          });
-
-          it('with an invalid token id', async function () {
-            await expect(this.token.connect(this.approved)[fragment](this.owner, this.to, nonExistentTokenId, ...extra))
-              .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-              .withArgs(nonExistentTokenId);
-          });
-        });
-      };
-
-      for (const { fnName, opts } of [
-        { fnName: 'transferFrom', opts: {} },
-        { fnName: '$_transfer', opts: { unrestricted: true } },
-      ]) {
-        describe(`via ${fnName}`, function () {
-          shouldTransferTokensByUsers(fnName, opts);
-        });
-      }
-
-      for (const { fnName, opts } of [
-        { fnName: 'safeTransferFrom', opts: {} },
-        { fnName: '$_safeTransfer', opts: { unrestricted: true } },
-      ]) {
-        describe(`via ${fnName}`, function () {
-          describe('with data', function () {
-            shouldTransferSafely(fnName, data, { ...opts, extra: [ethers.Typed.bytes(data)] });
-          });
-
-          describe('without data', function () {
-            shouldTransferSafely(fnName, '0x', opts);
-          });
-
-          describe('reverts', function () {
-            it('to a receiver contract returning unexpected value', async function () {
-              const invalidReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-                '0xdeadbeef',
-                RevertType.None,
-              ]);
-
-              await expect(this.token.connect(this.owner)[fnName](this.owner, invalidReceiver, tokenId))
-                .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-                .withArgs(invalidReceiver);
-            });
-
-            it('to a receiver contract that reverts with message', async function () {
-              const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-                RECEIVER_MAGIC_VALUE,
-                RevertType.RevertWithMessage,
-              ]);
-
-              await expect(
-                this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId),
-              ).to.be.revertedWith('ERC721ReceiverMock: reverting');
-            });
-
-            it('to a receiver contract that reverts without message', async function () {
-              const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-                RECEIVER_MAGIC_VALUE,
-                RevertType.RevertWithoutMessage,
-              ]);
-
-              await expect(this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId))
-                .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-                .withArgs(revertingReceiver);
-            });
-
-            it('to a receiver contract that reverts with custom error', async function () {
-              const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-                RECEIVER_MAGIC_VALUE,
-                RevertType.RevertWithCustomError,
-              ]);
-
-              await expect(this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId))
-                .to.be.revertedWithCustomError(revertingReceiver, 'CustomError')
-                .withArgs(RECEIVER_MAGIC_VALUE);
-            });
-
-            it('to a receiver contract that panics', async function () {
-              const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-                RECEIVER_MAGIC_VALUE,
-                RevertType.Panic,
-              ]);
-
-              await expect(
-                this.token.connect(this.owner)[fnName](this.owner, revertingReceiver, tokenId),
-              ).to.be.revertedWithPanic(PANIC_CODES.DIVISION_BY_ZERO);
-            });
-
-            it('to a contract that does not implement the required function', async function () {
-              const nonReceiver = await ethers.deployContract('CallReceiverMock');
-
-              await expect(this.token.connect(this.owner)[fnName](this.owner, nonReceiver, tokenId))
-                .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-                .withArgs(nonReceiver);
-            });
-          });
-        });
-      }
-    });
-
-    describe('approve', function () {
-      const tokenId = firstTokenId;
-
-      const itClearsApproval = function () {
-        it('clears approval for the token', async function () {
-          expect(await this.token.getApproved(tokenId)).to.equal(ethers.ZeroAddress);
-        });
-
-        it('emits an approval event', async function () {
-          await expect(this.tx).to.emit(this.token, 'Approval').withArgs(this.owner, ethers.ZeroAddress, tokenId);
-        });
-      };
-
-      const itApproves = function () {
-        it('sets the approval for the target address', async function () {
-          expect(await this.token.getApproved(tokenId)).to.equal(this.approved);
-        });
-
-        it('emits an approval event', async function () {
-          await expect(this.tx).to.emit(this.token, 'Approval').withArgs(this.owner, this.approved, tokenId);
-        });
-      };
-
-      describe('when clearing approval', function () {
-        describe('when there was no prior approval', function () {
-          beforeEach(async function () {
-            this.tx = await this.token.connect(this.owner).approve(ethers.ZeroAddress, tokenId);
-          });
-
-          itClearsApproval();
-        });
-
-        describe('when there was a prior approval', function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).approve(this.other, tokenId);
-            this.tx = await this.token.connect(this.owner).approve(ethers.ZeroAddress, tokenId);
-          });
-
-          itClearsApproval();
-        });
-      });
-
-      describe('when approving a non-zero address', function () {
-        describe('when there was no prior approval', function () {
-          beforeEach(async function () {
-            this.tx = await this.token.connect(this.owner).approve(this.approved, tokenId);
-          });
-
-          itApproves();
-        });
-
-        describe('when there was a prior approval to the same address', function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).approve(this.approved, tokenId);
-            this.tx = await this.token.connect(this.owner).approve(this.approved, tokenId);
-          });
-
-          itApproves();
-        });
-
-        describe('when there was a prior approval to a different address', function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).approve(this.other, tokenId);
-            this.tx = await this.token.connect(this.owner).approve(this.approved, tokenId);
-          });
-
-          itApproves();
-        });
-      });
-
-      describe('when the sender is an operator', function () {
-        beforeEach(async function () {
-          await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-
-          this.tx = await this.token.connect(this.operator).approve(this.approved, tokenId);
-        });
-
-        itApproves();
-      });
-
-      describe('reverts', function () {
-        it('when the sender does not own the given token ID', async function () {
-          await expect(this.token.connect(this.other).approve(this.approved, tokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidApprover')
-            .withArgs(this.other);
-        });
-
-        it('when the sender is approved for the given token ID', async function () {
-          await this.token.connect(this.owner).approve(this.approved, tokenId);
-
-          await expect(this.token.connect(this.approved).approve(this.other, tokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidApprover')
-            .withArgs(this.approved);
-        });
-
-        it('when the given token ID does not exist', async function () {
-          await expect(this.token.connect(this.operator).approve(this.approved, nonExistentTokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-            .withArgs(nonExistentTokenId);
-        });
       });
     });
 
-    describe('setApprovalForAll', function () {
-      describe('when the operator willing to approve is not the owner', function () {
-        describe('when there is no operator approval set by the sender', function () {
-          it('approves the operator', async function () {
-            await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-
-            expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
-          });
-
-          it('emits an approval event', async function () {
-            await expect(this.token.connect(this.owner).setApprovalForAll(this.operator, true))
-              .to.emit(this.token, 'ApprovalForAll')
-              .withArgs(this.owner, this.operator, true);
-          });
-        });
-
-        describe('when the operator was set as not approved', function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).setApprovalForAll(this.operator, false);
-            this.tx = await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-          });
-
-          it('approves the operator', async function () {
-            expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
-          });
-
-          it('emits an approval event', async function () {
-            await expect(this.tx).to.emit(this.token, 'ApprovalForAll').withArgs(this.owner, this.operator, true);
-          });
-
-          it('can unset the operator approval', async function () {
-            await this.token.connect(this.owner).setApprovalForAll(this.operator, false);
-
-            expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.false;
-          });
-        });
-
-        describe('when the operator was already approved', function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-            this.tx = this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-          });
-
-          it('keeps the approval to the given address', async function () {
-            expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
-          });
-
-          it('emits an approval event', async function () {
-            await expect(this.tx).to.emit(this.token, 'ApprovalForAll').withArgs(this.owner, this.operator, true);
-          });
-        });
-      });
-
-      it('when the operator is address zero', async function () {
-        await expect(this.token.connect(this.owner).setApprovalForAll(ethers.ZeroAddress, true))
-          .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOperator')
-          .withArgs(ethers.ZeroAddress);
-      });
-    });
-
-    describe('getApproved', function () {
-      it('when token is not minted', async function () {
-        await expect(this.token.getApproved(nonExistentTokenId))
+    describe('_burn', function () {
+      it('reverts when burning a non-existent token id', async function () {
+        await expect(this.token.$_burn(nonExistentTokenId))
           .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
           .withArgs(nonExistentTokenId);
       });
 
-      describe('when token has been minted ', async function () {
-        it('should return the zero address', async function () {
-          expect(await this.token.getApproved(firstTokenId)).to.equal(ethers.ZeroAddress);
+      describe('with minted tokens', function () {
+        beforeEach(async function () {
+          await this.token.$_mint(this.owner, firstTokenId);
+          await this.token.$_mint(this.owner, secondTokenId);
+          this.tx = await this.token.$_burn(firstTokenId);
         });
 
-        it('when account has been approved', async function () {
-          await this.token.connect(this.owner).approve(this.approved, firstTokenId);
-          expect(await this.token.getApproved(firstTokenId)).to.equal(this.approved);
+        it('emits a Transfer event', async function () {
+          await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, ethers.ZeroAddress, firstTokenId);
+        });
+
+        it('deletes the token', async function () {
+          expect(await this.token.balanceOf(this.owner)).to.equal(1n);
+          await expect(this.token.ownerOf(firstTokenId))
+            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+            .withArgs(firstTokenId);
+        });
+
+        it('reverts when burning a token id that has been deleted', async function () {
+          await expect(this.token.$_burn(firstTokenId))
+            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+            .withArgs(firstTokenId);
         });
       });
     });
   });
+}
 
-  describe('mint', function () {
-    describe('_mint', function () {
+function shouldBehaveLikeERC721Enumerable() {
+  describe('ERC721 Enumerable behaviour', function () {
+    beforeEach(async function () {
+      const [owner, newOwner, other] = await ethers.getSigners();
+      Object.assign(this, { owner, newOwner, other });
+    });
+
+    shouldSupportInterfaces(['ERC721Enumerable']);
+
+    describe('with minted tokens', function () {
+      beforeEach(async function () {
+        await this.token.$_mint(this.owner, firstTokenId);
+        await this.token.$_mint(this.owner, secondTokenId);
+        this.to = this.other;
+      });
+
+      describe('totalSupply', function () {
+        it('returns total token supply', async function () {
+          expect(await this.token.totalSupply()).to.equal(2n);
+        });
+      });
+
+      describe('tokenOfOwnerByIndex', function () {
+        describe('when the given index is lower than the amount of tokens owned by the given address', function () {
+          it('returns the token ID placed at the given index', async function () {
+            expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.equal(firstTokenId);
+          });
+        });
+
+        describe('when the index is greater than or equal to the total tokens owned by the given address', function () {
+          it('reverts', async function () {
+            await expect(this.token.tokenOfOwnerByIndex(this.owner, 2n))
+              .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
+              .withArgs(this.owner, 2n);
+          });
+        });
+
+        describe('when the given address does not own any token', function () {
+          it('reverts', async function () {
+            await expect(this.token.tokenOfOwnerByIndex(this.other, 0n))
+              .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
+              .withArgs(this.other, 0n);
+          });
+        });
+
+        describe('after transferring all tokens to another user', function () {
+          beforeEach(async function () {
+            await this.token.connect(this.owner).transferFrom(this.owner, this.other, firstTokenId);
+            await this.token.connect(this.owner).transferFrom(this.owner, this.other, secondTokenId);
+          });
+
+          it('returns correct token IDs for target', async function () {
+            expect(await this.token.balanceOf(this.other)).to.equal(2n);
+
+            expect(await Promise.all([0n, 1n].map(i => this.token.tokenOfOwnerByIndex(this.other, i)))).to.have.members(
+              [firstTokenId, secondTokenId],
+            );
+          });
+
+          it('returns empty collection for original owner', async function () {
+            expect(await this.token.balanceOf(this.owner)).to.equal(0n);
+            await expect(this.token.tokenOfOwnerByIndex(this.owner, 0n))
+              .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
+              .withArgs(this.owner, 0n);
+          });
+        });
+      });
+
+      describe('tokenByIndex', function () {
+        it('returns all tokens', async function () {
+          expect(await Promise.all([0n, 1n].map(i => this.token.tokenByIndex(i)))).to.have.members([
+            firstTokenId,
+            secondTokenId,
+          ]);
+        });
+
+        it('reverts if index is greater than supply', async function () {
+          await expect(this.token.tokenByIndex(2n))
+            .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
+            .withArgs(ethers.ZeroAddress, 2n);
+        });
+
+        for (const tokenId of [firstTokenId, secondTokenId]) {
+          it(`returns all tokens after burning token ${tokenId} and minting new tokens`, async function () {
+            const newTokenId = 300n;
+            const anotherNewTokenId = 400n;
+
+            await this.token.$_burn(tokenId);
+            await this.token.$_mint(this.newOwner, newTokenId);
+            await this.token.$_mint(this.newOwner, anotherNewTokenId);
+
+            expect(await this.token.totalSupply()).to.equal(3n);
+
+            expect(await Promise.all([0n, 1n, 2n].map(i => this.token.tokenByIndex(i))))
+              .to.have.members([firstTokenId, secondTokenId, newTokenId, anotherNewTokenId].filter(x => x !== tokenId))
+              .to.not.include(tokenId);
+          });
+        }
+      });
+    });
+
+    describe('_mint(address, uint256)', function () {
       it('reverts with a null destination address', async function () {
         await expect(this.token.$_mint(ethers.ZeroAddress, firstTokenId))
           .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
@@ -511,310 +777,53 @@ function shouldBehaveLikeERC721(extraTxTests) {
 
       describe('with minted token', async function () {
         beforeEach(async function () {
-          this.tx = await this.token.$_mint(this.owner, firstTokenId);
+          await this.token.$_mint(this.owner, firstTokenId);
         });
 
-        it('emits a Transfer event', async function () {
-          await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(ethers.ZeroAddress, this.owner, firstTokenId);
+        it('adjusts owner tokens by index', async function () {
+          expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.equal(firstTokenId);
         });
 
-        it('creates the token', async function () {
-          expect(await this.token.balanceOf(this.owner)).to.equal(1n);
-          expect(await this.token.ownerOf(firstTokenId)).to.equal(this.owner);
-        });
-
-        it('reverts when adding a token id that already exists', async function () {
-          await expect(this.token.$_mint(this.owner, firstTokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidSender')
-            .withArgs(ethers.ZeroAddress);
+        it('adjusts all tokens list', async function () {
+          expect(await this.token.tokenByIndex(0n)).to.equal(firstTokenId);
         });
       });
     });
 
-    describe('_safeMint', function () {
-      const tokenId = firstTokenId;
-      const data = '0x42';
-
-      it('executes when to is not a contract', async function () {
-        await this.token.$_safeMint(this.owner, tokenId);
-      });
-
-      it('calls onERC721Received — with data', async function () {
-        const receiver = await ethers.deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, RevertType.None]);
-
-        await expect(await this.token.$_safeMint(receiver, tokenId, ethers.Typed.bytes(data)))
-          .to.emit(receiver, 'Received')
-          .withArgs(anyValue, ethers.ZeroAddress, tokenId, data, anyValue);
-      });
-
-      it('calls onERC721Received — without data', async function () {
-        const receiver = await ethers.deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, RevertType.None]);
-
-        await expect(await this.token.$_safeMint(receiver, tokenId))
-          .to.emit(receiver, 'Received')
-          .withArgs(anyValue, ethers.ZeroAddress, tokenId, '0x', anyValue);
-      });
-
-      describe('reverts', function () {
-        it('to a receiver contract returning unexpected value', async function () {
-          const invalidReceiver = await ethers.deployContract('ERC721ReceiverMock', ['0xdeadbeef', RevertType.None]);
-
-          await expect(this.token.$_safeMint(invalidReceiver, tokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-            .withArgs(invalidReceiver);
-        });
-
-        it('to a receiver contract that reverts with message', async function () {
-          const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-            RECEIVER_MAGIC_VALUE,
-            RevertType.RevertWithMessage,
-          ]);
-
-          await expect(this.token.$_safeMint(revertingReceiver, tokenId)).to.be.revertedWith(
-            'ERC721ReceiverMock: reverting',
-          );
-        });
-
-        it('to a receiver contract that reverts without message', async function () {
-          const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-            RECEIVER_MAGIC_VALUE,
-            RevertType.RevertWithoutMessage,
-          ]);
-
-          await expect(this.token.$_safeMint(revertingReceiver, tokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-            .withArgs(revertingReceiver);
-        });
-
-        it('to a receiver contract that reverts with custom error', async function () {
-          const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-            RECEIVER_MAGIC_VALUE,
-            RevertType.RevertWithCustomError,
-          ]);
-
-          await expect(this.token.$_safeMint(revertingReceiver, tokenId))
-            .to.be.revertedWithCustomError(revertingReceiver, 'CustomError')
-            .withArgs(RECEIVER_MAGIC_VALUE);
-        });
-
-        it('to a receiver contract that panics', async function () {
-          const revertingReceiver = await ethers.deployContract('ERC721ReceiverMock', [
-            RECEIVER_MAGIC_VALUE,
-            RevertType.Panic,
-          ]);
-
-          await expect(this.token.$_safeMint(revertingReceiver, tokenId)).to.be.revertedWithPanic(
-            PANIC_CODES.DIVISION_BY_ZERO,
-          );
-        });
-
-        it('to a contract that does not implement the required function', async function () {
-          const nonReceiver = await ethers.deployContract('CallReceiverMock');
-
-          await expect(this.token.$_safeMint(nonReceiver, tokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-            .withArgs(nonReceiver);
-        });
-
-        it('to zero address', async function () {
-          await expect(this.token.$_safeMint(ethers.ZeroAddress, firstTokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-            .withArgs(ethers.ZeroAddress);
-        });
-      });
-    });
-  });
-
-  describe('_burn', function () {
-    it('reverts when burning a non-existent token id', async function () {
-      await expect(this.token.$_burn(nonExistentTokenId))
-        .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-        .withArgs(nonExistentTokenId);
-    });
-
-    describe('with minted tokens', function () {
-      beforeEach(async function () {
-        await this.token.$_mint(this.owner, firstTokenId);
-        await this.token.$_mint(this.owner, secondTokenId);
-        this.tx = await this.token.$_burn(firstTokenId);
-      });
-
-      it('emits a Transfer event', async function () {
-        await expect(this.tx).to.emit(this.token, 'Transfer').withArgs(this.owner, ethers.ZeroAddress, firstTokenId);
-      });
-
-      it('deletes the token', async function () {
-        expect(await this.token.balanceOf(this.owner)).to.equal(1n);
-        await expect(this.token.ownerOf(firstTokenId))
-          .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-          .withArgs(firstTokenId);
-      });
-
-      it('reverts when burning a token id that has been deleted', async function () {
+    describe('_burn', function () {
+      it('reverts when burning a non-existent token id', async function () {
         await expect(this.token.$_burn(firstTokenId))
           .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
           .withArgs(firstTokenId);
       });
-    });
-  });
-}
 
-function shouldBehaveLikeERC721Enumerable() {
-  beforeEach(async function () {
-    const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
-    Object.assign(this, { owner, newOwner, approved, operator, other });
-  });
-
-  shouldSupportInterfaces(['ERC721Enumerable']);
-
-  describe('with minted tokens', function () {
-    beforeEach(async function () {
-      await this.token.$_mint(this.owner, firstTokenId);
-      await this.token.$_mint(this.owner, secondTokenId);
-      this.to = this.other;
-    });
-
-    describe('totalSupply', function () {
-      it('returns total token supply', async function () {
-        expect(await this.token.totalSupply()).to.equal(2n);
-      });
-    });
-
-    describe('tokenOfOwnerByIndex', function () {
-      describe('when the given index is lower than the amount of tokens owned by the given address', function () {
-        it('returns the token ID placed at the given index', async function () {
-          expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.equal(firstTokenId);
-        });
-      });
-
-      describe('when the index is greater than or equal to the total tokens owned by the given address', function () {
-        it('reverts', async function () {
-          await expect(this.token.tokenOfOwnerByIndex(this.owner, 2n))
-            .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
-            .withArgs(this.owner, 2n);
-        });
-      });
-
-      describe('when the given address does not own any token', function () {
-        it('reverts', async function () {
-          await expect(this.token.tokenOfOwnerByIndex(this.other, 0n))
-            .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
-            .withArgs(this.other, 0n);
-        });
-      });
-
-      describe('after transferring all tokens to another user', function () {
+      describe('with minted tokens', function () {
         beforeEach(async function () {
-          await this.token.connect(this.owner).transferFrom(this.owner, this.other, firstTokenId);
-          await this.token.connect(this.owner).transferFrom(this.owner, this.other, secondTokenId);
+          await this.token.$_mint(this.owner, firstTokenId);
+          await this.token.$_mint(this.owner, secondTokenId);
         });
 
-        it('returns correct token IDs for target', async function () {
-          expect(await this.token.balanceOf(this.other)).to.equal(2n);
+        describe('with burnt token', function () {
+          beforeEach(async function () {
+            await this.token.$_burn(firstTokenId);
+          });
 
-          expect(await Promise.all([0n, 1n].map(i => this.token.tokenOfOwnerByIndex(this.other, i)))).to.have.members([
-            firstTokenId,
-            secondTokenId,
-          ]);
-        });
+          it('removes that token from the token list of the owner', async function () {
+            expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.equal(secondTokenId);
+          });
 
-        it('returns empty collection for original owner', async function () {
-          expect(await this.token.balanceOf(this.owner)).to.equal(0n);
-          await expect(this.token.tokenOfOwnerByIndex(this.owner, 0n))
-            .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
-            .withArgs(this.owner, 0n);
-        });
-      });
-    });
+          it('adjusts all tokens list', async function () {
+            expect(await this.token.tokenByIndex(0n)).to.equal(secondTokenId);
+          });
 
-    describe('tokenByIndex', function () {
-      it('returns all tokens', async function () {
-        expect(await Promise.all([0n, 1n].map(i => this.token.tokenByIndex(i)))).to.have.members([
-          firstTokenId,
-          secondTokenId,
-        ]);
-      });
+          it('burns all tokens', async function () {
+            await this.token.$_burn(secondTokenId);
+            expect(await this.token.totalSupply()).to.equal(0n);
 
-      it('reverts if index is greater than supply', async function () {
-        await expect(this.token.tokenByIndex(2n))
-          .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
-          .withArgs(ethers.ZeroAddress, 2n);
-      });
-
-      for (const tokenId of [firstTokenId, secondTokenId]) {
-        it(`returns all tokens after burning token ${tokenId} and minting new tokens`, async function () {
-          const newTokenId = 300n;
-          const anotherNewTokenId = 400n;
-
-          await this.token.$_burn(tokenId);
-          await this.token.$_mint(this.newOwner, newTokenId);
-          await this.token.$_mint(this.newOwner, anotherNewTokenId);
-
-          expect(await this.token.totalSupply()).to.equal(3n);
-
-          expect(await Promise.all([0n, 1n, 2n].map(i => this.token.tokenByIndex(i))))
-            .to.have.members([firstTokenId, secondTokenId, newTokenId, anotherNewTokenId].filter(x => x !== tokenId))
-            .to.not.include(tokenId);
-        });
-      }
-    });
-  });
-
-  describe('_mint(address, uint256)', function () {
-    it('reverts with a null destination address', async function () {
-      await expect(this.token.$_mint(ethers.ZeroAddress, firstTokenId))
-        .to.be.revertedWithCustomError(this.token, 'ERC721InvalidReceiver')
-        .withArgs(ethers.ZeroAddress);
-    });
-
-    describe('with minted token', async function () {
-      beforeEach(async function () {
-        await this.token.$_mint(this.owner, firstTokenId);
-      });
-
-      it('adjusts owner tokens by index', async function () {
-        expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.equal(firstTokenId);
-      });
-
-      it('adjusts all tokens list', async function () {
-        expect(await this.token.tokenByIndex(0n)).to.equal(firstTokenId);
-      });
-    });
-  });
-
-  describe('_burn', function () {
-    it('reverts when burning a non-existent token id', async function () {
-      await expect(this.token.$_burn(firstTokenId))
-        .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-        .withArgs(firstTokenId);
-    });
-
-    describe('with minted tokens', function () {
-      beforeEach(async function () {
-        await this.token.$_mint(this.owner, firstTokenId);
-        await this.token.$_mint(this.owner, secondTokenId);
-      });
-
-      describe('with burnt token', function () {
-        beforeEach(async function () {
-          await this.token.$_burn(firstTokenId);
-        });
-
-        it('removes that token from the token list of the owner', async function () {
-          expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.equal(secondTokenId);
-        });
-
-        it('adjusts all tokens list', async function () {
-          expect(await this.token.tokenByIndex(0n)).to.equal(secondTokenId);
-        });
-
-        it('burns all tokens', async function () {
-          await this.token.$_burn(secondTokenId);
-          expect(await this.token.totalSupply()).to.equal(0n);
-
-          await expect(this.token.tokenByIndex(0n))
-            .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
-            .withArgs(ethers.ZeroAddress, 0n);
+            await expect(this.token.tokenByIndex(0n))
+              .to.be.revertedWithCustomError(this.token, 'ERC721OutOfBoundsIndex')
+              .withArgs(ethers.ZeroAddress, 0n);
+          });
         });
       });
     });
@@ -835,7 +844,8 @@ function shouldBehaveLikeERC721Metadata(name, symbol) {
 
     describe('token URI', function () {
       beforeEach(async function () {
-        await this.token.$_mint(this.owner, firstTokenId);
+        const [owner] = await ethers.getSigners();
+        await this.token.$_mint(owner, firstTokenId);
       });
 
       it('return empty string by default', async function () {

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -458,18 +458,15 @@ function shouldBehaveLikeERC721() {
         describe('when the operator was set as not approved', function () {
           beforeEach(async function () {
             await this.token.connect(this.owner).setApprovalForAll(this.operator, false);
+            this.tx = await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
           });
 
           it('approves the operator', async function () {
-            await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-
             expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
           });
 
           it('emits an approval event', async function () {
-            await expect(this.token.connect(this.owner).setApprovalForAll(this.operator, true))
-              .to.emit(this.token, 'ApprovalForAll')
-              .withArgs(this.owner, this.operator, true);
+            await expect(this.tx).to.emit(this.token, 'ApprovalForAll').withArgs(this.owner, this.operator, true);
           });
 
           it('can unset the operator approval', async function () {
@@ -482,38 +479,31 @@ function shouldBehaveLikeERC721() {
         describe('when the operator was already approved', function () {
           beforeEach(async function () {
             await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
+            this.tx = this.token.connect(this.owner).setApprovalForAll(this.operator, true);
           });
 
           it('keeps the approval to the given address', async function () {
-            await this.token.connect(this.owner).setApprovalForAll(this.operator, true);
-
             expect(await this.token.isApprovedForAll(this.owner, this.operator)).to.be.true;
           });
 
           it('emits an approval event', async function () {
-            await expect(this.token.connect(this.owner).setApprovalForAll(this.operator, true))
-              .to.emit(this.token, 'ApprovalForAll')
-              .withArgs(this.owner, this.operator, true);
+            await expect(this.tx).to.emit(this.token, 'ApprovalForAll').withArgs(this.owner, this.operator, true);
           });
         });
       });
 
-      describe('when the operator is address zero', function () {
-        it('reverts', async function () {
-          await expect(this.token.connect(this.owner).setApprovalForAll(ethers.ZeroAddress, true))
-            .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOperator')
-            .withArgs(ethers.ZeroAddress);
-        });
+      it('when the operator is address zero', async function () {
+        await expect(this.token.connect(this.owner).setApprovalForAll(ethers.ZeroAddress, true))
+          .to.be.revertedWithCustomError(this.token, 'ERC721InvalidOperator')
+          .withArgs(ethers.ZeroAddress);
       });
     });
 
     describe('getApproved', async function () {
-      describe('when token is not minted', async function () {
-        it('reverts', async function () {
-          await expect(this.token.getApproved(nonExistentTokenId))
-            .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
-            .withArgs(nonExistentTokenId);
-        });
+      it('when token is not minted', async function () {
+        await expect(this.token.getApproved(nonExistentTokenId))
+          .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')
+          .withArgs(nonExistentTokenId);
       });
 
       describe('when token has been minted ', async function () {
@@ -522,13 +512,8 @@ function shouldBehaveLikeERC721() {
         });
 
         describe('when account has been approved', async function () {
-          beforeEach(async function () {
-            await this.token.connect(this.owner).approve(this.approved, firstTokenId);
-          });
-
-          it('returns approved account', async function () {
-            expect(await this.token.getApproved(firstTokenId)).to.equal(this.approved);
-          });
+          await this.token.connect(this.owner).approve(this.approved, firstTokenId);
+          expect(await this.token.getApproved(firstTokenId)).to.equal(this.approved);
         });
       });
     });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -145,7 +145,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
         });
 
         if (opts.unrestricted)
-          describe('when the address of the previous owner is incorrect', function () {
+          describe('when the sender is not authorized for the token ', function () {
             beforeEach(async function () {
               this.tx = await this.token.connect(this.other)[fragment](this.owner, this.to, tokenId, ...extra);
             });
@@ -245,7 +245,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
             shouldTransferSafely(fnName, '0x', opts);
           });
 
-          describe('reverts', async function () {
+          describe('reverts', function () {
             it('to a receiver contract returning unexpected value', async function () {
               const invalidReceiver = await ethers.deployContract('ERC721ReceiverMock', [
                 '0xdeadbeef',
@@ -393,7 +393,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
         itApproves();
       });
 
-      describe('reverts', async function () {
+      describe('reverts', function () {
         it('when the sender does not own the given token ID', async function () {
           await expect(this.token.connect(this.other).approve(this.approved, tokenId))
             .to.be.revertedWithCustomError(this.token, 'ERC721InvalidApprover')
@@ -476,7 +476,7 @@ function shouldBehaveLikeERC721(extraTxTests) {
       });
     });
 
-    describe('getApproved', async function () {
+    describe('getApproved', function () {
       it('when token is not minted', async function () {
         await expect(this.token.getApproved(nonExistentTokenId))
           .to.be.revertedWithCustomError(this.token, 'ERC721NonexistentToken')

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -18,7 +18,7 @@ async function fixture() {
   };
 }
 
-describe.only('ERC721', function () {
+describe('ERC721', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -7,13 +7,14 @@ const name = 'Non Fungible Token';
 const symbol = 'NFT';
 
 async function fixture() {
+  const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
   return {
-    accounts: await ethers.getSigners(),
+    owner, newOwner, approved, operator, other,
     token: await ethers.deployContract('$ERC721', [name, symbol]),
   };
 }
 
-describe('ERC721', function () {
+describe.only('ERC721', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -7,13 +7,7 @@ const name = 'Non Fungible Token';
 const symbol = 'NFT';
 
 async function fixture() {
-  const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
   return {
-    owner,
-    newOwner,
-    approved,
-    operator,
-    other,
     token: await ethers.deployContract('$ERC721', [name, symbol]),
   };
 }

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -9,7 +9,11 @@ const symbol = 'NFT';
 async function fixture() {
   const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
   return {
-    owner, newOwner, approved, operator, other,
+    owner,
+    newOwner,
+    approved,
+    operator,
+    other,
     token: await ethers.deployContract('$ERC721', [name, symbol]),
   };
 }

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -23,7 +23,7 @@ async function fixture() {
   };
 }
 
-describe.only('ERC721Enumerable', function () {
+describe('ERC721Enumerable', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -5,7 +5,7 @@ const {
   shouldBehaveLikeERC721,
   shouldBehaveLikeERC721Metadata,
   shouldBehaveLikeERC721Enumerable,
-} = require('./ERC721.behavior');
+} = require('../ERC721.behavior');
 
 const name = 'Non Fungible Token';
 const symbol = 'NFT';

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -11,13 +11,18 @@ const name = 'Non Fungible Token';
 const symbol = 'NFT';
 
 async function fixture() {
+  const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
   return {
-    accounts: await ethers.getSigners(),
+    owner,
+    newOwner,
+    approved,
+    operator,
+    other,
     token: await ethers.deployContract('$ERC721Enumerable', [name, symbol]),
   };
 }
 
-describe('ERC721', function () {
+describe('ERC721Enumerable', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -23,24 +23,26 @@ async function fixture() {
   };
 }
 
+const EXTRA_TX_TESTS_ENUMERABLE = {
+  different: function (tokenId) {
+    it('adjusts owners tokens by index', async function () {
+      expect(await this.token.tokenOfOwnerByIndex(this.to, 0n)).to.equal(tokenId);
+      expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.not.equal(tokenId);
+    });
+  },
+  same: function (ids) {
+    it('keeps same tokens by index', async function () {
+      for (const index in ids) expect(await this.token.tokenOfOwnerByIndex(this.owner, index)).to.equal(ids[index]);
+    });
+  },
+};
+
 describe('ERC721Enumerable', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
-  shouldBehaveLikeERC721({
-    different: function (tokenId) {
-      it('adjusts owners tokens by index', async function () {
-        expect(await this.token.tokenOfOwnerByIndex(this.to, 0n)).to.equal(tokenId);
-        expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.not.equal(tokenId);
-      });
-    },
-    same: function (ids) {
-      it('keeps same tokens by index', async function () {
-        for (const index in ids) expect(await this.token.tokenOfOwnerByIndex(this.owner, index)).to.equal(ids[index]);
-      });
-    },
-  });
+  shouldBehaveLikeERC721(EXTRA_TX_TESTS_ENUMERABLE);
   shouldBehaveLikeERC721Metadata(name, symbol);
   shouldBehaveLikeERC721Enumerable();
 });

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -1,4 +1,5 @@
 const { ethers } = require('hardhat');
+const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const {
@@ -22,12 +23,24 @@ async function fixture() {
   };
 }
 
-describe('ERC721Enumerable', function () {
+describe.only('ERC721Enumerable', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
-  shouldBehaveLikeERC721();
+  shouldBehaveLikeERC721({
+    different: function (tokenId) {
+      it('adjusts owners tokens by index', async function () {
+        expect(await this.token.tokenOfOwnerByIndex(this.to, 0n)).to.equal(tokenId);
+        expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.not.equal(tokenId);
+      });
+    },
+    same: function (ids) {
+      it('keeps same tokens by index', async function () {
+        for (const index in ids) expect(await this.token.tokenOfOwnerByIndex(this.owner, index)).to.equal(ids[index]);
+      });
+    },
+  });
   shouldBehaveLikeERC721Metadata(name, symbol);
   shouldBehaveLikeERC721Enumerable();
 });

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -24,13 +24,13 @@ async function fixture() {
 }
 
 const EXTRA_TX_TESTS_ENUMERABLE = {
-  different: function (tokenId) {
+  transferWasSuccessful: function (tokenId) {
     it('adjusts owners tokens by index', async function () {
       expect(await this.token.tokenOfOwnerByIndex(this.to, 0n)).to.equal(tokenId);
       expect(await this.token.tokenOfOwnerByIndex(this.owner, 0n)).to.not.equal(tokenId);
     });
   },
-  same: function (ids) {
+  toOwner: function (ids) {
     it('keeps same tokens by index', async function () {
       for (const index in ids) expect(await this.token.tokenOfOwnerByIndex(this.owner, index)).to.equal(ids[index]);
     });

--- a/test/token/ERC721/extensions/ERC721Enumerable.test.js
+++ b/test/token/ERC721/extensions/ERC721Enumerable.test.js
@@ -12,13 +12,7 @@ const name = 'Non Fungible Token';
 const symbol = 'NFT';
 
 async function fixture() {
-  const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
   return {
-    owner,
-    newOwner,
-    approved,
-    operator,
-    other,
     token: await ethers.deployContract('$ERC721Enumerable', [name, symbol]),
   };
 }

--- a/test/token/ERC721/extensions/ERC721Wrapper.test.js
+++ b/test/token/ERC721/extensions/ERC721Wrapper.test.js
@@ -11,14 +11,14 @@ const otherTokenId = 2n;
 
 async function fixture() {
   const accounts = await ethers.getSigners();
-  const [owner, approved, other] = accounts;
+  const [owner, newOwner, approved, operator, other] = accounts;
 
   const underlying = await ethers.deployContract('$ERC721', [name, symbol]);
   await underlying.$_safeMint(owner, tokenId);
   await underlying.$_safeMint(owner, otherTokenId);
   const token = await ethers.deployContract('$ERC721Wrapper', [`Wrapped ${name}`, `W${symbol}`, underlying]);
 
-  return { accounts, owner, approved, other, underlying, token };
+  return { owner, newOwner, approved, operator, other, underlying, token };
 }
 
 describe('ERC721Wrapper', function () {

--- a/test/token/ERC721/extensions/ERC721Wrapper.test.js
+++ b/test/token/ERC721/extensions/ERC721Wrapper.test.js
@@ -10,8 +10,7 @@ const tokenId = 1n;
 const otherTokenId = 2n;
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
-  const [owner, newOwner, approved, operator, other] = accounts;
+  const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
 
   const underlying = await ethers.deployContract('$ERC721', [name, symbol]);
   await underlying.$_safeMint(owner, tokenId);

--- a/test/token/ERC721/extensions/ERC721Wrapper.test.js
+++ b/test/token/ERC721/extensions/ERC721Wrapper.test.js
@@ -25,16 +25,18 @@ describe('ERC721Wrapper', function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
-  it('has a name', async function () {
-    expect(await this.token.name()).to.equal(`Wrapped ${name}`);
-  });
+  describe('Deploy parameters', function () {
+    it('has a name', async function () {
+      expect(await this.token.name()).to.equal(`Wrapped ${name}`);
+    });
 
-  it('has a symbol', async function () {
-    expect(await this.token.symbol()).to.equal(`W${symbol}`);
-  });
+    it('has a symbol', async function () {
+      expect(await this.token.symbol()).to.equal(`W${symbol}`);
+    });
 
-  it('has underlying', async function () {
-    expect(await this.token.underlying()).to.equal(this.underlying);
+    it('has underlying', async function () {
+      expect(await this.token.underlying()).to.equal(this.underlying);
+    });
   });
 
   describe('depositFor', function () {
@@ -194,7 +196,5 @@ describe('ERC721Wrapper', function () {
     });
   });
 
-  describe('ERC712 behavior', function () {
-    shouldBehaveLikeERC721();
-  });
+  shouldBehaveLikeERC721();
 });

--- a/test/token/ERC721/extensions/ERC721Wrapper.test.js
+++ b/test/token/ERC721/extensions/ERC721Wrapper.test.js
@@ -10,14 +10,14 @@ const tokenId = 1n;
 const otherTokenId = 2n;
 
 async function fixture() {
-  const [owner, newOwner, approved, operator, other] = await ethers.getSigners();
+  const [owner, approved, other] = await ethers.getSigners();
 
   const underlying = await ethers.deployContract('$ERC721', [name, symbol]);
   await underlying.$_safeMint(owner, tokenId);
   await underlying.$_safeMint(owner, otherTokenId);
   const token = await ethers.deployContract('$ERC721Wrapper', [`Wrapped ${name}`, `W${symbol}`, underlying]);
 
-  return { owner, newOwner, approved, operator, other, underlying, token };
+  return { owner, approved, other, underlying, token };
 }
 
 describe('ERC721Wrapper', function () {


### PR DESCRIPTION
#### PR Checklist

this is more of a suggestion than anything else

biggest takeaways:
 - removal of unused uri tests in default ERC721 behaviour
 - change of ordering to avoid 'describes'with only one 'it'
 - better use of 'changeTokenBalance'

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
