### PR TITLE
Update delegation method to perform additional check

### DIFF
--- a/.changeset/weak-wolves-turn.md
+++ b/.changeset/weak-wolves-turn.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Add check to '\_delegate' to exit early if the delegate does not change.

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -167,6 +167,9 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
      */
     function _delegate(address account, address delegatee) internal virtual {
         address oldDelegate = delegates(account);
+        if (oldDelegate == delegatee) {
+        return;
+        }
         _delegatee[account] = delegatee;
 
         emit DelegateChanged(account, oldDelegate, delegatee);


### PR DESCRIPTION
Adding a check to exit the function early if the delegatee is the same as the current delegate. This prevents emitting events and executing the vote movement logic unnecessarily when the delegate doesn't change, aiming to solve potential gas costs, especially in scenarios where the delegate is frequently updated.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
