### PR TITLE
Fix typo in GUIDELINES.md

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -55,7 +55,7 @@ External contributions must be reviewed separately by multiple maintainers.
 
 Automation should be used as much as possible to reduce the possibility of human error and forgetfulness.
 
-Automations that make use of sensitive credentials must use secure secret management, and must be strengthened against attacks such as [those on GitHub Actions worklows](https://github.com/nikitastupin/pwnhub).
+Automations that make use of sensitive credentials must use secure secret management, and must be strengthened against attacks such as [those on GitHub Actions workflows](https://github.com/nikitastupin/pwnhub).
 
 Some other examples of automation are:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ There is a bonus reward for issues introduced in release candidates that are rep
 
 ## Security Patches
 
-Security vulnerabilities will be patched as soon as responsibly possible, and published as an advisory on this repository (see [advisories]) and on the affected npm packages.
+Security vulnerabilities will be patched as soon as reasonably possible, and published as an advisory on this repository (see [advisories]) and on the affected npm packages.
 
 [advisories]: https://github.com/OpenZeppelin/openzeppelin-contracts/security/advisories
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ There is a bonus reward for issues introduced in release candidates that are rep
 
 ## Security Patches
 
-Security vulnerabilities will be patched as soon as reasonably possible, and published as an advisory on this repository (see [advisories]) and on the affected npm packages.
+Security vulnerabilities will be patched as soon as responsibly possible, and published as an advisory on this repository (see [advisories]) and on the affected npm packages.
 
 [advisories]: https://github.com/OpenZeppelin/openzeppelin-contracts/security/advisories
 


### PR DESCRIPTION
**Description**:

This pull request addresses two issues:

1. **Fix Typo in `GUIDELINES.md`**  
   In the `GUIDELINES.md` file, there was a typo in the following sentence:
   > "Automations that make use of sensitive credentials must use secure secret management, and must be strengthened against attacks such as those on GitHub Actions *worklows*."

   The word "*worklows*" should be "*workflows*". This change corrects the typo to:
   > "Automations that make use of sensitive credentials must use secure secret management, and must be strengthened against attacks such as those on GitHub Actions *workflows*."

   **Importance**: Although this is a minor typo, ensuring the correct spelling of terms is important for maintaining the professionalism and clarity of the documentation.

2. **Improve Clarity in `SECURITY.md`**  
   In the `SECURITY.md` file, there was an awkward phrasing in the sentence:
   > "Security vulnerabilities will be patched as soon as *responsibly* possible, and published as an advisory on this repository (see [advisories]) and on the affected npm packages."

   The phrase "*as soon as responsibly possible*" is unclear and uncommon. The corrected version uses the more standard and grammatically correct expression:
   > "Security vulnerabilities will be patched as soon as *reasonably* possible, and published as an advisory on this repository (see [advisories]) and on the affected npm packages."

   **Importance**: This change improves readability and ensures that the documentation uses the correct, widely-understood phrasing. The word "responsibly" in this context was not suitable and could confuse readers.



#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
