### PR TITLE
Bump pragma to 0.8.22 for all contract that depend on ERC1967Utils

### DIFF
--- a/.changeset/seven-donkeys-tap.md
+++ b/.changeset/seven-donkeys-tap.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Update some pragma directives to ensure that all file requirements match that of the files they import.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,8 @@ jobs:
         run: npm run test
       - name: Check linearisation of the inheritance graph
         run: npm run test:inheritance
+      - name: Check pragma consistency between files
+        run: npm run test:pragma
       - name: Check proceduraly generated contracts are up-to-date
         run: npm run test:generation
       - name: Compare gas costs
@@ -68,6 +70,8 @@ jobs:
         run: npm run test
       - name: Check linearisation of the inheritance graph
         run: npm run test:inheritance
+      - name: Check pragma consistency between files
+        run: npm run test:pragma
       - name: Check storage layout
         uses: ./.github/actions/storage-layout
         continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change') }}

--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {ERC1967Utils} from "../proxy/ERC1967/ERC1967Utils.sol";
 import {StorageSlot} from "../utils/StorageSlot.sol";

--- a/contracts/mocks/MerkleTreeMock.sol
+++ b/contracts/mocks/MerkleTreeMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {MerkleTree} from "../utils/structs/MerkleTree.sol";
 

--- a/contracts/mocks/Stateless.sol
+++ b/contracts/mocks/Stateless.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 // We keep these imports and a dummy contract just to we can run the test suite after transpilation.
 

--- a/contracts/mocks/governance/GovernorStorageMock.sol
+++ b/contracts/mocks/governance/GovernorStorageMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import {IGovernor, Governor} from "../../governance/Governor.sol";
 import {GovernorTimelockControl} from "../../governance/extensions/GovernorTimelockControl.sol";

--- a/contracts/mocks/proxy/UUPSUpgradeableMock.sol
+++ b/contracts/mocks/proxy/UUPSUpgradeableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {UUPSUpgradeable} from "../../proxy/utils/UUPSUpgradeable.sol";
 import {ERC1967Utils} from "../../proxy/ERC1967/ERC1967Utils.sol";

--- a/contracts/proxy/ERC1967/ERC1967Proxy.sol
+++ b/contracts/proxy/ERC1967/ERC1967Proxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (proxy/ERC1967/ERC1967Proxy.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {Proxy} from "../Proxy.sol";
 import {ERC1967Utils} from "./ERC1967Utils.sol";

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (proxy/ERC1967/ERC1967Utils.sol)
 
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.22;
 
 import {IBeacon} from "../beacon/IBeacon.sol";
 import {IERC1967} from "../../interfaces/IERC1967.sol";

--- a/contracts/proxy/beacon/BeaconProxy.sol
+++ b/contracts/proxy/beacon/BeaconProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (proxy/beacon/BeaconProxy.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {IBeacon} from "./IBeacon.sol";
 import {Proxy} from "../Proxy.sol";

--- a/contracts/proxy/transparent/ProxyAdmin.sol
+++ b/contracts/proxy/transparent/ProxyAdmin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (proxy/transparent/ProxyAdmin.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {ITransparentUpgradeableProxy} from "./TransparentUpgradeableProxy.sol";
 import {Ownable} from "../../access/Ownable.sol";

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (proxy/transparent/TransparentUpgradeableProxy.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
 import {ERC1967Proxy} from "../ERC1967/ERC1967Proxy.sol";

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (proxy/utils/UUPSUpgradeable.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.22;
 
 import {IERC1822Proxiable} from "../../interfaces/draft-IERC1822.sol";
 import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "generate": "scripts/generate/run.js",
     "version": "scripts/release/version.sh",
     "test": "hardhat test",
-    "test:inheritance": "scripts/checks/inheritance-ordering.js artifacts/build-info/*",
     "test:generation": "scripts/checks/generation.sh",
+    "test:inheritance": "scripts/checks/inheritance-ordering.js artifacts/build-info/*",
+    "test:pragma": "scripts/checks/pragma-consistency.js artifacts/build-info/*",
     "gas-report": "env ENABLE_GAS_REPORT=true npm run test",
     "slither": "npm run clean && slither ."
   },

--- a/scripts/checks/inheritance-ordering.js
+++ b/scripts/checks/inheritance-ordering.js
@@ -2,8 +2,12 @@
 
 const path = require('path');
 const graphlib = require('graphlib');
+const match = require('micromatch');
 const { findAll } = require('solidity-ast/utils');
 const { _: artifacts } = require('yargs').argv;
+
+// files to skip
+const skipPatterns = ['contracts-exposed/**', 'contracts/mocks/**'];
 
 for (const artifact of artifacts) {
   const { output: solcOutput } = require(path.resolve(__dirname, '../..', artifact));
@@ -13,10 +17,7 @@ for (const artifact of artifacts) {
   const linearized = [];
 
   for (const source in solcOutput.contracts) {
-    if (['contracts-exposed/', 'contracts/mocks/'].some(pattern => source.startsWith(pattern))) {
-      continue;
-    }
-
+    if (match.any(source, skipPatterns)) continue;
     for (const contractDef of findAll('ContractDefinition', solcOutput.sources[source].ast)) {
       names[contractDef.id] = contractDef.name;
       linearized.push(contractDef.linearizedBaseContracts);

--- a/scripts/checks/pragma-consistency.js
+++ b/scripts/checks/pragma-consistency.js
@@ -12,14 +12,14 @@ const skip = source => skipPatterns.some(pattern => source.startsWith(pattern));
 for (const artifact of artifacts) {
   const { output: solcOutput } = require(path.resolve(__dirname, '../..', artifact));
 
-  const pragma = {}
+  const pragma = {};
 
   // Extract pragma directive for all files
   for (const source in solcOutput.contracts) {
     if (skip(source)) continue;
-    for (const {literals} of findAll('PragmaDirective', solcOutput.sources[source].ast)) {
+    for (const { literals } of findAll('PragmaDirective', solcOutput.sources[source].ast)) {
       // There should only be one.
-      pragma[source] = literals.slice(1).join('')
+      pragma[source] = literals.slice(1).join('');
     }
   }
 
@@ -29,12 +29,14 @@ for (const artifact of artifacts) {
     // minimum version of the compiler that matches source's pragma
     const minVersion = semver.minVersion(pragma[source]);
     // loop over all imports in source
-    for (const {absolutePath} of findAll('ImportDirective', solcOutput.sources[source].ast)) {
+    for (const { absolutePath } of findAll('ImportDirective', solcOutput.sources[source].ast)) {
       // So files that only import without declaring anything cause issues, because they don't shop in in "pragma"
       if (!pragma[absolutePath]) continue;
       // Check that the minVersion for source satisfies the requirements of the imported files
       if (!semver.satisfies(minVersion, pragma[absolutePath])) {
-        console.log(`- ${source} uses ${pragma[source]} but depends on ${absolutePath} that requires ${pragma[absolutePath]}`);
+        console.log(
+          `- ${source} uses ${pragma[source]} but depends on ${absolutePath} that requires ${pragma[absolutePath]}`,
+        );
         process.exitCode = 1;
       }
     }

--- a/scripts/checks/pragma-consistency.js
+++ b/scripts/checks/pragma-consistency.js
@@ -6,7 +6,7 @@ const { findAll } = require('solidity-ast/utils');
 const { _: artifacts } = require('yargs').argv;
 
 // files to skip
-const skipPatterns = ['contracts-exposed/'];
+const skipPatterns = ['contracts-exposed/', 'contracts/mocks/WithInit.sol'];
 const skip = source => skipPatterns.some(pattern => source.startsWith(pattern));
 
 for (const artifact of artifacts) {

--- a/scripts/checks/pragma-consistency.js
+++ b/scripts/checks/pragma-consistency.js
@@ -19,7 +19,8 @@ for (const artifact of artifacts) {
     if (skip(source)) continue;
     for (const { literals } of findAll('PragmaDirective', solcOutput.sources[source].ast)) {
       // There should only be one.
-      pragma[source] = literals.slice(1).join('');
+      const [first, ...rest] = literals;
+      if (first === 'solidity') pragma[source] = rest.join('');
     }
   }
 

--- a/scripts/checks/pragma-consistency.js
+++ b/scripts/checks/pragma-consistency.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const semver = require('semver');
+const { findAll } = require('solidity-ast/utils');
+const { _: artifacts } = require('yargs').argv;
+
+// files to skip
+const skipPatterns = ['contracts-exposed/'];
+const skip = source => skipPatterns.some(pattern => source.startsWith(pattern));
+
+for (const artifact of artifacts) {
+  const { output: solcOutput } = require(path.resolve(__dirname, '../..', artifact));
+
+  const pragma = {}
+
+  // Extract pragma directive for all files
+  for (const source in solcOutput.contracts) {
+    if (skip(source)) continue;
+    for (const {literals} of findAll('PragmaDirective', solcOutput.sources[source].ast)) {
+      // There should only be one.
+      pragma[source] = literals.slice(1).join('')
+    }
+  }
+
+  // Compare the pragma directive of the file, to that of the files it imports
+  for (const source in solcOutput.contracts) {
+    if (skip(source)) continue;
+    // minimum version of the compiler that matches source's pragma
+    const minVersion = semver.minVersion(pragma[source]);
+    // loop over all imports in source
+    for (const {absolutePath} of findAll('ImportDirective', solcOutput.sources[source].ast)) {
+      // So files that only import without declaring anything cause issues, because they don't shop in in "pragma"
+      if (!pragma[absolutePath]) continue;
+      // Check that the minVersion for source satisfies the requirements of the imported files
+      if (!semver.satisfies(minVersion, pragma[absolutePath])) {
+        console.log(`- ${source} uses ${pragma[source]} but depends on ${absolutePath} that requires ${pragma[absolutePath]}`);
+        process.exitCode = 1;
+      }
+    }
+  }
+}
+
+if (!process.exitCode) {
+  console.log('Pragma directives are consistent.');
+}


### PR DESCRIPTION
`ERC1967Utils` emits events that are declared in the `IERC1967.sol` interface. 0.8.22 fixes a bug regarding such events:

> NatSpec: Fix internal error when requesting userdoc or devdoc for a contract that emits an event defined in a foreign contract or interface.

See: https://soliditylang.org/blog/2023/10/25/solidity-0.8.22-release-announcement/