### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.changeset/proud-planes-arrive.md
+++ b/.changeset/proud-planes-arrive.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`Bytes`: Add a library of common operation that operate on `bytes` objects.
+`Bytes`: Add a library of common operations that operate on `bytes` objects.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "common operation" to "common operations". Instead of "common operation", it should be "common operations", as it refers to the plural form.

Please review the changes and let me know if any additional changes are needed.

