### PR TITLE
Fix Verb Agreement in Token Holder Update VestingWallet.sol

### DIFF
--- a/contracts/finance/VestingWallet.sol
+++ b/contracts/finance/VestingWallet.sol
@@ -16,7 +16,7 @@ import {Ownable} from "../access/Ownable.sol";
  * Consequently, if the vesting has already started, any amount of tokens sent to this contract will (at least partly)
  * be immediately releasable.
  *
- * By setting the duration to 0, one can configure this contract to behave like an asset timelock that hold tokens for
+ * By setting the duration to 0, one can configure this contract to behave like an asset timelock that holds tokens for
  * a beneficiary until a specified time.
  *
  * NOTE: Since the wallet is {Ownable}, and ownership can be transferred, it is possible to sell unvested tokens.


### PR DESCRIPTION
I’ve corrected a small but important grammatical issue in the contract's documentation.
The phrase "that hold tokens" has been updated to "that holds tokens" to properly reflect the third-person singular subject "contract."  

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
