### PR TITLE
docs: Corrected article usage Update erc20-supply.adoc

### DIFF
--- a/docs/modules/ROOT/pages/erc20-supply.adoc
+++ b/docs/modules/ROOT/pages/erc20-supply.adoc
@@ -68,4 +68,4 @@ include::api:example$ERC20WithAutoMinerReward.sol[]
 [[wrapping-up]]
 == Wrapping Up
 
-We've seen how to implement a ERC-20 supply mechanism: internally through `_mint`. Hopefully this has helped you understand how to use OpenZeppelin Contracts and some of the design principles behind it, and you can apply them to your own smart contracts.
+We've seen how to implement an ERC-20 supply mechanism: internally through `_mint`. Hopefully this has helped you understand how to use OpenZeppelin Contracts and some of the design principles behind it, and you can apply them to your own smart contracts.


### PR DESCRIPTION
The text contained a minor grammatical inconsistency in the article usage before "ERC-20." The phrase:

> "We've seen how to implement a ERC-20 supply mechanism..."

was corrected to:

> "We've seen how to implement **an** ERC-20 supply mechanism..."

This change ensures proper article usage, as "ERC-20" starts with a vowel sound.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
