### PR TITLE
Remove unused import in `SafeERC20`

### DIFF
--- a/.changeset/light-dancers-obey.md
+++ b/.changeset/light-dancers-obey.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`SafeERC20`: removing unused import

--- a/.changeset/light-dancers-obey.md
+++ b/.changeset/light-dancers-obey.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`SafeERC20`: removing unused import

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.20;
 
 import {IERC20} from "../IERC20.sol";
 import {IERC1363} from "../../../interfaces/IERC1363.sol";
-import {Address} from "../../../utils/Address.sol";
 
 /**
  * @title SafeERC20


### PR DESCRIPTION
We are simply removing an used import. It seems it stopped being used in https://github.com/OpenZeppelin/openzeppelin-contracts/commit/5480641e5c572fc7f9d68d59003f4b6417168cdd


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
