### PR TITLE
Add clear function to Enumerable{Set,Map}

### DIFF
--- a/.changeset/good-cameras-rush.md
+++ b/.changeset/good-cameras-rush.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`EnumerableMap`: Add `clear` function to EnumerableMaps which deletes all entries in the map.

--- a/.changeset/sixty-tips-wink.md
+++ b/.changeset/sixty-tips-wink.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`EnumerableSet`: Add `clear` function to EnumerableSets which deletes all items in the set.
+`EnumerableSet`: Add `clear` function to EnumerableSets which deletes all values in the set.

--- a/.changeset/sixty-tips-wink.md
+++ b/.changeset/sixty-tips-wink.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`EnumerableSet`: Add `clear` function to EnumerableSets which deletes all items in the set.

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -16,6 +16,7 @@ import {EnumerableSet} from "./EnumerableSet.sol";
  * - Entries are added, removed, and checked for existence in constant time
  * (O(1)).
  * - Entries are enumerated in O(n). No guarantees are made on the ordering.
+ * - Map can be cleared (all entries removed) in O(n).
  *
  * ```solidity
  * contract Example {
@@ -88,6 +89,20 @@ library EnumerableMap {
     function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (bool) {
         delete map._values[key];
         return map._keys.remove(key);
+    }
+
+    /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(Bytes32ToBytes32Map storage map) internal {
+        uint256 len = length(map);
+        for (uint256 i = 0; i < len; ++i) {
+            delete map._values[map._keys.at(i)];
+        }
+        map._keys.clear();
     }
 
     /**
@@ -186,6 +201,16 @@ library EnumerableMap {
     }
 
     /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(UintToUintMap storage map) internal {
+        clear(map._inner);
+    }
+
+    /**
      * @dev Returns true if the key is in the map. O(1).
      */
     function contains(UintToUintMap storage map, uint256 key) internal view returns (bool) {
@@ -276,6 +301,16 @@ library EnumerableMap {
      */
     function remove(UintToAddressMap storage map, uint256 key) internal returns (bool) {
         return remove(map._inner, bytes32(key));
+    }
+
+    /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(UintToAddressMap storage map) internal {
+        clear(map._inner);
     }
 
     /**
@@ -372,6 +407,16 @@ library EnumerableMap {
     }
 
     /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(UintToBytes32Map storage map) internal {
+        clear(map._inner);
+    }
+
+    /**
      * @dev Returns true if the key is in the map. O(1).
      */
     function contains(UintToBytes32Map storage map, uint256 key) internal view returns (bool) {
@@ -462,6 +507,16 @@ library EnumerableMap {
      */
     function remove(AddressToUintMap storage map, address key) internal returns (bool) {
         return remove(map._inner, bytes32(uint256(uint160(key))));
+    }
+
+    /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(AddressToUintMap storage map) internal {
+        clear(map._inner);
     }
 
     /**
@@ -558,6 +613,16 @@ library EnumerableMap {
     }
 
     /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(AddressToAddressMap storage map) internal {
+        clear(map._inner);
+    }
+
+    /**
      * @dev Returns true if the key is in the map. O(1).
      */
     function contains(AddressToAddressMap storage map, address key) internal view returns (bool) {
@@ -648,6 +713,16 @@ library EnumerableMap {
      */
     function remove(AddressToBytes32Map storage map, address key) internal returns (bool) {
         return remove(map._inner, bytes32(uint256(uint160(key))));
+    }
+
+    /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(AddressToBytes32Map storage map) internal {
+        clear(map._inner);
     }
 
     /**
@@ -744,6 +819,16 @@ library EnumerableMap {
     }
 
     /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(Bytes32ToUintMap storage map) internal {
+        clear(map._inner);
+    }
+
+    /**
      * @dev Returns true if the key is in the map. O(1).
      */
     function contains(Bytes32ToUintMap storage map, bytes32 key) internal view returns (bool) {
@@ -834,6 +919,16 @@ library EnumerableMap {
      */
     function remove(Bytes32ToAddressMap storage map, bytes32 key) internal returns (bool) {
         return remove(map._inner, key);
+    }
+
+    /**
+     * @dev Removes all the entries from a map. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(Bytes32ToAddressMap storage map) internal {
+        clear(map._inner);
     }
 
     /**

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.20;
  *
  * - Elements are added, removed, and checked for existence in constant time
  * (O(1)).
- * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ * - Elements are enumerated and cleared in O(n). No guarantees are made on the ordering.
  *
  * ```solidity
  * contract Example {
@@ -115,6 +115,18 @@ library EnumerableSet {
     }
 
     /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function _clear(Set storage set) private {
+        for (uint256 i = _length(set); i > 0; --i) {
+            _remove(set, _at(set, i - 1));
+        }
+    }
+
+    /**
      * @dev Returns true if the value is in the set. O(1).
      */
     function _contains(Set storage set, bytes32 value) private view returns (bool) {
@@ -178,6 +190,16 @@ library EnumerableSet {
      */
     function remove(Bytes32Set storage set, bytes32 value) internal returns (bool) {
         return _remove(set._inner, value);
+    }
+
+    /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(Bytes32Set storage set) internal {
+        _clear(set._inner);
     }
 
     /**
@@ -254,6 +276,16 @@ library EnumerableSet {
     }
 
     /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(AddressSet storage set) internal {
+        _clear(set._inner);
+    }
+
+    /**
      * @dev Returns true if the value is in the set. O(1).
      */
     function contains(AddressSet storage set, address value) internal view returns (bool) {
@@ -324,6 +356,16 @@ library EnumerableSet {
      */
     function remove(UintSet storage set, uint256 value) internal returns (bool) {
         return _remove(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(UintSet storage set) internal {
+        _clear(set._inner);
     }
 
     /**

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -489,6 +489,24 @@ library EnumerableSet {
     }
 
     /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(Bytes32x2Set storage self) internal {
+        bytes32[2][] storage v = self._values;
+
+        uint256 len = length(self);
+        for (uint256 i = 0; i < len; ++i) {
+            delete self._positions[_hash(v[i])];
+        }
+        assembly ("memory-safe") {
+            sstore(v.slot, 0)
+        }
+    }
+
+    /**
      * @dev Returns true if the value is in the self. O(1).
      */
     function contains(Bytes32x2Set storage self, bytes32[2] memory value) internal view returns (bool) {

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -4,6 +4,8 @@
 
 pragma solidity ^0.8.20;
 
+import {Arrays} from "../Arrays.sol";
+
 /**
  * @dev Library for managing
  * https://en.wikipedia.org/wiki/Set_(abstract_data_type)[sets] of primitive
@@ -121,9 +123,11 @@ library EnumerableSet {
      * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
      */
     function _clear(Set storage set) private {
-        for (uint256 i = _length(set); i > 0; --i) {
-            _remove(set, _at(set, i - 1));
+        uint256 len = _length(set);
+        for (uint256 i = 0; i < len; ++i) {
+            delete set._positions[set._values[i]];
         }
+        Arrays.unsafeSetLength(set._values, 0);
     }
 
     /**

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -15,7 +15,8 @@ import {Arrays} from "../Arrays.sol";
  *
  * - Elements are added, removed, and checked for existence in constant time
  * (O(1)).
- * - Elements are enumerated and cleared in O(n). No guarantees are made on the ordering.
+ * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ * - Set can be cleared (all elements removed) in O(n).
  *
  * ```solidity
  * contract Example {

--- a/scripts/generate/templates/EnumerableMap.js
+++ b/scripts/generate/templates/EnumerableMap.js
@@ -17,6 +17,7 @@ import {EnumerableSet} from "./EnumerableSet.sol";
  * - Entries are added, removed, and checked for existence in constant time
  * (O(1)).
  * - Entries are enumerated in O(n). No guarantees are made on the ordering.
+ * - Map can be cleared (all entries removed) in O(n).
  *
  * \`\`\`solidity
  * contract Example {
@@ -89,6 +90,20 @@ function set(Bytes32ToBytes32Map storage map, bytes32 key, bytes32 value) intern
 function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (bool) {
     delete map._values[key];
     return map._keys.remove(key);
+}
+
+/**
+ * @dev Removes all the entries from a map. O(n).
+ *
+ * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+ * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+ */
+function clear(Bytes32ToBytes32Map storage map) internal {
+    uint256 len = length(map);
+    for (uint256 i = 0; i < len; ++i) {
+        delete map._values[map._keys.at(i)];
+    }
+    map._keys.clear();
 }
 
 /**
@@ -186,6 +201,16 @@ function set(${name} storage map, ${keyType} key, ${valueType} value) internal r
  */
 function remove(${name} storage map, ${keyType} key) internal returns (bool) {
     return remove(map._inner, ${toBytes32(keyType, 'key')});
+}
+
+/**
+ * @dev Removes all the entries from a map. O(n).
+ *
+ * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+ * function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+ */
+function clear(${name} storage map) internal {
+    clear(map._inner);
 }
 
 /**

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -16,7 +16,8 @@ import {Arrays} from "../Arrays.sol";
  *
  * - Elements are added, removed, and checked for existence in constant time
  * (O(1)).
- * - Elements are enumerated and cleared in O(n). No guarantees are made on the ordering.
+ * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ * - Set can be cleared (all elements removed) in O(n).
  *
  * \`\`\`solidity
  * contract Example {

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -5,6 +5,8 @@ const { TYPES } = require('./EnumerableSet.opts');
 const header = `\
 pragma solidity ^0.8.20;
 
+import {Arrays} from "../Arrays.sol";
+
 /**
  * @dev Library for managing
  * https://en.wikipedia.org/wiki/Set_(abstract_data_type)[sets] of primitive
@@ -124,9 +126,11 @@ function _remove(Set storage set, bytes32 value) private returns (bool) {
  * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
  */
 function _clear(Set storage set) private {
-    for (uint256 i = _length(set); i > 0; --i) {
-        _remove(set, _at(set, i - 1));
+    uint256 len = _length(set);
+    for (uint256 i = 0; i < len; ++i) {
+        delete set._positions[set._values[i]];
     }
+    Arrays.unsafeSetLength(set._values, 0);
 }
 
 /**

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -330,6 +330,24 @@ function remove(${name} storage self, ${type} memory value) internal returns (bo
 }
 
 /**
+ * @dev Removes all the values from a set. O(n).
+ *
+ * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+ * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+ */
+function clear(${name} storage self) internal {
+    ${type}[] storage v = self._values;
+
+    uint256 len = length(self);
+    for (uint256 i = 0; i < len; ++i) {
+        delete self._positions[_hash(v[i])];
+    }
+    assembly ("memory-safe") {
+        sstore(v.slot, 0)
+    }
+}
+
+/**
  * @dev Returns true if the value is in the self. O(1).
  */
 function contains(${name} storage self, ${type} memory value) internal view returns (bool) {

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -14,7 +14,7 @@ pragma solidity ^0.8.20;
  *
  * - Elements are added, removed, and checked for existence in constant time
  * (O(1)).
- * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ * - Elements are enumerated and cleared in O(n). No guarantees are made on the ordering.
  *
  * \`\`\`solidity
  * contract Example {
@@ -118,6 +118,18 @@ function _remove(Set storage set, bytes32 value) private returns (bool) {
 }
 
 /**
+ * @dev Removes all the values from a set. O(n).
+ *
+ * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+ * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+ */
+function _clear(Set storage set) private {
+    for (uint256 i = _length(set); i > 0; --i) {
+        _remove(set, _at(set, i - 1));
+    }
+}
+
+/**
  * @dev Returns true if the value is in the set. O(1).
  */
 function _contains(Set storage set, bytes32 value) private view returns (bool) {
@@ -183,6 +195,16 @@ function add(${name} storage set, ${type} value) internal returns (bool) {
  */
 function remove(${name} storage set, ${type} value) internal returns (bool) {
     return _remove(set._inner, ${toBytes32(type, 'value')});
+}
+
+/**
+ * @dev Removes all the values from a set. O(n).
+ *
+ * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+ * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+ */
+function clear(${name} storage set) internal {
+    _clear(set._inner);
 }
 
 /**

--- a/test/utils/structs/EnumerableMap.behavior.js
+++ b/test/utils/structs/EnumerableMap.behavior.js
@@ -117,6 +117,49 @@ function shouldBehaveLikeMap() {
     });
   });
 
+  describe('clear', function () {
+    it('clears a single item', async function () {
+      await this.methods.set(this.keyA, this.valueA);
+
+      await this.methods.clear();
+
+      expect(await this.methods.contains(this.keyA)).to.be.false;
+      await expectMembersMatch(this.methods, [], []);
+    });
+
+    it('clears multiple items', async function () {
+      await this.methods.set(this.keyA, this.valueA);
+      await this.methods.set(this.keyB, this.valueB);
+      await this.methods.set(this.keyC, this.valueC);
+
+      await this.methods.clear();
+
+      expect(await this.methods.contains(this.keyA)).to.be.false;
+      expect(await this.methods.contains(this.keyB)).to.be.false;
+      expect(await this.methods.contains(this.keyC)).to.be.false;
+      await expectMembersMatch(this.methods, [], []);
+    });
+
+    it('does not revert on empty set', async function () {
+      await this.methods.clear();
+    });
+
+    it('clear then add value', async function () {
+      await this.methods.set(this.keyA, this.valueA);
+      await this.methods.set(this.keyB, this.valueB);
+      await this.methods.set(this.keyC, this.valueC);
+
+      await this.methods.clear();
+
+      await this.methods.set(this.keyA, this.valueA);
+
+      expect(await this.methods.contains(this.keyA)).to.be.true;
+      expect(await this.methods.contains(this.keyB)).to.be.false;
+      expect(await this.methods.contains(this.keyC)).to.be.false;
+      await expectMembersMatch(this.methods, [this.keyA], [this.valueA]);
+    });
+  });
+
   describe('read', function () {
     beforeEach(async function () {
       await this.methods.set(this.keyA, this.valueA);

--- a/test/utils/structs/EnumerableMap.behavior.js
+++ b/test/utils/structs/EnumerableMap.behavior.js
@@ -118,7 +118,7 @@ function shouldBehaveLikeMap() {
   });
 
   describe('clear', function () {
-    it('clears a single item', async function () {
+    it('clears a single entry', async function () {
       await this.methods.set(this.keyA, this.valueA);
 
       await this.methods.clear();
@@ -127,7 +127,7 @@ function shouldBehaveLikeMap() {
       await expectMembersMatch(this.methods, [], []);
     });
 
-    it('clears multiple items', async function () {
+    it('clears multiple entries', async function () {
       await this.methods.set(this.keyA, this.valueA);
       await this.methods.set(this.keyB, this.valueB);
       await this.methods.set(this.keyC, this.valueC);
@@ -140,11 +140,11 @@ function shouldBehaveLikeMap() {
       await expectMembersMatch(this.methods, [], []);
     });
 
-    it('does not revert on empty set', async function () {
+    it('does not revert on empty map', async function () {
       await this.methods.clear();
     });
 
-    it('clear then add value', async function () {
+    it('clear then add entry', async function () {
       await this.methods.set(this.keyA, this.valueA);
       await this.methods.set(this.keyB, this.valueB);
       await this.methods.set(this.keyC, this.valueC);

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -26,6 +26,7 @@ async function fixture() {
             get: `$get_EnumerableMap_${name}(uint256,${keyType})`,
             tryGet: `$tryGet_EnumerableMap_${name}(uint256,${keyType})`,
             remove: `$remove_EnumerableMap_${name}(uint256,${keyType})`,
+            clear: `$clear_EnumerableMap_${name}(uint256)`,
             length: `$length_EnumerableMap_${name}(uint256)`,
             at: `$at_EnumerableMap_${name}(uint256,uint256)`,
             contains: `$contains_EnumerableMap_${name}(uint256,${keyType})`,

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -109,6 +109,41 @@ function shouldBehaveLikeSet() {
       expect(await this.methods.contains(this.valueB)).to.be.false;
     });
   });
+
+  describe('clear', function () {
+    it('clears a single item', async function () {
+      await this.methods.add(this.valueA);
+      await expect(this.methods.length()).to.eventually.equal(1);
+
+      await this.methods.clear();
+
+      await expect(this.methods.length()).to.eventually.equal(0);
+    });
+
+    it('clears multiple items', async function () {
+      await this.methods.add(this.valueA);
+      await this.methods.add(this.valueB);
+      await this.methods.add(this.valueC);
+      await expect(this.methods.length()).to.eventually.equal(3);
+
+      await this.methods.clear();
+
+      await expect(this.methods.length()).to.eventually.equal(0);
+    });
+
+    it('does not revert on empty set', async function () {
+      await this.methods.clear();
+    });
+
+    it('clear then add value', async function () {
+      await this.methods.add(this.valueA);
+      await this.methods.add(this.valueB);
+      await this.methods.clear();
+
+      await this.methods.add(this.valueA);
+      await expectMembersMatch(this.methods, [this.valueA]);
+    });
+  });
 }
 
 module.exports = {

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -113,22 +113,24 @@ function shouldBehaveLikeSet() {
   describe('clear', function () {
     it('clears a single item', async function () {
       await this.methods.add(this.valueA);
-      await expect(this.methods.length()).to.eventually.equal(1);
 
       await this.methods.clear();
 
-      await expect(this.methods.length()).to.eventually.equal(0);
+      expect(await this.methods.contains(this.valueA)).to.be.false;
+      await expectMembersMatch(this.methods, []);
     });
 
     it('clears multiple items', async function () {
       await this.methods.add(this.valueA);
       await this.methods.add(this.valueB);
       await this.methods.add(this.valueC);
-      await expect(this.methods.length()).to.eventually.equal(3);
 
       await this.methods.clear();
 
-      await expect(this.methods.length()).to.eventually.equal(0);
+      expect(await this.methods.contains(this.valueA)).to.be.false;
+      expect(await this.methods.contains(this.valueB)).to.be.false;
+      expect(await this.methods.contains(this.valueC)).to.be.false;
+      await expectMembersMatch(this.methods, []);
     });
 
     it('does not revert on empty set', async function () {
@@ -138,9 +140,15 @@ function shouldBehaveLikeSet() {
     it('clear then add value', async function () {
       await this.methods.add(this.valueA);
       await this.methods.add(this.valueB);
+      await this.methods.add(this.valueC);
+
       await this.methods.clear();
 
       await this.methods.add(this.valueA);
+
+      expect(await this.methods.contains(this.valueA)).to.be.true;
+      expect(await this.methods.contains(this.valueB)).to.be.false;
+      expect(await this.methods.contains(this.valueC)).to.be.false;
       await expectMembersMatch(this.methods, [this.valueA]);
     });
   });

--- a/test/utils/structs/EnumerableSet.behavior.js
+++ b/test/utils/structs/EnumerableSet.behavior.js
@@ -111,7 +111,7 @@ function shouldBehaveLikeSet() {
   });
 
   describe('clear', function () {
-    it('clears a single item', async function () {
+    it('clears a single value', async function () {
       await this.methods.add(this.valueA);
 
       await this.methods.clear();
@@ -120,7 +120,7 @@ function shouldBehaveLikeSet() {
       await expectMembersMatch(this.methods, []);
     });
 
-    it('clears multiple items', async function () {
+    it('clears multiple values', async function () {
       await this.methods.add(this.valueA);
       await this.methods.add(this.valueB);
       await this.methods.add(this.valueC);

--- a/test/utils/structs/EnumerableSet.test.js
+++ b/test/utils/structs/EnumerableSet.test.js
@@ -44,7 +44,7 @@ async function fixture() {
   return { mock, env };
 }
 
-describe.only('EnumerableSet', function () {
+describe('EnumerableSet', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });

--- a/test/utils/structs/EnumerableSet.test.js
+++ b/test/utils/structs/EnumerableSet.test.js
@@ -27,6 +27,7 @@ async function fixture() {
         methods: getMethods(mock, {
           add: `$add(uint256,${type})`,
           remove: `$remove(uint256,${type})`,
+          clear: `$clear_EnumerableSet_${name}(uint256)`,
           contains: `$contains(uint256,${type})`,
           length: `$length_EnumerableSet_${name}(uint256)`,
           at: `$at_EnumerableSet_${name}(uint256,uint256)`,
@@ -43,7 +44,7 @@ async function fixture() {
   return { mock, env };
 }
 
-describe('EnumerableSet', function () {
+describe.only('EnumerableSet', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
   });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Adds a new `clear` function to the EnumerableSet for each type of enumerable set. This function clears the set in reverse order (to save on gas). It does run in `O(n)` so developers should use it carefully and only when they are sure a set can not grow unbounded. I put a warning in the natspec for this.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
