### PR TITLE
SafeERC20.trySafeTransfer{,from}

### DIFF
--- a/.changeset/brown-seals-sing.md
+++ b/.changeset/brown-seals-sing.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`SafeERC20`: Add `trySafeTransfer` and `trySafeTransferFrom` that do not revert and return false if the transfer is not successful.

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -43,6 +43,20 @@ library SafeERC20 {
     }
 
     /**
+     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.
+     */
+    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {
+        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));
+    }
+
+    /**
+     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.
+     */
+    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {
+        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));
+    }
+
+    /**
      * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
      * non-reverting calls are assumed to be successful.
      *

--- a/test/token/ERC20/utils/SafeERC20.test.js
+++ b/test/token/ERC20/utils/SafeERC20.test.js
@@ -60,10 +60,22 @@ describe('SafeERC20', function () {
         .withArgs(this.token);
     });
 
+    it('returns false on trySafeTransfer', async function () {
+      await expect(this.mock.$trySafeTransfer(this.token, this.receiver, 0n))
+        .to.emit(this.mock, 'return$trySafeTransfer')
+        .withArgs(false);
+    });
+
     it('reverts on transferFrom', async function () {
       await expect(this.mock.$safeTransferFrom(this.token, this.mock, this.receiver, 0n))
         .to.be.revertedWithCustomError(this.mock, 'SafeERC20FailedOperation')
         .withArgs(this.token);
+    });
+
+    it('returns false on trySafeTransferFrom', async function () {
+      await expect(this.mock.$trySafeTransferFrom(this.token, this.mock, this.receiver, 0n))
+        .to.emit(this.mock, 'return$trySafeTransferFrom')
+        .withArgs(false);
     });
 
     it('reverts on increaseAllowance', async function () {
@@ -94,10 +106,22 @@ describe('SafeERC20', function () {
         .withArgs(this.token);
     });
 
+    it('returns false on trySafeTransfer', async function () {
+      await expect(this.mock.$trySafeTransfer(this.token, this.receiver, 0n))
+        .to.emit(this.mock, 'return$trySafeTransfer')
+        .withArgs(false);
+    });
+
     it('reverts on transferFrom', async function () {
       await expect(this.mock.$safeTransferFrom(this.token, this.mock, this.receiver, 0n))
         .to.be.revertedWithCustomError(this.mock, 'SafeERC20FailedOperation')
         .withArgs(this.token);
+    });
+
+    it('returns false on trySafeTransferFrom', async function () {
+      await expect(this.mock.$trySafeTransferFrom(this.token, this.mock, this.receiver, 0n))
+        .to.emit(this.mock, 'return$trySafeTransferFrom')
+        .withArgs(false);
     });
 
     it('reverts on increaseAllowance', async function () {
@@ -357,10 +381,22 @@ function shouldOnlyRevertOnErrors() {
         .withArgs(this.mock, this.receiver, 10n);
     });
 
+    it('returns true on trySafeTransfer', async function () {
+      await expect(this.mock.$trySafeTransfer(this.token, this.receiver, 10n))
+        .to.emit(this.mock, 'return$trySafeTransfer')
+        .withArgs(true);
+    });
+
     it("doesn't revert on transferFrom", async function () {
       await expect(this.mock.$safeTransferFrom(this.token, this.owner, this.receiver, 10n))
         .to.emit(this.token, 'Transfer')
         .withArgs(this.owner, this.receiver, 10n);
+    });
+
+    it('returns true on trySafeTransferFrom', async function () {
+      await expect(this.mock.$trySafeTransferFrom(this.token, this.owner, this.receiver, 10n))
+        .to.emit(this.mock, 'return$trySafeTransferFrom')
+        .withArgs(true);
     });
   });
 


### PR DESCRIPTION
Add 2 functions to `SafeERC20` that return a boolean instead of reverting when a transfer isn't successful.

This maybe be usefull for contract (Paymaster?) that want to return an error code instead of reverting.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
