### PR TITLE
fix: fix incorrect usage of import.meta.dirname in Node.js

### DIFF
--- a/certora/run.js
+++ b/certora/run.js
@@ -26,7 +26,7 @@ const argv = yargs(hideBin(process.argv))
     spec: {
       alias: 's',
       type: 'string',
-      default: path.resolve(import.meta.dirname, 'specs.json'),
+      default: path.resolve(path.dirname(new URL(import.meta.url).pathname), 'specs.json'),
     },
     parallel: {
       alias: 'p',


### PR DESCRIPTION
The current implementation references `import.meta.dirname`, which is not a valid property in Node.js. Instead, the correct approach is to use `import.meta.url` and convert it using `path`.  

I’ve updated the code to properly handle this conversion, ensuring compatibility and correctness. 


#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
