### PR TITLE
Improve Input Descriptions for Clarity and Default Values in GitHub Workflow

### DIFF
--- a/.github/actions/gas-compare/action.yml
+++ b/.github/actions/gas-compare/action.yml
@@ -2,18 +2,18 @@ name: Compare gas costs
 description: Compare gas costs between branches
 inputs:
   token:
-    description: github token
+    description: GitHub token, required to access GitHub API
     required: true
   report:
-    description: report to read from
+    description: Path to the report to compare, default is "gasReporterOutput.json"
     required: false
     default: gasReporterOutput.json
   out_report:
-    description: report to read
+    description: Path to save the output report, default is "${{ github.ref_name }}.gasreport.json"
     required: false
     default: ${{ github.ref_name }}.gasreport.json
   ref_report:
-    description: report to read from
+    description: Path to the reference report for comparison, default is "${{ github.base_ref }}.gasreport.json"
     required: false
     default: ${{ github.base_ref }}.gasreport.json
 


### PR DESCRIPTION
Changed description for the token input:

Old: description: github token
New: description: GitHub token, required to access GitHub API
Reason: Clarified the token’s purpose.
Changed description for the report input:

Old: description: report to read from
New: description: Path to the report to compare, default is "gasReporterOutput.json"
Reason: Specified that it's for comparison and added the default value.
Changed description for the out_report input:

Old: description: report to read
New: description: Path to save the output report, default is "${{ github.ref_name }}.gasreport.json"
Reason: Clarified that it's for saving the output and added the default value.
Changed description for the ref_report input:

Old: description: report to read from
New: description: Path to the reference report for comparison, default is "${{ github.base_ref }}.gasreport.json"
Reason: Clarified that it's the reference report for comparison and added the default value.
File Modified:
File: your-workflow-file.yaml
Descriptions for token, report, out_report, and ref_report were updated.





