### PR TITLE
Add Foundry tests to coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,5 +11,5 @@ coverage:
       default:
         threshold: 1%
 ignore:
-  - "test/**/*"
-  - "contracts/mocks/**/*"
+  - "test"
+  - "contracts/mocks"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,3 +10,6 @@ coverage:
     project:
       default:
         threshold: 1%
+ignore:
+  - "test/*"
+  - "contracts/mocks/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,5 +11,5 @@ coverage:
       default:
         threshold: 1%
 ignore:
-  - "test/*"
-  - "contracts/mocks/*"
+  - "test/**/*"
+  - "contracts/mocks/**/*"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,8 +91,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Install LCOV
-        run: sudo apt-get install lcov
       - name: Run coverage
         run: npm run coverage
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Install LCOV
+        run: sudo apt-get install lcov
       - name: Run coverage
         run: npm run coverage
       - uses: codecov/codecov-action@v4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "compile:harnesses": "env SRC=./certora/harnesses hardhat compile",
-    "coverage": "env COVERAGE=true hardhat coverage && FOUNDRY_FUZZ_RUNS=10 forge coverage --report lcov && lcov -o lcov.info --remove lcov.info 'test/*' 'contracts/mocks/*' && awk '!/,0/' lcov.info > temp && mv temp lcov.info",
+    "coverage": "scripts/checks/coverage.sh",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
     "prepare": "git config --local core.hooksPath .githooks",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "compile:harnesses": "env SRC=./certora/harnesses hardhat compile",
-    "coverage": "env COVERAGE=true hardhat coverage",
+    "coverage": "env COVERAGE=true hardhat coverage && forge coverage --report lcov --ir-minimum",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
     "prepare": "git config --local core.hooksPath .githooks",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "compile:harnesses": "env SRC=./certora/harnesses hardhat compile",
-    "coverage": "env COVERAGE=true hardhat coverage && forge coverage --report lcov --ir-minimum && lcov -o lcov.info --remove lcov.info --rc lcov_branch_coverage=1 --rc lcov_function_coverage=1 'test/*' 'contracts/mocks/*'",
+    "coverage": "env COVERAGE=true hardhat coverage && forge coverage --report lcov && lcov -o lcov.info --remove lcov.info --rc lcov_branch_coverage=1 --rc lcov_function_coverage=1 'test/*' 'contracts/mocks/*'",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
     "prepare": "git config --local core.hooksPath .githooks",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "compile:harnesses": "env SRC=./certora/harnesses hardhat compile",
-    "coverage": "env COVERAGE=true hardhat coverage && forge coverage --report lcov --ir-minimum",
+    "coverage": "env COVERAGE=true hardhat coverage && forge coverage --report lcov --ir-minimum && lcov -o lcov.info --remove lcov.info --rc lcov_branch_coverage=1 --rc lcov_function_coverage=1 'test/*' 'contracts/mocks/*'",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
     "prepare": "git config --local core.hooksPath .githooks",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "compile:harnesses": "env SRC=./certora/harnesses hardhat compile",
-    "coverage": "env COVERAGE=true hardhat coverage && forge coverage --report lcov && lcov -o lcov.info --remove lcov.info --rc lcov_branch_coverage=1 --rc lcov_function_coverage=1 'test/*' 'contracts/mocks/*'",
+    "coverage": "env COVERAGE=true hardhat coverage && FOUNDRY_FUZZ_RUNS=10 forge coverage --report lcov && lcov -o lcov.info --remove lcov.info 'test/*' 'contracts/mocks/*' && awk '!/,0/' lcov.info > temp && mv temp lcov.info",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
     "prepare": "git config --local core.hooksPath .githooks",

--- a/scripts/checks/coverage.sh
+++ b/scripts/checks/coverage.sh
@@ -11,8 +11,6 @@ hardhat coverage
 if [ "${CI:-"false"}" == "true" ]; then
   # Foundry coverage
   forge coverage --report lcov
-  # Remove test and mock data
-  lcov --rc derive_function_end_line=0 -o lcov.info --remove lcov.info 'test/*' 'contracts/mocks/*'
   # Remove zero hits
   sed -i '/,0/d' lcov.info
 fi

--- a/scripts/checks/coverage.sh
+++ b/scripts/checks/coverage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+export COVERAGE=true
+export FOUNDRY_FUZZ_RUNS=10
+
+# Hardhat coverage
+npx hardhat coverage
+
+# Foundry coverage
+forge coverage --report lcov
+# Remove test and mock data
+lcov --rc derive_function_end_line=0 -o lcov.info --remove lcov.info 'test/*' 'contracts/mocks/*'
+# Remove zero hits
+awk '!/,0/' lcov.info > temp && mv temp lcov.info
+
+# Reports are then uploaded to Codecov automatically by workflow, and merged.

--- a/scripts/checks/coverage.sh
+++ b/scripts/checks/coverage.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 export COVERAGE=true
 export FOUNDRY_FUZZ_RUNS=10
 
 # Hardhat coverage
-npx hardhat coverage
+hardhat coverage
 
-# Foundry coverage
-forge coverage --report lcov
-# Remove test and mock data
-lcov --rc derive_function_end_line=0 -o lcov.info --remove lcov.info 'test/*' 'contracts/mocks/*'
-# Remove zero hits
-awk '!/,0/' lcov.info > temp && mv temp lcov.info
+if [ "${CI:-"false"}" == "true" ]; then
+  # Foundry coverage
+  forge coverage --report lcov
+  # Remove test and mock data
+  lcov --rc derive_function_end_line=0 -o lcov.info --remove lcov.info 'test/*' 'contracts/mocks/*'
+  # Remove zero hits
+  sed -i '/,0/d' lcov.info
+fi
 
 # Reports are then uploaded to Codecov automatically by workflow, and merged.


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Adds Foundry tests to coverage and allows Codecov to combine both reports. The `coverage` script command removes zero hits in the Foundry report so that both reports can be merged exclusively, otherwise Codecov will mark lines as not covered, when in reality they are covered by Hardhat.

It increases coverage by 0.07% overall, 0.98% in Governor and 0.65% in Clones. Time increase for workflow is very small.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
