### PR TITLE
Corrected wording in the script  Update remove-ignored-artifacts.js

### DIFF
--- a/scripts/remove-ignored-artifacts.js
+++ b/scripts/remove-ignored-artifacts.js
@@ -42,4 +42,4 @@ for (const filename of filenames) {
   }
 }
 
-console.error(`Removed ${n} mock artifacts`);
+console.error(`Removed ${n} ignored artifacts`);


### PR DESCRIPTION
A minor but important typo in the script that removes build artifacts for ignored contracts. 

The message currently reads:
```javascript
console.error(`Removed ${n} mock artifacts`);
```
While the term "mock" is commonly used for test data, it is not the most accurate term in this case. The script is removing artifacts related to ignored contracts, so the word "ignored" better represents the action being performed.

The corrected line now reads:
```javascript
console.error(`Removed ${n} ignored artifacts`);
```

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
