### PR TITLE
Use free memory pointer for returndatacopy

### DIFF
--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -46,8 +46,9 @@ library Create2 {
             addr := create2(amount, add(bytecode, 0x20), mload(bytecode), salt)
             // if no address was created, and returndata is not empty, bubble revert
             if and(iszero(addr), not(iszero(returndatasize()))) {
-                returndatacopy(0, 0, returndatasize())
-                revert(0, returndatasize())
+                let p := mload(0x40)
+                returndatacopy(p, 0, returndatasize())
+                revert(p, returndatasize())
             }
         }
         if (addr == address(0)) {


### PR DESCRIPTION
Fixing memory safety as explained here: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5052/files#r1616302783

The Solidity docs state:

> these restrictions still need to be followed, even if the assembly block reverts or terminates. 