### PR TITLE
Fix: Ensure cross-platform compatibility for sed command in CI script

### DIFF
--- a/scripts/checks/coverage.sh
+++ b/scripts/checks/coverage.sh
@@ -12,7 +12,11 @@ if [ "${CI:-"false"}" == "true" ]; then
   # Foundry coverage
   forge coverage --report lcov --ir-minimum
   # Remove zero hits
-  sed -i '/,0/d' lcov.info
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' '/,0/d' lcov.info
+  else
+    sed -i '/,0/d' lcov.info
+  fi
 fi
 
 # Reports are then uploaded to Codecov automatically by workflow, and merged.


### PR DESCRIPTION
#### Problem  
In the CI script, the following command can cause issues on macOS:

```bash
sed -i '/,0/d' lcov.info
```

The `sed -i` flag directly edits a file in place, but its behavior differs across platforms:  
- On Linux, it works as expected.  
- On macOS, the `-i` option requires an argument for the extension of a backup file (even if it’s empty). Without this, the script fails.  

#### Proposed Fix  
To ensure compatibility across both Linux and macOS, we updated the script to detect the operating system and adjust the `sed` command accordingly.

#### Changes Made  
1. Added logic to check the operating system using `$OSTYPE`.  
2. Modified the `sed` command to use `sed -i ''` on macOS and `sed -i` on Linux.

#### Updated Code  
```bash
if [ "${CI:-"false"}" == "true" ]; then
  # Foundry coverage
  forge coverage --report lcov --ir-minimum
  # Remove zero hits
  if [[ "$OSTYPE" == "darwin"* ]]; then
    sed -i '' '/,0/d' lcov.info
  else
    sed -i '/,0/d' lcov.info
  fi
fi
```

#### Importance of Fix  
1. **Cross-platform Compatibility**: Ensures the script runs successfully on both Linux and macOS environments.  
2. **Robust CI/CD Process**: Prevents test pipeline failures caused by platform-specific inconsistencies.  
3. **Improved Developer Experience**: Developers using macOS will no longer encounter errors when running the script locally or in macOS-based CI workflows.  

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
