### PR TITLE
Allow pass in custom arguments to `shouldSupportInterfaces` test helper

### DIFF
--- a/test/helpers/iterate.js
+++ b/test/helpers/iterate.js
@@ -30,7 +30,12 @@ module.exports = {
 
   // ================================================ Object helpers =================================================
 
-  // Create a new object by mapping the values through a function, keeping the keys
+  // Create a new object by mapping the values through a function, keeping the keys. Second function can be used to pre-filter entries
   // Example: mapValues({a:1,b:2,c:3}, x => x**2) → {a:1,b:4,c:9}
-  mapValues: (obj, fn) => Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, fn(v)])),
+  mapValues: (obj, fn, fn2 = () => true) =>
+    Object.fromEntries(
+      Object.entries(obj)
+        .filter(fn2)
+        .map(([k, v]) => [k, fn(v)]),
+    ),
 };

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -92,7 +92,7 @@ const SIGNATURES = {
 
 const INTERFACE_IDS = mapValues(SIGNATURES, interfaceId);
 
-function shouldSupportInterfaces(interfaces = []) {
+function shouldSupportInterfaces(interfaces = [], signatures = SIGNATURES, interfaceIds = INTERFACE_IDS) {
   interfaces.unshift('ERC165');
 
   describe('ERC165', function () {
@@ -103,14 +103,14 @@ function shouldSupportInterfaces(interfaces = []) {
     describe('when the interfaceId is supported', function () {
       it('uses less than 30k gas', async function () {
         for (const k of interfaces) {
-          const interfaceId = INTERFACE_IDS[k] ?? k;
+          const interfaceId = interfaceIds[k] ?? k;
           expect(await this.contractUnderTest.supportsInterface.estimateGas(interfaceId)).to.lte(30_000n);
         }
       });
 
       it('returns true', async function () {
         for (const k of interfaces) {
-          const interfaceId = INTERFACE_IDS[k] ?? k;
+          const interfaceId = interfaceIds[k] ?? k;
           expect(await this.contractUnderTest.supportsInterface(interfaceId), `does not support ${k}`).to.be.true;
         }
       });
@@ -129,10 +129,10 @@ function shouldSupportInterfaces(interfaces = []) {
     it('all interface functions are in ABI', async function () {
       for (const k of interfaces) {
         // skip interfaces for which we don't have a function list
-        if (SIGNATURES[k] === undefined) continue;
+        if (signatures[k] === undefined) continue;
 
         // Check the presence of each function in the contract's interface
-        for (const fnSig of SIGNATURES[k]) {
+        for (const fnSig of signatures[k]) {
           expect(this.contractUnderTest.interface.hasFunction(fnSig), `did not find ${fnSig}`).to.be.true;
         }
       }
@@ -141,5 +141,7 @@ function shouldSupportInterfaces(interfaces = []) {
 }
 
 module.exports = {
+  SIGNATURES,
+  INTERFACE_IDS,
   shouldSupportInterfaces,
 };

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -92,8 +92,10 @@ const SIGNATURES = {
 
 const INTERFACE_IDS = mapValues(SIGNATURES, interfaceId);
 
-function shouldSupportInterfaces(interfaces = [], signatures = SIGNATURES, interfaceIds = INTERFACE_IDS) {
+function shouldSupportInterfaces(interfaces = [], signatures = SIGNATURES) {
   interfaces.unshift('ERC165');
+  signatures.ERC165 = SIGNATURES.ERC165;
+  const interfaceIds = mapValues(signatures, interfaceId, ([name]) => interfaces.includes(name));
 
   describe('ERC165', function () {
     beforeEach(function () {


### PR DESCRIPTION
### Motivation

These allows to reuse the `shouldSupportInterfaces` function in another context. One concrete example is that ERC-7802 requires ERC-165 in the community repository, where we can't test ERC-165 unless we copy paste the helpers or store the interface in this repository.

To avoid either, I think we should allow passing in more arguments to `shouldSupportInterfaces` so that the helper can be reused elsewhere.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
