### PR TITLE
Remove documented requirement in IERC1155's `balanceOf`

### DIFF
--- a/contracts/token/ERC1155/IERC1155.sol
+++ b/contracts/token/ERC1155/IERC1155.sol
@@ -44,10 +44,6 @@ interface IERC1155 is IERC165 {
 
     /**
      * @dev Returns the value of tokens of token type `id` owned by `account`.
-     *
-     * Requirements:
-     *
-     * - `account` cannot be the zero address.
      */
     function balanceOf(address account, uint256 id) external view returns (uint256);
 


### PR DESCRIPTION
The zero address check was removed from ERC1155's `balanceOf` in #4263; however, the documentation still displays the non-zero address as a requirement. This PR proposes to fix that.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
