### PR TITLE
Add variants of Array.sort for address[] and bytes32[]

### DIFF
--- a/.changeset/dirty-cobras-smile.md
+++ b/.changeset/dirty-cobras-smile.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`Arrays`: add a `sort` function.
+`Arrays`: add a `sort` functions for `address[]`, `bytes32[]` and `uint256[]` memory arrays.

--- a/contracts/mocks/ArraysMock.sol
+++ b/contracts/mocks/ArraysMock.sol
@@ -36,6 +36,18 @@ contract Uint256ArraysMock {
     function unsafeAccess(uint256 pos) external view returns (uint256) {
         return _array.unsafeAccess(pos).value;
     }
+
+    function sort(uint256[] memory array) external pure returns (uint256[] memory) {
+        return array.sort();
+    }
+
+    function sortReverse(uint256[] memory array) external pure returns (uint256[] memory) {
+        return array.sort(_reverse);
+    }
+
+    function _reverse(uint256 a, uint256 b) private pure returns (bool) {
+        return a > b;
+    }
 }
 
 contract AddressArraysMock {
@@ -50,6 +62,18 @@ contract AddressArraysMock {
     function unsafeAccess(uint256 pos) external view returns (address) {
         return _array.unsafeAccess(pos).value;
     }
+
+    function sort(address[] memory array) external pure returns (address[] memory) {
+        return array.sort();
+    }
+
+    function sortReverse(address[] memory array) external pure returns (address[] memory) {
+        return array.sort(_reverse);
+    }
+
+    function _reverse(address a, address b) private pure returns (bool) {
+        return uint160(a) > uint160(b);
+    }
 }
 
 contract Bytes32ArraysMock {
@@ -63,5 +87,17 @@ contract Bytes32ArraysMock {
 
     function unsafeAccess(uint256 pos) external view returns (bytes32) {
         return _array.unsafeAccess(pos).value;
+    }
+
+    function sort(bytes32[] memory array) external pure returns (bytes32[] memory) {
+        return array.sort();
+    }
+
+    function sortReverse(bytes32[] memory array) external pure returns (bytes32[] memory) {
+        return array.sort(_reverse);
+    }
+
+    function _reverse(bytes32 a, bytes32 b) private pure returns (bool) {
+        return uint256(a) > uint256(b);
     }
 }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -35,7 +35,7 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
      */
     function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
-        sort(array, _defaultComp);
+        _quickSort(array, 0, array.length, _defaultComp);
         return array;
     }
 
@@ -46,13 +46,7 @@ library Arrays {
         address[] memory array,
         function(address, address) pure returns (bool) comp
     ) internal pure returns (address[] memory) {
-        function(bytes32, bytes32) pure returns (bool) castedComp;
-        bytes32[] memory castedArray;
-        assembly {
-            castedComp := comp
-            castedArray := array
-        }
-        sort(castedArray, castedComp);
+        _quickSort(_castToBytes32Array(array), 0, array.length, _castToBytes32Comp(comp));
         return array;
     }
 
@@ -60,11 +54,7 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of address in increassing order.
      */
     function sort(address[] memory array) internal pure returns (address[] memory) {
-        bytes32[] memory castedArray;
-        assembly {
-            castedArray := array
-        }
-        sort(castedArray);
+        _quickSort(_castToBytes32Array(array), 0, array.length, _defaultComp);
         return array;
     }
 
@@ -75,13 +65,7 @@ library Arrays {
         uint256[] memory array,
         function(uint256, uint256) pure returns (bool) comp
     ) internal pure returns (uint256[] memory) {
-        function(bytes32, bytes32) pure returns (bool) castedComp;
-        bytes32[] memory castedArray;
-        assembly {
-            castedComp := comp
-            castedArray := array
-        }
-        sort(castedArray, castedComp);
+        _quickSort(_castToBytes32Array(array), 0, array.length, _castToBytes32Comp(comp));
         return array;
     }
 
@@ -89,11 +73,7 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of uint256 in increassing order.
      */
     function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
-        bytes32[] memory castedArray;
-        assembly {
-            castedArray := array
-        }
-        sort(castedArray);
+        _quickSort(_castToBytes32Array(array), 0, array.length, _defaultComp);
         return array;
     }
 
@@ -147,11 +127,41 @@ library Arrays {
         }
     }
 
-    /**
-     * @dev Comparator for sorting arrays in increassing order.
-     */
+    /// @dev Comparator for sorting arrays in increassing order.
     function _defaultComp(bytes32 a, bytes32 b) private pure returns (bool) {
         return uint256(a) < uint256(b);
+    }
+
+    /// @dev Helper: low level cast address memory array to bytes32 memory array
+    function _castToBytes32Array(address[] memory input) private pure returns (bytes32[] memory output) {
+        assembly {
+            output := input
+        }
+    }
+
+    /// @dev Helper: low level cast address memory array to bytes32 memory array
+    function _castToBytes32Array(uint256[] memory input) private pure returns (bytes32[] memory output) {
+        assembly {
+            output := input
+        }
+    }
+
+    /// @dev Helper: low level cast address comp function to bytes32 comp function
+    function _castToBytes32Comp(
+        function(address, address) pure returns (bool) input
+    ) private pure returns (function(bytes32, bytes32) pure returns (bool) output) {
+        assembly {
+            output := input
+        }
+    }
+
+    /// @dev Helper: low level cast address comp function to bytes32 comp function
+    function _castToBytes32Comp(
+        function(uint256, uint256) pure returns (bool) input
+    ) private pure returns (function(bytes32, bytes32) pure returns (bool) output) {
+        assembly {
+            output := input
+        }
     }
 
     /**

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -35,7 +35,7 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
      */
     function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
-        _quickSort(array, 0, array.length, _defaultComp);
+        sort(array, _defaultComp);
         return array;
     }
 

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -84,25 +84,25 @@ library Arrays {
     }
 
     /**
-     * @dev Performs a quick sort on an array in memory. The array is sorted following the `comp` comparator.
+     * @dev Performs a quick sort of a segment of memory. The segment sorted starts at `begin` (inclusive), and ends
+     * at end (exclusive). Sorting follows the `comp` comparator.
      *
-     * Invariant: `i <= j <= array.length`. This is the case when initially called by {sort} and is preserved in
-     * subcalls.
+     * Invariant: `begin <= end`. This is the case when initially called by {sort} and is preserved in subcalls.
      */
     function _quickSort(
-        uint256 start,
+        uint256 begin,
         uint256 end,
         function(bytes32, bytes32) pure returns (bool) comp
     ) private pure {
         unchecked {
-            if (end - start < 0x40) return;
+            if (end - begin < 0x40) return;
 
             // Use first element as pivot
-            bytes32 pivot = _mload(start);
+            bytes32 pivot = _mload(begin);
             // Position where the pivot should be at the end of the loop
-            uint256 pos = start;
+            uint256 pos = begin;
 
-            for (uint256 it = start + 0x20; it < end; it += 0x20) {
+            for (uint256 it = begin + 0x20; it < end; it += 0x20) {
                 if (comp(_mload(it), pivot)) {
                     // If array[k] is smaller than the pivot, we increment the position of the pivot and move array[k]
                     // there.
@@ -111,8 +111,8 @@ library Arrays {
                 }
             }
 
-            _swap(start, pos); // Swap pivot into place
-            _quickSort(start, pos, comp); // Sort the left side of the pivot
+            _swap(begin, pos); // Swap pivot into place
+            _quickSort(begin, pos, comp); // Sort the left side of the pivot
             _quickSort(pos + 0x20, end, comp); // Sort the right side of the pivot
         }
     }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -39,7 +39,7 @@ library Arrays {
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
+     * @dev Variant of {sort} that sorts an array of bytes32 in increasing order.
      */
     function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
         return sort(array, _defaultComp);
@@ -57,7 +57,7 @@ library Arrays {
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of address in increassing order.
+     * @dev Variant of {sort} that sorts an array of address in increasing order.
      */
     function sort(address[] memory array) internal pure returns (address[] memory) {
         sort(_castToBytes32Array(array), _defaultComp);
@@ -76,7 +76,7 @@ library Arrays {
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of uint256 in increassing order.
+     * @dev Variant of {sort} that sorts an array of uint256 in increasing order.
      */
     function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
         sort(_castToBytes32Array(array), _defaultComp);
@@ -134,7 +134,7 @@ library Arrays {
         }
     }
 
-    /// @dev Comparator for sorting arrays in increassing order.
+    /// @dev Comparator for sorting arrays in increasing order.
     function _defaultComp(bytes32 a, bytes32 b) private pure returns (bool) {
         return a < b;
     }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -81,6 +81,9 @@ library Arrays {
      * at end (exclusive). Sorting follows the `comp` comparator.
      *
      * Invariant: `begin <= end`. This is the case when initially called by {sort} and is preserved in subcalls.
+     *
+     * IMPORTANT: Memory locations between `begin` and `end` are not validated/zeroed. This function should
+     * be used only if the limits are within a memory array.
      */
     function _quickSort(uint256 begin, uint256 end, function(bytes32, bytes32) pure returns (bool) comp) private pure {
         unchecked {

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -84,7 +84,7 @@ library Arrays {
     }
 
     /**
-     * @dev Performs a quick sort of a segment of memory. The segment sorted starts at `begin` (inclusive), and ends
+     * @dev Performs a quick sort of a segment of memory. The segment sorted starts at `begin` (inclusive), and stops
      * at end (exclusive). Sorting follows the `comp` comparator.
      *
      * Invariant: `begin <= end`. This is the case when initially called by {sort} and is preserved in subcalls.

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -89,11 +89,7 @@ library Arrays {
      *
      * Invariant: `begin <= end`. This is the case when initially called by {sort} and is preserved in subcalls.
      */
-    function _quickSort(
-        uint256 begin,
-        uint256 end,
-        function(uint256, uint256) pure returns (bool) comp
-    ) private pure {
+    function _quickSort(uint256 begin, uint256 end, function(uint256, uint256) pure returns (bool) comp) private pure {
         unchecked {
             if (end - begin < 0x40) return;
 
@@ -121,7 +117,9 @@ library Arrays {
      * @dev Load memory word (as an unsigned integer) at location `ptr`.
      */
     function _mload(uint256 ptr) private pure returns (uint256 value) {
-        assembly { value := mload(ptr) }
+        assembly {
+            value := mload(ptr)
+        }
     }
 
     /**

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -35,7 +35,7 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
      */
     function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
-        _quickSort(array, 0, array.length, _compIncr);
+        _quickSort(array, 0, array.length, _defaultComp);
         return array;
     }
 
@@ -150,7 +150,7 @@ library Arrays {
     /**
      * @dev Comparator for sorting arrays in increassing order.
      */
-    function _compIncr(bytes32 a, bytes32 b) private pure returns (bool) {
+    function _defaultComp(bytes32 a, bytes32 b) private pure returns (bool) {
         return uint256(a) < uint256(b);
     }
 

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -100,8 +100,8 @@ library Arrays {
 
             for (uint256 it = begin + 0x20; it < end; it += 0x20) {
                 if (comp(_mload(it), pivot)) {
-                    // If array[k] is smaller than the pivot, we increment the position of the pivot and move array[k]
-                    // there.
+                    // If the value stored at the iterator's position is smaller than the pivot, we increment the
+                    // position of the pivot and move the value there.
                     pos += 0x20;
                     _swap(pos, it);
                 }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -93,7 +93,7 @@ library Arrays {
 
             for (uint256 it = begin + 0x20; it < end; it += 0x20) {
                 if (comp(_mload(it), pivot)) {
-                    // If the value stored at the iterator's position is smaller than the pivot, we increment the
+                    // If the value stored at the iterator's position comes before the pivot, we increment the
                     // position of the pivot and move the value there.
                     pos += 0x20;
                     _swap(pos, it);

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -27,14 +27,7 @@ library Arrays {
         bytes32[] memory array,
         function(bytes32, bytes32) pure returns (bool) comp
     ) internal pure returns (bytes32[] memory) {
-        uint256 begin;
-        uint256 end;
-        /// @solidity memory-safe-assembly
-        assembly {
-            begin := add(array, 0x20)
-            end := add(begin, mul(mload(array), 0x20))
-        }
-        _quickSort(begin, end, comp);
+        _quickSort(_begin(array), _end(array), comp);
         return array;
     }
 
@@ -110,6 +103,26 @@ library Arrays {
             _swap(begin, pos); // Swap pivot into place
             _quickSort(begin, pos, comp); // Sort the left side of the pivot
             _quickSort(pos + 0x20, end, comp); // Sort the right side of the pivot
+        }
+    }
+
+    /**
+     * @dev Pointer to the memory location of the first element of `array`.
+     */
+    function _begin(bytes32[] memory array) private pure returns (uint256 ptr) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            ptr := add(array, 0x20)
+        }
+    }
+
+    /**
+     * @dev Pointer to the memory location of the first memory word (32bytes) after `array`. This is the memory word
+     * that comes just after the last element of the array.
+     */
+    function _end(bytes32[] memory array) private pure returns (uint256 ptr) {
+        unchecked {
+            return _begin(array) + array.length * 0x20;
         }
     }
 

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -13,7 +13,7 @@ library Arrays {
     using StorageSlot for bytes32;
 
     /**
-     * @dev Sort an array of integers (in memory) following the provided comparator function.
+     * @dev Sort an array of bytes32 (in memory) following the provided comparator function.
      *
      * This function does the sorting "in place", meaning that it overrides the input. The object is returned for
      * convenience, but that returned value can be discarded safely if the caller has a memory pointer to the array.
@@ -24,9 +24,9 @@ library Arrays {
      * consume more gas than is available in a block, leading to potential DoS.
      */
     function sort(
-        uint256[] memory array,
-        function(uint256, uint256) pure returns (bool) comp
-    ) internal pure returns (uint256[] memory) {
+        bytes32[] memory array,
+        function(bytes32, bytes32) pure returns (bool) comp
+    ) internal pure returns (bytes32[] memory) {
         uint256 begin;
         uint256 end;
         /// @solidity memory-safe-assembly
@@ -39,9 +39,9 @@ library Arrays {
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of uint256 in increassing order.
+     * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
      */
-    function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
+    function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
         return sort(array, _defaultComp);
     }
 
@@ -52,7 +52,7 @@ library Arrays {
         address[] memory array,
         function(address, address) pure returns (bool) comp
     ) internal pure returns (address[] memory) {
-        sort(_castToUint256Array(array), _castToUint256Comp(comp));
+        sort(_castToBytes32Array(array), _castToBytes32Comp(comp));
         return array;
     }
 
@@ -60,26 +60,26 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of address in increassing order.
      */
     function sort(address[] memory array) internal pure returns (address[] memory) {
-        sort(_castToUint256Array(array), _defaultComp);
+        sort(_castToBytes32Array(array), _defaultComp);
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of bytes32 following a provided comparator function.
+     * @dev Variant of {sort} that sorts an array of uint256 following a provided comparator function.
      */
     function sort(
-        bytes32[] memory array,
-        function(bytes32, bytes32) pure returns (bool) comp
-    ) internal pure returns (bytes32[] memory) {
-        sort(_castToUint256Array(array), _castToUint256Comp(comp));
+        uint256[] memory array,
+        function(uint256, uint256) pure returns (bool) comp
+    ) internal pure returns (uint256[] memory) {
+        sort(_castToBytes32Array(array), _castToBytes32Comp(comp));
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
+     * @dev Variant of {sort} that sorts an array of uint256 in increassing order.
      */
-    function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
-        sort(_castToUint256Array(array), _defaultComp);
+    function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
+        sort(_castToBytes32Array(array), _defaultComp);
         return array;
     }
 
@@ -89,12 +89,12 @@ library Arrays {
      *
      * Invariant: `begin <= end`. This is the case when initially called by {sort} and is preserved in subcalls.
      */
-    function _quickSort(uint256 begin, uint256 end, function(uint256, uint256) pure returns (bool) comp) private pure {
+    function _quickSort(uint256 begin, uint256 end, function(bytes32, bytes32) pure returns (bool) comp) private pure {
         unchecked {
             if (end - begin < 0x40) return;
 
             // Use first element as pivot
-            uint256 pivot = _mload(begin);
+            bytes32 pivot = _mload(begin);
             // Position where the pivot should be at the end of the loop
             uint256 pos = begin;
 
@@ -114,9 +114,9 @@ library Arrays {
     }
 
     /**
-     * @dev Load memory word (as an unsigned integer) at location `ptr`.
+     * @dev Load memory word (as a bytes32) at location `ptr`.
      */
-    function _mload(uint256 ptr) private pure returns (uint256 value) {
+    function _mload(uint256 ptr) private pure returns (bytes32 value) {
         assembly {
             value := mload(ptr)
         }
@@ -135,37 +135,37 @@ library Arrays {
     }
 
     /// @dev Comparator for sorting arrays in increassing order.
-    function _defaultComp(uint256 a, uint256 b) private pure returns (bool) {
+    function _defaultComp(bytes32 a, bytes32 b) private pure returns (bool) {
         return a < b;
     }
 
     /// @dev Helper: low level cast address memory array to uint256 memory array
-    function _castToUint256Array(address[] memory input) private pure returns (uint256[] memory output) {
+    function _castToBytes32Array(address[] memory input) private pure returns (bytes32[] memory output) {
         assembly {
             output := input
         }
     }
 
-    /// @dev Helper: low level cast bytes32 memory array to uint256 memory array
-    function _castToUint256Array(bytes32[] memory input) private pure returns (uint256[] memory output) {
+    /// @dev Helper: low level cast uint256 memory array to uint256 memory array
+    function _castToBytes32Array(uint256[] memory input) private pure returns (bytes32[] memory output) {
         assembly {
             output := input
         }
     }
 
-    /// @dev Helper: low level cast address comp function to uint256 comp function
-    function _castToUint256Comp(
+    /// @dev Helper: low level cast address comp function to bytes32 comp function
+    function _castToBytes32Comp(
         function(address, address) pure returns (bool) input
-    ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
+    ) private pure returns (function(bytes32, bytes32) pure returns (bool) output) {
         assembly {
             output := input
         }
     }
 
-    /// @dev Helper: low level cast bytes32 comp function to uint256 comp function
-    function _castToUint256Comp(
-        function(bytes32, bytes32) pure returns (bool) input
-    ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
+    /// @dev Helper: low level cast uint256 comp function to bytes32 comp function
+    function _castToBytes32Comp(
+        function(uint256, uint256) pure returns (bool) input
+    ) private pure returns (function(bytes32, bytes32) pure returns (bool) output) {
         assembly {
             output := input
         }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -33,7 +33,9 @@ library Arrays {
      */
     function sort(address[] memory array) internal pure returns (address[] memory) {
         uint256[] memory casted;
-        assembly { casted := array }
+        assembly {
+            casted := array
+        }
         sort(casted);
         return array;
     }
@@ -43,7 +45,9 @@ library Arrays {
      */
     function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
         uint256[] memory casted;
-        assembly { casted := array }
+        assembly {
+            casted := array
+        }
         sort(casted);
         return array;
     }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -13,7 +13,7 @@ library Arrays {
     using StorageSlot for bytes32;
 
     /**
-     * @dev Sort an array (in memory) in increasing order.
+     * @dev Sort an array of integers (in memory) in increasing order.
      *
      * This function does the sorting "in place", meaning that it overrides the input. The object is returned for
      * convenience, but that returned value can be discarded safely if the caller has a memory pointer to the array.
@@ -25,6 +25,26 @@ library Arrays {
      */
     function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
         _quickSort(array, 0, array.length);
+        return array;
+    }
+
+    /**
+     * @dev Variant of {sort(uint256[] memory)} that operates on an array of addresses (in memory).
+     */
+    function sort(address[] memory array) internal pure returns (address[] memory) {
+        uint256[] memory casted;
+        assembly { casted := array }
+        sort(casted);
+        return array;
+    }
+
+    /**
+     * @dev Variant of {sort(uint256[] memory)} that operates on an array of bytes32 (in memory).
+     */
+    function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
+        uint256[] memory casted;
+        assembly { casted := array }
+        sort(casted);
         return array;
     }
 

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -24,9 +24,9 @@ library Arrays {
      * consume more gas than is available in a block, leading to potential DoS.
      */
     function sort(
-        bytes32[] memory array,
-        function(bytes32, bytes32) pure returns (bool) comp
-    ) internal pure returns (bytes32[] memory) {
+        uint256[] memory array,
+        function(uint256, uint256) pure returns (bool) comp
+    ) internal pure returns (uint256[] memory) {
         uint256 begin;
         uint256 end;
         /// @solidity memory-safe-assembly
@@ -39,9 +39,9 @@ library Arrays {
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
+     * @dev Variant of {sort} that sorts an array of uint256 in increassing order.
      */
-    function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
+    function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
         return sort(array, _defaultComp);
     }
 
@@ -52,7 +52,7 @@ library Arrays {
         address[] memory array,
         function(address, address) pure returns (bool) comp
     ) internal pure returns (address[] memory) {
-        sort(_castToBytes32Array(array), _castToBytes32Comp(comp));
+        sort(_castToUint256Array(array), _castToUint256Comp(comp));
         return array;
     }
 
@@ -60,26 +60,26 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of address in increassing order.
      */
     function sort(address[] memory array) internal pure returns (address[] memory) {
-        sort(_castToBytes32Array(array), _defaultComp);
+        sort(_castToUint256Array(array), _defaultComp);
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of uint256 following a provided comparator function.
+     * @dev Variant of {sort} that sorts an array of bytes32 following a provided comparator function.
      */
     function sort(
-        uint256[] memory array,
-        function(uint256, uint256) pure returns (bool) comp
-    ) internal pure returns (uint256[] memory) {
-        sort(_castToBytes32Array(array), _castToBytes32Comp(comp));
+        bytes32[] memory array,
+        function(bytes32, bytes32) pure returns (bool) comp
+    ) internal pure returns (bytes32[] memory) {
+        sort(_castToUint256Array(array), _castToUint256Comp(comp));
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of uint256 in increassing order.
+     * @dev Variant of {sort} that sorts an array of bytes32 in increassing order.
      */
-    function sort(uint256[] memory array) internal pure returns (uint256[] memory) {
-        sort(_castToBytes32Array(array), _defaultComp);
+    function sort(bytes32[] memory array) internal pure returns (bytes32[] memory) {
+        sort(_castToUint256Array(array), _defaultComp);
         return array;
     }
 
@@ -92,13 +92,13 @@ library Arrays {
     function _quickSort(
         uint256 begin,
         uint256 end,
-        function(bytes32, bytes32) pure returns (bool) comp
+        function(uint256, uint256) pure returns (bool) comp
     ) private pure {
         unchecked {
             if (end - begin < 0x40) return;
 
             // Use first element as pivot
-            bytes32 pivot = _mload(begin);
+            uint256 pivot = _mload(begin);
             // Position where the pivot should be at the end of the loop
             uint256 pos = begin;
 
@@ -118,17 +118,10 @@ library Arrays {
     }
 
     /**
-     * @dev Load memory word at location `ptr`.
+     * @dev Load memory word (as an unsigned integer) at location `ptr`.
      */
-    function _mload(uint256 ptr) private pure returns (bytes32 value) {
+    function _mload(uint256 ptr) private pure returns (uint256 value) {
         assembly { value := mload(ptr) }
-    }
-
-    /**
-     * @dev Set memory word at location `ptr` to `value`.
-     */
-    function _mstore(uint256 ptr, bytes32 value) private pure {
-        assembly { mstore(ptr, value) }
     }
 
     /**
@@ -144,37 +137,37 @@ library Arrays {
     }
 
     /// @dev Comparator for sorting arrays in increassing order.
-    function _defaultComp(bytes32 a, bytes32 b) private pure returns (bool) {
-        return uint256(a) < uint256(b);
+    function _defaultComp(uint256 a, uint256 b) private pure returns (bool) {
+        return a < b;
     }
 
-    /// @dev Helper: low level cast address memory array to bytes32 memory array
-    function _castToBytes32Array(address[] memory input) private pure returns (bytes32[] memory output) {
+    /// @dev Helper: low level cast address memory array to uint256 memory array
+    function _castToUint256Array(address[] memory input) private pure returns (uint256[] memory output) {
         assembly {
             output := input
         }
     }
 
-    /// @dev Helper: low level cast address memory array to bytes32 memory array
-    function _castToBytes32Array(uint256[] memory input) private pure returns (bytes32[] memory output) {
+    /// @dev Helper: low level cast bytes32 memory array to uint256 memory array
+    function _castToUint256Array(bytes32[] memory input) private pure returns (uint256[] memory output) {
         assembly {
             output := input
         }
     }
 
-    /// @dev Helper: low level cast address comp function to bytes32 comp function
-    function _castToBytes32Comp(
+    /// @dev Helper: low level cast address comp function to uint256 comp function
+    function _castToUint256Comp(
         function(address, address) pure returns (bool) input
-    ) private pure returns (function(bytes32, bytes32) pure returns (bool) output) {
+    ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
         assembly {
             output := input
         }
     }
 
-    /// @dev Helper: low level cast address comp function to bytes32 comp function
-    function _castToBytes32Comp(
-        function(uint256, uint256) pure returns (bool) input
-    ) private pure returns (function(bytes32, bytes32) pure returns (bool) output) {
+    /// @dev Helper: low level cast bytes32 comp function to uint256 comp function
+    function _castToUint256Comp(
+        function(bytes32, bytes32) pure returns (bool) input
+    ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
         assembly {
             output := input
         }

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -127,10 +127,10 @@ library Arrays {
      */
     function _swap(uint256 ptr1, uint256 ptr2) private pure {
         assembly {
-            let val1 := mload(ptr1)
-            let val2 := mload(ptr2)
-            mstore(ptr1, val2)
-            mstore(ptr2, val1)
+            let value1 := mload(ptr1)
+            let value2 := mload(ptr2)
+            mstore(ptr1, value2)
+            mstore(ptr2, value1)
         }
     }
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -7,11 +7,7 @@ function range(start, stop = undefined, step = 1) {
     stop = start;
     start = 0;
   }
-  return start < stop
-    ? Array(Math.ceil((stop - start) / step))
-        .fill()
-        .map((_, i) => start + i * step)
-    : [];
+  return start < stop ? Array.from({ length: Math.ceil((stop - start) / step) }, (_, i) => start + i * step) : [];
 }
 
 function unique(array, op = x => x) {
@@ -19,9 +15,7 @@ function unique(array, op = x => x) {
 }
 
 function zip(...args) {
-  return Array(Math.max(...args.map(arg => arg.length)))
-    .fill(null)
-    .map((_, i) => args.map(arg => arg[i]));
+  return Array.from({ length: Math.max(...args.map(arg => arg.length)) }, (_, i) => args.map(arg => arg[i]));
 }
 
 function capitalize(str) {

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -55,9 +55,7 @@ async function fixture() {
     },
   };
 
-  const schedule = Array(64)
-    .fill()
-    .map((_, i) => (BigInt(i) * duration) / 60n + start);
+  const schedule = Array.from({ length: 64 }, (_, i) => (BigInt(i) * duration) / 60n + start);
 
   const vestingFn = timestamp => min(amount, (amount * (timestamp - start)) / duration);
 

--- a/test/helpers/iterate.js
+++ b/test/helpers/iterate.js
@@ -5,9 +5,7 @@ const mapValues = (obj, fn) => Object.fromEntries(Object.entries(obj).map(([k, v
 const product = (...arrays) => arrays.reduce((a, b) => a.flatMap(ai => b.map(bi => [...ai, bi])), [[]]);
 const unique = (...array) => array.filter((obj, i) => array.indexOf(obj) === i);
 const zip = (...args) =>
-  Array(Math.max(...args.map(array => array.length)))
-    .fill()
-    .map((_, i) => args.map(array => array[i]));
+  Array.from({ length: Math.max(...args.map(array => array.length)) }, (_, i) => args.map(array => array[i]));
 
 module.exports = {
   mapValues,

--- a/test/helpers/random.js
+++ b/test/helpers/random.js
@@ -1,7 +1,5 @@
 const { ethers } = require('hardhat');
 
-const randomArray = (generator, arrayLength = 3) => Array(arrayLength).fill().map(generator);
-
 const generators = {
   address: () => ethers.Wallet.createRandom().address,
   bytes32: () => ethers.hexlify(ethers.randomBytes(32)),
@@ -15,6 +13,5 @@ generators.uint256.zero = 0n;
 generators.hexBytes.zero = '0x';
 
 module.exports = {
-  randomArray,
   generators,
 };

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -149,6 +149,13 @@ describe('Arrays', function () {
               this.elements = Array.from({ length }, generators[type]);
             });
 
+            afterEach(async function () {
+              const expected = Array.from(this.elements).sort(comp);
+              const reversed = Array.from(expected).reverse();
+              expect(await this.instance.sort(this.elements)).to.deep.equal(expected);
+              expect(await this.instance.sortReverse(this.elements)).to.deep.equal(reversed);
+            });
+
             it('sort array', async function () {
               // nothing to do here, beforeEach and afterEach already take care of everything.
             });
@@ -176,13 +183,6 @@ describe('Arrays', function () {
                 this.elements.unshift(this.elements.pop());
               });
             }
-
-            afterEach(async function () {
-              const expected = Array.from(this.elements).sort(comp);
-              const reversed = Array.from(expected).reverse();
-              expect(await this.instance.sort(this.elements)).to.deep.equal(expected);
-              expect(await this.instance.sortReverse(this.elements)).to.deep.equal(reversed);
-            });
           });
         }
       });

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -178,7 +178,6 @@ describe('Arrays', function () {
 
               it('sort almost sorted array', async function () {
                 // pre-sort + rotate (move the last element to the front) for an almost sorted effect
-                // Note: when using the first element as the pivot, this is the worst cast (complexity: O(n²))
                 this.elements.sort(comp);
                 this.elements.unshift(this.elements.pop());
               });

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { randomArray, generators } = require('../helpers/random');
+const { generators } = require('../helpers/random');
 
 // See https://en.cppreference.com/w/cpp/algorithm/lower_bound
 const lowerBound = (array, value) => {
@@ -37,7 +37,7 @@ describe('Arrays', function () {
       for (const length of [0, 1, 2, 8, 32, 128]) {
         describe(`${type}[] of length ${length}`, function () {
           beforeEach(async function () {
-            this.elements = randomArray(generators[type], length);
+            this.elements = Array.from({ length }, generators[type]);
           });
 
           it('sort array', async function () {
@@ -166,9 +166,9 @@ describe('Arrays', function () {
 
   describe('unsafeAccess', function () {
     for (const [type, { artifact, elements }] of Object.entries({
-      address: { artifact: 'AddressArraysMock', elements: randomArray(generators.address, 10) },
-      bytes32: { artifact: 'Bytes32ArraysMock', elements: randomArray(generators.bytes32, 10) },
-      uint256: { artifact: 'Uint256ArraysMock', elements: randomArray(generators.uint256, 10) },
+      address: { artifact: 'AddressArraysMock', elements: Array.from({ length: 10 }, generators.address) },
+      bytes32: { artifact: 'Bytes32ArraysMock', elements: Array.from({ length: 10 }, generators.bytes32) },
+      uint256: { artifact: 'Uint256ArraysMock', elements: Array.from({ length: 10 }, generators.uint256) },
     })) {
       describe(type, function () {
         describe('storage', function () {

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -16,7 +16,7 @@ const upperBound = (array, value) => {
   return i == -1 ? array.length : i;
 };
 
-const bigintSign = x => x > 0n ? 1 : x < 0n ? -1 : 0;
+const bigintSign = x => (x > 0n ? 1 : x < 0n ? -1 : 0);
 const hasDuplicates = array => array.some((v, i) => array.indexOf(v) != i);
 
 describe('Arrays', function () {
@@ -29,12 +29,11 @@ describe('Arrays', function () {
   });
 
   describe('sort', function () {
-    for (const [ type, comparator ] of Object.entries({
+    for (const [type, comparator] of Object.entries({
       address: (a, b) => bigintSign(ethers.toBigInt(a) - ethers.toBigInt(b)),
       bytes32: (a, b) => bigintSign(ethers.toBigInt(a) - ethers.toBigInt(b)),
       uint256: (a, b) => bigintSign(a - b),
-    }))
-    {
+    })) {
       for (const length of [0, 1, 2, 8, 32, 128]) {
         describe(`${type}[] of length ${length}`, function () {
           beforeEach(async function () {

--- a/test/utils/math/Math.test.js
+++ b/test/utils/math/Math.test.js
@@ -5,7 +5,7 @@ const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const { Rounding } = require('../../helpers/enums');
 const { min, max } = require('../../helpers/math');
-const { randomArray, generators } = require('../../helpers/random');
+const { generators } = require('../../helpers/random');
 
 const RoundingDown = [Rounding.Floor, Rounding.Trunc];
 const RoundingUp = [Rounding.Ceil, Rounding.Expand];
@@ -337,7 +337,7 @@ describe('Math', function () {
         });
 
         if (p != 0) {
-          for (const value of randomArray(generators.uint256, 16)) {
+          for (const value of Array.from({ length: 16 }, generators.uint256)) {
             const isInversible = factors.every(f => value % f);
             it(`trying to inverse ${value}`, async function () {
               const result = await this.mock.$invMod(value, p);

--- a/test/utils/structs/DoubleEndedQueue.test.js
+++ b/test/utils/structs/DoubleEndedQueue.test.js
@@ -8,7 +8,7 @@ async function fixture() {
 
   /** Rebuild the content of the deque as a JS array. */
   const getContent = () =>
-    mock.$length(0).then(length => Promise.all(Array.from({ length }, (_, i) => mock.$at(0, i))));
+    mock.$length(0).then(length => Promise.all(Array.from({ length: Number(length) }, (_, i) => mock.$at(0, i))));
 
   return { mock, getContent };
 }

--- a/test/utils/structs/DoubleEndedQueue.test.js
+++ b/test/utils/structs/DoubleEndedQueue.test.js
@@ -8,13 +8,7 @@ async function fixture() {
 
   /** Rebuild the content of the deque as a JS array. */
   const getContent = () =>
-    mock.$length(0).then(length =>
-      Promise.all(
-        Array(Number(length))
-          .fill()
-          .map((_, i) => mock.$at(0, i)),
-      ),
-    );
+    mock.$length(0).then(length => Promise.all(Array.from({ length }, (_, i) => mock.$at(0, i))));
 
   return { mock, getContent };
 }

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const { mapValues } = require('../../helpers/iterate');
-const { randomArray, generators } = require('../../helpers/random');
+const { generators } = require('../../helpers/random');
 const { TYPES, formatType } = require('../../../scripts/generate/templates/EnumerableMap.opts');
 
 const { shouldBehaveLikeMap } = require('./EnumerableMap.behavior');
@@ -17,8 +17,8 @@ async function fixture() {
       name,
       {
         keyType,
-        keys: randomArray(generators[keyType]),
-        values: randomArray(generators[valueType]),
+        keys: Array.from({ length: 3 }, generators[keyType]),
+        values: Array.from({ length: 3 }, generators[valueType]),
         zeroValue: generators[valueType].zero,
         methods: mapValues(
           {

--- a/test/utils/structs/EnumerableSet.test.js
+++ b/test/utils/structs/EnumerableSet.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const { mapValues } = require('../../helpers/iterate');
-const { randomArray, generators } = require('../../helpers/random');
+const { generators } = require('../../helpers/random');
 const { TYPES } = require('../../../scripts/generate/templates/EnumerableSet.opts');
 
 const { shouldBehaveLikeSet } = require('./EnumerableSet.behavior');
@@ -23,7 +23,7 @@ async function fixture() {
     TYPES.map(({ name, type }) => [
       type,
       {
-        values: randomArray(generators[type]),
+        values: Array.from({ length: 3 }, generators[type]),
         methods: getMethods(mock, {
           add: `$add(uint256,${type})`,
           remove: `$remove(uint256,${type})`,


### PR DESCRIPTION
This PR also refactors the `_quicksort` private function to use "memory pointers". This was shown to save ~16% gas when sorting a random array of length 100.

Fixes #4882

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
