### PR TITLE
Optimize Clone.sol  yul

### DIFF
--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.20;
 
 /**
- * @dev https://eips.ethereum.org/EIPS/eip-1167[ERC-1167] is a standard for
+ * @dev https://eips.ethereum.org/EIPS/eip-1167 [ERC-1167] is a standard for
  * deploying minimal proxy contracts, also known as "clones".
  *
  * > To simply and cheaply clone contract functionality in an immutable way, this standard specifies
@@ -30,7 +30,7 @@ library Clones {
         assembly {
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
+            mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create(0, 0x09, 0x37)
@@ -52,7 +52,7 @@ library Clones {
         assembly {
             // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
             // of the `implementation` address with the bytecode before the address.
-            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
+            mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
             // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
             mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -28,11 +28,12 @@ library Clones {
     function clone(address implementation) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
+            // Stores the bytecode after address
+            mstore(0x20, 0x5af43d82803e903d91602b57fd5bf3)
+            // implementation address
+            mstore(0x11, implementation)
+            // Packs the first 3 bytes of the `implementation` address with the bytecode before the address.
             mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create(0, 0x09, 0x37)
         }
         if (instance == address(0)) {
@@ -50,11 +51,12 @@ library Clones {
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
-            // of the `implementation` address with the bytecode before the address.
+            // Stores the bytecode after address
+            mstore(0x20, 0x5af43d82803e903d91602b57fd5bf3)
+            // implementation address
+            mstore(0x11, implementation)
+            // Packs the first 3 bytes of the `implementation` address with the bytecode before the address.
             mstore(0x00, or(shr(0x88, implementation), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
-            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
-            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
             instance := create2(0, 0x09, 0x37, salt)
         }
         if (instance == address(0)) {

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.20;
 
 /**
- * @dev https://eips.ethereum.org/EIPS/eip-1167 [ERC-1167] is a standard for
+ * @dev https://eips.ethereum.org/EIPS/eip-1167[ERC-1167] is a standard for
  * deploying minimal proxy contracts, also known as "clones".
  *
  * > To simply and cheaply clone contract functionality in an immutable way, this standard specifies


### PR DESCRIPTION
This PR optmizes the yul in Clones.sol

This optmization can be done because solidity already verify dirty bytes in addresses from calldata

There are other optmizations that can be done but those woud require th use of unallocated memory area


Metrics (with `npm run gas-report`):
```
·--------------------------------------|--------|--------|------|---------·
| Method                               · Before · After  · Diff · % Diff  |
·······································|········|········|······|·········|
| Deployments                          · 271943 · 270215 · 1296 ·  0.635% |
·······································|········|········|······|·········|
| $clone(address)                      ·  64079 ·  64070 ·    9 ·  0.014% |
·······································|········|········|······|·········|
| $cloneDeterministic(address,bytes32) ·  64654 ·  64646 ·    8 .  0.012% |
·--------------------------------------|--------|--------|------|---------·
```

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
