### PR TITLE
Avoid storing hashing function pointers in storage make MerkleTree structure upgrade-safe

### DIFF
--- a/contracts/utils/structs/MerkleTree.sol
+++ b/contracts/utils/structs/MerkleTree.sol
@@ -52,25 +52,24 @@ library MerkleTree {
      *
      * Calling this function on MerkleTree that was already setup and used will reset it to a blank state.
      *
+     * Once a tree is setup, any push to it must use the same hashing function. This means that values
+     * should be pushed to it using the default {xref-MerkleTree-push-struct-MerkleTree-Bytes32PushTree-bytes32-}[push] function.
+     *
      * IMPORTANT: The zero value should be carefully chosen since it will be stored in the tree representing
      * empty leaves. It should be a value that is not expected to be part of the tree.
-     *
-     * Once a tree is setup, any push to it must use the same hashing function. This means that values
-     * should be pushed to it using this push variant that uses the default hashing function.
      */
     function setup(Bytes32PushTree storage self, uint8 levels, bytes32 zero) internal returns (bytes32 initialRoot) {
         return setup(self, levels, zero, Hashes.commutativeKeccak256);
     }
 
     /**
-     * @dev Same as {setup}, but allows to specify a custom hashing function.
+     * @dev Same as {xref-MerkleTree-setup-struct-MerkleTree-Bytes32PushTree-uint8-bytes32-}[setup], but allows to specify a custom hashing function.
+     *
+     * Once a tree is setup, any push to it must use the same hashing function. This means that values
+     * should be pushed to it using the custom push function, which should be the same one as used during the setup.
      *
      * IMPORTANT: Providing a custom hashing function is a security-sensitive operation since it may
      * compromise the soundness of the tree. Consider using functions from {Hashes}.
-     *
-     * Once a tree is setup, any push to it must use the same hashing function. This means that values
-     * should be pushed to it using this push variant that takes a custom hashing function, which should
-     * be the same one as used during the setup.
      */
     function setup(
         Bytes32PushTree storage self,
@@ -103,7 +102,8 @@ library MerkleTree {
      * second pre-image attacks.
      *
      * This variant uses {Hashes-commutativeKeccak256} to hash internal nodes. It should only be used on merkle trees
-     * that were setup using the same (default) hashing function.
+     * that were setup using the same (default) hashing function (i.e. by calling 
+     * {xref-MerkleTree-setup-struct-MerkleTree-Bytes32PushTree-uint8-bytes32-}[the default setup] function).
      */
     function push(Bytes32PushTree storage self, bytes32 leaf) internal returns (uint256 index, bytes32 newRoot) {
         return push(self, leaf, Hashes.commutativeKeccak256);

--- a/contracts/utils/structs/MerkleTree.sol
+++ b/contracts/utils/structs/MerkleTree.sol
@@ -55,9 +55,8 @@ library MerkleTree {
      * IMPORTANT: The zero value should be carefully chosen since it will be stored in the tree representing
      * empty leaves. It should be a value that is not expected to be part of the tree.
      *
-     * Once a tree is setup, any push that that tree must use the same hashing function. This means that after a
-     * tree is setup using this function will, values should be pushed to it using the push variant that uses the
-     * default hashing function.
+     * Once a tree is setup, any push to it must use the same hashing function. This means that values
+     * should be pushed to it using this push variant that uses the default hashing function.
      */
     function setup(Bytes32PushTree storage self, uint8 levels, bytes32 zero) internal returns (bytes32 initialRoot) {
         return setup(self, levels, zero, Hashes.commutativeKeccak256);
@@ -69,9 +68,9 @@ library MerkleTree {
      * IMPORTANT: Providing a custom hashing function is a security-sensitive operation since it may
      * compromise the soundness of the tree. Consider using functions from {Hashes}.
      *
-     * Once a tree is setup, any push that that tree must use the same hashing function. This means that after a
-     * tree is setup using this function will, values must be pushed to it using the push variant that takes a
-     * custom hashing function, and the hashing function provided must be the same one as the one used during setup.
+     * Once a tree is setup, any push to it must use the same hashing function. This means that values
+     * should be pushed to it using this push variant that takes a custom hashing function, which should
+     * be the same one as used during the setup.
      */
     function setup(
         Bytes32PushTree storage self,
@@ -104,7 +103,7 @@ library MerkleTree {
      * second pre-image attacks.
      *
      * This variant uses {Hashes-commutativeKeccak256} to hash internal nodes. It should only be used on merkle trees
-     * setup using the same (default) ahshing function.
+     * that were setup using the same (default) hashing function.
      */
     function push(Bytes32PushTree storage self, bytes32 leaf) internal returns (uint256 index, bytes32 newRoot) {
         return push(self, leaf, Hashes.commutativeKeccak256);
@@ -117,7 +116,7 @@ library MerkleTree {
      * Hashing the leaf before calling this function is recommended as a protection against
      * second pre-image attacks.
      *
-     * This variant uses a custom hasing function to hash internal nodes. It should only be called with the same
+     * This variant uses a custom hashing function to hash internal nodes. It should only be called with the same
      * function as the one used during the initial setup of the merkle tree.
      */
     function push(

--- a/contracts/utils/structs/MerkleTree.sol
+++ b/contracts/utils/structs/MerkleTree.sol
@@ -102,7 +102,7 @@ library MerkleTree {
      * second pre-image attacks.
      *
      * This variant uses {Hashes-commutativeKeccak256} to hash internal nodes. It should only be used on merkle trees
-     * that were setup using the same (default) hashing function (i.e. by calling 
+     * that were setup using the same (default) hashing function (i.e. by calling
      * {xref-MerkleTree-setup-struct-MerkleTree-Bytes32PushTree-uint8-bytes32-}[the default setup] function).
      */
     function push(Bytes32PushTree storage self, bytes32 leaf) internal returns (uint256 index, bytes32 newRoot) {

--- a/contracts/utils/structs/MerkleTree.sol
+++ b/contracts/utils/structs/MerkleTree.sol
@@ -17,7 +17,7 @@ import {Panic} from "../Panic.sol";
  *
  * * Depth: The number of levels in the tree, it also defines the maximum number of leaves as 2**depth.
  * * Zero value: The value that represents an empty leaf. Used to avoid regular zero values to be part of the tree.
- * * Hashing function: A cryptographic hash function used to produce internal nodes.
+ * * Hashing function: A cryptographic hash function used to produce internal nodes. Defaults to {Hashes-commutativeKeccak256}.
  *
  * _Available since v5.1._
  */
@@ -26,9 +26,6 @@ library MerkleTree {
      * @dev A complete `bytes32` Merkle tree.
      *
      * The `sides` and `zero` arrays are set to have a length equal to the depth of the tree during setup.
-     *
-     * The hashing function used during initialization to compute the `zeros` values (value of a node at a given depth
-     * for which the subtree is full of zero leaves). This function is kept in the structure for handling insertions.
      *
      * Struct members have an underscore prefix indicating that they are "private" and should not be read or written to
      * directly. Use the functions provided below instead. Modifying the struct manually may violate assumptions and
@@ -148,7 +145,7 @@ library MerkleTree {
             }
 
             // Compute the current node hash by using the hash function
-            // with either the its sibling (side) or the zero value for that level.
+            // with either its sibling (side) or the zero value for that level.
             currentLevelHash = fnHash(
                 isLeft ? currentLevelHash : Arrays.unsafeAccess(self._sides, i).value,
                 isLeft ? Arrays.unsafeAccess(self._zeros, i).value : currentLevelHash

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -157,10 +157,10 @@ Building an on-chain Merkle Tree allow developers to keep track of the history o
 
 The Merkle Tree does not keep track of the roots purposely, so that developers can choose their tracking mechanism. Setting up and using an Merkle Tree in Solidity is as simple as follows:
 
+NOTE: Functions are exposed without access control for demonstration purposes
+
 [source,solidity]
 ----
-// NOTE: Functions are exposed without access control for demonstration purposes
-
 using MerkleTree for MerkleTree.Bytes32PushTree;
 MerkleTree.Bytes32PushTree private _tree;
 
@@ -173,6 +173,31 @@ function push(bytes32 leaf) public /* onlyOwner */ {
     // Store the new root.
 }
 ----
+
+The library also supports custom hashing functions, which can be passed as an extra parameter to the xref:api:utils.adoc#MerkleTree-push-struct-MerkleTree-Bytes32PushTree-bytes32-[`push`] and xref:api:utils.adoc#MerkleTree-setup-struct-MerkleTree-Bytes32PushTree-uint8-bytes32-[`setup`] functions.
+
+Using custom hashing functions is a sensitive operation. After setup, it requires to keep using the same hashing function for every new valued pushed to the tree to avoid corrupting the tree. For this reason, it's a good practice to keep your hashing function static in your implementation contract as follows:
+
+[source,solidity]
+----
+using MerkleTree for MerkleTree.Bytes32PushTree;
+MerkleTree.Bytes32PushTree private _tree;
+
+function setup(uint8 _depth, bytes32 _zero) public /* onlyOwner */ {
+    root = _tree.setup(_depth, _zero, _hashFn);
+}
+
+function push(bytes32 leaf) public /* onlyOwner */ {
+    (uint256 leafIndex, bytes32 currentRoot) = _tree.push(leaf, _hashFn);
+    // Store the new root.
+}
+
+function _hashFn(bytes32 a, bytes32 b) internal view returns(bytes32) {
+    // Custom hash function implementation
+    // Kept as an internal implementation detail to 
+    // guarantee the same function is always used
+}
+---- 
 
 [[misc]]
 == Misc

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -153,7 +153,7 @@ The `Enumerable*` structures are similar to mappings in that they store and remo
 
 === Building a Merkle Tree
 
-Building an on-chain Merkle Tree allow developers to keep track of the history of roots in a decentralized manner. For these cases, the xref:api:utils.adoc#MerkleTree[`MerkleTree`] includes a predefined structure with functions to manipulate the tree (e.g. pushing values or resetting the tree). Note that once a tree is setup, any push to it must use the same hashing function (default or custom).
+Building an on-chain Merkle Tree allow developers to keep track of the history of roots in a decentralized manner. For these cases, the xref:api:utils.adoc#MerkleTree[`MerkleTree`] includes a predefined structure with functions to manipulate the tree (e.g. pushing values or resetting the tree).
 
 The Merkle Tree does not keep track of the roots purposely, so that developers can choose their tracking mechanism. Setting up and using an Merkle Tree in Solidity is as simple as follows:
 

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -153,7 +153,7 @@ The `Enumerable*` structures are similar to mappings in that they store and remo
 
 === Building a Merkle Tree
 
-Building an on-chain Merkle Tree allow developers to keep track of the history of roots in a decentralized manner. For these cases, the xref:api:utils.adoc#MerkleTree[`MerkleTree`] includes a predefined structure with functions to manipulate the tree (e.g. pushing values or resetting the tree).
+Building an on-chain Merkle Tree allow developers to keep track of the history of roots in a decentralized manner. For these cases, the xref:api:utils.adoc#MerkleTree[`MerkleTree`] includes a predefined structure with functions to manipulate the tree (e.g. pushing values or resetting the tree). Note that once a tree is setup, any push to it must use the same hashing function (default or custom).
 
 The Merkle Tree does not keep track of the roots purposely, so that developers can choose their tracking mechanism. Setting up and using an Merkle Tree in Solidity is as simple as follows:
 


### PR DESCRIPTION
Fixes #5079

This is change to an unreleased feature, no need for a changeset entry.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
