### PR TITLE
Remove root from MerkleTree

### DIFF
--- a/contracts/mocks/MerkleTreeMock.sol
+++ b/contracts/mocks/MerkleTreeMock.sol
@@ -9,19 +9,20 @@ contract MerkleTreeMock {
 
     MerkleTree.Bytes32PushTree private _tree;
 
-    event LeafInserted(bytes32 leaf, uint256 index, bytes32 root);
-    event TreeSetup(uint8 depth, bytes32 zero, bytes32 root);
+    // This mock only stored the latest root.
+    // Production contract may want to store historical values.
+    bytes32 public root;
 
-    function setup(uint8 _depth, bytes32 _zero) public returns (bytes32) {
-        bytes32 initialRoot = _tree.setup(_depth, _zero);
-        emit TreeSetup(_depth, _zero, initialRoot);
-        return initialRoot;
+    event LeafInserted(bytes32 leaf, uint256 index, bytes32 root);
+
+    function setup(uint8 _depth, bytes32 _zero) public {
+        root = _tree.setup(_depth, _zero);
     }
 
-    function push(bytes32 leaf) public returns (uint256 leafIndex, bytes32 currentRoot) {
-        (leafIndex, currentRoot) = _tree.push(leaf);
+    function push(bytes32 leaf) public {
+        (uint256 leafIndex, bytes32 currentRoot) = _tree.push(leaf);
         emit LeafInserted(leaf, leafIndex, currentRoot);
-        return (leafIndex, currentRoot);
+        root = currentRoot;
     }
 
     function depth() public view returns (uint256) {

--- a/contracts/mocks/MerkleTreeMock.sol
+++ b/contracts/mocks/MerkleTreeMock.sol
@@ -10,18 +10,18 @@ contract MerkleTreeMock {
     MerkleTree.Bytes32PushTree private _tree;
 
     event LeafInserted(bytes32 leaf, uint256 index, bytes32 root);
+    event TreeSetup(uint8 depth, bytes32 zero, bytes32 root);
 
-    function setup(uint8 _depth, bytes32 _zero) public {
-        _tree.setup(_depth, _zero);
+    function setup(uint8 _depth, bytes32 _zero) public returns (bytes32) {
+        bytes32 initialRoot = _tree.setup(_depth, _zero);
+        emit TreeSetup(_depth, _zero, initialRoot);
+        return initialRoot;
     }
 
-    function push(bytes32 leaf) public {
-        (uint256 leafIndex, bytes32 currentRoot) = _tree.push(leaf);
+    function push(bytes32 leaf) public returns (uint256 leafIndex, bytes32 currentRoot) {
+        (leafIndex, currentRoot) = _tree.push(leaf);
         emit LeafInserted(leaf, leafIndex, currentRoot);
-    }
-
-    function root() public view returns (bytes32) {
-        return _tree.root();
+        return (leafIndex, currentRoot);
     }
 
     function depth() public view returns (uint256) {

--- a/test/utils/structs/MerkleTree.test.js
+++ b/test/utils/structs/MerkleTree.test.js
@@ -20,8 +20,8 @@ const ZERO = hashLeaf(ethers.ZeroHash);
 
 async function fixture() {
   const mock = await ethers.deployContract('MerkleTreeMock');
-  await mock.setup(DEPTH, ZERO);
-  return { mock };
+  const setupTx = await mock.setup(DEPTH, ZERO);
+  return { mock, setupTx };
 }
 
 describe('MerkleTree', function () {
@@ -32,7 +32,7 @@ describe('MerkleTree', function () {
   it('sets initial values at setup', async function () {
     const merkleTree = makeTree(Array.from({ length: 2 ** Number(DEPTH) }, () => ethers.ZeroHash));
 
-    expect(await this.mock.root()).to.equal(merkleTree.root);
+    expect(this.setupTx).to.emit(this.mock, 'TreeSetup').withArgs(DEPTH, ZERO, merkleTree.root);
     expect(await this.mock.depth()).to.equal(DEPTH);
     expect(await this.mock.nextLeafIndex()).to.equal(0n);
   });
@@ -53,7 +53,6 @@ describe('MerkleTree', function () {
         await expect(this.mock.push(hashedLeaf)).to.emit(this.mock, 'LeafInserted').withArgs(hashedLeaf, i, tree.root);
 
         // check tree
-        expect(await this.mock.root()).to.equal(tree.root);
         expect(await this.mock.nextLeafIndex()).to.equal(BigInt(i) + 1n);
       }
     });
@@ -76,25 +75,19 @@ describe('MerkleTree', function () {
     const tree = makeTree(leafs);
 
     // root should be that of a zero tree
-    expect(await this.mock.root()).to.equal(zeroTree.root);
+    expect(this.setupTx).to.emit(this.mock, 'TreeSetup').withArgs(DEPTH, ZERO, zeroTree.root);
     expect(await this.mock.nextLeafIndex()).to.equal(0n);
 
     // push leaf and check root
     await expect(this.mock.push(hashedLeaf)).to.emit(this.mock, 'LeafInserted').withArgs(hashedLeaf, 0, tree.root);
-
-    expect(await this.mock.root()).to.equal(tree.root);
     expect(await this.mock.nextLeafIndex()).to.equal(1n);
 
     // reset tree
-    await this.mock.setup(DEPTH, ZERO);
-
-    expect(await this.mock.root()).to.equal(zeroTree.root);
+    await expect(this.mock.setup(DEPTH, ZERO)).to.emit(this.mock, 'TreeSetup').withArgs(DEPTH, ZERO, zeroTree.root);
     expect(await this.mock.nextLeafIndex()).to.equal(0n);
 
     // re-push leaf and check root
     await expect(this.mock.push(hashedLeaf)).to.emit(this.mock, 'LeafInserted').withArgs(hashedLeaf, 0, tree.root);
-
-    expect(await this.mock.root()).to.equal(tree.root);
     expect(await this.mock.nextLeafIndex()).to.equal(1n);
   });
 });


### PR DESCRIPTION
Fixes #4946

After discussing, we considered it rather unnecessary to store the root of the tree along with it, and its core functionality is enough for anyone to build use cases where the root is tracked. 

With this change the user may decide to keep track of the root for purposes that may not require on-chain availability (e.g. a whitelist that stores roots every N insertions) or that may require a lookup mechanism (e.g. Bitmaps) for which storing the root is already an opinionated decision.

We can consider adding a default recommendation, such as #4911.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
