### PR TITLE
chore: fix incorrect mapping syntax in Solidity

### DIFF
--- a/contracts/finance/VestingWallet.sol
+++ b/contracts/finance/VestingWallet.sol
@@ -37,7 +37,7 @@ contract VestingWallet is Context, Ownable {
     event ERC20Released(address indexed token, uint256 amount);
 
     uint256 private _released;
-    mapping(address token => uint256) private _erc20Released;
+    mapping(address => uint256) private _erc20Released;
     uint64 private immutable _start;
     uint64 private immutable _duration;
 


### PR DESCRIPTION
Noticed an issue where the mapping key was unnecessarily given a variable name (`token`), which Solidity doesn't support. 

Fixed it by using the correct syntax:  

```solidity
mapping(address => uint256) private _erc20Released;
```  

**Now the mapping correctly links an `address` to a `uint256` without attempting to name the key.**

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
