### PR TITLE
Rename `arrayLengthPointer` -> `arrayLengthOffset` and add changeset

### DIFF
--- a/.changeset/seven-insects-taste.md
+++ b/.changeset/seven-insects-taste.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC7579Utils`: Add ABI decoding checks on calldata bounds within `decodeBatch`

--- a/contracts/account/utils/draft-ERC7579Utils.sol
+++ b/contracts/account/utils/draft-ERC7579Utils.sol
@@ -182,14 +182,14 @@ library ERC7579Utils {
             if (bufferLength < 32) revert ERC7579DecodingError();
 
             // Get the offset of the array (pointer to the array length).
-            uint256 arrayLengthPointer = uint256(bytes32(executionCalldata[0:32]));
+            uint256 arrayLengthOffset = uint256(bytes32(executionCalldata[0:32]));
 
-            // The array length (at arrayLengthPointer) should be 32 bytes long. We check that this is within the
+            // The array length (at arrayLengthOffset) should be 32 bytes long. We check that this is within the
             // buffer bounds. Since we know bufferLength is at least 32, we can subtract with no overflow risk.
-            if (arrayLengthPointer > bufferLength - 32) revert ERC7579DecodingError();
+            if (arrayLengthOffset > bufferLength - 32) revert ERC7579DecodingError();
 
-            // Get the array length. arrayLengthPointer + 32 is bounded by bufferLength so it does not overflow.
-            uint256 arrayLength = uint256(bytes32(executionCalldata[arrayLengthPointer:arrayLengthPointer + 32]));
+            // Get the array length. arrayLengthOffset + 32 is bounded by bufferLength so it does not overflow.
+            uint256 arrayLength = uint256(bytes32(executionCalldata[arrayLengthOffset:arrayLengthOffset + 32]));
 
             // Check that the buffer is long enough to store the array elements as "offset pointer":
             // - each element of the array is an "offset pointer" to the data.
@@ -197,13 +197,13 @@ library ERC7579Utils {
             // - validity of the calldata at that location is checked when the array element is accessed, so we only
             //   need to check that the buffer is large enough to hold the pointers.
             //
-            // Since we know bufferLength is at least arrayLengthPointer + 32, we can subtract with no overflow risk.
+            // Since we know bufferLength is at least arrayLengthOffset + 32, we can subtract with no overflow risk.
             // Solidity limits length of such arrays to 2**64-1, this guarantees `arrayLength * 32` does not overflow.
-            if (arrayLength > type(uint64).max || bufferLength - arrayLengthPointer - 32 < arrayLength * 32)
+            if (arrayLength > type(uint64).max || bufferLength - arrayLengthOffset - 32 < arrayLength * 32)
                 revert ERC7579DecodingError();
 
             assembly ("memory-safe") {
-                executionBatch.offset := add(add(executionCalldata.offset, arrayLengthPointer), 32)
+                executionBatch.offset := add(add(executionCalldata.offset, arrayLengthOffset), 32)
                 executionBatch.length := arrayLength
             }
         }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

We'll need a changeset to perform a proper release. Also, I'm amending a mistake while renaming a variable inside `decodeBatch`

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
