### PR TITLE
Run linter before pushing to git

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+npm run lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-if [ "$CI" != "true" ]; then
+if [ "${CI:-"false"}" != "false" ]; then
   npm run lint
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,5 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 npm run lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-if [ "${CI:-"false"}" != "false" ]; then
+if [ "${CI:-"false"}" != "true" ]; then
   npm run lint
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
- if [ "$CI" != "true" ]; then
+if [ "$CI" != "true" ]; then
   npm run lint
- fi
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,4 +2,6 @@
 
 set -euo pipefail
 
-npm run lint
+ if [ "$CI" != "true" ]; then
+  npm run lint
+ fi

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "coverage": "env COVERAGE=true hardhat coverage",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
+    "prepare": "git config --local core.hooksPath .githooks",
     "prepare-docs": "scripts/prepare-docs.sh",
     "lint": "npm run lint:js && npm run lint:sol",
     "lint:fix": "npm run lint:js:fix && npm run lint:sol:fix",


### PR DESCRIPTION
We often get code pushed that does not pass the linter, and require a second pass. This configuration changes that.

We could move that rule into the `pre-commit` hook, but that may be a bit to intrusive. @ernestognw WDYT? By having the rule in `pre-push`, you can still commit locally if you code doesn't pass the linter, you just cannot push.

Any other hooks we should consider?