### PR TITLE
Optimizations to P256 operations

### DIFF
--- a/contracts/utils/cryptography/P256.sol
+++ b/contracts/utils/cryptography/P256.sol
@@ -229,9 +229,9 @@ library P256 {
             let s := mulmod(4, mulmod(x, yy, p), p) // s = 4*x*y²
             let m := addmod(mulmod(3, mulmod(x, x, p), p), mulmod(A, mulmod(zz, zz, p), p), p) // m = 3*x²+a*z⁴
 
-            // x' = t
-            rx := addmod(mulmod(m, m, p), sub(p, mulmod(2, s, p)), p) // t = m²-2*s
-            // y' = m*(s-t)-8*y⁴
+            // x' = t = m²-2*s
+            rx := addmod(mulmod(m, m, p), sub(p, mulmod(2, s, p)), p)
+            // y' = m*(s-t)-8*y⁴ = m*(s-x')-8*y⁴
             ry := addmod(mulmod(m, addmod(s, sub(p, rx), p), p), sub(p, mulmod(8, mulmod(yy, yy, p), p)), p)
             // z' = 2*y*z
             rz := mulmod(2, mulmod(y, z, p), p)

--- a/contracts/utils/cryptography/P256.sol
+++ b/contracts/utils/cryptography/P256.sol
@@ -125,11 +125,12 @@ library P256 {
             return (0, 0);
         }
 
+        uint256 p = P; // cache P on the stack
         uint256 rx = uint256(r);
-        uint256 ry2 = addmod(mulmod(addmod(mulmod(rx, rx, P), A, P), rx, P), B, P); // weierstrass equation y² = x³ + a.x + b
-        uint256 ry = Math.modExp(ry2, P1DIV4, P); // This formula for sqrt work because P ≡ 3 (mod 4)
-        if (mulmod(ry, ry, P) != ry2) return (0, 0); // Sanity check
-        if (ry % 2 != v % 2) ry = P - ry;
+        uint256 ry2 = addmod(mulmod(addmod(mulmod(rx, rx, p), A, p), rx, p), B, p); // weierstrass equation y² = x³ + a.x + b
+        uint256 ry = Math.modExp(ry2, P1DIV4, p); // This formula for sqrt work because P ≡ 3 (mod 4)
+        if (mulmod(ry, ry, p) != ry2) return (0, 0); // Sanity check
+        if (ry % 2 != v % 2) ry = p - ry;
 
         JPoint[16] memory points = _preComputeJacobianPoints(rx, ry);
         uint256 w = Math.invModPrime(uint256(r), N);

--- a/contracts/utils/cryptography/P256.sol
+++ b/contracts/utils/cryptography/P256.sol
@@ -192,19 +192,24 @@ library P256 {
             let p := P
             let z1 := mload(add(p1, 0x40))
             let zz1 := mulmod(z1, z1, p) // zz1 = z1²
-            let zz2 := mulmod(z2, z2, p) // zz2 = z2²
-            let s1 := mulmod(mload(add(p1, 0x20)), mulmod(zz2, z2, p), p) // s1 = y1*z2³
+            let s1 := mulmod(mload(add(p1, 0x20)), mulmod(mulmod(z2, z2, p), z2, p), p) // s1 = y1*z2³
             let r := addmod(mulmod(y2, mulmod(zz1, z1, p), p), sub(p, s1), p) // r = s2-s1
-            let u1 := mulmod(mload(p1), zz2, p) // u1 = x1*z2²
+            let u1 := mulmod(mload(p1), mulmod(z2, z2, p), p) // u1 = x1*z2²
             let h := addmod(mulmod(x2, zz1, p), sub(p, u1), p) // h = u2-u1
             let hh := mulmod(h, h, p) // h²
-            let hhh := mulmod(h, hh, p) // h³
-            let v := mulmod(u1, hh, p) // v = u1*h²
 
             // x' = r²-h³-2*u1*h²
-            rx := addmod(addmod(mulmod(r, r, p), sub(p, hhh), p), sub(p, mulmod(2, v, p)), p)
+            rx := addmod(
+                addmod(mulmod(r, r, p), sub(p, mulmod(h, hh, p)), p),
+                sub(p, mulmod(2, mulmod(u1, hh, p), p)),
+                p
+            )
             // y' = r*(u1*h²-x')-s1*h³
-            ry := addmod(mulmod(r, addmod(v, sub(p, rx), p), p), sub(p, mulmod(s1, hhh, p)), p)
+            ry := addmod(
+                mulmod(r, addmod(mulmod(u1, hh, p), sub(p, rx), p), p),
+                sub(p, mulmod(s1, mulmod(h, hh, p), p)),
+                p
+            )
             // z' = h*z1*z2
             rz := mulmod(h, mulmod(z1, z2, p), p)
         }

--- a/contracts/utils/cryptography/P256.sol
+++ b/contracts/utils/cryptography/P256.sol
@@ -195,9 +195,9 @@ library P256 {
             let z1 := mload(add(p1, 0x40))
             let zz1 := mulmod(z1, z1, p) // zz1 = z1²
             let s1 := mulmod(mload(add(p1, 0x20)), mulmod(mulmod(z2, z2, p), z2, p), p) // s1 = y1*z2³
-            let r := addmod(mulmod(y2, mulmod(zz1, z1, p), p), sub(p, s1), p) // r = s2-s1
+            let r := addmod(mulmod(y2, mulmod(zz1, z1, p), p), sub(p, s1), p) // r = s2-s1 = y2*z1³-s1
             let u1 := mulmod(mload(p1), mulmod(z2, z2, p), p) // u1 = x1*z2²
-            let h := addmod(mulmod(x2, zz1, p), sub(p, u1), p) // h = u2-u1
+            let h := addmod(mulmod(x2, zz1, p), sub(p, u1), p) // h = u2-u1 = x2*z1²-u1
             let hh := mulmod(h, h, p) // h²
 
             // x' = r²-h³-2*u1*h²
@@ -299,7 +299,7 @@ library P256 {
         points[0x09] = _jAddPoint(points[0x01], points[0x08]); // 1,2 (p+2g)
         points[0x0a] = _jAddPoint(points[0x02], points[0x08]); // 2,2 (2p+2g)
         points[0x0b] = _jAddPoint(points[0x03], points[0x08]); // 3,2 (3p+2g)
-        points[0x0c] = _jAddPoint(points[0x04], points[0x08]); // 0,2 (g+2g)
+        points[0x0c] = _jAddPoint(points[0x04], points[0x08]); // 0,3 (g+2g)
         points[0x0d] = _jAddPoint(points[0x01], points[0x0c]); // 1,3 (p+3g)
         points[0x0e] = _jAddPoint(points[0x02], points[0x0c]); // 2,3 (2p+3g)
         points[0x0f] = _jAddPoint(points[0x03], points[0x0C]); // 3,3 (3p+3g)

--- a/contracts/utils/cryptography/P256.sol
+++ b/contracts/utils/cryptography/P256.sol
@@ -170,11 +170,12 @@ library P256 {
      */
     function _affineFromJacobian(uint256 jx, uint256 jy, uint256 jz) private view returns (uint256 ax, uint256 ay) {
         if (jz == 0) return (0, 0);
-        uint256 zinv = Math.invModPrime(jz, P);
+        uint256 p = P; // cache P on the stack
+        uint256 zinv = Math.invModPrime(jz, p);
         assembly ("memory-safe") {
-            let zzinv := mulmod(zinv, zinv, P)
-            ax := mulmod(jx, zzinv, P)
-            ay := mulmod(jy, mulmod(zzinv, zinv, P), P)
+            let zzinv := mulmod(zinv, zinv, p)
+            ax := mulmod(jx, zzinv, p)
+            ay := mulmod(jy, mulmod(zzinv, zinv, p), p)
         }
     }
 

--- a/test/utils/cryptography/P256.t.sol
+++ b/test/utils/cryptography/P256.t.sol
@@ -12,29 +12,124 @@ contract P256Test is Test {
     function testVerify(uint256 seed, bytes32 digest) public {
         uint256 privateKey = bound(uint256(keccak256(abi.encode(seed))), 1, P256.N - 1);
 
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
+        (bytes32 x, bytes32 y) = P256PublicKey.getPublicKey(privateKey);
         (bytes32 r, bytes32 s) = vm.signP256(privateKey, digest);
         s = _ensureLowerS(s);
-        assertTrue(P256.verify(digest, r, s, bytes32(x), bytes32(y)));
-        assertTrue(P256.verifySolidity(digest, r, s, bytes32(x), bytes32(y)));
+        assertTrue(P256.verify(digest, r, s, x, y));
+        assertTrue(P256.verifySolidity(digest, r, s, x, y));
     }
 
     /// forge-config: default.fuzz.runs = 512
     function testRecover(uint256 seed, bytes32 digest) public {
         uint256 privateKey = bound(uint256(keccak256(abi.encode(seed))), 1, P256.N - 1);
 
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
+        (bytes32 x, bytes32 y) = P256PublicKey.getPublicKey(privateKey);
         (bytes32 r, bytes32 s) = vm.signP256(privateKey, digest);
         s = _ensureLowerS(s);
         (bytes32 qx0, bytes32 qy0) = P256.recovery(digest, 0, r, s);
         (bytes32 qx1, bytes32 qy1) = P256.recovery(digest, 1, r, s);
-        assertTrue((qx0 == bytes32(x) && qy0 == bytes32(y)) || (qx1 == bytes32(x) && qy1 == bytes32(y)));
+        assertTrue((qx0 == x && qy0 == y) || (qx1 == x && qy1 == y));
     }
 
     function _ensureLowerS(bytes32 s) private pure returns (bytes32) {
         uint256 _s = uint256(s);
         unchecked {
             return _s > P256.N / 2 ? bytes32(P256.N - _s) : s;
+        }
+    }
+}
+
+/**
+ * @dev Library to derive P256 public key from private key
+ * Should be removed if Foundry adds this functionality
+ * See https://github.com/foundry-rs/foundry/issues/7908
+ */
+library P256PublicKey {
+    function getPublicKey(uint256 privateKey) internal view returns (bytes32, bytes32) {
+        (uint256 x, uint256 y, uint256 z) = _jMult(P256.GX, P256.GY, 1, privateKey);
+        return _affineFromJacobian(x, y, z);
+    }
+
+    function _jMult(
+        uint256 x,
+        uint256 y,
+        uint256 z,
+        uint256 k
+    ) private pure returns (uint256 rx, uint256 ry, uint256 rz) {
+        unchecked {
+            for (uint256 i = 0; i < 256; ++i) {
+                if (rz > 0) {
+                    (rx, ry, rz) = _jDouble(rx, ry, rz);
+                }
+                if (k >> 255 > 0) {
+                    if (rz == 0) {
+                        (rx, ry, rz) = (x, y, z);
+                    } else {
+                        (rx, ry, rz) = _jAdd(rx, ry, rz, x, y, z);
+                    }
+                }
+                k <<= 1;
+            }
+        }
+    }
+
+    /// From P256.sol
+
+    function _affineFromJacobian(uint256 jx, uint256 jy, uint256 jz) private view returns (bytes32 ax, bytes32 ay) {
+        if (jz == 0) return (0, 0);
+        uint256 zinv = Math.invModPrime(jz, P256.P);
+        uint256 zzinv = mulmod(zinv, zinv, P256.P);
+        uint256 zzzinv = mulmod(zzinv, zinv, P256.P);
+        ax = bytes32(mulmod(jx, zzinv, P256.P));
+        ay = bytes32(mulmod(jy, zzzinv, P256.P));
+    }
+
+    function _jDouble(uint256 x, uint256 y, uint256 z) private pure returns (uint256 rx, uint256 ry, uint256 rz) {
+        uint256 p = P256.P;
+        uint256 a = P256.A;
+        assembly ("memory-safe") {
+            let yy := mulmod(y, y, p)
+            let zz := mulmod(z, z, p)
+            let s := mulmod(4, mulmod(x, yy, p), p) // s = 4*x*y²
+            let m := addmod(mulmod(3, mulmod(x, x, p), p), mulmod(a, mulmod(zz, zz, p), p), p) // m = 3*x²+a*z⁴
+            let t := addmod(mulmod(m, m, p), sub(p, mulmod(2, s, p)), p) // t = m²-2*s
+
+            // x' = t
+            rx := t
+            // y' = m*(s-t)-8*y⁴
+            ry := addmod(mulmod(m, addmod(s, sub(p, t), p), p), sub(p, mulmod(8, mulmod(yy, yy, p), p)), p)
+            // z' = 2*y*z
+            rz := mulmod(2, mulmod(y, z, p), p)
+        }
+    }
+
+    function _jAdd(
+        uint256 x1,
+        uint256 y1,
+        uint256 z1,
+        uint256 x2,
+        uint256 y2,
+        uint256 z2
+    ) private pure returns (uint256 rx, uint256 ry, uint256 rz) {
+        uint256 p = P256.P;
+        assembly ("memory-safe") {
+            let zz1 := mulmod(z1, z1, p) // zz1 = z1²
+            let zz2 := mulmod(z2, z2, p) // zz2 = z2²
+            let u1 := mulmod(x1, zz2, p) // u1 = x1*z2²
+            let u2 := mulmod(x2, zz1, p) // u2 = x2*z1²
+            let s1 := mulmod(y1, mulmod(zz2, z2, p), p) // s1 = y1*z2³
+            let s2 := mulmod(y2, mulmod(zz1, z1, p), p) // s2 = y2*z1³
+            let h := addmod(u2, sub(p, u1), p) // h = u2-u1
+            let hh := mulmod(h, h, p) // h²
+            let hhh := mulmod(h, hh, p) // h³
+            let r := addmod(s2, sub(p, s1), p) // r = s2-s1
+
+            // x' = r²-h³-2*u1*h²
+            rx := addmod(addmod(mulmod(r, r, p), sub(p, hhh), p), sub(p, mulmod(2, mulmod(u1, hh, p), p)), p)
+            // y' = r*(u1*h²-x')-s1*h³
+            ry := addmod(mulmod(r, addmod(mulmod(u1, hh, p), sub(p, rx), p), p), sub(p, mulmod(s1, hhh, p)), p)
+            // z' = h*z1*z2
+            rz := mulmod(h, mulmod(z1, z2, p), p)
         }
     }
 }

--- a/test/utils/cryptography/P256.t.sol
+++ b/test/utils/cryptography/P256.t.sol
@@ -12,124 +12,29 @@ contract P256Test is Test {
     function testVerify(uint256 seed, bytes32 digest) public {
         uint256 privateKey = bound(uint256(keccak256(abi.encode(seed))), 1, P256.N - 1);
 
-        (bytes32 x, bytes32 y) = P256PublicKey.getPublicKey(privateKey);
+        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
         (bytes32 r, bytes32 s) = vm.signP256(privateKey, digest);
         s = _ensureLowerS(s);
-        assertTrue(P256.verify(digest, r, s, x, y));
-        assertTrue(P256.verifySolidity(digest, r, s, x, y));
+        assertTrue(P256.verify(digest, r, s, bytes32(x), bytes32(y)));
+        assertTrue(P256.verifySolidity(digest, r, s, bytes32(x), bytes32(y)));
     }
 
     /// forge-config: default.fuzz.runs = 512
     function testRecover(uint256 seed, bytes32 digest) public {
         uint256 privateKey = bound(uint256(keccak256(abi.encode(seed))), 1, P256.N - 1);
 
-        (bytes32 x, bytes32 y) = P256PublicKey.getPublicKey(privateKey);
+        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
         (bytes32 r, bytes32 s) = vm.signP256(privateKey, digest);
         s = _ensureLowerS(s);
         (bytes32 qx0, bytes32 qy0) = P256.recovery(digest, 0, r, s);
         (bytes32 qx1, bytes32 qy1) = P256.recovery(digest, 1, r, s);
-        assertTrue((qx0 == x && qy0 == y) || (qx1 == x && qy1 == y));
+        assertTrue((qx0 == bytes32(x) && qy0 == bytes32(y)) || (qx1 == bytes32(x) && qy1 == bytes32(y)));
     }
 
     function _ensureLowerS(bytes32 s) private pure returns (bytes32) {
         uint256 _s = uint256(s);
         unchecked {
             return _s > P256.N / 2 ? bytes32(P256.N - _s) : s;
-        }
-    }
-}
-
-/**
- * @dev Library to derive P256 public key from private key
- * Should be removed if Foundry adds this functionality
- * See https://github.com/foundry-rs/foundry/issues/7908
- */
-library P256PublicKey {
-    function getPublicKey(uint256 privateKey) internal view returns (bytes32, bytes32) {
-        (uint256 x, uint256 y, uint256 z) = _jMult(P256.GX, P256.GY, 1, privateKey);
-        return _affineFromJacobian(x, y, z);
-    }
-
-    function _jMult(
-        uint256 x,
-        uint256 y,
-        uint256 z,
-        uint256 k
-    ) private pure returns (uint256 rx, uint256 ry, uint256 rz) {
-        unchecked {
-            for (uint256 i = 0; i < 256; ++i) {
-                if (rz > 0) {
-                    (rx, ry, rz) = _jDouble(rx, ry, rz);
-                }
-                if (k >> 255 > 0) {
-                    if (rz == 0) {
-                        (rx, ry, rz) = (x, y, z);
-                    } else {
-                        (rx, ry, rz) = _jAdd(rx, ry, rz, x, y, z);
-                    }
-                }
-                k <<= 1;
-            }
-        }
-    }
-
-    /// From P256.sol
-
-    function _affineFromJacobian(uint256 jx, uint256 jy, uint256 jz) private view returns (bytes32 ax, bytes32 ay) {
-        if (jz == 0) return (0, 0);
-        uint256 zinv = Math.invModPrime(jz, P256.P);
-        uint256 zzinv = mulmod(zinv, zinv, P256.P);
-        uint256 zzzinv = mulmod(zzinv, zinv, P256.P);
-        ax = bytes32(mulmod(jx, zzinv, P256.P));
-        ay = bytes32(mulmod(jy, zzzinv, P256.P));
-    }
-
-    function _jDouble(uint256 x, uint256 y, uint256 z) private pure returns (uint256 rx, uint256 ry, uint256 rz) {
-        uint256 p = P256.P;
-        uint256 a = P256.A;
-        assembly ("memory-safe") {
-            let yy := mulmod(y, y, p)
-            let zz := mulmod(z, z, p)
-            let s := mulmod(4, mulmod(x, yy, p), p) // s = 4*x*y²
-            let m := addmod(mulmod(3, mulmod(x, x, p), p), mulmod(a, mulmod(zz, zz, p), p), p) // m = 3*x²+a*z⁴
-            let t := addmod(mulmod(m, m, p), sub(p, mulmod(2, s, p)), p) // t = m²-2*s
-
-            // x' = t
-            rx := t
-            // y' = m*(s-t)-8*y⁴
-            ry := addmod(mulmod(m, addmod(s, sub(p, t), p), p), sub(p, mulmod(8, mulmod(yy, yy, p), p)), p)
-            // z' = 2*y*z
-            rz := mulmod(2, mulmod(y, z, p), p)
-        }
-    }
-
-    function _jAdd(
-        uint256 x1,
-        uint256 y1,
-        uint256 z1,
-        uint256 x2,
-        uint256 y2,
-        uint256 z2
-    ) private pure returns (uint256 rx, uint256 ry, uint256 rz) {
-        uint256 p = P256.P;
-        assembly ("memory-safe") {
-            let zz1 := mulmod(z1, z1, p) // zz1 = z1²
-            let zz2 := mulmod(z2, z2, p) // zz2 = z2²
-            let u1 := mulmod(x1, zz2, p) // u1 = x1*z2²
-            let u2 := mulmod(x2, zz1, p) // u2 = x2*z1²
-            let s1 := mulmod(y1, mulmod(zz2, z2, p), p) // s1 = y1*z2³
-            let s2 := mulmod(y2, mulmod(zz1, z1, p), p) // s2 = y2*z1³
-            let h := addmod(u2, sub(p, u1), p) // h = u2-u1
-            let hh := mulmod(h, h, p) // h²
-            let hhh := mulmod(h, hh, p) // h³
-            let r := addmod(s2, sub(p, s1), p) // r = s2-s1
-
-            // x' = r²-h³-2*u1*h²
-            rx := addmod(addmod(mulmod(r, r, p), sub(p, hhh), p), sub(p, mulmod(2, mulmod(u1, hh, p), p)), p)
-            // y' = r*(u1*h²-x')-s1*h³
-            ry := addmod(mulmod(r, addmod(mulmod(u1, hh, p), sub(p, rx), p), p), sub(p, mulmod(s1, hhh, p)), p)
-            // z' = h*z1*z2
-            rz := mulmod(h, mulmod(z1, z2, p), p)
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Optimizes some `P256` operations by removing single-used variables and instead using the space for values that are used multiple times. 

### Gas report

#### Before
| test/utils/cryptography/P256.t.sol:GasMeasurer contract |                 |        |        |        |         |
|---------------------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                                         | Deployment Size |        |        |        |         |
| 638441                                                  | 2736            |        |        |        |         |
| Function Name                                           | min             | avg    | median | max    | # calls |
| verify                                                  | 255695          | 260876 | 261075 | 265421 | 256     |
| verifySolidity                                          | 251722          | 256903 | 257102 | 261448 | 256     |

#### After
| test/utils/cryptography/P256.t.sol:GasMeasurer contract |                 |        |        |        |         |
|---------------------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                                         | Deployment Size |        |        |        |         |
| 631952                                                  | 2706            |        |        |        |         |
| Function Name                                           | min             | avg    | median | max    | # calls |
| verify                                                  | 250795          | 256630 | 256547 | 261111 | 256     |
| verifySolidity                                          | 246822          | 252657 | 252574 | 257138 | 256     |

#### Difference

- `verify`: average gas reduced by 1.64% (4246 gas)
- `verifySolidity`: average gas reduced by 1.67% (4246 gas)
- Deployment cost: reduced by 1.02% (6489 gas)

<details>
  <summary>Replicate</summary>
Modify the P256 foundry tests slightly to perform the operations via a contract that uses the library (in order to be able to generate the gas report with forge):

```solidity
contract GasMeasurer {
    function verify(bytes32 digest, bytes32 r, bytes32 s, bytes32 x, bytes32 y) external returns (bool) {
        return P256.verify(digest, r, s, x, y);
    }

    function verifySolidity(bytes32 digest, bytes32 r, bytes32 s, bytes32 x, bytes32 y) external returns (bool) {
        return P256.verifySolidity(digest, r, s, x, y);
    }
}

contract P256Test is Test {
    /// forge-config: default.fuzz.runs = 512
    function testVerify(uint256 seed, bytes32 digest) public {
        GasMeasurer gas = new GasMeasurer();
        uint256 privateKey = bound(uint256(keccak256(abi.encode(seed))), 1, P256.N - 1);

        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
        (bytes32 r, bytes32 s) = vm.signP256(privateKey, digest);
        s = _ensureLowerS(s);
        assertTrue(gas.verify(digest, r, s, bytes32(x), bytes32(y)));
        assertTrue(gas.verifySolidity(digest, r, s, bytes32(x), bytes32(y)));
    }
```

Then run: `forge t --mc P256Test --gas-report`
</details>

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
