### PR TITLE
Update MerkleProof note clarifying empty set definition

### DIFF
--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -169,9 +169,8 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
-     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
-     * validating the leaves elsewhere.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * The `leaves` should be validated independently. See {processMultiProof}.
      */
     function multiProofVerify(
         bytes32[] memory proof,
@@ -193,6 +192,10 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function processMultiProof(
         bytes32[] memory proof,
@@ -252,9 +255,8 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
-     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
-     * validating the leaves elsewhere.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * The `leaves` should be validated independently. See {processMultiProof}.
      */
     function multiProofVerify(
         bytes32[] memory proof,
@@ -277,6 +279,10 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function processMultiProof(
         bytes32[] memory proof,
@@ -337,9 +343,8 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
-     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
-     * validating the leaves elsewhere.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * The `leaves` should be validated independently. See {processMultiProofCalldata}.
      */
     function multiProofVerifyCalldata(
         bytes32[] calldata proof,
@@ -361,6 +366,10 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function processMultiProofCalldata(
         bytes32[] calldata proof,
@@ -420,9 +429,8 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
-     * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
-     * validating the leaves elsewhere.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * The `leaves` should be validated independently. See {processMultiProofCalldata}.
      */
     function multiProofVerifyCalldata(
         bytes32[] calldata proof,
@@ -445,6 +453,10 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
+     * 
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
+     * validating the leaves elsewhere.
      */
     function processMultiProofCalldata(
         bytes32[] calldata proof,

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -170,7 +170,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
      * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
-     * The `leaves` should be validated independently. See {processMultiProof}.
+     * The `leaves` must be validated independently. See {processMultiProof}.
      */
     function multiProofVerify(
         bytes32[] memory proof,
@@ -192,7 +192,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
@@ -256,7 +256,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
      * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
-     * The `leaves` should be validated independently. See {processMultiProof}.
+     * The `leaves` must be validated independently. See {processMultiProof}.
      */
     function multiProofVerify(
         bytes32[] memory proof,
@@ -279,7 +279,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
@@ -344,7 +344,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
      * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
-     * The `leaves` should be validated independently. See {processMultiProofCalldata}.
+     * The `leaves` must be validated independently. See {processMultiProofCalldata}.
      */
     function multiProofVerifyCalldata(
         bytes32[] calldata proof,
@@ -366,7 +366,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
@@ -430,7 +430,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
      * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
-     * The `leaves` should be validated independently. See {processMultiProofCalldata}.
+     * The `leaves` must be validated independently. See {processMultiProofCalldata}.
      */
     function multiProofVerifyCalldata(
         bytes32[] calldata proof,
@@ -453,7 +453,7 @@ library MerkleProof {
      * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
-     * 
+     *
      * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -169,7 +169,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */
@@ -252,7 +252,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */
@@ -337,7 +337,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */
@@ -420,7 +420,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 0 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
      * and therefore a valid multiproof (i.e. it returns `true`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */

--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -169,7 +169,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
      * The `leaves` must be validated independently. See {processMultiProof}.
      */
     function multiProofVerify(
@@ -193,7 +193,7 @@ library MerkleProof {
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */
@@ -255,7 +255,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
      * The `leaves` must be validated independently. See {processMultiProof}.
      */
     function multiProofVerify(
@@ -280,7 +280,7 @@ library MerkleProof {
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */
@@ -343,7 +343,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
      * The `leaves` must be validated independently. See {processMultiProofCalldata}.
      */
     function multiProofVerifyCalldata(
@@ -367,7 +367,7 @@ library MerkleProof {
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */
@@ -429,7 +429,7 @@ library MerkleProof {
      *
      * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
      *
-     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return true.
+     * NOTE: Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
      * The `leaves` must be validated independently. See {processMultiProofCalldata}.
      */
     function multiProofVerifyCalldata(
@@ -454,7 +454,7 @@ library MerkleProof {
      * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
      * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
      *
-     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a noop,
+     * NOTE: The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
      * and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
      * validating the leaves elsewhere.
      */

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -89,7 +89,7 @@ const templateMultiProof = ({ suffix, location, visibility, hash }) => `\
  *
  * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
  *
- * NOTE: The _empty set_ (i.e. the case where \`proof.length == 0 && leaves.length == 0\`) is considered a noop,
+ * NOTE: The _empty set_ (i.e. the case where \`proof.length == 1 && leaves.length == 0\`) is considered a noop,
  * and therefore a valid multiproof (i.e. it returns \`true\`). Consider disallowing this case if you're not
  * validating the leaves elsewhere.
  */

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -89,9 +89,8 @@ const templateMultiProof = ({ suffix, location, visibility, hash }) => `\
  *
  * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
  *
- * NOTE: The _empty set_ (i.e. the case where \`proof.length == 1 && leaves.length == 0\`) is considered a noop,
- * and therefore a valid multiproof (i.e. it returns \`true\`). Consider disallowing this case if you're not
- * validating the leaves elsewhere.
+ * NOTE: Consider the case where \`root == proof[0] && leaves.length == 0\` as it will return true.
+ * The \`leaves\` should be validated independently. See {processMultiProof${suffix}}.
  */
 function multiProofVerify${suffix}(${formatArgsMultiline(
   `bytes32[] ${location} proof`,
@@ -114,6 +113,10 @@ function multiProofVerify${suffix}(${formatArgsMultiline(
  * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
  * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
  * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
+ * 
+ * NOTE: The _empty set_ (i.e. the case where \`proof.length == 1 && leaves.length == 0\`) is considered a noop,
+ * and therefore a valid multiproof (i.e. it returns \`proof[0]\`). Consider disallowing this case if you're not
+ * validating the leaves elsewhere.
  */
 function processMultiProof${suffix}(${formatArgsMultiline(
   `bytes32[] ${location} proof`,

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -90,7 +90,7 @@ const templateMultiProof = ({ suffix, location, visibility, hash }) => `\
  * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
  *
  * NOTE: Consider the case where \`root == proof[0] && leaves.length == 0\` as it will return true.
- * The \`leaves\` should be validated independently. See {processMultiProof${suffix}}.
+ * The \`leaves\` must be validated independently. See {processMultiProof${suffix}}.
  */
 function multiProofVerify${suffix}(${formatArgsMultiline(
   `bytes32[] ${location} proof`,
@@ -113,7 +113,7 @@ function multiProofVerify${suffix}(${formatArgsMultiline(
  * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
  * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
  * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
- * 
+ *
  * NOTE: The _empty set_ (i.e. the case where \`proof.length == 1 && leaves.length == 0\`) is considered a noop,
  * and therefore a valid multiproof (i.e. it returns \`proof[0]\`). Consider disallowing this case if you're not
  * validating the leaves elsewhere.

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -89,7 +89,7 @@ const templateMultiProof = ({ suffix, location, visibility, hash }) => `\
  *
  * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
  *
- * NOTE: Consider the case where \`root == proof[0] && leaves.length == 0\` as it will return true.
+ * NOTE: Consider the case where \`root == proof[0] && leaves.length == 0\` as it will return \`true\`.
  * The \`leaves\` must be validated independently. See {processMultiProof${suffix}}.
  */
 function multiProofVerify${suffix}(${formatArgsMultiline(
@@ -114,7 +114,7 @@ function multiProofVerify${suffix}(${formatArgsMultiline(
  * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
  * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
  *
- * NOTE: The _empty set_ (i.e. the case where \`proof.length == 1 && leaves.length == 0\`) is considered a noop,
+ * NOTE: The _empty set_ (i.e. the case where \`proof.length == 1 && leaves.length == 0\`) is considered a no-op,
  * and therefore a valid multiproof (i.e. it returns \`proof[0]\`). Consider disallowing this case if you're not
  * validating the leaves elsewhere.
  */


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

In the last commit ([bcd4beb](https://github.com/OpenZeppelin/openzeppelin-contracts/commit/bcd4beb5e7fd8bd8edf160fbffb5d5b03804efdb)), the definition of the empty set was incorrect as it needs to include the root within the proof. This PR updates it to the correct definition.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
