### PR TITLE
Create a ERC1363Utils helper similar to existing ERC721Utils and ERC1155Utils

### DIFF
--- a/.changeset/tricky-bats-pretend.md
+++ b/.changeset/tricky-bats-pretend.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC1363Utils`: new helper similar to the existing `ERC721Utils` and `ERC1155Utils`

--- a/.changeset/tricky-bats-pretend.md
+++ b/.changeset/tricky-bats-pretend.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC1363Utils`: new helper similar to the existing `ERC721Utils` and `ERC1155Utils`
+`ERC1363Utils`: Add helper similar to the existing `ERC721Utils` and `ERC1155Utils`

--- a/contracts/token/ERC1155/README.adoc
+++ b/contracts/token/ERC1155/README.adoc
@@ -39,3 +39,5 @@ NOTE: This core set of contracts is designed to be unopinionated, allowing devel
 == Utilities
 
 {{ERC1155Holder}}
+
+{{ERC1155Utils}}

--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -71,3 +71,5 @@ NOTE: This core set of contracts is designed to be unopinionated, allowing devel
 == Utilities
 
 {{SafeERC20}}
+
+{{ERC1363Utils}}

--- a/contracts/token/ERC20/utils/ERC1363Utils.sol
+++ b/contracts/token/ERC20/utils/ERC1363Utils.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {IERC1363Receiver} from "../../../interfaces/IERC1363Receiver.sol";
+import {IERC1363Spender} from "../../../interfaces/IERC1363Spender.sol";
+
+/**
+ * @dev Library that provide common ERC-1363 utility functions.
+ *
+ * See https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].
+ */
+library ERC1363Utils {
+    /**
+     * @dev Indicates a failure with the token `receiver`. Used in transfers.
+     * @param receiver Address to which tokens are being transferred.
+     */
+    error ERC1363InvalidReceiver(address receiver);
+
+    /**
+     * @dev Indicates a failure with the token `spender`. Used in approvals.
+     * @param spender Address that may be allowed to operate on tokens without being their owner.
+     */
+    error ERC1363InvalidSpender(address spender);
+
+    /**
+     * @dev Performs a call to {IERC1363Receiver-onTransferReceived} on a target address.
+     *
+     * Requirements:
+     *
+     * - The target has code (i.e. is a contract).
+     * - The target `to` must implement the {IERC1363Receiver} interface.
+     * - The target must return the {IERC1363Receiver-onTransferReceived} selector to accept the transfer.
+     */
+    function checkOnERC1363TransferReceived(
+        address operator,
+        address from,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal {
+        if (to.code.length == 0) {
+            revert ERC1363InvalidReceiver(to);
+        }
+
+        try IERC1363Receiver(to).onTransferReceived(operator, from, value, data) returns (bytes4 retval) {
+            if (retval != IERC1363Receiver.onTransferReceived.selector) {
+                revert ERC1363InvalidReceiver(to);
+            }
+        } catch (bytes memory reason) {
+            if (reason.length == 0) {
+                revert ERC1363InvalidReceiver(to);
+            } else {
+                /// @solidity memory-safe-assembly
+                assembly {
+                    revert(add(32, reason), mload(reason))
+                }
+            }
+        }
+    }
+
+    /**
+     * @dev Performs a call to {IERC1363Spender-onApprovalReceived} on a target address.
+     *
+     * Requirements:
+     *
+     * - The target has code (i.e. is a contract).
+     * - The target `spender` must implement the {IERC1363Spender} interface.
+     * - The target must return the {IERC1363Spender-onApprovalReceived} selector to accept the approval.
+     */
+    function checkOnERC1363ApprovalReceived(
+        address operator,
+        address spender,
+        uint256 value,
+        bytes memory data
+    ) internal {
+        if (spender.code.length == 0) {
+            revert ERC1363InvalidSpender(spender);
+        }
+
+        try IERC1363Spender(spender).onApprovalReceived(operator, value, data) returns (bytes4 retval) {
+            if (retval != IERC1363Spender.onApprovalReceived.selector) {
+                revert ERC1363InvalidSpender(spender);
+            }
+        } catch (bytes memory reason) {
+            if (reason.length == 0) {
+                revert ERC1363InvalidSpender(spender);
+            } else {
+                /// @solidity memory-safe-assembly
+                assembly {
+                    revert(add(32, reason), mload(reason))
+                }
+            }
+        }
+    }
+}

--- a/contracts/token/ERC20/utils/ERC1363Utils.sol
+++ b/contracts/token/ERC20/utils/ERC1363Utils.sol
@@ -6,7 +6,7 @@ import {IERC1363Receiver} from "../../../interfaces/IERC1363Receiver.sol";
 import {IERC1363Spender} from "../../../interfaces/IERC1363Spender.sol";
 
 /**
- * @dev Library that provide common ERC-1363 utility functions.
+ * @dev Library that provides common ERC-1363 utility functions.
  *
  * See https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].
  */

--- a/contracts/token/ERC721/README.adoc
+++ b/contracts/token/ERC721/README.adoc
@@ -65,3 +65,5 @@ NOTE: This core set of contracts is designed to be unopinionated, allowing devel
 == Utilities
 
 {{ERC721Holder}}
+
+{{ERC721Utils}}


### PR DESCRIPTION
This would be usefull if someone wanted to implement a `mintAndCall` function, for example in the context of an ERC-4626 vault with ERC-1363 compliant functions.

It also replicates the design that we have in ERC721 and ERC1155.

Test are unaffected.

Moving the custom error from ERC1363 to ERC1363Utils is very slightly breaking if we put that in 5.2, after 1363 is introduced. Not breaking at all if we cherrypick that on 5.1.

#### PR Checklist

- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
