### PR TITLE
Remove unused rounding modes `Trunc` and `Expand`

### DIFF
--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -11,10 +11,8 @@ import {SafeCast} from "./SafeCast.sol";
  */
 library Math {
     enum Rounding {
-        Floor, // Toward negative infinity
-        Ceil, // Toward positive infinity
-        Trunc, // Toward zero
-        Expand // Away from zero
+        Floor, // Towards zero
+        Ceil // Towards infinity
     }
 
     /**
@@ -226,7 +224,7 @@ library Math {
      * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.
      */
     function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {
-        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);
+        return mulDiv(x, y, denominator) + unsignedRoundsUp(rounding, mulmod(x, y, denominator) > 0);
     }
 
     /**
@@ -529,7 +527,7 @@ library Math {
     function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {
         unchecked {
             uint256 result = sqrt(a);
-            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);
+            return result + unsignedRoundsUp(rounding, result * result < a);
         }
     }
 
@@ -585,7 +583,7 @@ library Math {
     function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {
         unchecked {
             uint256 result = log2(value);
-            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);
+            return result + unsignedRoundsUp(rounding, 1 << result < value);
         }
     }
 
@@ -634,7 +632,7 @@ library Math {
     function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {
         unchecked {
             uint256 result = log10(value);
-            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);
+            return result + unsignedRoundsUp(rounding, 10 ** result < value);
         }
     }
 
@@ -664,14 +662,14 @@ library Math {
     function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {
         unchecked {
             uint256 result = log256(value);
-            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);
+            return result + unsignedRoundsUp(rounding, 1 << (result << 3) < value);
         }
     }
 
     /**
-     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.
+     * @dev Returns 1 if rounding up is required and 0 if rounding up is not required.
      */
-    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {
-        return uint8(rounding) % 2 == 1;
+    function unsignedRoundsUp(Rounding rounding, bool cond) internal pure returns (uint256) {
+        return SafeCast.toUint(rounding == Rounding.Ceil && cond);
     }
 }

--- a/test/helpers/enums.js
+++ b/test/helpers/enums.js
@@ -6,7 +6,7 @@ module.exports = {
   Enum,
   ProposalState: Enum('Pending', 'Active', 'Canceled', 'Defeated', 'Succeeded', 'Queued', 'Expired', 'Executed'),
   VoteType: Object.assign(Enum('Against', 'For', 'Abstain'), { Parameters: 255n }),
-  Rounding: Enum('Floor', 'Ceil', 'Trunc', 'Expand'),
+  Rounding: Enum('Floor', 'Ceil'),
   OperationState: Enum('Unset', 'Waiting', 'Ready', 'Done'),
   RevertType: Enum('None', 'RevertWithoutMessage', 'RevertWithMessage', 'RevertWithCustomError', 'Panic'),
 };

--- a/test/utils/math/Math.t.sol
+++ b/test/utils/math/Math.t.sol
@@ -42,12 +42,10 @@ contract MathTest is Test {
 
         // square of result is bigger than input
         if (_squareBigger(result, input)) {
-            assertTrue(Math.unsignedRoundsUp(rounding));
             assertTrue(_squareSmaller(result - 1, input));
         }
         // square of result is smaller than input
         else if (_squareSmaller(result, input)) {
-            assertFalse(Math.unsignedRoundsUp(rounding));
             assertTrue(_squareBigger(result + 1, input));
         }
         // input is perfect square
@@ -109,10 +107,8 @@ contract MathTest is Test {
         if (input == 0) {
             assertEq(result, 0);
         } else if (_powerOf2Bigger(result, input)) {
-            assertTrue(Math.unsignedRoundsUp(rounding));
             assertTrue(_powerOf2Smaller(result - 1, input));
         } else if (_powerOf2Smaller(result, input)) {
-            assertFalse(Math.unsignedRoundsUp(rounding));
             assertTrue(_powerOf2Bigger(result + 1, input));
         } else {
             assertEq(2 ** result, input);
@@ -136,10 +132,8 @@ contract MathTest is Test {
         if (input == 0) {
             assertEq(result, 0);
         } else if (_powerOf10Bigger(result, input)) {
-            assertTrue(Math.unsignedRoundsUp(rounding));
             assertTrue(_powerOf10Smaller(result - 1, input));
         } else if (_powerOf10Smaller(result, input)) {
-            assertFalse(Math.unsignedRoundsUp(rounding));
             assertTrue(_powerOf10Bigger(result + 1, input));
         } else {
             assertEq(10 ** result, input);
@@ -163,10 +157,8 @@ contract MathTest is Test {
         if (input == 0) {
             assertEq(result, 0);
         } else if (_powerOf256Bigger(result, input)) {
-            assertTrue(Math.unsignedRoundsUp(rounding));
             assertTrue(_powerOf256Smaller(result - 1, input));
         } else if (_powerOf256Smaller(result, input)) {
-            assertFalse(Math.unsignedRoundsUp(rounding));
             assertTrue(_powerOf256Bigger(result + 1, input));
         } else {
             assertEq(256 ** result, input);

--- a/test/utils/math/Math.test.js
+++ b/test/utils/math/Math.test.js
@@ -8,8 +8,8 @@ const { min, max, modExp } = require('../../helpers/math');
 const { generators } = require('../../helpers/random');
 const { product, range } = require('../../helpers/iterate');
 
-const RoundingDown = [Rounding.Floor, Rounding.Trunc];
-const RoundingUp = [Rounding.Ceil, Rounding.Expand];
+const RoundingDown = [Rounding.Floor];
+const RoundingUp = [Rounding.Ceil];
 
 const bytes = (value, width = undefined) => ethers.Typed.bytes(ethers.toBeHex(value, width));
 const uint256 = value => ethers.Typed.uint256(value);


### PR DESCRIPTION
Fixes #5411

In the Rounding-Modes API (in the Math library):
```
    enum Rounding {
        Floor, // Toward negative infinity
        Ceil, // Toward positive infinity
        Trunc, // Toward zero
        Expand // Away from zero
    }
```
Remove the last two options, which are not in use throughout the codebase.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
