### PR TITLE
Compatible with 4.0.0, custom proxyAdmin upgrade contract

### DIFF
--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -92,7 +92,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * @dev If caller is the admin process the call internally, otherwise transparently fallback to the proxy behavior.
      */
     function _fallback() internal virtual override {
-        if (msg.sender == _proxyAdmin()) {
+        if (msg.sender == _proxyAdmin() || msg.sender == ProxyAdmin(_admin).owner()) {
             if (msg.sig != ITransparentUpgradeableProxy.upgradeToAndCall.selector) {
                 revert ProxyDeniedAdminAccess();
             } else {


### PR DESCRIPTION
version：5.0.0

🧐 Motivation
When I used the above version of the proxy contract, I was surprised to find that deploying the proxy contract would trigger the deployment of the proxyAdmin contract and give the proxy upgrade permission to proxyAdmin. I think it is unreasonable. If there are many proxy contracts in my project, I There are many admin contract addresses to remember.

📝 Details
I saw the constructors logic, admin, and data of the transparent proxy in the previous version. Among them, admin is the proxyAdmin contract address. It is possible to manage multiple agency contracts with one admin contract. But in the latest version, I found that the constructor is logic, owner, data, where owner is the manager who automatically deploys admin. That is to say, each agent contract will deploy an admin contract internally for management and upgrade. However, there is no external method to obtain the admin contract address, and it can only be viewed through the released changeAdmin event.

`/**
* @dev Returns the admin of this proxy.
*/
function _proxyAdmin() internal virtual returns (address) {
return _admin;
}
Added method to obtain proxyAdmin!

constructor(address _logic, address initialOwner, bytes memory _data) payable ERC1967Proxy(_logic, _data) {
_admin = address(new ProxyAdmin(initialOwner));
// Set the storage value and emit an event for ERC-1967 compatibility
ERC1967Utils.changeAdmin(_proxyAdmin());
}

constructor(address logic, address admin, bytes memory _data) payable ERC1967Proxy(_logic, _data) {
changeAdmin(admin);
}
Or adjust the constructor to the specified proxyAdmin contract address that has been deployed.
`
I hope it can be updated as soon as possible, because it is a headache for users to deploy multiple agents and have multiple management contracts! Hope to adopt!