### PR TITLE
Fix leading-underscore rule for constant variables

### DIFF
--- a/scripts/solhint-custom/index.js
+++ b/scripts/solhint-custom/index.js
@@ -48,8 +48,8 @@ module.exports = [
 
     VariableDeclaration(node) {
       if (node.isDeclaredConst) {
-        // TODO: expand visibility and fix
-        if (node.visibility === 'private' && /^_/.test(node.name)) {
+        // Check all constant variables regardless of visibility
+        if (/^_/.test(node.name)) {
           this.error(node, 'Constant variables should not have leading underscore');
         }
       } else if (node.visibility === 'private' && !/^_/.test(node.name)) {


### PR DESCRIPTION
Fixes #XXXX <!-- Fill in with issue number if one exists -->

## Description

This PR implements the TODO in the solhint-custom/index.js file to expand the leading-underscore rule for constant variables. The rule now checks all constant variables regardless of their visibility, not just private ones.

Previously, the rule only checked private constant variables for leading underscores, but according to the coding standards, no constant variables should have leading underscores regardless of their visibility.

## Changes

- Modified the `leading-underscore` rule in `scripts/solhint-custom/index.js` to check all constant variables for leading underscores, not just private ones
- Removed the TODO comment as the issue is now fixed

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests <!-- No new tests needed as this is a linting rule change -->
- [x] Documentation <!-- No documentation changes needed -->
- [ ] Changeset entry (run `npx changeset add`)