### PR TITLE
Fix `UPGRADE_INTERFACE_VERSION` documentation in `ProxyAdmin`

### DIFF
--- a/.changeset/chilly-humans-warn.md
+++ b/.changeset/chilly-humans-warn.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ProxyAdmin`: Fixed documentation for `UPGRADE_INTERFACE_VERSION` getter.

--- a/contracts/proxy/transparent/ProxyAdmin.sol
+++ b/contracts/proxy/transparent/ProxyAdmin.sol
@@ -12,10 +12,10 @@ import {Ownable} from "../../access/Ownable.sol";
  */
 contract ProxyAdmin is Ownable {
     /**
-     * @dev The version of the upgrade interface of the contract. If this getter is missing, both `upgrade(address)`
-     * and `upgradeAndCall(address,bytes)` are present, and `upgradeTo` must be used if no function should be called,
-     * while `upgradeAndCall` will invoke the `receive` function if the second argument is the empty byte string.
-     * If the getter returns `"5.0.0"`, only `upgradeAndCall(address,bytes)` is present, and the second argument must
+     * @dev The version of the upgrade interface of the contract. If this getter is missing, both `upgrade(address,address)`
+     * and `upgradeAndCall(address,address,bytes)` are present, and `upgrade` must be used if no function should be called,
+     * while `upgradeAndCall` will invoke the `receive` function if the third argument is the empty byte string.
+     * If the getter returns `"5.0.0"`, only `upgradeAndCall(address,address,bytes)` is present, and the third argument must
      * be the empty byte string if no function should be called, making it impossible to invoke the `receive` function
      * during an upgrade.
      */


### PR DESCRIPTION
The NatSpec documentation for `UPGRADE_INTERFACE_VERSION` in `ProxyAdmin` describes functions using the wrong number of arguments and a wrong function name. Notably, it is missing the first argument which is the address of the proxy.

This PR fixes the documented references to `upgrade` and `upgradeAndCall`.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
