### PR TITLE
Procedurally generate packing libraries

### DIFF
--- a/.changeset/heavy-baboons-give.md
+++ b/.changeset/heavy-baboons-give.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`Packing`: Added a new utility for packing and unpacking multiple values into a single bytes32. Includes initial support for packing two `uint128` in an `Uint128x2` type.
+`PackingBytes32`, `PackingBytes16`, `PackingBytes8`, `PackingBytes4`: Added a new utility for packing and unpacking multiple values into bytes. It includes initial support for packing 2 or 4 values on each available bytes type.

--- a/contracts/mocks/Stateless.sol
+++ b/contracts/mocks/Stateless.sol
@@ -26,7 +26,7 @@ import {Math} from "../utils/math/Math.sol";
 import {MerkleProof} from "../utils/cryptography/MerkleProof.sol";
 import {MessageHashUtils} from "../utils/cryptography/MessageHashUtils.sol";
 import {Panic} from "../utils/Panic.sol";
-import {Packing} from "../utils/Packing.sol";
+import {PackingBytes32, PackingBytes16, PackingBytes8, PackingBytes4} from "../utils/Packing.sol";
 import {SafeCast} from "../utils/math/SafeCast.sol";
 import {SafeERC20} from "../token/ERC20/utils/SafeERC20.sol";
 import {ShortStrings} from "../utils/ShortStrings.sol";

--- a/contracts/utils/Packing.sol
+++ b/contracts/utils/Packing.sol
@@ -15,7 +15,7 @@ pragma solidity ^0.8.20;
  *
  *     function foo(bytes4 value) internal {
  *        // Convert any bytes4 into a packed uint16x2
- *        Packing.Uint16x2 myUint16x2 = value.asUint16x2();
+ *        PackingBytes4.Uint16x2 myUint16x2 = value.asUint16x2();
  *
  *        // Access values through index
  *        uint16 b = myUint16x2.at(1);
@@ -104,7 +104,7 @@ library PackingBytes4 {
  *
  *     function foo(bytes8 value) internal {
  *        // Convert any bytes8 into a packed uint32x2
- *        Packing.Uint32x2 myUint32x2 = value.asUint32x2();
+ *        PackingBytes8.Uint32x2 myUint32x2 = value.asUint32x2();
  *
  *        // Access values through index
  *        uint32 b = myUint32x2.at(1);
@@ -193,7 +193,7 @@ library PackingBytes8 {
  *
  *     function foo(bytes16 value) internal {
  *        // Convert any bytes16 into a packed uint64x2
- *        Packing.Uint64x2 myUint64x2 = value.asUint64x2();
+ *        PackingBytes16.Uint64x2 myUint64x2 = value.asUint64x2();
  *
  *        // Access values through index
  *        uint64 b = myUint64x2.at(1);
@@ -282,7 +282,7 @@ library PackingBytes16 {
  *
  *     function foo(bytes32 value) internal {
  *        // Convert any bytes32 into a packed uint128x2
- *        Packing.Uint128x2 myUint128x2 = value.asUint128x2();
+ *        PackingBytes32.Uint128x2 myUint128x2 = value.asUint128x2();
  *
  *        // Access values through index
  *        uint128 b = myUint128x2.at(1);

--- a/contracts/utils/Packing.sol
+++ b/contracts/utils/Packing.sol
@@ -1,11 +1,299 @@
 // SPDX-License-Identifier: MIT
+// This file was procedurally generated from scripts/generate/templates/Packing.js.
 
 pragma solidity ^0.8.20;
 
 /**
- * @dev Helper library packing and unpacking multiple values into bytes32
+ * @dev Helper library packing and unpacking multiple values into bytes4.
+ *
+ * Example usage:
+ *
+ * ```solidity
+ * contract Example {
+ *     // Add the library methods
+ *     using PackingBytes4 for *;
+ *
+ *     function foo(bytes4 value) internal {
+ *        // Convert any bytes4 into a packed uint16x2
+ *        Packing.Uint16x2 myUint16x2 = value.asUint16x2();
+ *
+ *        // Access values through index
+ *        uint16 b = myUint16x2.at(1);
+ *
+ *        // Convert back to bytes4
+ *        bytes4 newValue = myUint16x2.asBytes32();
+ *     }
+ * }
+ * ```
  */
-library Packing {
+library PackingBytes4 {
+    type Uint16x2 is bytes4;
+
+    /// @dev Cast a bytes4 into a Uint16x2
+    function asUint16x2(bytes4 self) internal pure returns (Uint16x2) {
+        return Uint16x2.wrap(self);
+    }
+
+    /// @dev Cast a Uint16x2 into a bytes4
+    function asBytes4(Uint16x2 self) internal pure returns (bytes4) {
+        return Uint16x2.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint16x2 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint16x2 self, uint8 pos) internal pure returns (uint16) {
+        return uint16(bytes2(bytes32(Uint16x2.unwrap(self)) << (pos * 16)));
+    }
+
+    /// @dev Pack 2 uint16 into a Uint16x2
+    function pack(uint16 arg0, uint16 arg1) internal pure returns (Uint16x2) {
+        return Uint16x2.wrap((bytes4(uint32(arg0)) << 16) | bytes4(uint32(arg1)));
+    }
+
+    /// @dev Split a Uint16x2 into 2 uint16
+    function split(Uint16x2 self) internal pure returns (uint16, uint16) {
+        return (at(self, 0), at(self, 1));
+    }
+
+    type Uint8x4 is bytes4;
+
+    /// @dev Cast a bytes4 into a Uint8x4
+    function asUint8x4(bytes4 self) internal pure returns (Uint8x4) {
+        return Uint8x4.wrap(self);
+    }
+
+    /// @dev Cast a Uint8x4 into a bytes4
+    function asBytes4(Uint8x4 self) internal pure returns (bytes4) {
+        return Uint8x4.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint8x4 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint8x4 self, uint8 pos) internal pure returns (uint8) {
+        return uint8(bytes1(bytes32(Uint8x4.unwrap(self)) << (pos * 8)));
+    }
+
+    /// @dev Pack 4 uint8 into a Uint8x4
+    function pack(uint8 arg0, uint8 arg1, uint8 arg2, uint8 arg3) internal pure returns (Uint8x4) {
+        return
+            Uint8x4.wrap(
+                (bytes4(uint32(arg0)) << 24) |
+                    (bytes4(uint32(arg1)) << 16) |
+                    (bytes4(uint32(arg2)) << 8) |
+                    bytes4(uint32(arg3))
+            );
+    }
+
+    /// @dev Split a Uint8x4 into 4 uint8
+    function split(Uint8x4 self) internal pure returns (uint8, uint8, uint8, uint8) {
+        return (at(self, 0), at(self, 1), at(self, 2), at(self, 3));
+    }
+}
+
+/**
+ * @dev Helper library packing and unpacking multiple values into bytes8.
+ *
+ * Example usage:
+ *
+ * ```solidity
+ * contract Example {
+ *     // Add the library methods
+ *     using PackingBytes8 for *;
+ *
+ *     function foo(bytes8 value) internal {
+ *        // Convert any bytes8 into a packed uint32x2
+ *        Packing.Uint32x2 myUint32x2 = value.asUint32x2();
+ *
+ *        // Access values through index
+ *        uint32 b = myUint32x2.at(1);
+ *
+ *        // Convert back to bytes8
+ *        bytes8 newValue = myUint32x2.asBytes32();
+ *     }
+ * }
+ * ```
+ */
+library PackingBytes8 {
+    type Uint32x2 is bytes8;
+
+    /// @dev Cast a bytes8 into a Uint32x2
+    function asUint32x2(bytes8 self) internal pure returns (Uint32x2) {
+        return Uint32x2.wrap(self);
+    }
+
+    /// @dev Cast a Uint32x2 into a bytes8
+    function asBytes8(Uint32x2 self) internal pure returns (bytes8) {
+        return Uint32x2.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint32x2 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint32x2 self, uint8 pos) internal pure returns (uint32) {
+        return uint32(bytes4(bytes32(Uint32x2.unwrap(self)) << (pos * 32)));
+    }
+
+    /// @dev Pack 2 uint32 into a Uint32x2
+    function pack(uint32 arg0, uint32 arg1) internal pure returns (Uint32x2) {
+        return Uint32x2.wrap((bytes8(uint64(arg0)) << 32) | bytes8(uint64(arg1)));
+    }
+
+    /// @dev Split a Uint32x2 into 2 uint32
+    function split(Uint32x2 self) internal pure returns (uint32, uint32) {
+        return (at(self, 0), at(self, 1));
+    }
+
+    type Uint16x4 is bytes8;
+
+    /// @dev Cast a bytes8 into a Uint16x4
+    function asUint16x4(bytes8 self) internal pure returns (Uint16x4) {
+        return Uint16x4.wrap(self);
+    }
+
+    /// @dev Cast a Uint16x4 into a bytes8
+    function asBytes8(Uint16x4 self) internal pure returns (bytes8) {
+        return Uint16x4.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint16x4 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint16x4 self, uint8 pos) internal pure returns (uint16) {
+        return uint16(bytes2(bytes32(Uint16x4.unwrap(self)) << (pos * 16)));
+    }
+
+    /// @dev Pack 4 uint16 into a Uint16x4
+    function pack(uint16 arg0, uint16 arg1, uint16 arg2, uint16 arg3) internal pure returns (Uint16x4) {
+        return
+            Uint16x4.wrap(
+                (bytes8(uint64(arg0)) << 48) |
+                    (bytes8(uint64(arg1)) << 32) |
+                    (bytes8(uint64(arg2)) << 16) |
+                    bytes8(uint64(arg3))
+            );
+    }
+
+    /// @dev Split a Uint16x4 into 4 uint16
+    function split(Uint16x4 self) internal pure returns (uint16, uint16, uint16, uint16) {
+        return (at(self, 0), at(self, 1), at(self, 2), at(self, 3));
+    }
+}
+
+/**
+ * @dev Helper library packing and unpacking multiple values into bytes16.
+ *
+ * Example usage:
+ *
+ * ```solidity
+ * contract Example {
+ *     // Add the library methods
+ *     using PackingBytes16 for *;
+ *
+ *     function foo(bytes16 value) internal {
+ *        // Convert any bytes16 into a packed uint64x2
+ *        Packing.Uint64x2 myUint64x2 = value.asUint64x2();
+ *
+ *        // Access values through index
+ *        uint64 b = myUint64x2.at(1);
+ *
+ *        // Convert back to bytes16
+ *        bytes16 newValue = myUint64x2.asBytes32();
+ *     }
+ * }
+ * ```
+ */
+library PackingBytes16 {
+    type Uint64x2 is bytes16;
+
+    /// @dev Cast a bytes16 into a Uint64x2
+    function asUint64x2(bytes16 self) internal pure returns (Uint64x2) {
+        return Uint64x2.wrap(self);
+    }
+
+    /// @dev Cast a Uint64x2 into a bytes16
+    function asBytes16(Uint64x2 self) internal pure returns (bytes16) {
+        return Uint64x2.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint64x2 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint64x2 self, uint8 pos) internal pure returns (uint64) {
+        return uint64(bytes8(bytes32(Uint64x2.unwrap(self)) << (pos * 64)));
+    }
+
+    /// @dev Pack 2 uint64 into a Uint64x2
+    function pack(uint64 arg0, uint64 arg1) internal pure returns (Uint64x2) {
+        return Uint64x2.wrap((bytes16(uint128(arg0)) << 64) | bytes16(uint128(arg1)));
+    }
+
+    /// @dev Split a Uint64x2 into 2 uint64
+    function split(Uint64x2 self) internal pure returns (uint64, uint64) {
+        return (at(self, 0), at(self, 1));
+    }
+
+    type Uint32x4 is bytes16;
+
+    /// @dev Cast a bytes16 into a Uint32x4
+    function asUint32x4(bytes16 self) internal pure returns (Uint32x4) {
+        return Uint32x4.wrap(self);
+    }
+
+    /// @dev Cast a Uint32x4 into a bytes16
+    function asBytes16(Uint32x4 self) internal pure returns (bytes16) {
+        return Uint32x4.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint32x4 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint32x4 self, uint8 pos) internal pure returns (uint32) {
+        return uint32(bytes4(bytes32(Uint32x4.unwrap(self)) << (pos * 32)));
+    }
+
+    /// @dev Pack 4 uint32 into a Uint32x4
+    function pack(uint32 arg0, uint32 arg1, uint32 arg2, uint32 arg3) internal pure returns (Uint32x4) {
+        return
+            Uint32x4.wrap(
+                (bytes16(uint128(arg0)) << 96) |
+                    (bytes16(uint128(arg1)) << 64) |
+                    (bytes16(uint128(arg2)) << 32) |
+                    bytes16(uint128(arg3))
+            );
+    }
+
+    /// @dev Split a Uint32x4 into 4 uint32
+    function split(Uint32x4 self) internal pure returns (uint32, uint32, uint32, uint32) {
+        return (at(self, 0), at(self, 1), at(self, 2), at(self, 3));
+    }
+}
+
+/**
+ * @dev Helper library packing and unpacking multiple values into bytes32.
+ *
+ * Example usage:
+ *
+ * ```solidity
+ * contract Example {
+ *     // Add the library methods
+ *     using PackingBytes32 for *;
+ *
+ *     function foo(bytes32 value) internal {
+ *        // Convert any bytes32 into a packed uint128x2
+ *        Packing.Uint128x2 myUint128x2 = value.asUint128x2();
+ *
+ *        // Access values through index
+ *        uint128 b = myUint128x2.at(1);
+ *
+ *        // Convert back to bytes32
+ *        bytes32 newValue = myUint128x2.asBytes32();
+ *     }
+ * }
+ * ```
+ */
+library PackingBytes32 {
     type Uint128x2 is bytes32;
 
     /// @dev Cast a bytes32 into a Uint128x2
@@ -18,23 +306,55 @@ library Packing {
         return Uint128x2.unwrap(self);
     }
 
-    /// @dev Pack two uint128 into a Uint128x2
-    function pack(uint128 first128, uint128 second128) internal pure returns (Uint128x2) {
-        return Uint128x2.wrap(bytes32(bytes16(first128)) | bytes32(uint256(second128)));
+    /// @dev Get the Nth element of a Uint128x2 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint128x2 self, uint8 pos) internal pure returns (uint128) {
+        return uint128(bytes16(bytes32(Uint128x2.unwrap(self)) << (pos * 128)));
     }
 
-    /// @dev Split a Uint128x2 into two uint128
+    /// @dev Pack 2 uint128 into a Uint128x2
+    function pack(uint128 arg0, uint128 arg1) internal pure returns (Uint128x2) {
+        return Uint128x2.wrap((bytes32(uint256(arg0)) << 128) | bytes32(uint256(arg1)));
+    }
+
+    /// @dev Split a Uint128x2 into 2 uint128
     function split(Uint128x2 self) internal pure returns (uint128, uint128) {
-        return (first(self), second(self));
+        return (at(self, 0), at(self, 1));
     }
 
-    /// @dev Get the first element of a Uint128x2 counting from higher to lower bytes
-    function first(Uint128x2 self) internal pure returns (uint128) {
-        return uint128(bytes16(Uint128x2.unwrap(self)));
+    type Uint64x4 is bytes32;
+
+    /// @dev Cast a bytes32 into a Uint64x4
+    function asUint64x4(bytes32 self) internal pure returns (Uint64x4) {
+        return Uint64x4.wrap(self);
     }
 
-    /// @dev Get the second element of a Uint128x2 counting from higher to lower bytes
-    function second(Uint128x2 self) internal pure returns (uint128) {
-        return uint128(uint256(Uint128x2.unwrap(self)));
+    /// @dev Cast a Uint64x4 into a bytes32
+    function asBytes32(Uint64x4 self) internal pure returns (bytes32) {
+        return Uint64x4.unwrap(self);
+    }
+
+    /// @dev Get the Nth element of a Uint64x4 counting from higher to lower bytes
+    ///
+    /// NOTE: Returns 0 if pos is out of bounds.
+    function at(Uint64x4 self, uint8 pos) internal pure returns (uint64) {
+        return uint64(bytes8(bytes32(Uint64x4.unwrap(self)) << (pos * 64)));
+    }
+
+    /// @dev Pack 4 uint64 into a Uint64x4
+    function pack(uint64 arg0, uint64 arg1, uint64 arg2, uint64 arg3) internal pure returns (Uint64x4) {
+        return
+            Uint64x4.wrap(
+                (bytes32(uint256(arg0)) << 192) |
+                    (bytes32(uint256(arg1)) << 128) |
+                    (bytes32(uint256(arg2)) << 64) |
+                    bytes32(uint256(arg3))
+            );
+    }
+
+    /// @dev Split a Uint64x4 into 4 uint64
+    function split(Uint64x4 self) internal pure returns (uint64, uint64, uint64, uint64) {
+        return (at(self, 0), at(self, 1), at(self, 2), at(self, 3));
     }
 }

--- a/scripts/generate/run.js
+++ b/scripts/generate/run.js
@@ -36,6 +36,7 @@ for (const [file, template] of Object.entries({
   'utils/structs/EnumerableSet.sol': './templates/EnumerableSet.js',
   'utils/structs/EnumerableMap.sol': './templates/EnumerableMap.js',
   'utils/structs/Checkpoints.sol': './templates/Checkpoints.js',
+  'utils/Packing.sol': './templates/Packing.js',
   'utils/SlotDerivation.sol': './templates/SlotDerivation.js',
   'utils/StorageSlot.sol': './templates/StorageSlot.js',
   'utils/Arrays.sol': './templates/Arrays.js',
@@ -48,6 +49,7 @@ for (const [file, template] of Object.entries({
 for (const [file, template] of Object.entries({
   'utils/structs/Checkpoints.t.sol': './templates/Checkpoints.t.js',
   'utils/SlotDerivation.t.sol': './templates/SlotDerivation.t.js',
+  'utils/Packing.t.sol': './templates/Packing.t.js',
 })) {
   generateFromTemplate(file, template, './test/');
 }

--- a/scripts/generate/templates/Packing.js
+++ b/scripts/generate/templates/Packing.js
@@ -19,9 +19,9 @@ const natspec = (fromBytesSize, toUintType, packSize) => `\
  *
  *     function foo(bytes${fromBytesSize} value) internal {
  *        // Convert any bytes${fromBytesSize} into a packed ${toUintType}x${packSize}
- *        Packing.${capitalize(toUintType)}x${packSize} my${capitalize(toUintType)}x${packSize} = value.as${capitalize(
+ *        PackingBytes${fromBytesSize}.${capitalize(toUintType)}x${packSize} my${capitalize(
    toUintType,
- )}x${packSize}();
+ )}x${packSize} = value.as${capitalize(toUintType)}x${packSize}();
  *        
  *        // Access values through index
  *        ${toUintType} b = my${capitalize(toUintType)}x${packSize}.at(1);

--- a/scripts/generate/templates/Packing.js
+++ b/scripts/generate/templates/Packing.js
@@ -1,0 +1,106 @@
+const { capitalize } = require('../../helpers');
+const format = require('../format-lines');
+const { BYTES_PACK_SIZES } = require('./Packing.opts');
+
+const header = `\
+pragma solidity ^0.8.20;
+`;
+
+const natspec = (fromBytesSize, toUintType, packSize) => `\
+/**
+ * @dev Helper library packing and unpacking multiple values into bytes${fromBytesSize}.
+ *
+ * Example usage:
+ *
+ * \`\`\`solidity
+ * contract Example {
+ *     // Add the library methods
+ *     using PackingBytes${fromBytesSize} for *;
+ *
+ *     function foo(bytes${fromBytesSize} value) internal {
+ *        // Convert any bytes${fromBytesSize} into a packed ${toUintType}x${packSize}
+ *        Packing.${capitalize(toUintType)}x${packSize} my${capitalize(toUintType)}x${packSize} = value.as${capitalize(
+   toUintType,
+ )}x${packSize}();
+ *        
+ *        // Access values through index
+ *        ${toUintType} b = my${capitalize(toUintType)}x${packSize}.at(1);
+ * 
+ *        // Convert back to bytes${fromBytesSize}
+ *        bytes${fromBytesSize} newValue = my${capitalize(toUintType)}x${packSize}.asBytes32();
+ *     }
+ * }
+ * \`\`\`
+ */`;
+
+const argTypes = (toUintType, packSize) => new Array(packSize).fill().map((_, i) => `${toUintType} arg${i}`);
+
+const returnTypes = (toUintType, packSize) => new Array(packSize).fill().map(() => toUintType);
+
+const returnSplit = packSize => new Array(packSize).fill().map((_, i) => `at(self, ${i})`);
+
+const wrapArgShift = (fromBytesSize, packSize, i, array) =>
+  i < array.length - 1 ? `<< ${(array.length - 1 - i) * (fromBytesSize / packSize) * 8}` : '';
+
+const wrapArgs = (fromBytesSize, packSize) =>
+  new Array(packSize)
+    .fill()
+    .map(
+      (_, i, array) =>
+        `bytes${fromBytesSize}(uint${fromBytesSize * 8}(arg${i}))` + wrapArgShift(fromBytesSize, packSize, i, array),
+    )
+    .join(' | ');
+
+const template = (fromBytesSize, toUintType, packSize) => `\
+type ${capitalize(toUintType)}x${packSize} is bytes${fromBytesSize};
+
+/// @dev Cast a bytes${fromBytesSize} into a ${capitalize(toUintType)}x${packSize}
+function as${capitalize(toUintType)}x${packSize}(bytes${fromBytesSize} self) internal pure returns (${capitalize(
+  toUintType,
+)}x${packSize}) {
+    return ${capitalize(toUintType)}x${packSize}.wrap(self);
+}
+
+/// @dev Cast a ${capitalize(toUintType)}x${packSize} into a bytes${fromBytesSize}
+function asBytes${fromBytesSize}(${capitalize(
+  toUintType,
+)}x${packSize} self) internal pure returns (bytes${fromBytesSize}) {
+    return ${capitalize(toUintType)}x${packSize}.unwrap(self);
+}
+
+/// @dev Get the Nth element of a ${capitalize(toUintType)}x${packSize} counting from higher to lower bytes
+/// 
+/// NOTE: Returns 0 if pos is out of bounds.
+function at(${capitalize(toUintType)}x${packSize} self, uint8 pos) internal pure returns (${toUintType}) {
+    return ${toUintType}(bytes${fromBytesSize / packSize}(bytes32(
+        ${capitalize(toUintType)}x${packSize}.unwrap(self)) << (pos * ${(fromBytesSize / packSize) * 8})) 
+    );
+}
+
+/// @dev Pack ${packSize} ${toUintType} into a ${capitalize(toUintType)}x${packSize}
+function pack(${argTypes(toUintType, packSize)}) internal pure returns (${capitalize(toUintType)}x${packSize}) {
+    return ${capitalize(toUintType)}x${packSize}.wrap(${wrapArgs(fromBytesSize, packSize)});
+}
+
+/// @dev Split a ${capitalize(toUintType)}x${packSize} into ${packSize} ${toUintType}
+function split(${capitalize(toUintType)}x${packSize} self) internal pure returns (${returnTypes(
+  toUintType,
+  packSize,
+)}) {
+    return (${returnSplit(packSize)});
+}
+`;
+
+// GENERATE
+module.exports = format(
+  header.trimEnd(),
+  Object.entries(BYTES_PACK_SIZES).map(([fromBytesSize, opts]) => {
+    const entries = Object.entries(opts);
+    return [
+      natspec(fromBytesSize, entries[0][0], entries[0][1]),
+      `library PackingBytes${fromBytesSize} {`,
+      ...entries.map(([toUintType, packSize]) => [template(fromBytesSize, toUintType, packSize)]),
+      '}',
+    ];
+  }),
+);

--- a/scripts/generate/templates/Packing.opts.js
+++ b/scripts/generate/templates/Packing.opts.js
@@ -1,0 +1,20 @@
+const BYTES_PACK_SIZES = {
+  32: {
+    uint128: 2,
+    uint64: 4,
+  },
+  16: {
+    uint64: 2,
+    uint32: 4,
+  },
+  8: {
+    uint32: 2,
+    uint16: 4,
+  },
+  4: {
+    uint16: 2,
+    uint8: 4,
+  },
+};
+
+module.exports = { BYTES_PACK_SIZES };

--- a/scripts/generate/templates/Packing.t.js
+++ b/scripts/generate/templates/Packing.t.js
@@ -1,0 +1,58 @@
+const { BYTES_PACK_SIZES } = require('./Packing.opts');
+const format = require('../format-lines');
+const { capitalize } = require('../../helpers');
+
+// TEMPLATE
+const header = `\
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {PackingBytes32, PackingBytes16, PackingBytes8, PackingBytes4} from "@openzeppelin/contracts/utils/Packing.sol";
+`;
+
+const tuple = (toUintType, packSize, prefix = 'arg') =>
+  new Array(packSize).fill().map((_, i) => `${toUintType} ${prefix}${i}`);
+const assertAt = packSize =>
+  new Array(packSize)
+    .fill()
+    .map((_, i) => `assertEq(packed.at(${i}), arg${i})`)
+    .join(';') + ';';
+const assertRecovered = packSize =>
+  new Array(packSize)
+    .fill()
+    .map((_, i) => `assertEq(recovered${i}, arg${i})`)
+    .join(';') + ';';
+const packArgs = packSize => new Array(packSize).fill().map((_, i) => `arg${i}`);
+
+const template = (fromBytesSize, toUintType, packSize) => `\
+/// @dev Pack a pair of arbitrary ${toUintType}, and check that split recovers the correct values
+function test${capitalize(toUintType)}x${packSize}(${tuple(toUintType, packSize)}) external {
+    PackingBytes${fromBytesSize}.${capitalize(
+      toUintType,
+    )}x${packSize} packed = PackingBytes${fromBytesSize}.pack(${packArgs(packSize)});
+    ${assertAt(packSize)}
+
+    (${tuple(toUintType, packSize, 'recovered')}) = packed.split();
+    ${assertRecovered(packSize)}
+}
+
+/// @dev Split an arbitrary bytes${fromBytesSize} into a pair of ${toUintType}, and check that repack matches the input
+function test${capitalize(toUintType)}x${packSize}(bytes${fromBytesSize} input) external {
+    (${tuple(toUintType, packSize)}) = input.as${capitalize(toUintType)}x${packSize}().split();
+    assertEq(PackingBytes${fromBytesSize}.pack(${packArgs(packSize)}).asBytes${fromBytesSize}(), input);
+}
+`;
+
+// GENERATE
+module.exports = format(
+  header,
+  Object.entries(BYTES_PACK_SIZES).map(([fromBytesSize, opts]) => {
+    const entries = Object.entries(opts);
+    return [
+      `contract PackingBytes${fromBytesSize}Test is Test {`,
+      `using PackingBytes${fromBytesSize} for *;`,
+      ...entries.map(([toUintType, packSize]) => template(fromBytesSize, toUintType, packSize)),
+      '}',
+    ];
+  }),
+);

--- a/test/utils/Packing.t.sol
+++ b/test/utils/Packing.t.sol
@@ -1,27 +1,175 @@
 // SPDX-License-Identifier: MIT
+// This file was procedurally generated from scripts/generate/templates/Packing.t.js.
 
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {Packing} from "@openzeppelin/contracts/utils/Packing.sol";
+import {PackingBytes32, PackingBytes16, PackingBytes8, PackingBytes4} from "@openzeppelin/contracts/utils/Packing.sol";
 
-contract PackingTest is Test {
-    using Packing for *;
+contract PackingBytes4Test is Test {
+    using PackingBytes4 for *;
 
-    // Pack a pair of arbitrary uint128, and check that split recovers the correct values
-    function testUint128x2(uint128 first, uint128 second) external {
-        Packing.Uint128x2 packed = Packing.pack(first, second);
-        assertEq(packed.first(), first);
-        assertEq(packed.second(), second);
+    /// @dev Pack a pair of arbitrary uint16, and check that split recovers the correct values
+    function testUint16x2(uint16 arg0, uint16 arg1) external {
+        PackingBytes4.Uint16x2 packed = PackingBytes4.pack(arg0, arg1);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
 
-        (uint128 recoveredFirst, uint128 recoveredSecond) = packed.split();
-        assertEq(recoveredFirst, first);
-        assertEq(recoveredSecond, second);
+        (uint16 recovered0, uint16 recovered1) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
     }
 
-    // split an arbitrary bytes32 into a pair of uint128, and check that repack matches the input
+    /// @dev Split an arbitrary bytes4 into a pair of uint16, and check that repack matches the input
+    function testUint16x2(bytes4 input) external {
+        (uint16 arg0, uint16 arg1) = input.asUint16x2().split();
+        assertEq(PackingBytes4.pack(arg0, arg1).asBytes4(), input);
+    }
+
+    /// @dev Pack a pair of arbitrary uint8, and check that split recovers the correct values
+    function testUint8x4(uint8 arg0, uint8 arg1, uint8 arg2, uint8 arg3) external {
+        PackingBytes4.Uint8x4 packed = PackingBytes4.pack(arg0, arg1, arg2, arg3);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+        assertEq(packed.at(2), arg2);
+        assertEq(packed.at(3), arg3);
+
+        (uint8 recovered0, uint8 recovered1, uint8 recovered2, uint8 recovered3) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+        assertEq(recovered2, arg2);
+        assertEq(recovered3, arg3);
+    }
+
+    /// @dev Split an arbitrary bytes4 into a pair of uint8, and check that repack matches the input
+    function testUint8x4(bytes4 input) external {
+        (uint8 arg0, uint8 arg1, uint8 arg2, uint8 arg3) = input.asUint8x4().split();
+        assertEq(PackingBytes4.pack(arg0, arg1, arg2, arg3).asBytes4(), input);
+    }
+}
+
+contract PackingBytes8Test is Test {
+    using PackingBytes8 for *;
+
+    /// @dev Pack a pair of arbitrary uint32, and check that split recovers the correct values
+    function testUint32x2(uint32 arg0, uint32 arg1) external {
+        PackingBytes8.Uint32x2 packed = PackingBytes8.pack(arg0, arg1);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+
+        (uint32 recovered0, uint32 recovered1) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+    }
+
+    /// @dev Split an arbitrary bytes8 into a pair of uint32, and check that repack matches the input
+    function testUint32x2(bytes8 input) external {
+        (uint32 arg0, uint32 arg1) = input.asUint32x2().split();
+        assertEq(PackingBytes8.pack(arg0, arg1).asBytes8(), input);
+    }
+
+    /// @dev Pack a pair of arbitrary uint16, and check that split recovers the correct values
+    function testUint16x4(uint16 arg0, uint16 arg1, uint16 arg2, uint16 arg3) external {
+        PackingBytes8.Uint16x4 packed = PackingBytes8.pack(arg0, arg1, arg2, arg3);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+        assertEq(packed.at(2), arg2);
+        assertEq(packed.at(3), arg3);
+
+        (uint16 recovered0, uint16 recovered1, uint16 recovered2, uint16 recovered3) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+        assertEq(recovered2, arg2);
+        assertEq(recovered3, arg3);
+    }
+
+    /// @dev Split an arbitrary bytes8 into a pair of uint16, and check that repack matches the input
+    function testUint16x4(bytes8 input) external {
+        (uint16 arg0, uint16 arg1, uint16 arg2, uint16 arg3) = input.asUint16x4().split();
+        assertEq(PackingBytes8.pack(arg0, arg1, arg2, arg3).asBytes8(), input);
+    }
+}
+
+contract PackingBytes16Test is Test {
+    using PackingBytes16 for *;
+
+    /// @dev Pack a pair of arbitrary uint64, and check that split recovers the correct values
+    function testUint64x2(uint64 arg0, uint64 arg1) external {
+        PackingBytes16.Uint64x2 packed = PackingBytes16.pack(arg0, arg1);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+
+        (uint64 recovered0, uint64 recovered1) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+    }
+
+    /// @dev Split an arbitrary bytes16 into a pair of uint64, and check that repack matches the input
+    function testUint64x2(bytes16 input) external {
+        (uint64 arg0, uint64 arg1) = input.asUint64x2().split();
+        assertEq(PackingBytes16.pack(arg0, arg1).asBytes16(), input);
+    }
+
+    /// @dev Pack a pair of arbitrary uint32, and check that split recovers the correct values
+    function testUint32x4(uint32 arg0, uint32 arg1, uint32 arg2, uint32 arg3) external {
+        PackingBytes16.Uint32x4 packed = PackingBytes16.pack(arg0, arg1, arg2, arg3);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+        assertEq(packed.at(2), arg2);
+        assertEq(packed.at(3), arg3);
+
+        (uint32 recovered0, uint32 recovered1, uint32 recovered2, uint32 recovered3) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+        assertEq(recovered2, arg2);
+        assertEq(recovered3, arg3);
+    }
+
+    /// @dev Split an arbitrary bytes16 into a pair of uint32, and check that repack matches the input
+    function testUint32x4(bytes16 input) external {
+        (uint32 arg0, uint32 arg1, uint32 arg2, uint32 arg3) = input.asUint32x4().split();
+        assertEq(PackingBytes16.pack(arg0, arg1, arg2, arg3).asBytes16(), input);
+    }
+}
+
+contract PackingBytes32Test is Test {
+    using PackingBytes32 for *;
+
+    /// @dev Pack a pair of arbitrary uint128, and check that split recovers the correct values
+    function testUint128x2(uint128 arg0, uint128 arg1) external {
+        PackingBytes32.Uint128x2 packed = PackingBytes32.pack(arg0, arg1);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+
+        (uint128 recovered0, uint128 recovered1) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+    }
+
+    /// @dev Split an arbitrary bytes32 into a pair of uint128, and check that repack matches the input
     function testUint128x2(bytes32 input) external {
-        (uint128 first, uint128 second) = input.asUint128x2().split();
-        assertEq(Packing.pack(first, second).asBytes32(), input);
+        (uint128 arg0, uint128 arg1) = input.asUint128x2().split();
+        assertEq(PackingBytes32.pack(arg0, arg1).asBytes32(), input);
+    }
+
+    /// @dev Pack a pair of arbitrary uint64, and check that split recovers the correct values
+    function testUint64x4(uint64 arg0, uint64 arg1, uint64 arg2, uint64 arg3) external {
+        PackingBytes32.Uint64x4 packed = PackingBytes32.pack(arg0, arg1, arg2, arg3);
+        assertEq(packed.at(0), arg0);
+        assertEq(packed.at(1), arg1);
+        assertEq(packed.at(2), arg2);
+        assertEq(packed.at(3), arg3);
+
+        (uint64 recovered0, uint64 recovered1, uint64 recovered2, uint64 recovered3) = packed.split();
+        assertEq(recovered0, arg0);
+        assertEq(recovered1, arg1);
+        assertEq(recovered2, arg2);
+        assertEq(recovered3, arg3);
+    }
+
+    /// @dev Split an arbitrary bytes32 into a pair of uint64, and check that repack matches the input
+    function testUint64x4(bytes32 input) external {
+        (uint64 arg0, uint64 arg1, uint64 arg2, uint64 arg3) = input.asUint64x4().split();
+        assertEq(PackingBytes32.pack(arg0, arg1, arg2, arg3).asBytes32(), input);
     }
 }


### PR DESCRIPTION
### Description

This PR extends the new (unreleased) Packing library to be automatically generated. It allows for packing values into `bytes32`, `bytes16`, `bytes8` and `bytes4`.

I decided to split the contract in `PackingBytes32`, `PackingBytes16`, `PackingBytes8` and `PackingBytes4`. The reason is that when function identifiers collide (i.e. there are multiple definitions of `at` and `pack` so the compiler can't dissambiguate).

The alternative is to give users instructions of how to apply the `using` syntax to only apply the functions to those types intended. This is simpler imo.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
