### PR TITLE
Remove Unnecessary Initialisation of `_paused`

### DIFF
--- a/.changeset/green-drinks-report.md
+++ b/.changeset/green-drinks-report.md
@@ -1,0 +1,5 @@
+---
+"openzeppelin-solidity": minor
+---
+
+`Pausable`: Stop explicitly setting `paused` to `false` during construction.

--- a/contracts/utils/Pausable.sol
+++ b/contracts/utils/Pausable.sol
@@ -38,13 +38,6 @@ abstract contract Pausable is Context {
     error ExpectedPause();
 
     /**
-     * @dev Initializes the contract in unpaused state.
-     */
-    constructor() {
-        _paused = false;
-    }
-
-    /**
      * @dev Modifier to make a function callable only when the contract is not paused.
      *
      * Requirements:


### PR DESCRIPTION
This PR removes the unnecessary initialisation of `_paused`. The state variable is already set at compile-time to `false` here: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/332bcb5f4d9cf0ae0f98fe91c77d9c1fb9951506/contracts/utils/Pausable.sol#L18

Not sure if this requires a changeset. Feel free to push one.