### PR TITLE
chore: fix quotation marks

### DIFF
--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -30,7 +30,7 @@ interface IERC4626 is IERC20, IERC20Metadata {
     function asset() external view returns (address assetTokenAddress);
 
     /**
-     * @dev Returns the total amount of the underlying asset that is “managed” by Vault.
+     * @dev Returns the total amount of the underlying asset that is "managed" by Vault.
      *
      * - SHOULD include any compounding that occurs from yield.
      * - MUST be inclusive of any fees that are charged against assets in the Vault.
@@ -47,8 +47,8 @@ interface IERC4626 is IERC20, IERC20Metadata {
      * - MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
      * - MUST NOT revert.
      *
-     * NOTE: This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-     * “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
+     * NOTE: This calculation MAY NOT reflect the "per-user" price-per-share, and instead should reflect the
+     * "average-user’s" price-per-share, meaning what the average user should expect to see when exchanging to and
      * from.
      */
     function convertToShares(uint256 assets) external view returns (uint256 shares);
@@ -62,8 +62,8 @@ interface IERC4626 is IERC20, IERC20Metadata {
      * - MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
      * - MUST NOT revert.
      *
-     * NOTE: This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-     * “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
+     * NOTE: This calculation MAY NOT reflect the "per-user" price-per-share, and instead should reflect the
+     * "average-user’s" price-per-share, meaning what the average user should expect to see when exchanging to and
      * from.
      */
     function convertToAssets(uint256 shares) external view returns (uint256 assets);

--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.20;
 /**
  * @dev A https://github.com/ethereum/ercs/blob/master/ERCS/erc-4337.md#useroperation[user operation] is composed of the following elements:
  * - `sender` (`address`): The account making the operation
- * - `nonce` (`uint256`): Anti-replay parameter (see “Semi-abstracted Nonce Support” )
+ * - `nonce` (`uint256`): Anti-replay parameter (see "Semi-abstracted Nonce Support" )
  * - `factory` (`address`): account factory, only for new accounts
  * - `factoryData` (`bytes`): data for account factory (only if account factory exists)
  * - `callData` (`bytes`): The data to pass to the sender during the main execution call
@@ -188,13 +188,13 @@ interface IAccount {
      * * MUST validate the caller is a trusted EntryPoint
      * * MUST validate that the signature is a valid signature of the userOpHash, and SHOULD
      *   return SIG_VALIDATION_FAILED (and not revert) on signature mismatch. Any other error MUST revert.
-     * * MUST pay the entryPoint (caller) at least the “missingAccountFunds” (which might
+     * * MUST pay the entryPoint (caller) at least the "missingAccountFunds" (which might
      *   be zero, in case the current account’s deposit is high enough)
      *
      * Returns an encoded packed validation data that is composed of the following elements:
      *
      * - `authorizer` (`address`): 0 for success, 1 for failure, otherwise the address of an authorizer contract
-     * - `validUntil` (`uint48`): The UserOp is valid only up to this time. Zero for “infinite”.
+     * - `validUntil` (`uint48`): The UserOp is valid only up to this time. Zero for "infinite".
      * - `validAfter` (`uint48`): The UserOp is valid only after this time.
      */
     function validateUserOp(

--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -8,7 +8,7 @@ NOTE: Find detailed contract documentation at xref:api:governance.adoc[Governanc
 
 Decentralized protocols are in constant evolution from the moment they are publicly released. Often, the initial team retains control of this evolution in the first stages, but eventually delegates it to a community of stakeholders. The process by which this community makes decisions is called on-chain governance, and it has become a central component of decentralized protocols, fueling varied decisions such as parameter tweaking, smart contract upgrades, integrations with other protocols, treasury management, grants, etc.
 
-This governance protocol is generally implemented in a special-purpose contract called “Governor”. The GovernorAlpha and GovernorBravo contracts designed by Compound have been very successful and popular so far, with the downside that projects with different requirements have had to fork the code to customize it for their needs, which can pose a high risk of introducing security issues. For OpenZeppelin Contracts, we set out to build a modular system of Governor contracts so that forking is not needed, and different requirements can be accommodated by writing small modules using Solidity inheritance. You will find the most common requirements out of the box in OpenZeppelin Contracts, but writing additional ones is simple, and we will be adding new features as requested by the community in future releases. Additionally, the design of OpenZeppelin Governor requires minimal use of storage and results in more gas efficient operation.
+This governance protocol is generally implemented in a special-purpose contract called "Governor". The GovernorAlpha and GovernorBravo contracts designed by Compound have been very successful and popular so far, with the downside that projects with different requirements have had to fork the code to customize it for their needs, which can pose a high risk of introducing security issues. For OpenZeppelin Contracts, we set out to build a modular system of Governor contracts so that forking is not needed, and different requirements can be accommodated by writing small modules using Solidity inheritance. You will find the most common requirements out of the box in OpenZeppelin Contracts, but writing additional ones is simple, and we will be adding new features as requested by the community in future releases. Additionally, the design of OpenZeppelin Governor requires minimal use of storage and results in more gas efficient operation.
 
 == Compatibility
 
@@ -16,7 +16,7 @@ OpenZeppelin’s Governor system was designed with a concern for compatibility w
 
 === ERC20Votes & ERC20VotesComp
 
-The ERC-20 extension to keep track of votes and vote delegation is one such case. The shorter one is the more generic version because it can support token supplies greater than 2^96, while the “Comp” variant is limited in that regard, but exactly fits the interface of the COMP token that is used by GovernorAlpha and Bravo. Both contract variants share the same events, so they are fully compatible when looking at events only.
+The ERC-20 extension to keep track of votes and vote delegation is one such case. The shorter one is the more generic version because it can support token supplies greater than 2^96, while the "Comp" variant is limited in that regard, but exactly fits the interface of the COMP token that is used by GovernorAlpha and Bravo. Both contract variants share the same events, so they are fully compatible when looking at events only.
 
 === Governor & GovernorStorage
 
@@ -122,7 +122,7 @@ await governor.propose(
   [tokenAddress],
   [0],
   [transferCalldata],
-  “Proposal #1: Give grant to team”,
+  "Proposal #1: Give grant to team",
 );
 ```
 
@@ -149,7 +149,7 @@ If a timelock was set up, the first step to execution is queueing. You will noti
 To queue, we call the queue function:
 
 ```javascript
-const descriptionHash = ethers.utils.id(“Proposal #1: Give grant to team”);
+const descriptionHash = ethers.utils.id("Proposal #1: Give grant to team");
 
 await governor.queue(
   [tokenAddress],


### PR DESCRIPTION
The unexpected marks might confuse readers and be distracted by them. Also, some editors might not render correctly depending on the software or platform used, appearing as gibberish or causing formatting problems.