### PR TITLE
Fix grammar in documentation

### DIFF
--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -10,7 +10,7 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
 
 /**
  * @dev Extension of {Governor} that binds the execution process to a Compound Timelock. This adds a delay, enforced by
- * the external timelock to all successful proposal (in addition to the voting duration). The {Governor} needs to be
+ * the external timelock to all successful proposals (in addition to the voting duration). The {Governor} needs to be
  * the admin of the timelock for any operation to be performed. A public, unrestricted,
  * {GovernorTimelockCompound-__acceptAdmin} is available to accept ownership of the timelock.
  *

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -1,3 +1,3 @@
 ## Testing
 
-Unit test are critical to OpenZeppelin Contracts. They help ensure code quality and mitigate against security vulnerabilities. The directory structure within the `/test` directory corresponds to the `/contracts` directory.
+Unit tests are critical to OpenZeppelin Contracts. They help ensure code quality and mitigate against security vulnerabilities. The directory structure within the `/test` directory corresponds to the `/contracts` directory.


### PR DESCRIPTION
1. In contracts/governance/extensions/GovernorTimelockCompound.sol:
Changed "proposal" to "proposals" in the documentation comment

2. In test/TESTING.md:
Changed "test" to "tests" in the documentation
