### PR TITLE
Bump ERC1967Utils pragma to 0.8.21 and set Slither CI version to 0.10.1

### DIFF
--- a/.changeset/tame-lies-do.md
+++ b/.changeset/tame-lies-do.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-'ERC1967Utils': Increase pragma to support latest functionalities.

--- a/.changeset/tame-lies-do.md
+++ b/.changeset/tame-lies-do.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+'ERC1967Utils': Increase pragma to support latest functionalities.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,6 +118,7 @@ jobs:
       - uses: crytic/slither-action@v0.3.2
         with:
           node-version: 18.15
+          slither-version: 0.10.1
 
   codespell:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Breaking changes
+
+- `ERC1967Utils`: Removed duplicate declaration of the `Upgraded`, `AdminChanged` and `BeaconUpgraded` events. These events are still avaible through the `IERC1967` interface located under the `contracts/interfaces/` directory. Minimum pragma version is now 0.8.21.
+
 ### Custom error changes
 
 This version comes with changes to the custom error identifiers. Contracts previously depending on the following errors should be replaced accordingly:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-- `ERC1967Utils`: Removed duplicate declaration of the `Upgraded`, `AdminChanged` and `BeaconUpgraded` events. These events are still avaible through the `IERC1967` interface located under the `contracts/interfaces/` directory. Minimum pragma version is now 0.8.21.
+- `ERC1967Utils`: Removed duplicate declaration of the `Upgraded`, `AdminChanged` and `BeaconUpgraded` events. These events are still available through the `IERC1967` interface located under the `contracts/interfaces/` directory. Minimum pragma version is now 0.8.21.
 
 ### Custom error changes
 

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (proxy/ERC1967/ERC1967Utils.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.21;
 
 import {IBeacon} from "../beacon/IBeacon.sol";
 import {IERC1967} from "../../interfaces/IERC1967.sol";


### PR DESCRIPTION
Fixes #4995  

I noticed the related issue about the pragma that is used. After minor local tests, I verified that the increase to 0.8.21 works well.

Same as #4999 but with the proper files added. Excuse my previous PR, I am a first time contributor. Sorry for any inconvenience.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
