### PR TITLE
Extend `onlyAuthorized` to support extra functions in AccessManager

### DIFF
--- a/.changeset/light-news-listen.md
+++ b/.changeset/light-news-listen.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`AccessManager`: Allow the `onlyAuthorize` modifier to restrict functions added to the manager.

--- a/.changeset/light-news-listen.md
+++ b/.changeset/light-news-listen.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`AccessManager`: Allow the `onlyAuthorize` modifier to restrict functions added to the manager.
+`AccessManager`: Allow the `onlyAuthorized` modifier to restrict functions added to the manager.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/certora/diff/access_manager_AccessManager.sol.patch
+++ b/certora/diff/access_manager_AccessManager.sol.patch
@@ -64,8 +64,8 @@
       */
      function _getAdminRestrictions(
          bytes calldata data
--    ) private view returns (bool restricted, uint64 roleAdminId, uint32 executionDelay) {
-+    ) internal view returns (bool restricted, uint64 roleAdminId, uint32 executionDelay) { // private → internal for FV
+-    ) private view returns (bool adminRestricted, uint64 roleAdminId, uint32 executionDelay) {
++    ) internal view returns (bool adminRestricted, uint64 roleAdminId, uint32 executionDelay) { // private → internal for FV
          if (data.length < 4) {
              return (false, 0, 0);
          }

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -412,9 +412,6 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * Emits a {TargetClosed} event.
      */
     function _setTargetClosed(address target, bool closed) internal virtual {
-        if (target == address(this)) {
-            revert AccessManagerLockedAccount(target);
-        }
         _targets[target].closed = closed;
         emit TargetClosed(target, closed);
     }

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -82,7 +82,6 @@ interface IAccessManager {
     error AccessManagerNotScheduled(bytes32 operationId);
     error AccessManagerNotReady(bytes32 operationId);
     error AccessManagerExpired(bytes32 operationId);
-    error AccessManagerLockedAccount(address account);
     error AccessManagerLockedRole(uint64 roleId);
     error AccessManagerBadConfirmation();
     error AccessManagerUnauthorizedAccount(address msgsender, uint64 roleId);
@@ -108,7 +107,7 @@ interface IAccessManager {
      * is backward compatible. Some contracts may thus ignore the second return argument. In that case they will fail
      * to identify the indirect workflow, and will consider calls that require a delay to be forbidden.
      *
-     * NOTE: This function does not report the permissions of this manager itself. These are defined by the
+     * NOTE: This function does not report the permissions of the admin functions in the manager itself. These are defined by the
      * {AccessManager} documentation.
      */
     function canCall(
@@ -134,6 +133,8 @@ interface IAccessManager {
 
     /**
      * @dev Get whether the contract is closed disabling any access. Otherwise role permissions are applied.
+     *
+     * NOTE: When the manager itself is closed, admin functions are still accessible to avoid locking the contract.
      */
     function isTargetClosed(address target) external view returns (bool);
 
@@ -307,6 +308,8 @@ interface IAccessManager {
 
     /**
      * @dev Set the closed flag for a contract.
+     *
+     * Closing the manager itself won't disable access to admin methods to avoid locking the contract.
      *
      * Requirements:
      *

--- a/contracts/mocks/AccessManagerMock.sol
+++ b/contracts/mocks/AccessManagerMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {AccessManager} from "../access/manager/AccessManager.sol";
+import {StorageSlot} from "../utils/StorageSlot.sol";
+
+contract AccessManagerMock is AccessManager {
+    event CalledRestricted(address caller);
+    event CalledUnrestricted(address caller);
+
+    constructor(address initialAdmin) AccessManager(initialAdmin) {}
+
+    function fnRestricted() public onlyAuthorized {
+        emit CalledRestricted(msg.sender);
+    }
+
+    function fnUnrestricted() public {
+        emit CalledUnrestricted(msg.sender);
+    }
+}

--- a/test/access/manager/AccessManager.behavior.js
+++ b/test/access/manager/AccessManager.behavior.js
@@ -194,7 +194,7 @@ function shouldBehaveLikeAManagedRestrictedOperation() {
 }
 
 /**
- * @requires this.{manager,roles,calldata,role}
+ * @requires this.{target,manager,roles,calldata,role}
  */
 function shouldBehaveLikeASelfRestrictedOperation() {
   const getAccessPath = LIKE_COMMON_GET_ACCESS;

--- a/test/access/manager/AccessManager.behavior.js
+++ b/test/access/manager/AccessManager.behavior.js
@@ -222,7 +222,7 @@ function shouldBehaveLikeASelfRestrictedOperation() {
     it('reverts as AccessManagerUnauthorizedAccount', async function () {
       await expect(this.caller.sendTransaction({ to: this.target, data: this.calldata }))
         .to.be.revertedWithCustomError(this.manager, 'AccessManagerUnauthorizedAccount')
-        .withArgs(this.caller, 0); // There's no way to know the required role of a function executed by the manager since the selector will be that of "execute"
+        .withArgs(this.caller, this.role?.id ?? 0n);
     });
   };
 

--- a/test/access/manager/AccessManager.behavior.js
+++ b/test/access/manager/AccessManager.behavior.js
@@ -193,9 +193,62 @@ function shouldBehaveLikeAManagedRestrictedOperation() {
   });
 }
 
+/**
+ * @requires this.{manager,roles,calldata,role}
+ */
+function shouldBehaveLikeASelfRestrictedOperation() {
+  const getAccessPath = LIKE_COMMON_GET_ACCESS;
+
+  function testScheduleOperation(mineDelay) {
+    return function self() {
+      self.mineDelay = mineDelay;
+      beforeEach('sets execution delay', async function () {
+        this.scheduleIn = this.executionDelay; // For testAsSchedulableOperation
+      });
+      testAsSchedulableOperation(LIKE_COMMON_SCHEDULABLE);
+    };
+  }
+
+  getAccessPath.requiredRoleIsGranted.roleGrantingIsDelayed.callerHasAnExecutionDelay.afterGrantDelay =
+    testScheduleOperation(true);
+  getAccessPath.requiredRoleIsGranted.roleGrantingIsNotDelayed.callerHasAnExecutionDelay = testScheduleOperation(false);
+
+  beforeEach('set target as manager', function () {
+    this.target = this.manager;
+  });
+
+  const isExecutingPath = LIKE_COMMON_IS_EXECUTING;
+  isExecutingPath.notExecuting = function () {
+    it('reverts as AccessManagerUnauthorizedAccount', async function () {
+      await expect(this.caller.sendTransaction({ to: this.target, data: this.calldata }))
+        .to.be.revertedWithCustomError(this.manager, 'AccessManagerUnauthorizedAccount')
+        .withArgs(this.caller, 0); // There's no way to know the required role of a function executed by the manager since the selector will be that of "execute"
+    });
+  };
+
+  testAsRestrictedOperation({
+    callerIsTheManager: isExecutingPath,
+    callerIsNotTheManager() {
+      testAsHasRole({
+        publicRoleIsRequired() {
+          it('succeeds called directly', async function () {
+            await this.caller.sendTransaction({ to: this.target, data: this.calldata });
+          });
+
+          it('succeeds via execute', async function () {
+            await this.manager.connect(this.caller).execute(this.target, this.calldata);
+          });
+        },
+        specificRoleIsRequired: getAccessPath,
+      });
+    },
+  });
+}
+
 module.exports = {
   shouldBehaveLikeDelayedAdminOperation,
   shouldBehaveLikeNotDelayedAdminOperation,
   shouldBehaveLikeRoleAdminOperation,
   shouldBehaveLikeAManagedRestrictedOperation,
+  shouldBehaveLikeASelfRestrictedOperation,
 };

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -1673,17 +1673,21 @@ describe('AccessManager', function () {
 
   describe('access managed self operations', function () {
     describe('when calling a restricted target function', function () {
-      beforeEach('set required role', function () {
-        this.method = this.manager.fnRestricted.getFragment();
+      const method = 'fnRestricted()';
+
+      beforeEach('set required role', async function () {
         this.role = { id: 785913n };
-        this.manager.$_setTargetFunctionRole(this.target, this.method.selector, this.role.id);
+        await this.manager.$_setTargetFunctionRole(
+          this.manager,
+          this.manager[method].getFragment().selector,
+          this.role.id,
+        );
       });
 
       describe('restrictions', function () {
         beforeEach('set method and args', function () {
-          this.calldata = this.manager.interface.encodeFunctionData(this.method, []);
           this.caller = this.user;
-          this.target = this.manager; // For shouldBehaveLikeASelfRestrictedOperation
+          this.calldata = this.manager.interface.encodeFunctionData(method, []);
         });
 
         shouldBehaveLikeASelfRestrictedOperation();
@@ -1692,11 +1696,7 @@ describe('AccessManager', function () {
       it('succeeds called by a role member', async function () {
         await this.manager.$_grantRole(this.role.id, this.user, 0, 0);
 
-        await expect(
-          this.manager.connect(this.user)[this.method.selector]({
-            data: this.calldata,
-          }),
-        )
+        await expect(this.manager.connect(this.user)[method]())
           .to.emit(this.manager, 'CalledRestricted')
           .withArgs(this.user);
       });
@@ -1715,11 +1715,7 @@ describe('AccessManager', function () {
       });
 
       it('succeeds called by anyone', async function () {
-        await expect(
-          this.manager.connect(this.user)[method]({
-            data: this.calldata,
-          }),
-        )
+        await expect(this.manager.connect(this.user)[method]())
           .to.emit(this.manager, 'CalledUnrestricted')
           .withArgs(this.user);
       });
@@ -1728,16 +1724,21 @@ describe('AccessManager', function () {
 
   describe('access managed target operations', function () {
     describe('when calling a restricted target function', function () {
-      beforeEach('set required role', function () {
-        this.method = this.target.fnRestricted.getFragment();
+      const method = 'fnRestricted()';
+
+      beforeEach('set required role', async function () {
         this.role = { id: 3597243n };
-        this.manager.$_setTargetFunctionRole(this.target, this.method.selector, this.role.id);
+        await this.manager.$_setTargetFunctionRole(
+          this.target,
+          this.target[method].getFragment().selector,
+          this.role.id,
+        );
       });
 
       describe('restrictions', function () {
         beforeEach('set method and args', function () {
-          this.calldata = this.target.interface.encodeFunctionData(this.method, []);
           this.caller = this.user;
+          this.calldata = this.target.interface.encodeFunctionData(method, []);
         });
 
         shouldBehaveLikeAManagedRestrictedOperation();
@@ -1746,11 +1747,7 @@ describe('AccessManager', function () {
       it('succeeds called by a role member', async function () {
         await this.manager.$_grantRole(this.role.id, this.user, 0, 0);
 
-        await expect(
-          this.target.connect(this.user)[this.method.selector]({
-            data: this.calldata,
-          }),
-        )
+        await expect(this.target.connect(this.user)[method]())
           .to.emit(this.target, 'CalledRestricted')
           .withArgs(this.user);
       });
@@ -1769,11 +1766,7 @@ describe('AccessManager', function () {
       });
 
       it('succeeds called by anyone', async function () {
-        await expect(
-          this.target.connect(this.user)[method]({
-            data: this.calldata,
-          }),
-        )
+        await expect(this.target.connect(this.user)[method]())
           .to.emit(this.target, 'CalledUnrestricted')
           .withArgs(this.user);
       });

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -1106,10 +1106,18 @@ describe('AccessManager', function () {
           expect(await this.manager.isTargetClosed(this.target)).to.be.false;
         });
 
-        it('reverts if closing the manager', async function () {
-          await expect(this.manager.connect(this.admin).setTargetClosed(this.manager, true))
-            .to.be.revertedWithCustomError(this.manager, 'AccessManagerLockedAccount')
-            .withArgs(this.manager);
+        describe('when the target is the manager', async function () {
+          it('closes and opens the manager', async function () {
+            await expect(this.manager.connect(this.admin).setTargetClosed(this.manager, true))
+              .to.emit(this.manager, 'TargetClosed')
+              .withArgs(this.manager, true);
+            expect(await this.manager.isTargetClosed(this.manager)).to.be.true;
+
+            await expect(this.manager.connect(this.admin).setTargetClosed(this.manager, false))
+              .to.emit(this.manager, 'TargetClosed')
+              .withArgs(this.manager, false);
+            expect(await this.manager.isTargetClosed(this.manager)).to.be.false;
+          });
         });
       });
 

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -1674,15 +1674,16 @@ describe('AccessManager', function () {
   describe('access managed self operations', function () {
     describe('when calling a restricted target function', function () {
       beforeEach('set required role', function () {
-        this.method = this.target.fnRestricted.getFragment();
+        this.method = this.manager.fnRestricted.getFragment();
         this.role = { id: 785913n };
         this.manager.$_setTargetFunctionRole(this.target, this.method.selector, this.role.id);
       });
 
       describe('restrictions', function () {
         beforeEach('set method and args', function () {
-          this.calldata = this.target.interface.encodeFunctionData(this.method, []);
+          this.calldata = this.manager.interface.encodeFunctionData(this.method, []);
           this.caller = this.user;
+          this.target = this.manager; // For shouldBehaveLikeASelfRestrictedOperation
         });
 
         shouldBehaveLikeASelfRestrictedOperation();
@@ -1692,11 +1693,11 @@ describe('AccessManager', function () {
         await this.manager.$_grantRole(this.role.id, this.user, 0, 0);
 
         await expect(
-          this.target.connect(this.user)[this.method.selector]({
+          this.manager.connect(this.user)[this.method.selector]({
             data: this.calldata,
           }),
         )
-          .to.emit(this.target, 'CalledRestricted')
+          .to.emit(this.manager, 'CalledRestricted')
           .withArgs(this.user);
       });
     });
@@ -1707,19 +1708,19 @@ describe('AccessManager', function () {
       beforeEach('set required role', async function () {
         this.role = { id: 879435n };
         await this.manager.$_setTargetFunctionRole(
-          this.target,
-          this.target[method].getFragment().selector,
+          this.manager,
+          this.manager[method].getFragment().selector,
           this.role.id,
         );
       });
 
       it('succeeds called by anyone', async function () {
         await expect(
-          this.target.connect(this.user)[method]({
+          this.manager.connect(this.user)[method]({
             data: this.calldata,
           }),
         )
-          .to.emit(this.target, 'CalledUnrestricted')
+          .to.emit(this.manager, 'CalledUnrestricted')
           .withArgs(this.user);
       });
     });


### PR DESCRIPTION
This PR adds the ability to extend the AccessManager and use the `onlyAuthorized` modifer for those functions as well.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
