### PR TITLE
use arrays.unsafeMemoryAccess in ERC1155Supply

### DIFF
--- a/.changeset/wise-news-think.md
+++ b/.changeset/wise-news-think.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-Use arrays.unsafeMemoryAccess in ERC1155Supply

--- a/.changeset/wise-news-think.md
+++ b/.changeset/wise-news-think.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Use arrays.unsafeMemoryAccess in ERC1155Supply

--- a/contracts/token/ERC1155/extensions/ERC1155Supply.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Supply.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.20;
 
 import {ERC1155} from "../ERC1155.sol";
+import {Arrays} from "../../../utils/Arrays.sol";
 
 /**
  * @dev Extension of ERC-1155 that adds tracking of total supply per id.
@@ -19,6 +20,8 @@ import {ERC1155} from "../ERC1155.sol";
  * CAUTION: This extension should not be added in an upgrade to an already deployed contract.
  */
 abstract contract ERC1155Supply is ERC1155 {
+    using Arrays for uint256[];
+
     mapping(uint256 id => uint256) private _totalSupply;
     uint256 private _totalSupplyAll;
 
@@ -57,9 +60,9 @@ abstract contract ERC1155Supply is ERC1155 {
         if (from == address(0)) {
             uint256 totalMintValue = 0;
             for (uint256 i = 0; i < ids.length; ++i) {
-                uint256 value = values[i];
+                uint256 value = values.unsafeMemoryAccess(i);
                 // Overflow check required: The rest of the code assumes that totalSupply never overflows
-                _totalSupply[ids[i]] += value;
+                _totalSupply[ids.unsafeMemoryAccess(i)] += value;
                 totalMintValue += value;
             }
             // Overflow check required: The rest of the code assumes that totalSupplyAll never overflows
@@ -69,11 +72,11 @@ abstract contract ERC1155Supply is ERC1155 {
         if (to == address(0)) {
             uint256 totalBurnValue = 0;
             for (uint256 i = 0; i < ids.length; ++i) {
-                uint256 value = values[i];
+                uint256 value = values.unsafeMemoryAccess(i);
 
                 unchecked {
                     // Overflow not possible: values[i] <= balanceOf(from, ids[i]) <= totalSupply(ids[i])
-                    _totalSupply[ids[i]] -= value;
+                    _totalSupply[ids.unsafeMemoryAccess(i)] -= value;
                     // Overflow not possible: sum_i(values[i]) <= sum_i(totalSupply(ids[i])) <= totalSupplyAll
                     totalBurnValue += value;
                 }


### PR DESCRIPTION
This pr makes ERC1155Supply use the same pattern to access arrays as the rest of the ERC1155 contracts 

#### PR Checklist

- [X] Tests
- [X] Documentation
- [X] Changeset entry (run `npx changeset add`)
