### PR TITLE
Expose `_isTrustedByTarget` internally in ERC2771Forwarder

### DIFF
--- a/.changeset/famous-timers-compare.md
+++ b/.changeset/famous-timers-compare.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC2771Forwarder`: Expose the `_isTrustedByTarget` internal function to check whether a target trusts the forwarder.

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -302,8 +302,12 @@ contract ERC2771Forwarder is EIP712, Nonces {
      *
      * This function performs a static call to the target contract calling the
      * {ERC2771Context-isTrustedForwarder} function.
+     *
+     * NOTE: Consider the execution of this forwarder is permissionless. Without
+     * this check, users may approve token spending to this contract allowing
+     * any relayer to transfer their tokens.
      */
-    function _isTrustedByTarget(address target) private view returns (bool) {
+    function _isTrustedByTarget(address target) internal view virtual returns (bool) {
         bytes memory encodedParams = abi.encodeCall(ERC2771Context.isTrustedForwarder, (address(this)));
 
         bool success;

--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -303,9 +303,8 @@ contract ERC2771Forwarder is EIP712, Nonces {
      * This function performs a static call to the target contract calling the
      * {ERC2771Context-isTrustedForwarder} function.
      *
-     * NOTE: Consider the execution of this forwarder is permissionless. Without
-     * this check, users may approve token spending to this contract allowing
-     * any relayer to transfer their tokens.
+     * NOTE: Consider the execution of this forwarder is permissionless. Without this check, anyone may transfer assets
+     * that are owned by, or are approved to this forwarder.
      */
     function _isTrustedByTarget(address target) internal view virtual returns (bool) {
         bytes memory encodedParams = abi.encodeCall(ERC2771Context.isTrustedForwarder, (address(this)));


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #5375 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
