### PR TITLE
Lower fuzz runs to 5000

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,8 +86,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run tests
         run: forge test -vv
-        env:
-          FOUNDRY_PROFILE: CI
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,6 +86,8 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run tests
         run: forge test -vv
+        env:
+          FOUNDRY_PROFILE: CI
 
   coverage:
     runs-on: ubuntu-latest

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,6 @@ libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'cache_forge'
 
-[fuzz]
-runs = 10000
+[profile.ci.fuzz]
+runs = 5000
 max_test_rejects = 150000

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,6 @@ libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'cache_forge'
 
-[profile.ci.fuzz]
+[fuzz]
 runs = 5000
 max_test_rejects = 150000


### PR DESCRIPTION
Right now the foundry tests are the job that takes the longest to run (~9 min). But, after the ethers test migration we made the unit tests way faster (~4 min). Now that the fuzz tests are taking longer than the unit tests, I think it's safe to lower the runs a bit.

I couldn't find any concrete reason to use 10_000 and I think we'd benefit from faster CI jobs.

Also, I made the 5_000 runs to only apply in the CI so our dev experience is better when running locally (with 256 runs)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
