### PR TITLE
Bubble up `returndata` from reverted Create2 deployments

### DIFF
--- a/.changeset/nervous-eyes-teach.md
+++ b/.changeset/nervous-eyes-teach.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Create2`: Capture and Utilization of returndata from failed deployment

--- a/.changeset/nervous-eyes-teach.md
+++ b/.changeset/nervous-eyes-teach.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`Create2`: Capture and Utilization of returndata from failed deployment
+`Create2`: Bubbles up returndata from a deployed contract that reverted during construction.

--- a/contracts/mocks/ConstructorMock.sol
+++ b/contracts/mocks/ConstructorMock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+contract ConstructorMock {
+    enum RevertType {
+        None,
+        RevertWithoutMessage,
+        RevertWithMessage,
+        RevertWithCustomError,
+        Panic
+    }
+
+    error CustomError();
+
+    constructor(RevertType error) {
+        if (error == RevertType.RevertWithoutMessage) {
+            revert();
+        } else if (error == RevertType.RevertWithMessage) {
+            revert("ConstructorMock: reverting");
+        } else if (error == RevertType.RevertWithCustomError) {
+            revert CustomError();
+        } else if (error == RevertType.Panic) {
+            uint256 a = uint256(0) / uint256(0);
+            a;
+        }
+    }
+}

--- a/contracts/mocks/ConstructorMock.sol
+++ b/contracts/mocks/ConstructorMock.sol
@@ -3,6 +3,8 @@
 pragma solidity ^0.8.20;
 
 contract ConstructorMock {
+    bool foo;
+
     enum RevertType {
         None,
         RevertWithoutMessage,
@@ -14,6 +16,10 @@ contract ConstructorMock {
     error CustomError();
 
     constructor(RevertType error) {
+        // After transpilation to upgradeable contract, the constructor will become an initializer
+        // To silence the `... can be restricted to view` warning, we write to state
+        foo = true;
+
         if (error == RevertType.RevertWithoutMessage) {
             revert();
         } else if (error == RevertType.RevertWithMessage) {

--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -41,7 +41,6 @@ library Create2 {
         if (bytecode.length == 0) {
             revert Create2EmptyBytecode();
         }
-
         /// @solidity memory-safe-assembly
         assembly {
             addr := create2(amount, add(bytecode, 0x20), mload(bytecode), salt)
@@ -51,7 +50,6 @@ library Create2 {
                 revert(0, returndatasize())
             }
         }
-
         if (addr == address(0)) {
             revert Errors.FailedDeployment();
         }

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -137,7 +137,7 @@ describe('Create2', function () {
     });
 
     describe('reverts error thrown during contract creation', function () {
-      it('Revert without message', async function () {
+      it('bubbles up without message', async function () {
         await expect(
           this.factory.$deploy(
             0n,
@@ -150,7 +150,7 @@ describe('Create2', function () {
         ).to.be.revertedWithCustomError(this.factory, 'FailedDeployment');
       });
 
-      it('Revert with message', async function () {
+      it('bubbles up message', async function () {
         await expect(
           this.factory.$deploy(
             0n,
@@ -163,7 +163,7 @@ describe('Create2', function () {
         ).to.be.revertedWith('ConstructorMock: reverting');
       });
 
-      it('Revert with custom error', async function () {
+      it('bubbles up custom error', async function () {
         await expect(
           this.factory.$deploy(
             0n,
@@ -176,7 +176,7 @@ describe('Create2', function () {
         ).to.be.revertedWithCustomError({ interface: this.mockFactory.interface }, 'CustomError');
       });
 
-      it('Panic', async function () {
+      it('bubbles up panic', async function () {
         await expect(
           this.factory.$deploy(
             0n,

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -1,6 +1,9 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
+
+const { RevertType } = require('../helpers/enums');
 
 async function fixture() {
   const [deployer, other] = await ethers.getSigners();
@@ -19,7 +22,9 @@ async function fixture() {
     .getContractFactory('$Create2')
     .then(({ bytecode, interface }) => ethers.concat([bytecode, interface.encodeDeploy([])]));
 
-  return { deployer, other, factory, constructorByteCode, constructorLessBytecode };
+  const mockFactory = await ethers.getContractFactory('ConstructorMock');
+
+  return { deployer, other, factory, constructorByteCode, constructorLessBytecode, mockFactory };
 }
 
 describe('Create2', function () {
@@ -129,6 +134,57 @@ describe('Create2', function () {
       await expect(this.factory.$deploy(1n, saltHex, this.constructorByteCode))
         .to.be.revertedWithCustomError(this.factory, 'InsufficientBalance')
         .withArgs(0n, 1n);
+    });
+
+    describe('reverts error thrown during contract creation', function () {
+      it('Revert without message', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([
+              this.mockFactory.bytecode,
+              this.mockFactory.interface.encodeDeploy([RevertType.RevertWithoutMessage]),
+            ]),
+          ),
+        ).to.be.revertedWithCustomError(this.factory, 'FailedDeployment');
+      });
+
+      it('Revert with message', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([
+              this.mockFactory.bytecode,
+              this.mockFactory.interface.encodeDeploy([RevertType.RevertWithMessage]),
+            ]),
+          ),
+        ).to.be.revertedWith('ConstructorMock: reverting');
+      });
+
+      it('Revert with custom error', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([
+              this.mockFactory.bytecode,
+              this.mockFactory.interface.encodeDeploy([RevertType.RevertWithCustomError]),
+            ]),
+          ),
+        ).to.be.revertedWithCustomError({ interface: this.mockFactory.interface }, 'CustomError');
+      });
+
+      it('Panic', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([this.mockFactory.bytecode, this.mockFactory.interface.encodeDeploy([RevertType.Panic])]),
+          ),
+        ).to.be.revertedWithPanic(PANIC_CODES.DIVISION_BY_ZERO);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #5046 

I am uploading this PR to propose a solution for issue #5046. The current implementation simply reverts with a generic FailedDeployment error, which obscures potentially useful debugging information contained in the returndata.
So in the changes, deploy function was enhanced in the following way:

- returndata is captured when a create2 deployment fails.
- If returndata is available, it is used to revert, providing the original error message from the failed deployment.
- If no returndata is available, the function reverts with the existing generic FailedDeployment error.

The changes were tested locally, and the expected output was given.

- [x] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
