### PR TITLE
Create an helper @openzeppelin/contracts-helpers package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
         "@nomicfoundation/hardhat-ethers": "^3.0.4",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.3",
+        "@openzeppelin/contracts-helpers": "file:test/helpers",
         "@openzeppelin/docs-utils": "^0.1.5",
         "@openzeppelin/merkle-tree": "^1.0.7",
         "@openzeppelin/upgrade-safe-transpiler": "^0.3.32",
@@ -2005,6 +2006,10 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@openzeppelin/contracts-helpers": {
+      "resolved": "test/helpers",
+      "link": true
     },
     "node_modules/@openzeppelin/docs-utils": {
       "version": "0.1.5",
@@ -12202,6 +12207,11 @@
     },
     "scripts/solhint-custom": {
       "name": "solhint-plugin-openzeppelin",
+      "version": "0.0.0",
+      "dev": true
+    },
+    "test/helpers": {
+      "name": "@openzeppelin/contracts-helpers",
       "version": "0.0.0",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.3",
+    "@openzeppelin/contracts-helpers": "file:test/helpers",
     "@openzeppelin/docs-utils": "^0.1.5",
     "@openzeppelin/merkle-tree": "^1.0.7",
     "@openzeppelin/upgrade-safe-transpiler": "^0.3.32",

--- a/scripts/generate/templates/Arrays.js
+++ b/scripts/generate/templates/Arrays.js
@@ -1,5 +1,5 @@
 const format = require('../format-lines');
-const { capitalize } = require('../../helpers');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 const { TYPES } = require('./Arrays.opts');
 
 const header = `\

--- a/scripts/generate/templates/Checkpoints.t.js
+++ b/scripts/generate/templates/Checkpoints.t.js
@@ -1,5 +1,5 @@
 const format = require('../format-lines');
-const { capitalize } = require('../../helpers');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 const { OPTS } = require('./Checkpoints.opts.js');
 
 // TEMPLATE

--- a/scripts/generate/templates/EnumerableMap.opts.js
+++ b/scripts/generate/templates/EnumerableMap.opts.js
@@ -1,4 +1,4 @@
-const { capitalize } = require('../../helpers');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 
 const mapType = str => (str == 'uint256' ? 'Uint' : capitalize(str));
 

--- a/scripts/generate/templates/EnumerableSet.opts.js
+++ b/scripts/generate/templates/EnumerableSet.opts.js
@@ -1,4 +1,4 @@
-const { capitalize } = require('../../helpers');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 
 const mapType = str => (str == 'uint256' ? 'Uint' : capitalize(str));
 

--- a/scripts/generate/templates/MerkleProof.opts.js
+++ b/scripts/generate/templates/MerkleProof.opts.js
@@ -1,4 +1,4 @@
-const { product } = require('../../helpers');
+const { product } = require('@openzeppelin/contracts-helpers/iterate');
 
 const OPTS = product(
   [

--- a/scripts/generate/templates/Packing.js
+++ b/scripts/generate/templates/Packing.js
@@ -1,6 +1,6 @@
 const format = require('../format-lines');
 const sanitize = require('../helpers/sanitize');
-const { product } = require('../../helpers');
+const { product } = require('@openzeppelin/contracts-helpers/iterate');
 const { SIZES } = require('./Packing.opts');
 
 // TEMPLATE

--- a/scripts/generate/templates/Packing.t.js
+++ b/scripts/generate/templates/Packing.t.js
@@ -1,5 +1,5 @@
 const format = require('../format-lines');
-const { product } = require('../../helpers');
+const { product } = require('@openzeppelin/contracts-helpers/iterate');
 const { SIZES } = require('./Packing.opts');
 
 // TEMPLATE

--- a/scripts/generate/templates/SafeCast.js
+++ b/scripts/generate/templates/SafeCast.js
@@ -1,5 +1,5 @@
 const format = require('../format-lines');
-const { range } = require('../../helpers');
+const { range } = require('@openzeppelin/contracts-helpers/iterate');
 
 const LENGTHS = range(8, 256, 8).reverse(); // 248 → 8 (in steps of 8)
 

--- a/scripts/generate/templates/Slot.opts.js
+++ b/scripts/generate/templates/Slot.opts.js
@@ -1,4 +1,4 @@
-const { capitalize } = require('../../helpers');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 
 const TYPES = [
   { type: 'address', isValueType: true },

--- a/scripts/generate/templates/SlotDerivation.t.js
+++ b/scripts/generate/templates/SlotDerivation.t.js
@@ -1,5 +1,5 @@
 const format = require('../format-lines');
-const { capitalize } = require('../../helpers');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 const { TYPES } = require('./Slot.opts');
 
 const header = `\

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,7 +1,0 @@
-const iterate = require('../test/helpers/iterate');
-const strings = require('../test/helpers/strings');
-
-module.exports = {
-  ...iterate,
-  ...strings,
-};

--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const time = require('../helpers/time');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldSupportInterfaces } = require('../utils/introspection/SupportsInterface.behavior');
 

--- a/test/access/extensions/AccessControlDefaultAdminRules.test.js
+++ b/test/access/extensions/AccessControlDefaultAdminRules.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const time = require('../../helpers/time');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const {
   shouldBehaveLikeAccessControl,

--- a/test/access/manager/AccessManaged.test.js
+++ b/test/access/manager/AccessManaged.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { impersonate } = require('../../helpers/account');
-const time = require('../../helpers/time');
+const { impersonate } = require('@openzeppelin/contracts-helpers/account');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 async function fixture() {
   const [admin, roleMember, other] = await ethers.getSigners();

--- a/test/access/manager/AccessManager.predicate.js
+++ b/test/access/manager/AccessManager.predicate.js
@@ -2,9 +2,13 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { setStorageAt } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { EXECUTION_ID_STORAGE_SLOT, EXPIRATION, prepareOperation } = require('../../helpers/access-manager');
-const { impersonate } = require('../../helpers/account');
-const time = require('../../helpers/time');
+const {
+  EXECUTION_ID_STORAGE_SLOT,
+  EXPIRATION,
+  prepareOperation,
+} = require('@openzeppelin/contracts-helpers/access-manager');
+const { impersonate } = require('@openzeppelin/contracts-helpers/account');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 // ============ COMMON PREDICATES ============
 

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -2,10 +2,10 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { impersonate } = require('../../helpers/account');
-const { MAX_UINT48 } = require('../../helpers/constants');
-const { selector } = require('../../helpers/methods');
-const time = require('../../helpers/time');
+const { impersonate } = require('@openzeppelin/contracts-helpers/account');
+const { MAX_UINT48 } = require('@openzeppelin/contracts-helpers/constants');
+const { selector } = require('@openzeppelin/contracts-helpers/methods');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const {
   buildBaseRoles,
@@ -16,7 +16,7 @@ const {
   CONSUMING_SCHEDULE_STORAGE_SLOT,
   prepareOperation,
   hashOperation,
-} = require('../../helpers/access-manager');
+} = require('@openzeppelin/contracts-helpers/access-manager');
 
 const {
   shouldBehaveLikeDelayedAdminOperation,

--- a/test/account/utils/draft-ERC4337Utils.test.js
+++ b/test/account/utils/draft-ERC4337Utils.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { packValidationData, UserOperation } = require('../../helpers/erc4337');
-const { MAX_UINT48 } = require('../../helpers/constants');
+const { packValidationData, UserOperation } = require('@openzeppelin/contracts-helpers/erc4337');
+const { MAX_UINT48 } = require('@openzeppelin/contracts-helpers/constants');
 const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
 
 const fixture = async () => {

--- a/test/account/utils/draft-ERC7579Utils.test.js
+++ b/test/account/utils/draft-ERC7579Utils.test.js
@@ -10,8 +10,8 @@ const {
   CALL_TYPE_CALL,
   CALL_TYPE_BATCH,
   encodeMode,
-} = require('../../helpers/erc7579');
-const { selector } = require('../../helpers/methods');
+} = require('@openzeppelin/contracts-helpers/erc7579');
+const { selector } = require('@openzeppelin/contracts-helpers/methods');
 
 const coder = ethers.AbiCoder.defaultAbiCoder();
 

--- a/test/finance/VestingWallet.behavior.js
+++ b/test/finance/VestingWallet.behavior.js
@@ -1,6 +1,6 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
-const time = require('../helpers/time');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 async function envSetup(mock, beneficiary, token) {
   return {

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { min } = require('../helpers/math');
-const time = require('../helpers/time');
+const { min } = require('@openzeppelin/contracts-helpers/math');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { envSetup, shouldBehaveLikeVesting } = require('./VestingWallet.behavior');
 

--- a/test/finance/VestingWalletCliff.test.js
+++ b/test/finance/VestingWalletCliff.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { min } = require('../helpers/math');
-const time = require('../helpers/time');
+const { min } = require('@openzeppelin/contracts-helpers/math');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { envSetup, shouldBehaveLikeVesting } = require('./VestingWallet.behavior');
 

--- a/test/governance/Governor.test.js
+++ b/test/governance/Governor.test.js
@@ -2,10 +2,10 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../helpers/governance');
-const { getDomain, Ballot } = require('../helpers/eip712');
-const { ProposalState, VoteType } = require('../helpers/enums');
-const time = require('../helpers/time');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { getDomain, Ballot } = require('@openzeppelin/contracts-helpers/eip712');
+const { ProposalState, VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldSupportInterfaces } = require('../utils/introspection/SupportsInterface.behavior');
 const { shouldBehaveLikeERC6372 } = require('./utils/ERC6372.behavior');

--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -3,9 +3,9 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { GovernorHelper } = require('../helpers/governance');
-const { OperationState } = require('../helpers/enums');
-const time = require('../helpers/time');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { OperationState } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldSupportInterfaces } = require('../utils/introspection/SupportsInterface.behavior');
 

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -2,10 +2,10 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { VoteType } = require('../../helpers/enums');
-const { zip } = require('../../helpers/iterate');
-const { sum } = require('../../helpers/math');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const { zip } = require('@openzeppelin/contracts-helpers/iterate');
+const { sum } = require('@openzeppelin/contracts-helpers/math');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorCountingOverridable.test.js
+++ b/test/governance/extensions/GovernorCountingOverridable.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture, mine } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { getDomain, OverrideBallot } = require('../../helpers/eip712');
-const { VoteType } = require('../../helpers/enums');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { getDomain, OverrideBallot } = require('@openzeppelin/contracts-helpers/eip712');
+const { VoteType } = require('@openzeppelin/contracts-helpers/enums');
 
 const TOKENS = [
   { Token: '$ERC20VotesExtendedMock', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorERC721.test.js
+++ b/test/governance/extensions/GovernorERC721.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { VoteType } = require('../../helpers/enums');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { VoteType } = require('@openzeppelin/contracts-helpers/enums');
 
 const TOKENS = [
   { Token: '$ERC721Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorPreventLateQuorum.test.js
+++ b/test/governance/extensions/GovernorPreventLateQuorum.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { ProposalState, VoteType } = require('../../helpers/enums');
-const time = require('../../helpers/time');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { ProposalState, VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorStorage.test.js
+++ b/test/governance/extensions/GovernorStorage.test.js
@@ -4,8 +4,8 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { GovernorHelper, timelockSalt } = require('../../helpers/governance');
-const { VoteType } = require('../../helpers/enums');
+const { GovernorHelper, timelockSalt } = require('@openzeppelin/contracts-helpers/governance');
+const { VoteType } = require('@openzeppelin/contracts-helpers/enums');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorTimelockAccess.test.js
+++ b/test/governance/extensions/GovernorTimelockAccess.test.js
@@ -3,12 +3,12 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { hashOperation } = require('../../helpers/access-manager');
-const { max } = require('../../helpers/math');
-const { selector } = require('../../helpers/methods');
-const { ProposalState, VoteType } = require('../../helpers/enums');
-const time = require('../../helpers/time');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { hashOperation } = require('@openzeppelin/contracts-helpers/access-manager');
+const { max } = require('@openzeppelin/contracts-helpers/math');
+const { selector } = require('@openzeppelin/contracts-helpers/methods');
+const { ProposalState, VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 function prepareOperation({ sender, target, value = 0n, data = '0x' }) {
   return {

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -3,9 +3,9 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { ProposalState, VoteType } = require('../../helpers/enums');
-const time = require('../../helpers/time');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { ProposalState, VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorTimelockControl.test.js
+++ b/test/governance/extensions/GovernorTimelockControl.test.js
@@ -4,9 +4,9 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { GovernorHelper, timelockSalt } = require('../../helpers/governance');
-const { OperationState, ProposalState, VoteType } = require('../../helpers/enums');
-const time = require('../../helpers/time');
+const { GovernorHelper, timelockSalt } = require('@openzeppelin/contracts-helpers/governance');
+const { OperationState, ProposalState, VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorVotesQuorumFraction.test.js
+++ b/test/governance/extensions/GovernorVotesQuorumFraction.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture, mine } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { ProposalState, VoteType } = require('../../helpers/enums');
-const time = require('../../helpers/time');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { ProposalState, VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/extensions/GovernorWithParams.test.js
+++ b/test/governance/extensions/GovernorWithParams.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { GovernorHelper } = require('../../helpers/governance');
-const { VoteType } = require('../../helpers/enums');
-const { getDomain, ExtendedBallot } = require('../../helpers/eip712');
+const { GovernorHelper } = require('@openzeppelin/contracts-helpers/governance');
+const { VoteType } = require('@openzeppelin/contracts-helpers/enums');
+const { getDomain, ExtendedBallot } = require('@openzeppelin/contracts-helpers/eip712');
 
 const TOKENS = [
   { Token: '$ERC20Votes', mode: 'blocknumber' },

--- a/test/governance/utils/ERC6372.behavior.js
+++ b/test/governance/utils/ERC6372.behavior.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const time = require('../../helpers/time');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 function shouldBehaveLikeERC6372(mode = 'blocknumber') {
   describe(`ERC-6372 behavior in ${mode} mode`, function () {

--- a/test/governance/utils/Votes.behavior.js
+++ b/test/governance/utils/Votes.behavior.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { mine } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getDomain, Delegation } = require('../../helpers/eip712');
-const time = require('../../helpers/time');
+const { getDomain, Delegation } = require('@openzeppelin/contracts-helpers/eip712');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldBehaveLikeERC6372 } = require('./ERC6372.behavior');
 

--- a/test/governance/utils/Votes.test.js
+++ b/test/governance/utils/Votes.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { sum } = require('../../helpers/math');
-const { zip } = require('../../helpers/iterate');
-const time = require('../../helpers/time');
+const { sum } = require('@openzeppelin/contracts-helpers/math');
+const { zip } = require('@openzeppelin/contracts-helpers/iterate');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldBehaveLikeVotes } = require('./Votes.behavior');
 

--- a/test/governance/utils/VotesExtended.test.js
+++ b/test/governance/utils/VotesExtended.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture, mine } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { sum } = require('../../helpers/math');
-const { zip } = require('../../helpers/iterate');
-const time = require('../../helpers/time');
+const { sum } = require('@openzeppelin/contracts-helpers/math');
+const { zip } = require('@openzeppelin/contracts-helpers/iterate');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldBehaveLikeVotes } = require('./Votes.behavior');
 

--- a/test/helpers/package.json
+++ b/test/helpers/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "@openzeppelin/contracts-helpers",
-  "version": "0.0.0",
-  "private": true
-}

--- a/test/helpers/package.json
+++ b/test/helpers/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@openzeppelin/contracts-helpers",
+  "version": "0.0.0",
+  "private": true
+}

--- a/test/metatx/ERC2771Context.test.js
+++ b/test/metatx/ERC2771Context.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { impersonate } = require('../helpers/account');
-const { getDomain, ForwardRequest } = require('../helpers/eip712');
-const { MAX_UINT48 } = require('../helpers/constants');
+const { impersonate } = require('@openzeppelin/contracts-helpers/account');
+const { getDomain, ForwardRequest } = require('@openzeppelin/contracts-helpers/eip712');
+const { MAX_UINT48 } = require('@openzeppelin/contracts-helpers/constants');
 
 const { shouldBehaveLikeRegularContext } = require('../utils/Context.behavior');
 

--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getDomain, ForwardRequest } = require('../helpers/eip712');
-const { sum } = require('../helpers/math');
-const time = require('../helpers/time');
+const { getDomain, ForwardRequest } = require('@openzeppelin/contracts-helpers/eip712');
+const { sum } = require('@openzeppelin/contracts-helpers/math');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 async function fixture() {
   const [sender, refundReceiver, another, ...accounts] = await ethers.getSigners();

--- a/test/proxy/Clones.test.js
+++ b/test/proxy/Clones.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { generators } = require('../helpers/random');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 
 const shouldBehaveLikeClone = require('./Clones.behaviour');
 

--- a/test/proxy/ERC1967/ERC1967Utils.test.js
+++ b/test/proxy/ERC1967/ERC1967Utils.test.js
@@ -2,7 +2,13 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getAddressInSlot, setSlot, ImplementationSlot, AdminSlot, BeaconSlot } = require('../../helpers/storage');
+const {
+  getAddressInSlot,
+  setSlot,
+  ImplementationSlot,
+  AdminSlot,
+  BeaconSlot,
+} = require('@openzeppelin/contracts-helpers/storage');
 
 async function fixture() {
   const [, admin, anotherAccount] = await ethers.getSigners();

--- a/test/proxy/Proxy.behaviour.js
+++ b/test/proxy/Proxy.behaviour.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const { getAddressInSlot, ImplementationSlot } = require('../helpers/storage');
+const { getAddressInSlot, ImplementationSlot } = require('@openzeppelin/contracts-helpers/storage');
 
 module.exports = function shouldBehaveLikeProxy() {
   it('cannot be initialized with a non-contract address', async function () {

--- a/test/proxy/beacon/BeaconProxy.test.js
+++ b/test/proxy/beacon/BeaconProxy.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getAddressInSlot, BeaconSlot } = require('../../helpers/storage');
+const { getAddressInSlot, BeaconSlot } = require('@openzeppelin/contracts-helpers/storage');
 
 async function fixture() {
   const [admin, other] = await ethers.getSigners();

--- a/test/proxy/transparent/ProxyAdmin.test.js
+++ b/test/proxy/transparent/ProxyAdmin.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getAddressInSlot, ImplementationSlot } = require('../../helpers/storage');
+const { getAddressInSlot, ImplementationSlot } = require('@openzeppelin/contracts-helpers/storage');
 
 async function fixture() {
   const [admin, other] = await ethers.getSigners();

--- a/test/proxy/transparent/TransparentUpgradeableProxy.behaviour.js
+++ b/test/proxy/transparent/TransparentUpgradeableProxy.behaviour.js
@@ -1,8 +1,8 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const { impersonate } = require('../../helpers/account');
-const { getAddressInSlot, ImplementationSlot, AdminSlot } = require('../../helpers/storage');
+const { impersonate } = require('@openzeppelin/contracts-helpers/account');
+const { getAddressInSlot, ImplementationSlot, AdminSlot } = require('@openzeppelin/contracts-helpers/storage');
 
 // createProxy, initialOwner, accounts
 module.exports = function shouldBehaveLikeTransparentUpgradeableProxy() {

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -1,6 +1,6 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
-const { MAX_UINT64 } = require('../../helpers/constants');
+const { MAX_UINT64 } = require('@openzeppelin/contracts-helpers/constants');
 
 describe('Initializable', function () {
   describe('basic testing without inheritance', function () {

--- a/test/proxy/utils/UUPSUpgradeable.test.js
+++ b/test/proxy/utils/UUPSUpgradeable.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getAddressInSlot, ImplementationSlot } = require('../../helpers/storage');
+const { getAddressInSlot, ImplementationSlot } = require('@openzeppelin/contracts-helpers/storage');
 
 async function fixture() {
   const implInitial = await ethers.deployContract('UUPSUpgradeableMock');

--- a/test/token/ERC1155/ERC1155.behavior.js
+++ b/test/token/ERC1155/ERC1155.behavior.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
 
-const { RevertType } = require('../../helpers/enums');
+const { RevertType } = require('@openzeppelin/contracts-helpers/enums');
 const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
 
 function shouldBehaveLikeERC1155() {

--- a/test/token/ERC1155/ERC1155.test.js
+++ b/test/token/ERC1155/ERC1155.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { zip } = require('../../helpers/iterate');
+const { zip } = require('@openzeppelin/contracts-helpers/iterate');
 const { shouldBehaveLikeERC1155 } = require('./ERC1155.behavior');
 
 const initialURI = 'https://token-cdn-domain/{id}.json';

--- a/test/token/ERC1155/utils/ERC1155Utils.test.js
+++ b/test/token/ERC1155/utils/ERC1155Utils.test.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { RevertType } = require('../../../helpers/enums');
+const { RevertType } = require('@openzeppelin/contracts-helpers/enums');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const firstTokenId = 1n;

--- a/test/token/ERC20/extensions/ERC1363.test.js
+++ b/test/token/ERC20/extensions/ERC1363.test.js
@@ -8,7 +8,7 @@ const {
   shouldBehaveLikeERC20Approve,
 } = require('../ERC20.behavior.js');
 const { shouldSupportInterfaces } = require('../../../utils/introspection/SupportsInterface.behavior');
-const { RevertType } = require('../../../helpers/enums.js');
+const { RevertType } = require('@openzeppelin/contracts-helpers/enums.js');
 
 const name = 'My Token';
 const symbol = 'MTKN';

--- a/test/token/ERC20/extensions/ERC20Permit.test.js
+++ b/test/token/ERC20/extensions/ERC20Permit.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getDomain, domainSeparator, Permit } = require('../../../helpers/eip712');
-const time = require('../../../helpers/time');
+const { getDomain, domainSeparator, Permit } = require('@openzeppelin/contracts-helpers/eip712');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const name = 'My Token';
 const symbol = 'MTKN';

--- a/test/token/ERC20/extensions/ERC20Votes.test.js
+++ b/test/token/ERC20/extensions/ERC20Votes.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture, mine } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getDomain, Delegation } = require('../../../helpers/eip712');
-const { batchInBlock } = require('../../../helpers/txpool');
-const time = require('../../../helpers/time');
+const { getDomain, Delegation } = require('@openzeppelin/contracts-helpers/eip712');
+const { batchInBlock } = require('@openzeppelin/contracts-helpers/txpool');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldBehaveLikeVotes } = require('../../../governance/utils/Votes.behavior');
 

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { Enum } = require('../../../helpers/enums');
+const { Enum } = require('@openzeppelin/contracts-helpers/enums');
 
 const name = 'My Token';
 const symbol = 'MTKN';

--- a/test/token/ERC20/extensions/draft-ERC20TemporaryApproval.test.js
+++ b/test/token/ERC20/extensions/draft-ERC20TemporaryApproval.test.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { max, min } = require('../../../helpers/math.js');
+const { max, min } = require('@openzeppelin/contracts-helpers/math.js');
 
 const { shouldBehaveLikeERC20 } = require('../ERC20.behavior.js');
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -4,7 +4,7 @@ const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
 
 const { shouldSupportInterfaces } = require('../../utils/introspection/SupportsInterface.behavior');
-const { RevertType } = require('../../helpers/enums');
+const { RevertType } = require('@openzeppelin/contracts-helpers/enums');
 
 const firstTokenId = 5042n;
 const secondTokenId = 79217n;

--- a/test/token/ERC721/extensions/ERC721Consecutive.test.js
+++ b/test/token/ERC721/extensions/ERC721Consecutive.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { sum } = require('../../../helpers/math');
+const { sum } = require('@openzeppelin/contracts-helpers/math');
 
 const name = 'Non Fungible Token';
 const symbol = 'NFT';

--- a/test/token/ERC721/extensions/ERC721Votes.test.js
+++ b/test/token/ERC721/extensions/ERC721Votes.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture, mine } = require('@nomicfoundation/hardhat-network-helpers');
 
-const time = require('../../../helpers/time');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const { shouldBehaveLikeVotes } = require('../../../governance/utils/Votes.behavior');
 

--- a/test/token/ERC721/utils/ERC721Utils.test.js
+++ b/test/token/ERC721/utils/ERC721Utils.test.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { RevertType } = require('../../../helpers/enums');
+const { RevertType } = require('@openzeppelin/contracts-helpers/enums');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const tokenId = 1n;

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { generators } = require('../helpers/random');
-const { capitalize } = require('../../scripts/helpers');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
+const { capitalize } = require('@openzeppelin/contracts-helpers/strings');
 const { TYPES } = require('../../scripts/generate/templates/Arrays.opts');
 
 // See https://en.cppreference.com/w/cpp/algorithm/lower_bound

--- a/test/utils/CAIP.test.js
+++ b/test/utils/CAIP.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { CHAINS, getLocalCAIP } = require('../helpers/chains');
+const { CHAINS, getLocalCAIP } = require('@openzeppelin/contracts-helpers/chains');
 
 async function fixture() {
   const caip2 = await ethers.deployContract('$CAIP2');

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { RevertType } = require('../helpers/enums');
+const { RevertType } = require('@openzeppelin/contracts-helpers/enums');
 
 async function fixture() {
   const [deployer, other] = await ethers.getSigners();

--- a/test/utils/Packing.test.js
+++ b/test/utils/Packing.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { forceDeployCode } = require('../helpers/deploy');
-const { product } = require('../helpers/iterate');
+const { forceDeployCode } = require('@openzeppelin/contracts-helpers/deploy');
+const { product } = require('@openzeppelin/contracts-helpers/iterate');
 const { SIZES } = require('../../scripts/generate/templates/Packing.opts');
 
 async function fixture() {

--- a/test/utils/SlotDerivation.test.js
+++ b/test/utils/SlotDerivation.test.js
@@ -1,8 +1,8 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { erc7201Slot } = require('../helpers/storage');
-const { generators } = require('../helpers/random');
+const { erc7201Slot } = require('@openzeppelin/contracts-helpers/storage');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 
 async function fixture() {
   const [account] = await ethers.getSigners();

--- a/test/utils/StorageSlot.test.js
+++ b/test/utils/StorageSlot.test.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { generators } = require('../helpers/random');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 
 const slot = ethers.id('some.storage.slot');
 const otherSlot = ethers.id('some.other.storage.slot');

--- a/test/utils/TransientSlot.test.js
+++ b/test/utils/TransientSlot.test.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { generators } = require('../helpers/random');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 
 const slot = ethers.id('some.storage.slot');
 const otherSlot = ethers.id('some.other.storage.slot');

--- a/test/utils/cryptography/EIP712.test.js
+++ b/test/utils/cryptography/EIP712.test.js
@@ -2,8 +2,8 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { getDomain, domainSeparator, hashTypedData } = require('../../helpers/eip712');
-const { formatType } = require('../../helpers/eip712-types');
+const { getDomain, domainSeparator, hashTypedData } = require('@openzeppelin/contracts-helpers/eip712');
+const { formatType } = require('@openzeppelin/contracts-helpers/eip712-types');
 
 const LENGTHS = {
   short: ['A Name', '1'],

--- a/test/utils/cryptography/MessageHashUtils.test.js
+++ b/test/utils/cryptography/MessageHashUtils.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { domainSeparator, hashTypedData } = require('../../helpers/eip712');
+const { domainSeparator, hashTypedData } = require('@openzeppelin/contracts-helpers/eip712');
 
 async function fixture() {
   const mock = await ethers.deployContract('$MessageHashUtils');

--- a/test/utils/introspection/SupportsInterface.behavior.js
+++ b/test/utils/introspection/SupportsInterface.behavior.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
-const { interfaceId } = require('../../helpers/methods');
-const { mapValues } = require('../../helpers/iterate');
+const { interfaceId } = require('@openzeppelin/contracts-helpers/methods');
+const { mapValues } = require('@openzeppelin/contracts-helpers/iterate');
 
 const INVALID_ID = '0xffffffff';
 const SIGNATURES = {

--- a/test/utils/math/Math.test.js
+++ b/test/utils/math/Math.test.js
@@ -3,10 +3,10 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { Rounding } = require('../../helpers/enums');
-const { min, max, modExp } = require('../../helpers/math');
-const { generators } = require('../../helpers/random');
-const { product, range } = require('../../helpers/iterate');
+const { Rounding } = require('@openzeppelin/contracts-helpers/enums');
+const { min, max, modExp } = require('@openzeppelin/contracts-helpers/math');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
+const { product, range } = require('@openzeppelin/contracts-helpers/iterate');
 
 const RoundingDown = [Rounding.Floor, Rounding.Trunc];
 const RoundingUp = [Rounding.Ceil, Rounding.Expand];

--- a/test/utils/math/SafeCast.test.js
+++ b/test/utils/math/SafeCast.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { range } = require('../../helpers/iterate');
+const { range } = require('@openzeppelin/contracts-helpers/iterate');
 
 async function fixture() {
   const mock = await ethers.deployContract('$SafeCast');

--- a/test/utils/math/SignedMath.test.js
+++ b/test/utils/math/SignedMath.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { min, max } = require('../../helpers/math');
+const { min, max } = require('@openzeppelin/contracts-helpers/math');
 
 async function testCommutative(fn, lhs, rhs, expected, ...extra) {
   expect(await fn(lhs, rhs, ...extra)).to.deep.equal(expected);

--- a/test/utils/structs/CircularBuffer.test.js
+++ b/test/utils/structs/CircularBuffer.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const { generators } = require('../../helpers/random');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 
 const LENGTH = 4;
 

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -1,8 +1,8 @@
 const { ethers } = require('hardhat');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { mapValues } = require('../../helpers/iterate');
-const { generators } = require('../../helpers/random');
+const { mapValues } = require('@openzeppelin/contracts-helpers/iterate');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 const { TYPES, formatType } = require('../../../scripts/generate/templates/EnumerableMap.opts');
 
 const { shouldBehaveLikeMap } = require('./EnumerableMap.behavior');

--- a/test/utils/structs/EnumerableSet.test.js
+++ b/test/utils/structs/EnumerableSet.test.js
@@ -1,8 +1,8 @@
 const { ethers } = require('hardhat');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { mapValues } = require('../../helpers/iterate');
-const { generators } = require('../../helpers/random');
+const { mapValues } = require('@openzeppelin/contracts-helpers/iterate');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 const { TYPES } = require('../../../scripts/generate/templates/EnumerableSet.opts');
 
 const { shouldBehaveLikeSet } = require('./EnumerableSet.behavior');

--- a/test/utils/structs/MerkleTree.test.js
+++ b/test/utils/structs/MerkleTree.test.js
@@ -4,7 +4,7 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 const { StandardMerkleTree } = require('@openzeppelin/merkle-tree');
 
-const { generators } = require('../../helpers/random');
+const { generators } = require('@openzeppelin/contracts-helpers/random');
 
 const makeTree = (leaves = [ethers.ZeroHash]) =>
   StandardMerkleTree.of(

--- a/test/utils/types/Time.test.js
+++ b/test/utils/types/Time.test.js
@@ -2,9 +2,9 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
-const { product } = require('../../helpers/iterate');
-const { max } = require('../../helpers/math');
-const time = require('../../helpers/time');
+const { product } = require('@openzeppelin/contracts-helpers/iterate');
+const { max } = require('@openzeppelin/contracts-helpers/math');
+const time = require('@openzeppelin/contracts-helpers/time');
 
 const MAX_UINT32 = 1n << (32n - 1n);
 const MAX_UINT48 = 1n << (48n - 1n);


### PR DESCRIPTION
This would make it easier for the community repo to use the helpers by adding the following dev dependency
```
"@openzeppelin/contracts-helpers": "file:lib/@openzeppelin-contracts/test/helpers"
```
It would however prevent installing the dev-dependency without first fetching the submodule. Is that an issue?


Also, I believe it improves the overall syntax of the main repon (here)

