### PR TITLE
Fix typo in ERC721 API reference docs

### DIFF
--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bugfree status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warranties about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bugfree status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 

--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warranties about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bugfree status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bugfree status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 

--- a/contracts/token/ERC721/README.adoc
+++ b/contracts/token/ERC721/README.adoc
@@ -22,7 +22,7 @@ OpenZeppelin Contracts provides implementations of all four interfaces:
 
 Additionally there are a few of other extensions:
 
-* {ERC721Consecutive}: An implementation of https://eips.ethereum.org/EIPS/eip-2309[ERC-2309] for minting batchs of tokens during construction, in accordance with ERC-721.
+* {ERC721Consecutive}: An implementation of https://eips.ethereum.org/EIPS/eip-2309[ERC-2309] for minting batches of tokens during construction, in accordance with ERC-721.
 * {ERC721URIStorage}: A more flexible but more expensive way of storing metadata.
 * {ERC721Votes}: Support for voting and vote delegation.
 * {ERC721Royalty}: A way to signal royalty information following ERC-2981.


### PR DESCRIPTION
## Description:
This pull request corrects typographical errors in the following files:
- `audits/2017-03.md` – corrected "warrantees" to "warranties".
- `contracts/token/ERC721/README.adoc` – corrected "batchs" to "batches".

### PR Checklist:
- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
