### PR TITLE
Update hashProposal visibility to view

### DIFF
--- a/.changeset/popular-horses-tell.md
+++ b/.changeset/popular-horses-tell.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+- update `hashProposal()` visibility to view instead of pure to allow `address(this)` and `block.chainid` to be part of the proposal id computation if more uniqueness between different chains is desired

--- a/.changeset/popular-horses-tell.md
+++ b/.changeset/popular-horses-tell.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-- update `hashProposal()` visibility to view instead of pure to allow `address(this)` and `block.chainid` to be part of the proposal id computation if more uniqueness between different chains is desired
+- Update `hashProposal()` visibility to view instead of pure to allow `address(this)` and `block.chainid` to be part of the `proposalId` computation if more uniqueness between different chains is desired

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -117,10 +117,8 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
      * can be produced from the proposal data which is part of the {ProposalCreated} event. It can even be computed in
      * advance, before the proposal is submitted.
      *
-     * Note that the chainId and the governor address are not part of the proposal id computation. Consequently, the
-     * same proposal (with same operation and same description) will have the same id if submitted on multiple governors
-     * across multiple networks. This also means that in order to execute the same operation twice (on the same
-     * governor) the proposer will have to change the description in order to avoid proposal id conflicts.
+     * Note that the chainId and the governor address are not part of the proposal id computation, but can be added to
+     * guarantee more uniqueness if the same proposal is to submitted on multiple governors across multiple networks.
      */
     function hashProposal(
         address[] memory targets,

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -127,7 +127,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) public pure virtual returns (uint256) {
+    ) public view virtual returns (uint256) {
         return uint256(keccak256(abi.encode(targets, values, calldatas, descriptionHash)));
     }
 

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -207,7 +207,7 @@ interface IGovernor is IERC165, IERC6372 {
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) external pure returns (uint256);
+    ) external view returns (uint256);
 
     /**
      * @notice module:core


### PR DESCRIPTION
Fixes

Update `hashProposal()` function visibility to `view` instead of `pure` to allow an override using `block.chainid` and/or `address(this)` in order to guarantee more uniqueness on the same proposal but on different networks.

Can be very useful when the proposal is used as a kind of proof to validate the vote, and the same proposal is created on different networks.  This allows the developer to mitigate a replay attack over the same `proposalId` in a clean way by overriding the function to read from the environment or the contract's state.


#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
