### PR TITLE
docs: fix typo Update README.adoc

### DIFF
--- a/contracts/token/ERC721/README.adoc
+++ b/contracts/token/ERC721/README.adoc
@@ -3,7 +3,7 @@
 [.readme-notice]
 NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/token/erc721
 
-This set of interfaces, contracts, and utilities are all related to the https://eips.ethereum.org/EIPS/eip-721[ERC-721 Non-Fungible Token Standard].
+This set of interfaces, contracts, and utilities is all related to the https://eips.ethereum.org/EIPS/eip-721[ERC-721 Non-Fungible Token Standard].
 
 TIP: For a walk through on how to create an ERC-721 token read our xref:ROOT:erc721.adoc[ERC-721 guide].
 


### PR DESCRIPTION
The document has a grammatical inconsistency in this sentence:

> "This set of interfaces, contracts, and utilities are all related to the..."

The subject of the sentence, *"This set,"* is singular. Therefore, the verb should also be singular (*"is"*) instead of plural (*"are"*).

**Corrected to:**

> "This set of interfaces, contracts, and utilities **is** all related to the..."


#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
