### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug free status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warranties about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug free status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 
@@ -159,7 +159,7 @@ Allows owner to set a public string of contract information. No issues.
 
 This needs some work. Doesn't check if `_required <= len(_owners)` for instance, that would be a bummer. What if _required were like `MAX - 1`?
 
-I have a general concern about the difference between `owners`, `_owners`, and `owner` in `Ownable.sol`. I recommend "Owners" be renamed. In general we do not recomment single character differences in variable names, although a preceding underscore is not uncommon in Solidity code.
+I have a general concern about the difference between `owners`, `_owners`, and `owner` in `Ownable.sol`. I recommend "Owners" be renamed. In general we do not recommend single character differences in variable names, although a preceding underscore is not uncommon in Solidity code.
 
 Line 34: "this contract only has six types of events"...actually only two.
 


### PR DESCRIPTION


## Changes in audits/2017-03.md:

1. "warrantees" -> "warranties"
- Old: "The audit makes no statements or warrantees about utility of the code"
- New: "The audit makes no statements or warranties about utility of the code"
- Reason: "Warranties" is the correct spelling for legal guarantees

2. "recomment" -> "recommend" 
- Old: "In general we do not recomment single character differences"
- New: "In general we do not recommend single character differences"
- Reason: Fixed typo to correct spelling

These changes improve documentation readability by fixing spelling errors.
