### PR TITLE
add if(_owners[tokenId] != to) condition to save some gas on each NFT minting, burning or transferring

### DIFF
--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -262,7 +262,9 @@ abstract contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Er
             }
         }
 
-        _owners[tokenId] = to;
+        if (_owners[tokenId] != to) {
+            _owners[tokenId] = to;
+        }
 
         emit Transfer(from, to, tokenId);
 


### PR DESCRIPTION

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

**Files changed:**
1. https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol


**Description of the change:**
Very small change of adding a check before always updating **[_owners[tokenId] = to;](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L265)** on each minting, burning or transfering of NFT.
