### PR TITLE
Add a Calldata library with `emptyBytes` and `emptyString` functions

### DIFF
--- a/.changeset/good-cameras-serve.md
+++ b/.changeset/good-cameras-serve.md
@@ -2,4 +2,4 @@
 "openzeppelin-solidity": minor
 ---
 
-`Calldata`: Library with `emptyCalldataBytes` and `emptyCalldataString` functions to generate empty `bytes` and `string` calldata types.
+`Calldata`: Library with `emptyBytes` and `emptyString` functions to generate empty `bytes` and `string` calldata types.

--- a/.changeset/good-cameras-serve.md
+++ b/.changeset/good-cameras-serve.md
@@ -1,0 +1,5 @@
+---
+"openzeppelin-solidity": minor
+---
+
+`Calldata`: Library with `emptyCalldataBytes` and `emptyCalldataString` functions to generate empty `bytes` and `string` calldata types.

--- a/contracts/account/utils/draft-ERC4337Utils.sol
+++ b/contracts/account/utils/draft-ERC4337Utils.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 
 import {PackedUserOperation} from "../../interfaces/draft-IERC4337.sol";
 import {Math} from "../../utils/math/Math.sol";
+import {Calldata} from "../../utils/Calldata.sol";
 import {Packing} from "../../utils/Packing.sol";
 
 /**
@@ -106,7 +107,7 @@ library ERC4337Utils {
 
     /// @dev Returns `factoryData` from the {PackedUserOperation}, or empty bytes if the initCode is empty or not properly formatted.
     function factoryData(PackedUserOperation calldata self) internal pure returns (bytes calldata) {
-        return self.initCode.length < 20 ? _emptyCalldataBytes() : self.initCode[20:];
+        return self.initCode.length < 20 ? Calldata.emptyBytes() : self.initCode[20:];
     }
 
     /// @dev Returns `verificationGasLimit` from the {PackedUserOperation}.
@@ -156,14 +157,6 @@ library ERC4337Utils {
 
     /// @dev Returns the fourth section of `paymasterAndData` from the {PackedUserOperation}.
     function paymasterData(PackedUserOperation calldata self) internal pure returns (bytes calldata) {
-        return self.paymasterAndData.length < 52 ? _emptyCalldataBytes() : self.paymasterAndData[52:];
-    }
-
-    // slither-disable-next-line write-after-write
-    function _emptyCalldataBytes() private pure returns (bytes calldata result) {
-        assembly ("memory-safe") {
-            result.offset := 0
-            result.length := 0
-        }
+        return self.paymasterAndData.length < 52 ? Calldata.emptyBytes() : self.paymasterAndData[52:];
     }
 }

--- a/contracts/utils/Calldata.sol
+++ b/contracts/utils/Calldata.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.24;
+
+/**
+ * @dev Helper library for manipulating objects in calldata.
+ */
+library Calldata {
+    // slither-disable-next-line write-after-write
+    function emptyBytes() internal pure returns (bytes calldata result) {
+        assembly ("memory-safe") {
+            result.offset := 0
+            result.length := 0
+        }
+    }
+
+    // slither-disable-next-line write-after-write
+    function emptyString() internal pure returns (string calldata result) {
+        assembly ("memory-safe") {
+            result.offset := 0
+            result.length := 0
+        }
+    }
+}

--- a/contracts/utils/Calldata.sol
+++ b/contracts/utils/Calldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.20;
 
 /**
  * @dev Helper library for manipulating objects in calldata.

--- a/test/utils/Calldata.test.js
+++ b/test/utils/Calldata.test.js
@@ -1,0 +1,22 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
+async function fixture() {
+  const mock = await ethers.deployContract('$Calldata');
+  return { mock };
+}
+
+describe('Calldata utilities', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  it('emptyBytes', async function () {
+    await expect(this.mock.$emptyBytes()).to.eventually.equal('0x');
+  });
+
+  it('emptyString', async function () {
+    await expect(this.mock.$emptyString()).to.eventually.equal('');
+  });
+});


### PR DESCRIPTION
Currently defined in
- `draft-ERC4337Utils.sol` (contracts)
- `ERC7821.sol` (community-contracts)
- `ERC7739Utils.sol` (community-contracts)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
