### PR TITLE
Fix Typographical Errors in Contracts and Tests

### DIFF
--- a/contracts/token/common/ERC2981.sol
+++ b/contracts/token/common/ERC2981.sol
@@ -39,7 +39,7 @@ abstract contract ERC2981 is IERC2981, ERC165 {
     error ERC2981InvalidDefaultRoyaltyReceiver(address receiver);
 
     /**
-     * @dev The royalty set for an specific `tokenId` is invalid (eg. (numerator / denominator) >= 1).
+     * @dev The royalty set for a specific `tokenId` is invalid (eg. (numerator / denominator) >= 1).
      */
     error ERC2981InvalidTokenRoyalty(uint256 tokenId, uint256 numerator, uint256 denominator);
 

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -448,7 +448,7 @@ library Arrays {
     }
 
     /**
-     * @dev Helper to set the length of an dynamic array. Directly writing to `.length` is forbidden.
+     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
      *
      * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
      */
@@ -459,7 +459,7 @@ library Arrays {
     }
 
     /**
-     * @dev Helper to set the length of an dynamic array. Directly writing to `.length` is forbidden.
+     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
      *
      * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
      */
@@ -470,7 +470,7 @@ library Arrays {
     }
 
     /**
-     * @dev Helper to set the length of an dynamic array. Directly writing to `.length` is forbidden.
+     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
      *
      * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
      */

--- a/contracts/utils/TransientSlot.sol
+++ b/contracts/utils/TransientSlot.sol
@@ -32,7 +32,7 @@ pragma solidity ^0.8.24;
  */
 library TransientSlot {
     /**
-     * @dev UDVT that represent a slot holding a address.
+     * @dev UDVT that represent a slot holding an address.
      */
     type AddressSlot is bytes32;
 

--- a/contracts/utils/TransientSlot.sol
+++ b/contracts/utils/TransientSlot.sol
@@ -32,7 +32,7 @@ pragma solidity ^0.8.24;
  */
 library TransientSlot {
     /**
-     * @dev UDVT that represent a slot holding an address.
+     * @dev UDVT that represent a slot holding a address.
      */
     type AddressSlot is bytes32;
 

--- a/scripts/generate/templates/Arrays.js
+++ b/scripts/generate/templates/Arrays.js
@@ -346,7 +346,7 @@ function unsafeMemoryAccess(${type}[] memory arr, uint256 pos) internal pure ret
 
 const unsafeSetLength = type => `\
 /**
- * @dev Helper to set the length of an dynamic array. Directly writing to \`.length\` is forbidden.
+ * @dev Helper to set the length of a dynamic array. Directly writing to \`.length\` is forbidden.
  *
  * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
  */

--- a/test/metatx/ERC2771Forwarder.t.sol
+++ b/test/metatx/ERC2771Forwarder.t.sol
@@ -171,7 +171,7 @@ contract ERC2771ForwarderTest is Test {
         uint256 refundExpected = 0;
         uint256 nonce = _erc2771Forwarder.nonces(_signer);
 
-        // create an sign array or requests (that may fail)
+        // create a sign array or requests (that may fail)
         ERC2771Forwarder.ForwardRequestData[] memory requests = new ERC2771Forwarder.ForwardRequestData[](batchSize);
         for (uint256 i = 0; i < batchSize; ++i) {
             bool failure = (seed >> i) & 0x1 == 0x1;
@@ -229,7 +229,7 @@ contract ERC2771ForwarderTest is Test {
         TamperType tamper = _asTamper(_tamper);
         uint256 nonce = _erc2771Forwarder.nonces(_signer);
 
-        // create an sign array or requests
+        // create a sign array or requests
         ERC2771Forwarder.ForwardRequestData[] memory requests = new ERC2771Forwarder.ForwardRequestData[](3);
         for (uint256 i = 0; i < requests.length; ++i) {
             requests[i] = _forgeRequestData({
@@ -252,7 +252,7 @@ contract ERC2771ForwarderTest is Test {
         TamperType tamper = _asTamper(_tamper);
         uint256 nonce = _erc2771Forwarder.nonces(_signer);
 
-        // create an sign array or requests
+        // create a sign array or requests
         ERC2771Forwarder.ForwardRequestData[] memory requests = new ERC2771Forwarder.ForwardRequestData[](3);
         for (uint256 i = 0; i < requests.length; ++i) {
             requests[i] = _forgeRequestData({


### PR DESCRIPTION
This PR resolves minor typographical errors across several files in the repository to improve clarity and maintain code quality. Changes include:

1. **ERC2981.sol**:
   - Fixed typo in the error documentation for `ERC2981InvalidTokenRoyalty`.

2. **Arrays.sol**:
   - Corrected typos in the documentation related to setting the length of a dynamic array.

3. **TransientSlot.sol**:
   - Fixed typo in the documentation for `AddressSlot`.

4. **ERC2771Forwarder.t.sol**:
   - Corrected typos in comments for test case setup.

#### PR Checklist:
- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`) 

This is a minor update with no functional changes to the codebase. It ensures better readability and adherence to documentation standards.
