### PR TITLE
Fix typo in paymasterData function comment

### DIFF
--- a/contracts/account/utils/draft-ERC4337Utils.sol
+++ b/contracts/account/utils/draft-ERC4337Utils.sol
@@ -154,7 +154,7 @@ library ERC4337Utils {
         return self.paymasterAndData.length < 52 ? 0 : uint128(bytes16(self.paymasterAndData[36:52]));
     }
 
-    /// @dev Returns the forth section of `paymasterAndData` from the {PackedUserOperation}.
+    /// @dev Returns the fourth section of `paymasterAndData` from the {PackedUserOperation}.
     function paymasterData(PackedUserOperation calldata self) internal pure returns (bytes calldata) {
         return self.paymasterAndData.length < 52 ? _emptyCalldataBytes() : self.paymasterAndData[52:];
     }


### PR DESCRIPTION
This update addresses a minor issue in the comment for the `paymasterData` function. The word "forth" was incorrectly used, when the correct term should be "fourth." Although this is just a comment change, ensuring accurate terminology is crucial for maintaining clear and professional code documentation. 

<img width="811" alt="Снимок экрана 2024-12-01 в 18 58 53" src="https://github.com/user-attachments/assets/429cbe65-58a1-49d7-a9f9-5f54e541286a">

By correcting this typo, we improve the readability of the code and avoid potential confusion for anyone reading the documentation in the future. Proper terminology enhances the quality of the project and ensures consistency in the comments across the codebase.

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
