### PR TITLE
Add stake management function to ERC4337Utils

### DIFF
--- a/.changeset/chilly-guests-jam.md
+++ b/.changeset/chilly-guests-jam.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC4337Utils`: Add functions to manage deposit and stake on the paymaster.

--- a/contracts/account/utils/draft-ERC4337Utils.sol
+++ b/contracts/account/utils/draft-ERC4337Utils.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.20;
 
-import {PackedUserOperation} from "../../interfaces/draft-IERC4337.sol";
+import {IEntryPoint, PackedUserOperation} from "../../interfaces/draft-IERC4337.sol";
 import {Math} from "../../utils/math/Math.sol";
 import {Calldata} from "../../utils/Calldata.sol";
 import {Packing} from "../../utils/Packing.sol";
@@ -15,6 +15,9 @@ import {Packing} from "../../utils/Packing.sol";
  */
 library ERC4337Utils {
     using Packing for *;
+
+    /// @dev Address of the entrypoint v0.7.0
+    IEntryPoint internal constant ENTRYPOINT = IEntryPoint(0x0000000071727De22E5E9d8BAf0edAc6f37da032);
 
     /// @dev For simulation purposes, validateUserOp (and validatePaymasterUserOp) return this value on success.
     uint256 internal constant SIG_VALIDATION_SUCCESS = 0;
@@ -159,5 +162,30 @@ library ERC4337Utils {
     /// @dev Returns the fourth section of `paymasterAndData` from the {PackedUserOperation}.
     function paymasterData(PackedUserOperation calldata self) internal pure returns (bytes calldata) {
         return self.paymasterAndData.length < 52 ? Calldata.emptyBytes() : self.paymasterAndData[52:];
+    }
+
+    /// @dev Deposit ether into the entrypoint.
+    function depositTo(address to, uint256 value) internal {
+        ENTRYPOINT.depositTo{value: value}(to);
+    }
+
+    /// @dev Withdraw ether from the entrypoint.
+    function withdrawTo(address payable to, uint256 value) internal {
+        ENTRYPOINT.withdrawTo(to, value);
+    }
+
+    /// @dev Add stake to the entrypoint.
+    function addStake(uint256 value, uint32 unstakeDelaySec) internal {
+        ENTRYPOINT.addStake{value: value}(unstakeDelaySec);
+    }
+
+    /// @dev Unlock stake on the entrypoint.
+    function unlockStake() internal {
+        ENTRYPOINT.unlockStake();
+    }
+
+    /// @dev Withdraw unlocked stake from the entrypoint.
+    function withdrawStake(address payable to) internal {
+        ENTRYPOINT.withdrawStake(to);
     }
 }

--- a/test/helpers/time.js
+++ b/test/helpers/time.js
@@ -7,8 +7,11 @@ const clock = {
   timestamp: () => time.latest().then(ethers.toBigInt),
 };
 const clockFromReceipt = {
-  blocknumber: receipt => Promise.resolve(ethers.toBigInt(receipt.blockNumber)),
-  timestamp: receipt => ethers.provider.getBlock(receipt.blockNumber).then(block => ethers.toBigInt(block.timestamp)),
+  blocknumber: receipt => Promise.resolve(receipt).then(({ blockNumber }) => ethers.toBigInt(blockNumber)),
+  timestamp: receipt =>
+    Promise.resolve(receipt)
+      .then(({ blockNumber }) => ethers.provider.getBlock(blockNumber))
+      .then(({ timestamp }) => ethers.toBigInt(timestamp)),
 };
 const increaseBy = {
   blockNumber: mine,


### PR DESCRIPTION
This PR:
- Add a constant `ENTRYPOINT` to `ERC4337Utils`. Using it will avoid hardcoding the value in multiple places (`AccountCore.sol`, `PaymasterCore.sol`, ...), and will facilitate updating the value when new version of the paymaster are released.
- Provide primitives to manage deposit and stake on the entrypoint (usefull for building paymasters?)


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
