### PR TITLE
Remove note about event access in `ERC1967Utils.sol`

### DIFF
--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -12,8 +12,6 @@ import {StorageSlot} from "../../utils/StorageSlot.sol";
  * https://eips.ethereum.org/EIPS/eip-1967[ERC-1967] slots.
  */
 library ERC1967Utils {
-    // We re-declare ERC-1967 events here because they can't be used directly from IERC1967.
-    // This will be fixed in Solidity 0.8.21. At that point we should remove these events.
     /**
      * @dev Emitted when the implementation is upgraded.
      */


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #4860  <!-- Fill in with issue number -->

Removes the now non-applicable comment in `ERC1967Utils.sol` on events being redeclared in the file prior to 0.8.20 which allows qualified event access from external contracts. The comment is no longer applicable since `ERC1967Utils.sol` was transitioned from an abstract contract to a library and now does not inherit `IERC1967.sol`.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
