### PR TITLE
fix: Add error handling for npm pack command Update pack.sh

### DIFF
--- a/scripts/release/workflow/pack.sh
+++ b/scripts/release/workflow/pack.sh
@@ -19,7 +19,7 @@ dist_tag() {
 }
 
 cd contracts
-TARBALL="$(npm pack | tee /dev/stderr | tail -1)"
+TARBALL="$(npm pack | tee /dev/stderr | tail -1)" || { echo "npm pack failed"; exit 1; }
 echo "tarball_name=$TARBALL" >> $GITHUB_OUTPUT
 echo "tarball=$(pwd)/$TARBALL" >> $GITHUB_OUTPUT
 echo "tag=$(dist_tag)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In this update, we’ve enhanced the script to handle potential errors when running the `npm pack` command. Previously, if there were issues with permissions or configurations, the script could fail without providing clear feedback. Now, if `npm pack` encounters an error, the script will output a specific error message ("npm pack failed") and exit gracefully, ensuring better debugging and reliability in the workflow. 

This fix ensures that the process doesn’t continue silently in case of failure, allowing us to quickly identify and address issues related to the packaging process.

#### PR Checklist


- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
