### PR TITLE
fix typo Update inheritance-ordering.js

### DIFF
--- a/scripts/checks/inheritance-ordering.js
+++ b/scripts/checks/inheritance-ordering.js
@@ -31,7 +31,7 @@ for (const artifact of artifacts) {
   }
 
   /// graphlib.alg.findCycles will not find minimal cycles.
-  /// We are only interested int cycles of lengths 2 (needs proof)
+  /// We are only interested in cycles of lengths 2 (needs proof)
   graph.nodes().forEach((x, i, nodes) =>
     nodes
       .slice(i + 1)


### PR DESCRIPTION
Previously, the comment read:

<img width="542" alt="Снимок экрана 2024-12-10 в 14 05 24" src="https://github.com/user-attachments/assets/d1ad27c8-3b65-4e7e-839c-6a77b75ddcee">

The word "int" was incorrectly used instead of "in". While this is a small issue, it is important for maintaining clarity and accuracy in the codebase, especially for anyone reading the comments to understand the intended logic.

The corrected comment now reads:
```javascript
/// We are only interested in cycles of lengths 2 (needs proof)
```

By fixing this typo, we ensure that the comment better conveys the intended meaning and maintains the quality of the code documentation.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
