### PR TITLE
Revert EIP-2098 support drop in ECDSA.sol

### DIFF
--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -54,10 +54,10 @@ library ECDSA {
      * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]
      */
     function tryRecover(bytes32 hash, bytes memory signature) internal pure returns (address, RecoverError, bytes32) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
         if (signature.length == 65) {
-            bytes32 r;
-            bytes32 s;
-            uint8 v;
             // ecrecover takes the signature parameters, and the only way to get them
             // currently is to use assembly.
             /// @solidity memory-safe-assembly
@@ -65,6 +65,17 @@ library ECDSA {
                 r := mload(add(signature, 0x20))
                 s := mload(add(signature, 0x40))
                 v := byte(0, mload(add(signature, 0x60)))
+            }
+            return tryRecover(hash, v, r, s);
+        } if (signature.length == 64) {
+            // ecrecover takes the signature parameters, and the only way to get them
+            // currently is to use assembly.
+            /// @solidity memory-safe-assembly
+            assembly {
+                let vs := mload(add(signature, 0x40))
+                r := mload(add(signature, 0x20))
+                s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+                v := add(shr(255, vs), 27)
             }
             return tryRecover(hash, v, r, s);
         } else {


### PR DESCRIPTION
This refactor allows dApp's to optimize calldata gas usage integrating EIP-2098 even after deployment. Specifically, it reduces the gas cost to 136 units by compressing the signature before it's passed into calldata. This compression strategy takes advantage of the gas pricing mechanism, where 1 non-zero byte costs 16 gas units, and each of the 31 padding zero bytes incurs a cost of 4 gas units.