### PR TITLE
fix: Fix incorrect symbols for success/error Update run.js

### DIFF
--- a/certora/run.js
+++ b/certora/run.js
@@ -160,7 +160,7 @@ function writeEntry(spec, contract, success, url) {
     formatRow(
       spec,
       contract,
-      success ? ':x:' : ':heavy_check_mark:',
+      success ? ':heavy_check_mark:' : ':x:',
       url ? `[link](${url?.replace('/output/', '/jobStatus/')})` : 'error',
       url ? `[link](${url})` : 'error',
     ),


### PR DESCRIPTION
I noticed that in the `writeEntry` function, the symbols for displaying the result of a check are used incorrectly. Currently, `:x:` (cross) is shown for success, and `:heavy_check_mark:` (checkmark) is shown for errors.

This is counterintuitive, as a cross typically represents an error, and a checkmark represents success.

I’ve swapped these symbols to align with common conventions and improve clarity.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
