### PR TITLE
Fix the CLI output of formal verification runs

### DIFF
--- a/certora/run.js
+++ b/certora/run.js
@@ -160,7 +160,7 @@ function writeEntry(spec, contract, success, url) {
     formatRow(
       spec,
       contract,
-      success ? ':x:' : ':heavy_check_mark:',
+      success ? ':heavy_check_mark:' : ':x:',
       url ? `[link](${url?.replace('/output/', '/jobStatus/')})` : 'error',
       url ? `[link](${url})` : 'error',
     ),


### PR DESCRIPTION
I noticed that the icons for success and error states were reversed. Currently, `:x:` is displayed for success (`success == 0`) and `:heavy_check_mark:` for errors (`success != 0`). This is counterintuitive, as `:x:` typically represents failure and `:heavy_check_mark:` success.

I've corrected the logic to align with common conventions.

Now, `:heavy_check_mark:` is shown for success and `:x:` for errors.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
