### PR TITLE
fix: Fix grammar in log message

### DIFF
--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -23,7 +23,7 @@ interface IAccessControl {
      * @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`
      *
      * `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
-     * {RoleAdminChanged} not being emitted signaling this.
+     * {RoleAdminChanged} not being emitted to signal this.
      */
     event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
 


### PR DESCRIPTION
"not being emitted signaling this" sounded a bit off grammatically.
Changed it to "not being emitted to signal this" for better clarity.

**Thanks for your contracts!**

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
