### PR TITLE
Fix Syntax Errors in Mapping Definitions

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -48,11 +48,11 @@ import {ERC165} from "../utils/introspection/ERC165.sol";
  */
 abstract contract AccessControl is Context, IAccessControl, ERC165 {
     struct RoleData {
-        mapping(address account => bool) hasRole;
+        mapping(address => bool) hasRole;
         bytes32 adminRole;
     }
 
-    mapping(bytes32 role => RoleData) private _roles;
+    mapping(bytes32 => RoleData) private _roles;
 
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
 


### PR DESCRIPTION
This update addresses a critical issue with the syntax used in the mapping definitions within the `RoleData` structure and the `_roles` mapping. The original code used an incorrect format that would cause a compilation failure.

### Changes made:
- The incorrect mapping definition:
  ```solidity
  mapping(address account => bool) hasRole;
  ```
  has been corrected to:
  ```solidity
  mapping(address => bool) hasRole;
  ```

- A similar mistake was found in the `_roles` mapping:
  ```solidity
  mapping(bytes32 role => RoleData) private _roles;
  ```
  which has been corrected to:
  ```solidity
  mapping(bytes32 => RoleData) private _roles;
  ```

### Importance:
These syntax errors prevent the contract from compiling, as Solidity does not support the use of named parameters in mapping definitions. The correct syntax requires the use of the `keyType => valueType` format. Fixing these errors is crucial to ensure that the contract compiles successfully and functions as expected.

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
