### PR TITLE
fix: Fix incorrect mapping syntax

### DIFF
--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -35,9 +35,9 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
     bytes32 private constant DELEGATION_TYPEHASH =
         keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
 
-    mapping(address account => address) private _delegatee;
+    mapping(address => address) private _delegatee;
 
-    mapping(address delegatee => Checkpoints.Trace208) private _delegateCheckpoints;
+    mapping(address => Checkpoints.Trace208) private _delegateCheckpoints;
 
     Checkpoints.Trace208 private _totalCheckpoints;
 


### PR DESCRIPTION
#### Description 
The `mapping` syntax in the contract was incorrect due to the use of named parameters, which Solidity does not support. This caused compilation errors.  

Fixed the following lines:  
- `mapping(address account => address) private _delegatee;` → `mapping(address => address) private _delegatee;`  
- `mapping(address delegatee => Checkpoints.Trace208) private _delegateCheckpoints;` → `mapping(address => Checkpoints.Trace208) private _delegateCheckpoints;`  

🚀

#### PR Checklist

- [x] Tests
- [] Documentation
- [x] Changeset entry (run `npx changeset add`)
