### PR TITLE
Fix inaccurate comment for callGasLimit function in ERC4337Utils

### DIFF
--- a/contracts/account/utils/draft-ERC4337Utils.sol
+++ b/contracts/account/utils/draft-ERC4337Utils.sol
@@ -114,7 +114,7 @@ library ERC4337Utils {
         return uint128(self.accountGasLimits.extract_32_16(0));
     }
 
-    /// @dev Returns `accountGasLimits` from the {PackedUserOperation}.
+    /// @dev Returns `callGasLimit` from the {PackedUserOperation}.
     function callGasLimit(PackedUserOperation calldata self) internal pure returns (uint256) {
         return uint128(self.accountGasLimits.extract_32_16(16));
     }


### PR DESCRIPTION
### Description
While reviewing the code, I noticed a minor inaccuracy in the comment for the `callGasLimit` function within the `ERC4337Utils` library. The current comment states that the function returns `accountGasLimits`, which is incorrect. The function actually returns `callGasLimit`.  

I’ve updated the comment to correctly describe the function’s behavior. Here’s the corrected comment:  
```solidity
/// @dev Returns `callGasLimit` from the {PackedUserOperation}.
```  

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
