### PR TITLE
Fix typos and improve consistency in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Breaking changes
 
 - `ERC1967Utils`: Removed duplicate declaration of the `Upgraded`, `AdminChanged` and `BeaconUpgraded` events. These events are still available through the `IERC1967` interface located under the `contracts/interfaces/` directory. Minimum pragma version is now 0.8.21.
-- `Governor`, `GovernorCountingSimple`: The `_countVote` virtual function now returns an `uint256` with the total votes casted. This change allows for more flexibility for partial and fractional voting. Upgrading users may get a compilation error that can be fixed by adding a return statement to the `_countVote` function.
+- `Governor`, `GovernorCountingSimple`: The `_countVote` virtual function now returns an `uint256` with the total votes cast. This change allows for more flexibility for partial and fractional voting. Upgrading users may get a compilation error that can be fixed by adding a return statement to the `_countVote` function.
 
 #### Custom error changes
 

--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -159,7 +159,7 @@ Allows owner to set a public string of contract information. No issues.
 
 This needs some work. Doesn't check if `_required <= len(_owners)` for instance, that would be a bummer. What if _required were like `MAX - 1`?
 
-I have a general concern about the difference between `owners`, `_owners`, and `owner` in `Ownable.sol`. I recommend "Owners" be renamed. In general we do not recomment single character differences in variable names, although a preceding underscore is not uncommon in Solidity code.
+I have a general concern about the difference between `owners`, `_owners`, and `owner` in `Ownable.sol`. I recommend "Owners" be renamed. In general we do not recommend single character differences in variable names, although a preceding underscore is not uncommon in Solidity code.
 
 Line 34: "this contract only has six types of events"...actually only two.
 
@@ -246,7 +246,7 @@ Delete not actually necessary since the value is overwritten in the next line an
 
 ### Bounty
 
-Avoids potential race condition by having each researcher deploy a separate contract for attack; if a research manages to break his associated contract, other researchers can't immediately claim the reward, they have to reproduce the attack in their own contracts.
+Avoids potential race condition by having each researcher deploy a separate contract for attack; if a researcher manages to break his associated contract, other researchers can't immediately claim the reward, they have to reproduce the attack in their own contracts.
 
 A developer could subvert this intent by implementing `deployContract()` to always return the same address. However, this would break the `researchers` mapping, updating the researcher address associated with the contract. This could be prevented by blocking rewrites in `researchers`.
 


### PR DESCRIPTION
## Changes Made

### 1. In CHANGELOG.md:
Changed "casted" → "cast"
- with the total votes casted
+ with the total votes cast

**Reason**: "Cast" is the correct past tense form of the verb "to cast". "Casted" is an incorrect form.

### 2. In audits/2017-03.md:
Changed "recomment" → "recommend"
- we do not recomment single character differences
+ we do not recommend single character differences

**Reason**: Fixed a typo - "recomment" is not a word, while "recommend" is the correct spelling.

### 3. In audits/2017-03.md:
Changed "research" → "researcher"
- if a research manages to break his associated contract
+ if a researcher manages to break his associated contract

**Reason**: "Researcher" is the correct noun for a person conducting research, while "research"
