### PR TITLE
Update links to the eth_sign JSON-RPC method in MessageHashUtils

### DIFF
--- a/contracts/utils/cryptography/MessageHashUtils.sol
+++ b/contracts/utils/cryptography/MessageHashUtils.sol
@@ -19,7 +19,7 @@ library MessageHashUtils {
      *
      * The digest is calculated by prefixing a bytes32 `messageHash` with
      * `"\x19Ethereum Signed Message:\n32"` and hashing the result. It corresponds with the
-     * hash signed when using the https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`] JSON-RPC method.
+     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.
      *
      * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with
      * keccak256, although any bytes32 value can be safely used because the final digest will
@@ -41,7 +41,7 @@ library MessageHashUtils {
      *
      * The digest is calculated by prefixing an arbitrary `message` with
      * `"\x19Ethereum Signed Message:\n" + len(message)` and hashing the result. It corresponds with the
-     * hash signed when using the https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`] JSON-RPC method.
+     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.
      *
      * See {ECDSA-recover}.
      */


### PR DESCRIPTION
The current documentation references https://eth.wiki/json-rpc/API#eth_sign which is no longer accessible. This PR updates the link to the current Ethereum documentation at https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign

- Replace eth.wiki link with official ethereum.org documentation

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
