### PR TITLE
Fix Syntax Error in _balances Mapping Declaration

### DIFF
--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -20,7 +20,7 @@ abstract contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI, IER
     using Arrays for uint256[];
     using Arrays for address[];
 
-    mapping(uint256 id => mapping(address account => uint256)) private _balances;
+    mapping(uint256 => mapping(address => uint256)) private _balances;
 
     mapping(address account => mapping(address operator => bool)) private _operatorApprovals;
 


### PR DESCRIPTION
This update corrects a syntax issue in the declaration of the `_balances` mapping. Previously, the code defined the mapping as:  

```solidity
mapping(uint256 id => mapping(address account => uint256)) private _balances;
```  

This syntax is invalid in Solidity because it uses identifiers (`id`, `account`) instead of the correct `=>` syntax for specifying key-value types. The corrected mapping declaration is:  

```solidity
mapping(uint256 => mapping(address => uint256)) private _balances;
```  

### Why This Matters:  

The error prevents the contract from compiling, which would block its deployment and usage. This fix ensures that the contract adheres to Solidity's syntax requirements, restoring functionality and enabling developers to build on the codebase without compilation issues.  

By resolving this issue, the contract aligns with Solidity's mapping type standards, improving reliability and usability.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
