### PR TITLE
Imported ForwardRequest struct correctly

### DIFF
--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -2,7 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getDomain, ForwardRequest } = require('../helpers/eip712');
+const { getDomain } = require('../helpers/eip712');
+const { ForwardRequest } = require('../helpers/eip712-types');
+
 const { sum } = require('../helpers/math');
 const time = require('../helpers/time');
 


### PR DESCRIPTION
ForwardRequest struct resides in eip712-types.js file , fixed that import

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
