### PR TITLE
Run gas-compare action on push to master 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run test:generation
       - name: Compare gas costs
         uses: ./.github/actions/gas-compare
-        if: github.base_ref == 'master'
+        if: github.event_name == 'pull_request' && github.base_ref == 'master' || github.event_name == 'push' && github.ref_name == 'master'
         with:
           token: ${{ github.token }}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,6 @@ jobs:
         run: npm run test:generation
       - name: Compare gas costs
         uses: ./.github/actions/gas-compare
-        if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref_name == 'master')
         with:
           token: ${{ github.token }}
 
@@ -71,7 +70,6 @@ jobs:
         run: npm run test:inheritance
       - name: Check storage layout
         uses: ./.github/actions/storage-layout
-        if: github.base_ref == 'master'
         continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change') }}
         with:
           token: ${{ github.token }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run test:generation
       - name: Compare gas costs
         uses: ./.github/actions/gas-compare
-        if: github.event_name == 'pull_request' && github.base_ref == 'master' || github.event_name == 'push' && github.ref_name == 'master'
+        if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref_name == 'master')
         with:
           token: ${{ github.token }}
 


### PR DESCRIPTION
After #4824, the #4822 PR was synced. However, it is still not producing the gas comparison because the report from `master` is not executed given `github.base_ref` is empty when a commit triggered the run. In that case, [the `master` report is just skipped.](https://github.com/OpenZeppelin/openzeppelin-contracts/actions/runs/7508535099/job/20445181704)

With this change, we'll be running the comparison only in commits to master and pull requests targeting to master

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
