### PR TITLE
Fix typos

### DIFF
--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -7,7 +7,7 @@ Authored by Dennis Peterson and Peter Vessenes
 
 # Introduction
 
-Zeppelin requested that New Alchemy perform an audit of the contracts in their OpenZeppelin library. The OpenZeppelin contracts are a set of contracts intended to be a safe building block for a variety of uses by parties that may not be as sophisticated as the OpenZeppelin team. It is a design goal that the contracts be deployable safely and "as-is".
+Zeppelin requested that New Alchemy perform an audit of the contracts in their OpenZeppelin library. The OpenZeppelin contracts are a set of contracts intended to be a safe building block for a variety of uses by parties that may not be as sophisticated as the OpenZeppelin team. It is a design goal that the contracts to be deployable safely and "as-is".
 
 The contracts are hosted at:
 
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warranties about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug free status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warranties about the utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug free status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 


### PR DESCRIPTION
1. "contracts be deployable safely" → "contracts to be deployable safely"
Old: "It is a design goal that the contracts be deployable safely and 'as-is'."
New: "It is a design goal that the contracts to be deployable safely and 'as-is'."
Reason for change:
The correction ensures proper grammatical structure. "To be" is the correct form when referring to a future state or intended condition.
2. "about utility of the code" → "about the utility of the code"
Old: "The audit makes no statements or warranties about utility of the code, safety of the code..."
New: "The audit makes no statements or warranties about the utility of the code, safety of the code..."
Reason for change:
The definite article "the" is necessary before "utility" to indicate specificity, making the sentence grammatically correct and clearer.