### PR TITLE
fix: Fix mkdirp function Update prepack.sh

### DIFF
--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -5,7 +5,7 @@ shopt -s globstar
 
 # cross platform `mkdir -p`
 mkdirp() {
-  node -e "fs.mkdirSync('$1', { recursive: true })"
+  mkdir -p "$1"
 }
 
 # cd to the root of the repo


### PR DESCRIPTION

I noticed that the `mkdirp` function uses `node -e` to create directories, which can fail if the path contains special characters like spaces or quotes. I've updated it to use the built-in `mkdir -p` command instead, which handles these cases correctly. This should resolve the issue and make the function more robust.


#### PR Checklist


- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
