### PR TITLE
Fix typos improved clarity

### DIFF
--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bugfree status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug-free status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 

--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug-free status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug free status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 

--- a/certora/README.md
+++ b/certora/README.md
@@ -2,14 +2,14 @@
 
 These instructions detail the process for running Certora Verification Tool on OpenZeppelin Contracts.
 
-Documentation for CVT and the specification language are available [here](https://certora.atlassian.net/wiki/spaces/CPD/overview).
+Documentation for CVT and the specification language is available [here](https://certora.atlassian.net/wiki/spaces/CPD/overview).
 
 ## Prerequisites
 
 Follow the [Certora installation guide](https://docs.certora.com/en/latest/docs/user-guide/getting-started/install.html) in order to get the Certora Prover Package and the `solc` executable folder in your path.
 
 > **Note**
-> An API Key is required for local testing. Although the prover will run on a Github Actions' CI environment on selected Pull Requests.
+> An API Key is required for local testing. Although the prover will run on a GitHub Actions CI environment on selected Pull Requests.
 
 ## Running the verification
 

--- a/certora/README.md
+++ b/certora/README.md
@@ -9,7 +9,7 @@ Documentation for CVT and the specification language is available [here](https:/
 Follow the [Certora installation guide](https://docs.certora.com/en/latest/docs/user-guide/getting-started/install.html) in order to get the Certora Prover Package and the `solc` executable folder in your path.
 
 > **Note**
-> An API Key is required for local testing. Although the prover will run on a GitHub Actions CI environment on selected Pull Requests.
+> An API Key is required for local testing. Although the prover will run on a GitHub Actions' CI environment on selected Pull Requests.
 
 ## Running the verification
 

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -1,3 +1,3 @@
 ## Testing
 
-Unit test are critical to OpenZeppelin Contracts. They help ensure code quality and mitigate against security vulnerabilities. The directory structure within the `/test` directory corresponds to the `/contracts` directory.
+Unit tests are critical to OpenZeppelin Contracts. They help ensure code quality and mitigate against security vulnerabilities. The directory structure within the `/test` directory corresponds to the `/contracts` directory.


### PR DESCRIPTION
This pull request includes three text corrections in the documentation:

Fixing "bugfree" to "bug-free":
In the disclaimer section, the term "bugfree" was corrected to "bug-free" for proper spelling.

Correcting "test" to "tests":
In the relevant section, "test" was updated to "tests" to match the plural form and ensure consistency in the text.

Fixing " Github Actions' CI" to "GitHub Actions CI"
