### PR TITLE
improve clarity, grammar and fix typo across documentation

### DIFF
--- a/.changeset/brave-islands-sparkle.md
+++ b/.changeset/brave-islands-sparkle.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`GovernorSequentialProposalId`: Adds a `Governor` extension that sequentially numbers proposal ids instead of using the hash.
+`GovernorSequentialProposalId`: Adds a `Governor` extension that sequentially numbers proposal IDs instead of using the hash.

--- a/.changeset/cyan-taxis-travel.md
+++ b/.changeset/cyan-taxis-travel.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`Address`: bubble up revert data on `sendValue` failed call
+`Address`: Bubble up revert data on `sendValue` failed call.

--- a/.changeset/seven-insects-taste.md
+++ b/.changeset/seven-insects-taste.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC7579Utils`: Add ABI decoding checks on calldata bounds within `decodeBatch`
+`ERC7579Utils`: Add ABI decoding checks on calldata bounds within `decodeBatch`.

--- a/docs/modules/ROOT/pages/backwards-compatibility.adoc
+++ b/docs/modules/ROOT/pages/backwards-compatibility.adoc
@@ -19,7 +19,7 @@ ERCs that are not Final can change in incompatible ways. For this reason, we avo
 
 Almost all functions in this library are virtual with some exceptions, but this does not mean that overrides are encouraged. There is a subset of functions that are designed to be overridden. By defining overrides outside of this subset you are potentially relying on internal implementation details. We make efforts to preserve backwards compatibility even in these cases but it is extremely difficult and easy to accidentally break. Caution is advised.
 
-Additionally, some minor updates may result in new compilation errors of the kind "two or more base classes define function with same name and parameter types" or "need to specify overridden contract", due to what Solidity considers ambiguity in inherited functions. This should be resolved by adding an override that invokes the function via `super`.
+Additionally, some minor updates may result in new compilation errors of the kind "two or more base classes define a function with the same name and parameter types" or "need to specify overridden contract", due to what Solidity considers ambiguity in inherited functions. This should be resolved by adding an override that invokes the function via `super`.
 
 See xref:extending-contracts.adoc[Extending Contracts] for more about virtual and overrides.
 
@@ -39,7 +39,7 @@ An important aspect that major releases may break is "upgrade compatibility", in
 
 == Storage Layout
 
-Minor and patch updates always preserve storage layout compatibility. This means that a live contract can be upgraded from one minor to another without corrupting the storage layout. In some cases it may be necessary to initialize new state variables when upgrading, although we expect this to be infrequent.
+Minor and patch updates always preserve storage layout compatibility. This means that a live contract can be upgraded from one minor to another without corrupting the storage layout. In some cases it may be necessary to initialize new state variables when upgrading, although we expect this to happen infrequently.
 
 We recommend using xref:upgrades-plugins::index.adoc[OpenZeppelin Upgrades Plugins or CLI] to ensure storage layout safety of upgrades.
 

--- a/docs/modules/ROOT/pages/erc20.adoc
+++ b/docs/modules/ROOT/pages/erc20.adoc
@@ -48,7 +48,7 @@ To work around this, xref:api:token/ERC20.adoc#ERC20[`ERC20`] provides a xref:ap
 
 How can this be achieved? It's actually very simple: a token contract can use larger integer values, so that a balance of `50` will represent `5 GLD`, a transfer of `15` will correspond to `1.5 GLD` being sent, and so on.
 
-It is important to understand that `decimals` is _only used for display purposes_. All arithmetic inside the contract is still performed on integers, and it is the different user interfaces (wallets, exchanges, etc.) that must adjust the displayed values according to `decimals`. The total token supply and balance of each account are not specified in `GLD`: you need to divide by `10 ** decimals` to get the actual `GLD` amount.
+It is important to understand that `decimals` is _only used for display purposes_. All arithmetic inside the contract is still performed on integers, and it is the different user interfaces (wallets, exchanges, etc.) that must adjust the displayed values according to `decimals`. The total token supply and balance of each account are not specified in `GLD`: you need to divide by `10 ** decimals` to determine the actual `GLD` amount.
 
 You'll probably want to use a `decimals` value of `18`, just like Ether and most ERC-20 token contracts in use, unless you have a very special reason not to. When minting tokens or transferring them around, you will be actually sending the number `num GLD * (10 ** decimals)`.
 

--- a/docs/modules/ROOT/pages/erc6909.adoc
+++ b/docs/modules/ROOT/pages/erc6909.adoc
@@ -1,6 +1,6 @@
 = ERC-6909
 
-ERC-6909 is a draft EIP that draws on ERC-1155 learnings since it was published in 2018. The main goals of ERC-6909 is to decrease gas costs and complexity--this is mainly accomplished by removing batching and callbacks.
+ERC-6909 is a draft EIP that draws on ERC-1155 learnings since it was published in 2018. The main goal of ERC-6909 is to decrease gas costs and complexity -- this is mainly accomplished by removing batching and callbacks.
 
 TIP: To understand the inspiration for a multi token standard, see the xref:erc1155.adoc#multi-token-standard[multi token standard] section within the EIP-1155 docs.
 
@@ -10,13 +10,13 @@ There are three main changes from ERC-1155 which are as follows:
 
 . The removal of batch operations.
 . The removal of transfer callbacks.
-. Granularization in approvals--approvals can be set globally (as operators) or as amounts per token (inspired by ERC20).
+. Granularization in approvals -- approvals can be set globally (as operators) or as amounts per token (inspired by ERC20).
 
 == Constructing an ERC-6909 Token Contract
 
-We'll use ERC-6909 to track multiple items in a game, each having their own unique attributes. All item types will by minted to the deployer of the contract, which we can later transfer to players. We'll also use the xref:api:token/ERC6909.adoc#ERC6909Metadata[`ERC6909Metadata`] extension to add decimals to our fungible items (the vanilla ERC-6909 implementation does not have decimals).
+We'll use ERC-6909 to track multiple items in a game, each having their own unique attributes. All item types will be minted to the deployer of the contract, which we can later transfer to players. We'll also use the xref:api:token/ERC6909.adoc#ERC6909Metadata[`ERC6909Metadata`] extension to add decimals to our fungible items (the vanilla ERC-6909 implementation does not have decimals).
 
-For simplicity, we will mint all items in the constructor--however, minting functionality could be added to the contract to mint on demand to players.
+For simplicity, we will mint all items in the constructor -- however, minting functionality could be added to the contract to mint on demand to players.
 
 TIP: For an overview of minting mechanisms, check out xref:erc20-supply.adoc[Creating ERC-20 Supply].
 

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -4,7 +4,7 @@
 
 When calling external addresses from your contract it is unsafe to assume that an address is an externally-owned account (EOA) and not a contract. Attempting to prevent calls from contracts is highly discouraged. It breaks composability, breaks support for smart wallets like Gnosis Safe, and does not provide security since it can be circumvented by calling from a contract constructor.
 
-Although checking that the address has code, `address.code.length > 0`, may seem to differentiate contracts from EOAs, it can only say that an address is currently a contract, and its negation (that an address is not currently a contract) does not imply that the address is an EOA. Some counterexamples are:
+Although checking whether an address has code using `address.code.length > 0` may seem to differentiate contracts from EOAs, it can only say that an address is currently a contract, and its negation (that an address is not currently a contract) does not imply that the address is an EOA. Some counterexamples are:
 
  - address of a contract in construction
  - address where a contract will be created


### PR DESCRIPTION
This PR refines various documentation files by improving clarity, fixing grammatical inconsistencies and typographical mistakes, ensuring consistent formatting.  

### **Changes:**  
#### **1. `.changeset/brave-islands-sparkle.md`**  
- Improved clarity: "proposal ids" → "proposal IDs" in `GovernorSequentialProposalId`.  

#### **2. `.changeset/cyan-taxis-travel.md`**  
- Adjusted phrasing: "bubble up revert data" → "Bubble up revert data" in `Address` module for consistency and added missing dot.  

#### **3. `.changeset/seven-insects-taste.md`**  
- Added missing dot.  

#### **4. `docs/modules/ROOT/pages/backwards-compatibility.adoc`**  
- Improved grammar for more clarity: "although we expect this to be infrequent" → "although we expect this to happen infrequently."  

#### **5. `docs/modules/ROOT/pages/erc20.adoc`**  
- Improved grammar for more clarity "to get the actual `GLD` amount" → "to determine the actual `GLD` amount."  

#### **6. `docs/modules/ROOT/pages/erc6909.adoc`**  
- Corrected a typo: "All item types will by minted" → "All item types will be minted" and "The main goals of ERC-6909" → "The main goal of ERC-6909".
- Added missing spaces in `--`.  

#### **7. `docs/modules/ROOT/pages/faq.adoc`**    
- Improved readability: "Checking that the address has code, `address.code.length > 0`," → "Checking whether an address has code using `address.code.length > 0`."  

PR Checklist
- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
