### PR TITLE
Remove relative path in solhint.config.js in favor of npm virtual package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12203,7 +12203,10 @@
     "scripts/solhint-custom": {
       "name": "solhint-plugin-openzeppelin",
       "version": "0.0.0",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.1.2"
+      }
     }
   }
 }

--- a/scripts/solhint-custom/package.json
+++ b/scripts/solhint-custom/package.json
@@ -1,5 +1,8 @@
 {
   "name": "solhint-plugin-openzeppelin",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "minimatch": "^3.1.2"
+  }
 }

--- a/solhint.config.js
+++ b/solhint.config.js
@@ -1,4 +1,4 @@
-const customRules = require('./scripts/solhint-custom');
+const customRules = require('solhint-plugin-openzeppelin');
 
 const rules = [
   'avoid-tx-origin',


### PR DESCRIPTION
This will allow us to simlink `solhint.config.js` into the community repo without having to also ship/vendor/link the corresponding module. The dependency will take care of that.

Note: we also need to make it explicit that `solhint-plugin-openzeppelin` uses `minimatch`, otherwize it won't be correctly linked when installed recursivelly as a sub-dependency of `@openzeppelin/contracts`