### PR TITLE
Optimize `MerkleTree` for loops by using `uint256` iterators

### DIFF
--- a/.changeset/three-news-jump.md
+++ b/.changeset/three-news-jump.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`MerkleTree`: Changed the iterators from `uint32` to `uint256`.

--- a/.changeset/three-news-jump.md
+++ b/.changeset/three-news-jump.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`MerkleTree`: Changed the iterators from `uint32` to `uint256`.

--- a/contracts/utils/structs/MerkleTree.sol
+++ b/contracts/utils/structs/MerkleTree.sol
@@ -88,7 +88,7 @@ library MerkleTree {
 
         // Build each root of zero-filled subtrees
         bytes32 currentZero = zero;
-        for (uint32 i = 0; i < treeDepth; ++i) {
+        for (uint256 i = 0; i < treeDepth; ++i) {
             Arrays.unsafeAccess(self._zeros, i).value = currentZero;
             currentZero = fnHash(currentZero, currentZero);
         }
@@ -143,7 +143,7 @@ library MerkleTree {
         // Rebuild branch from leaf to root
         uint256 currentIndex = index;
         bytes32 currentLevelHash = leaf;
-        for (uint32 i = 0; i < treeDepth; i++) {
+        for (uint256 i = 0; i < treeDepth; i++) {
             // Reaching the parent node, is currentLevelHash the left child?
             bool isLeft = currentIndex % 2 == 0;
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #5414

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Changes the `for` loop iterators in `MerkleTree` iterating from `0` to `uint8 treeDepth` from `uint32` to `uint256` to minimize conversions and save gas.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
