### PR TITLE
Add Arachnid's and Micah's deployer to the common contracts

### DIFF
--- a/hardhat/common-contracts.js
+++ b/hardhat/common-contracts.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 
 const INSTANCES = {
+  // Entrypoint v0.7.0
   entrypoint: {
     address: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
     abi: JSON.parse(fs.readFileSync(path.resolve(__dirname, '../test/bin/EntryPoint070.abi'), 'utf-8')),
@@ -15,6 +16,14 @@ const INSTANCES = {
     address: '0xEFC2c1444eBCC4Db75e7613d20C6a62fF67A167C',
     abi: JSON.parse(fs.readFileSync(path.resolve(__dirname, '../test/bin/SenderCreator070.abi'), 'utf-8')),
     bytecode: fs.readFileSync(path.resolve(__dirname, '../test/bin/SenderCreator070.bytecode'), 'hex'),
+  },
+  // Arachnid's deterministic deployment proxy
+  // See: https://github.com/Arachnid/deterministic-deployment-proxy/tree/master
+  arachnidDeployer: {
+    address: '0x4e59b44847b379578588920ca78fbf26c0b4956c',
+    abi: [],
+    bytecode:
+      '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3',
   },
 };
 

--- a/hardhat/common-contracts.js
+++ b/hardhat/common-contracts.js
@@ -20,10 +20,16 @@ const INSTANCES = {
   // Arachnid's deterministic deployment proxy
   // See: https://github.com/Arachnid/deterministic-deployment-proxy/tree/master
   arachnidDeployer: {
-    address: '0x4e59b44847b379578588920ca78fbf26c0b4956c',
+    address: '0x4e59b44847b379578588920cA78FbF26c0B4956C',
     abi: [],
     bytecode:
       '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3',
+  },
+  // Mocah's deployer
+  mocahDeployer: {
+    address: '0x7A0D94F55792C434d74a40883C6ed8545E406D12',
+    abi: [],
+    bytecode: '0x60003681823780368234f58015156014578182fd5b80825250506014600cf3',
   },
 };
 

--- a/hardhat/common-contracts.js
+++ b/hardhat/common-contracts.js
@@ -25,8 +25,8 @@ const INSTANCES = {
     bytecode:
       '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3',
   },
-  // Mocah's deployer
-  mocahDeployer: {
+  // Micah's deployer
+  micahDeployer: {
     address: '0x7A0D94F55792C434d74a40883C6ed8545E406D12',
     abi: [],
     bytecode: '0x60003681823780368234f58015156014578182fd5b80825250506014600cf3',


### PR DESCRIPTION
This is an evolution of the test environment. Shouldn't need a changelog entry.

This is an interresting factory to use with the ERC-4337 entrypoint (in the community repo)

Note: this contract is provided by default in Foundry.
