### PR TITLE
Fix incorrect syntax in RoleData mapping definition

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -48,7 +48,7 @@ import {ERC165} from "../utils/introspection/ERC165.sol";
  */
 abstract contract AccessControl is Context, IAccessControl, ERC165 {
     struct RoleData {
-        mapping(address account => bool) hasRole;
+        mapping(address => bool) hasRole;
         bytes32 adminRole;
     }
 


### PR DESCRIPTION
### Description:
In the `RoleData` struct, there was a syntax issue in the `mapping` definition:

```solidity
struct RoleData {
    mapping(address account => bool) hasRole;
    bytes32 adminRole;
}
```

The mapping definition was incorrectly using `account => bool`. In Solidity, the correct syntax for defining a mapping is `mapping(address => bool)` without naming the parameters.

This fix ensures that the contract compiles correctly by adhering to Solidity's syntax rules. Using the correct `mapping(address => bool)` syntax is important because any deviation would cause a compilation error, potentially preventing the contract from being deployed or tested.

This correction is crucial for ensuring the proper functioning of the access control logic, which relies on the correct structure for role assignments and permissions management.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
