### PR TITLE
fix: Fixing issue with import.meta.dirname usage Update run.js

### DIFF
--- a/certora/run.js
+++ b/certora/run.js
@@ -26,7 +26,7 @@ const argv = yargs(hideBin(process.argv))
     spec: {
       alias: 's',
       type: 'string',
-      default: path.resolve(import.meta.dirname, 'specs.json'),
+      default: path.resolve(__dirname, 'specs.json'),
     },
     parallel: {
       alias: 'p',


### PR DESCRIPTION
I noticed a problem with the code where `import.meta.dirname` was used in the following line:

```javascript
default: path.resolve(import.meta.dirname, 'specs.json'),
```

It turns out that `import.meta.dirname` is not supported in JavaScript, and this leads to an error when the code is executed. To resolve this, I replaced `import.meta.dirname` with `__dirname`, which is the correct way to reference the current directory in Node.js.

This should fix the issue and prevent errors related to the incorrect usage of `import.meta.dirname`.


#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
