### PR TITLE
Chore/add empty set note merkle proof

### DIFF
--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -168,7 +168,7 @@ library MerkleProof {
      * This version handles multiproofs in memory with the default hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
@@ -250,7 +250,7 @@ library MerkleProof {
      * This version handles multiproofs in memory with a custom hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
@@ -334,7 +334,7 @@ library MerkleProof {
      * This version handles multiproofs in calldata with the default hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
@@ -416,7 +416,7 @@ library MerkleProof {
      * This version handles multiproofs in calldata with a custom hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -168,6 +168,10 @@ library MerkleProof {
      * This version handles multiproofs in memory with the default hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function multiProofVerify(
         bytes32[] memory proof,
@@ -246,6 +250,10 @@ library MerkleProof {
      * This version handles multiproofs in memory with a custom hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function multiProofVerify(
         bytes32[] memory proof,
@@ -326,6 +334,10 @@ library MerkleProof {
      * This version handles multiproofs in calldata with the default hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function multiProofVerifyCalldata(
         bytes32[] calldata proof,
@@ -404,6 +416,10 @@ library MerkleProof {
      * This version handles multiproofs in calldata with a custom hashing function.
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function multiProofVerifyCalldata(
         bytes32[] calldata proof,

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -88,6 +88,10 @@ const templateMultiProof = ({ suffix, location, visibility, hash }) => `\
  * This version handles multiproofs in ${location} with ${hash ? 'a custom' : 'the default'} hashing function.
  *
  * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+ * 
+ * NOTE: The _empty set_ (i.e. the case where \`proof.length == 0 && leaves.length == 0\`) is considered a noop,
+ * and therefore a valid multiproof (i.e. it returns \`true\`). Consider disallowing this case if you're not
+ * validating the leaves elsewhere.
  */
 function multiProofVerify${suffix}(${formatArgsMultiline(
   `bytes32[] ${location} proof`,

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -88,7 +88,7 @@ const templateMultiProof = ({ suffix, location, visibility, hash }) => `\
  * This version handles multiproofs in ${location} with ${hash ? 'a custom' : 'the default'} hashing function.
  *
  * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
- * 
+ *
  * NOTE: The _empty set_ (i.e. the case where \`proof.length == 0 && leaves.length == 0\`) is considered a noop,
  * and therefore a valid multiproof (i.e. it returns \`true\`). Consider disallowing this case if you're not
  * validating the leaves elsewhere.


### PR DESCRIPTION
Makes it explicit that users verifying multiproofs should consider that the empty set is valid.
Most implementations do check the validity of the leaves or build them within the contract, which makes it impossible to validate a proof incorrectly.

This is consistent with our no-ops policy

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
