### PR TITLE
feat: TimelockController receive virtual

### DIFF
--- a/.changeset/gorgeous-apes-jam.md
+++ b/.changeset/gorgeous-apes-jam.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Added virtual keyboard to receive method on TimelockController

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -152,7 +152,7 @@ contract TimelockController is AccessControl, ERC721Holder, ERC1155Holder {
     /**
      * @dev Contract might receive/hold ETH as part of the maintenance process.
      */
-    receive() external payable {}
+    receive() external payable virtual {}
 
     /**
      * @dev See {IERC165-supportsInterface}.


### PR DESCRIPTION
Fixes #5504

Makes the receive method on `TimelockController` virtual
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
