### PR TITLE
Update ERC1363 error signatures

### DIFF
--- a/contracts/token/ERC20/extensions/ERC1363.sol
+++ b/contracts/token/ERC20/extensions/ERC1363.sol
@@ -37,16 +37,16 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
 
     /**
      * @dev Indicates a failure within the {transferFrom} part of a transferFromAndCall operation.
-     * @param sender The address from which to send tokens.
-     * @param receiver The address to which tokens are being transferred.
-     * @param value The amount of tokens to be transferred.
+     * @param sender Address from which to send tokens.
+     * @param receiver Address to which tokens are being transferred.
+     * @param value Amount of tokens to be transferred.
      */
     error ERC1363TransferFromFailed(address sender, address receiver, uint256 value);
 
     /**
      * @dev Indicates a failure within the {approve} part of a approveAndCall operation.
-     * @param spender The address which will spend the funds.
-     * @param value The amount of tokens to be spent.
+     * @param spender Address which will spend the funds.
+     * @param value Amount of tokens to be spent.
      */
     error ERC1363ApproveFailed(address spender, uint256 value);
 

--- a/contracts/token/ERC20/extensions/ERC1363.sol
+++ b/contracts/token/ERC20/extensions/ERC1363.sol
@@ -30,16 +30,23 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
 
     /**
      * @dev Indicates a failure within the {transfer} part of a transferAndCall operation.
+     * @param receiver The address to which tokens are being transferred.
+     * @param value The amount of tokens to be transferred.
      */
     error ERC1363TransferFailed(address receiver, uint256 value);
 
     /**
      * @dev Indicates a failure within the {transferFrom} part of a transferFromAndCall operation.
+     * @param sender The address from which to send tokens.
+     * @param receiver The address to which tokens are being transferred.
+     * @param value The amount of tokens to be transferred.
      */
     error ERC1363TransferFromFailed(address sender, address receiver, uint256 value);
 
     /**
      * @dev Indicates a failure within the {approve} part of a approveAndCall operation.
+     * @param spender The address which will spend the funds.
+     * @param value The amount of tokens to be spent.
      */
     error ERC1363ApproveFailed(address spender, uint256 value);
 

--- a/contracts/token/ERC20/extensions/ERC1363.sol
+++ b/contracts/token/ERC20/extensions/ERC1363.sol
@@ -31,12 +31,12 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
     /**
      * @dev Indicates a failure within the {transfer} part of a transferAndCall operation.
      */
-    error ERC1363TransferFailed(address to, uint256 value);
+    error ERC1363TransferFailed(address receiver, uint256 value);
 
     /**
      * @dev Indicates a failure within the {transferFrom} part of a transferFromAndCall operation.
      */
-    error ERC1363TransferFromFailed(address from, address to, uint256 value);
+    error ERC1363TransferFromFailed(address sender, address receiver, uint256 value);
 
     /**
      * @dev Indicates a failure within the {approve} part of a approveAndCall operation.

--- a/contracts/token/ERC20/extensions/ERC1363.sol
+++ b/contracts/token/ERC20/extensions/ERC1363.sol
@@ -30,7 +30,7 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
 
     /**
      * @dev Indicates a failure within the {transfer} part of a transferAndCall operation.
-     * @param receiver The address to which tokens are being transferred.
+     * @param receiver Address to which tokens are being transferred.
      * @param value The amount of tokens to be transferred.
      */
     error ERC1363TransferFailed(address receiver, uint256 value);

--- a/contracts/token/ERC20/extensions/ERC1363.sol
+++ b/contracts/token/ERC20/extensions/ERC1363.sol
@@ -31,7 +31,7 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
     /**
      * @dev Indicates a failure within the {transfer} part of a transferAndCall operation.
      * @param receiver Address to which tokens are being transferred.
-     * @param value The amount of tokens to be transferred.
+     * @param value Amount of tokens to be transferred.
      */
     error ERC1363TransferFailed(address receiver, uint256 value);
 


### PR DESCRIPTION
In order for the ERC1363 errors to adhere at EIP-6093, I changed `from\to` with `sender\receiver` as expressed in [eip-6093#parameter-glossary](https://eips.ethereum.org/EIPS/eip-6093#parameter-glossary).

Also added missing natspec comments for parameters as they were inserted for all the other errors.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
