### PR TITLE
Update documentation in IAccessControl

### DIFF
--- a/.changeset/metal-foxes-listen.md
+++ b/.changeset/metal-foxes-listen.md
@@ -1,0 +1,5 @@
+---
+"openzeppelin-solidity": patch
+---
+
+fix: update the natspec comment of IAccessControl on `RoleGranted` event to align with latest logic on AccessControl

--- a/.changeset/metal-foxes-listen.md
+++ b/.changeset/metal-foxes-listen.md
@@ -1,5 +1,0 @@
----
-"openzeppelin-solidity": patch
----
-
-fix: update the natspec comment of IAccessControl on `RoleGranted` event to align with latest logic on AccessControl

--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -30,8 +30,8 @@ interface IAccessControl {
     /**
      * @dev Emitted when `account` is granted `role`.
      *
-     * `sender` is the account that originated the contract call. This account bears the admin role (for the granted
-     * role), expect in cases where the role was granted using the internal {AccessControl-_grantRole}.
+     * `sender` is the account that originated the contract call. This account bears the admin role (for the granted role).
+     * Expected in cases where the role was granted using the internal {AccessControl-_grantRole}.
      */
     event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
 

--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -30,7 +30,7 @@ interface IAccessControl {
     /**
      * @dev Emitted when `account` is granted `role`.
      *
-     * `sender` is the account that originated the contract call. This account bears the admin role (for the granted 
+     * `sender` is the account that originated the contract call. This account bears the admin role (for the granted
      * role), expect in cases where the role was granted using the internal {AccessControl-_grantRole}.
      */
     event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);

--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -30,7 +30,8 @@ interface IAccessControl {
     /**
      * @dev Emitted when `account` is granted `role`.
      *
-     * `sender` is the account that originated the contract call i.e. the admin role bearer.
+     * `sender` is the account that originated the contract call. This account bears the admin role (for the granted 
+     * role), expect in cases where the role was granted using the internal {AccessControl-_grantRole}.
      */
     event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
 

--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -30,8 +30,7 @@ interface IAccessControl {
     /**
      * @dev Emitted when `account` is granted `role`.
      *
-     * `sender` is the account that originated the contract call, an admin role
-     * bearer except when using {AccessControl-_setupRole}.
+     * `sender` is the account that originated the contract call i.e. the admin role bearer.
      */
     event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
 


### PR DESCRIPTION
Fixes #4923

As mentioned, this is to fix the natspec comment of IAccessControl on "RoleGranted" event to confirm with latest logic on AccessControl.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
