### PR TITLE
Fixed ERC1155 token transfer for unauthorized account

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -108,7 +108,7 @@ abstract contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI, IER
      */
     function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes memory data) public virtual {
         address sender = _msgSender();
-        if (from != sender && !isApprovedForAll(from, sender)) {
+        if (from != sender || !isApprovedForAll(from, sender)) {
             revert ERC1155MissingApprovalForAll(sender, from);
         }
         _safeTransferFrom(from, to, id, value, data);


### PR DESCRIPTION
Hello, I was studying ```ERC1155.sol``` and noticed that unapproved account executed ```safeTransferFrom``` function.

Testing flow is as follows.

1. ```setApprovalForAll```: set approved false in an account.
2. ```safeTransferFrom```: when transferring from an account to the other.
    Expected result: ```revert ERC1155MissingApprovalForAll```
    Actual result: execute ```_safeTransferFrom```

```safeTransferFrom``` should not be executed for unapproved account.
![openzeppelin ERC1155](https://github.com/OpenZeppelin/openzeppelin-contracts/assets/44286914/c5cc5fa7-5ba9-4aba-a6ea-bd3661701302)
