### PR TITLE
Add ERC to `ERC4337` interface names

### DIFF
--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -54,7 +54,7 @@ struct PackedUserOperation {
  *
  * See https://eips.ethereum.org/EIPS/eip-7766[ERC-7766]
  */
-interface IAggregator {
+interface IERC4337Aggregator {
     /**
      * @dev Validates the signature for a user operation.
      * Returns an alternative signature that should be used during bundling.
@@ -89,7 +89,7 @@ interface IAggregator {
  *
  * See https://eips.ethereum.org/EIPS/eip-4337#semi-abstracted-nonce-support[ERC-4337 semi-abstracted nonce support].
  */
-interface IEntryPointNonces {
+interface IERC4337EntryPointNonces {
     /**
      * @dev Returns the nonce for a `sender` account and a `key`.
      *
@@ -105,7 +105,7 @@ interface IEntryPointNonces {
  * and thus have more flexibility in their storage access
  * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-global-entities[reputation, throttling and banning.])
  */
-interface IEntryPointStake {
+interface IERC4337EntryPointStake {
     /**
      * @dev Returns the balance of the account.
      */
@@ -142,7 +142,7 @@ interface IEntryPointStake {
  *
  * User operations are validated and executed by this contract.
  */
-interface IEntryPoint is IEntryPointNonces, IEntryPointStake {
+interface IERC4337EntryPoint is IERC4337EntryPointNonces, IERC4337EntryPointStake {
     /**
      * @dev A user operation at `opIndex` failed with `reason`.
      */
@@ -158,7 +158,7 @@ interface IEntryPoint is IEntryPointNonces, IEntryPointStake {
      */
     struct UserOpsPerAggregator {
         PackedUserOperation[] userOps;
-        IAggregator aggregator;
+        IERC4337Aggregator aggregator;
         bytes signature;
     }
 
@@ -181,7 +181,7 @@ interface IEntryPoint is IEntryPointNonces, IEntryPointStake {
 /**
  * @dev Base interface for an ERC-4337 account.
  */
-interface IAccount {
+interface IERC4337Account {
     /**
      * @dev Validates a user operation.
      *
@@ -208,7 +208,7 @@ interface IAccount {
  * @dev Support for executing user operations by prepending the {executeUserOp} function selector
  * to the UserOperation's `callData`.
  */
-interface IAccountExecute {
+interface IERC4337AccountExecute {
     /**
      * @dev Executes a user operation.
      */
@@ -220,7 +220,7 @@ interface IAccountExecute {
  *
  * NOTE: A paymaster must hold a stake to cover the required entrypoint stake and also the gas for the transaction.
  */
-interface IPaymaster {
+interface IERC4337Paymaster {
     enum PostOpMode {
         opSucceeded,
         opReverted,
@@ -229,7 +229,7 @@ interface IPaymaster {
 
     /**
      * @dev Validates whether the paymaster is willing to pay for the user operation. See
-     * {IAccount-validateUserOp} for additional information on the return value.
+     * {IERC4337Account-validateUserOp} for additional information on the return value.
      *
      * NOTE: Bundlers will reject this method if it modifies the state, unless it's whitelisted.
      */

--- a/contracts/interfaces/draft-IERC7579.sol
+++ b/contracts/interfaces/draft-IERC7579.sol
@@ -51,7 +51,7 @@ interface IERC7579Validator is IERC7579Module {
      *
      * MUST validate that the signature is a valid signature of the userOpHash
      * SHOULD return ERC-4337's SIG_VALIDATION_FAILED (and not revert) on signature mismatch
-     * See {IAccount-validateUserOp} for additional information on the return value
+     * See {IERC4337Account-validateUserOp} for additional information on the return value
      */
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external returns (uint256);
 

--- a/test/account/utils/draft-ERC7579Utils.t.sol
+++ b/test/account/utils/draft-ERC7579Utils.t.sol
@@ -9,18 +9,19 @@ pragma solidity ^0.8.24;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-import {PackedUserOperation, IAccount, IEntryPoint} from "@openzeppelin/contracts/interfaces/draft-IERC4337.sol";
+import {PackedUserOperation, IERC4337Account, IERC4337EntryPoint} from "@openzeppelin/contracts/interfaces/draft-IERC4337.sol";
 import {ERC4337Utils} from "@openzeppelin/contracts/account/utils/draft-ERC4337Utils.sol";
 import {ERC7579Utils, Mode, CallType, ExecType, ModeSelector, ModePayload, Execution} from "@openzeppelin/contracts/account/utils/draft-ERC7579Utils.sol";
 import {Test, Vm, console} from "forge-std/Test.sol";
 
-contract SampleAccount is IAccount, Ownable {
+contract SampleAccount is IERC4337Account, Ownable {
     using ECDSA for *;
     using MessageHashUtils for *;
     using ERC4337Utils for *;
     using ERC7579Utils for *;
 
-    IEntryPoint internal constant ENTRY_POINT = IEntryPoint(payable(0x0000000071727De22E5E9d8BAf0edAc6f37da032));
+    IERC4337EntryPoint internal constant ENTRY_POINT =
+        IERC4337EntryPoint(payable(0x0000000071727De22E5E9d8BAf0edAc6f37da032));
 
     event Log(bool duringValidation, Execution[] calls);
 
@@ -105,7 +106,8 @@ contract ERC7579UtilsTest is Test {
     using ERC4337Utils for *;
     using ERC7579Utils for *;
 
-    IEntryPoint private constant ENTRYPOINT = IEntryPoint(payable(0x0000000071727De22E5E9d8BAf0edAc6f37da032));
+    IERC4337EntryPoint private constant ENTRYPOINT =
+        IERC4337EntryPoint(payable(0x0000000071727De22E5E9d8BAf0edAc6f37da032));
     address private _owner;
     uint256 private _ownerKey;
     address private _account;
@@ -218,7 +220,7 @@ contract ERC7579UtilsTest is Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IEntryPoint.FailedOpWithRevert.selector,
+                IERC4337EntryPoint.FailedOpWithRevert.selector,
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(ERC7579Utils.ERC7579DecodingError.selector)
@@ -276,7 +278,7 @@ contract ERC7579UtilsTest is Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IEntryPoint.FailedOpWithRevert.selector,
+                IERC4337EntryPoint.FailedOpWithRevert.selector,
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(ERC7579Utils.ERC7579DecodingError.selector)


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

ERC4337 declares interfaces without the ERC present in them. To increase clarity, eliminate chance of interface name collision, and maintain consistancy with [ERC7579 interfaces](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/interfaces/draft-IERC7579.sol), this PR adds the ERC to the specced interface name.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
