### PR TITLE
Improve Clarity in Warning Description

### DIFF
--- a/hardhat/ignore-unreachable-warnings.js
+++ b/hardhat/ignore-unreachable-warnings.js
@@ -3,7 +3,7 @@
 // with hardhat-ignore-warnings we are not able to selectively ignore them without potentially ignoring relevant
 // warnings that we don't want to miss.
 // Thus, we need to handle these warnings separately. We force Hardhat to compile them in a separate compilation job and
-// then ignore the warnings about unreachable code that come from that compilation job.
+// then ignore the warnings about unreachable code coming from that compilation job.
 
 const { task } = require('hardhat/config');
 const {


### PR DESCRIPTION
Old: "then ignore the warnings about unreachable code that come from that compilation job."
New: "then ignore the warnings about unreachable code coming from that compilation job."
Reason for Change:
The rephrasing enhances the sentence flow and removes unnecessary words, making it clearer without changing the meaning.