### PR TITLE
Optimize `forceApprove` for 0 value calls

### DIFF
--- a/.changeset/cuddly-masks-live.md
+++ b/.changeset/cuddly-masks-live.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`forceApprove` gas optimization: skip second approval call whenever `value == 0`.

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -76,7 +76,9 @@ library SafeERC20 {
 
         if (!_callOptionalReturnBool(token, approvalCall)) {
             _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));
-            _callOptionalReturn(token, approvalCall);
+            if (value > 0) {
+                _callOptionalReturn(token, approvalCall);
+            }
         }
     }
 

--- a/test/token/ERC20/utils/SafeERC20.test.js
+++ b/test/token/ERC20/utils/SafeERC20.test.js
@@ -159,6 +159,11 @@ describe('SafeERC20', function () {
         await this.mock.$forceApprove(this.token, this.spender, 200n);
         expect(await this.token.allowance(this.mock, this.spender)).to.equal(200n);
       });
+
+      it('forceApprove works for zero allowance', async function () {
+        await this.mock.$forceApprove(this.token, this.spender, 0);
+        expect(await this.token.allowance(this.mock, this.spender)).to.equal(0);
+      });
     });
   });
 


### PR DESCRIPTION

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

In certain cases, we might want to:
- `forceApprove` a certain amount for a given spender.
- Call an external function that makes use of that approval, but potentially less: e.g. a swap given out, where the amount of tokens to be pulled by the call is not known in advance.
- Reset the allowance to 0, eliminating any leftover that was not consumed by the call from the previous step.

With the current codebase, if `_callOptionalReturnBool` returns false, the workflow described above will make 4 calls to `token.approve`; the last 2 of them will use `value = 0`. This PR skips the last one, which is unnecessary in this case.

#### PR Checklist

- [x] Tests
- N/A Documentation
- [x] Changeset entry (run `npx changeset add`)
