### PR TITLE
Clarify hardhat & foundry configs and enable optimisation by default.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,8 @@
 [profile.default]
 solc_version = '0.8.24'
 evm_version = 'cancun'
+optimizer = true
+optimizer-runs = 200
 src = 'contracts'
 out = 'out'
 libs = ['node_modules', 'lib']

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,12 +1,12 @@
 /// ENVVAR
-// - COMPILE_VERSION:   compiler version (default: 0.8.20)
-// - SRC:               contracts folder to compile (default: contracts)
-// - COMPILE_MODE:      production modes enables optimizations (default: development)
-// - IR:                enable IR compilation (default: false)
-// - COVERAGE:          enable coverage report
-// - ENABLE_GAS_REPORT: enable gas report
-// - COINMARKETCAP:     coinmarkercat api key for USD value in gas report
-// - CI:                output gas report to file instead of stdout
+// - COMPILER:      compiler version (default: 0.8.24)
+// - SRC:           contracts folder to compile (default: contracts)
+// - RUNS:          number of optimization runs (default: 200)
+// - IR:            enable IR compilation (default: false)
+// - COVERAGE:      enable coverage report (default: false)
+// - GAS:           enable gas report (default: false)
+// - COINMARKETCAP: coinmarketcap api key for USD value in gas report
+// - CI:            output gas report to file instead of stdout
 
 const fs = require('fs');
 const path = require('path');
@@ -25,11 +25,10 @@ const { argv } = require('yargs/yargs')()
       type: 'string',
       default: 'contracts',
     },
-    mode: {
-      alias: 'compileMode',
-      type: 'string',
-      choices: ['production', 'development'],
-      default: 'development',
+    runs: {
+      alias: 'optimizationRuns',
+      type: 'number',
+      default: 200,
     },
     ir: {
       alias: 'enableIR',
@@ -69,9 +68,6 @@ for (const f of fs.readdirSync(path.join(__dirname, 'hardhat'))) {
   require(path.join(__dirname, 'hardhat', f));
 }
 
-const withOptimizations = argv.gas || argv.coverage || argv.compileMode === 'production';
-const allowUnlimitedContractSize = argv.gas || argv.coverage || argv.compileMode === 'development';
-
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
@@ -80,11 +76,11 @@ module.exports = {
     version: argv.compiler,
     settings: {
       optimizer: {
-        enabled: withOptimizations,
-        runs: 200,
+        enabled: true,
+        runs: argv.runs,
       },
       evmVersion: argv.evm,
-      viaIR: withOptimizations && argv.ir,
+      viaIR: argv.ir,
       outputSelection: { '*': { '*': ['storageLayout'] } },
     },
   },
@@ -94,7 +90,7 @@ module.exports = {
       'initcode-size': 'off',
     },
     '*': {
-      'code-size': withOptimizations,
+      'code-size': true,
       'unused-param': !argv.coverage, // coverage causes unused-param warnings
       'transient-storage': false,
       default: 'error',
@@ -103,7 +99,9 @@ module.exports = {
   networks: {
     hardhat: {
       hardfork: argv.evm,
-      allowUnlimitedContractSize,
+      // Exposed contracts often exceed the maximum contract size. For normal contract,
+      // we rely on the `code-size` compiler warning, that will cause a compilation error.
+      allowUnlimitedContractSize: true,
       initialBaseFeePerGas: argv.coverage ? 0 : undefined,
     },
   },


### PR DESCRIPTION
### Before this PR:

- Local tests on our machine run in development mode without `GAS` or `COVERAGE` (default). This results in:
  - optimization disabled
  - unlimited contract size
- Non upgradeable tests on the CI set the GAS flag (to produce a report). This results in:
  - optimization enabled
    - code size warning
  - unlimited contract size
- Coverage tests on the CI set the COVERAGE flag. This results in:
  - optimization enabled
    - code size warning
  - unlimited contract size
  - some additional stuff (unused params, initialBaseFeePerGas)
- Upgradeable tests do not set any flag. They run in development mode. This results in:
  - optimization disabled
  - unlimited contract size

All this was not necessarily clear. In particular, the fact that by default, out local tests run in a mode that doesnt match the CI (unless we have some `.env` to override that). Also, setting the `IR` flag has no effect unless you also enable optimization (either through the production mode, or implicitelly when doing gas or coverage checks)

### This PR does the following changes:

- All compilation is done with optimization. That is what our users should all use in production, so that is what we should test.
- Make code size unlimited by default. That is what we had previously, but it was "hidden". This PR makes it obvious what is happening here.
- Gas no longer affect the compiler settings, it only enables/disables the gas module.
- No changes to the config specific to coverage

### Note

- This PR **does not** change the compiler settings during CI, so the gas reports continue to be valid. 
- This PR **does** change the compiler settings when running tests locally.