### PR TITLE
Fix Typo and Improve Function Return Type in Initializable.spec

### DIFF
--- a/certora/specs/Initializable.spec
+++ b/certora/specs/Initializable.spec
@@ -12,8 +12,8 @@ methods {
     function nested_reinit_reinit(uint64,uint64) external envfree;
 
     // view
-    function version()      external returns uint64 envfree;
-    function initializing() external returns bool   envfree;
+    function version()      external returns (uint64) envfree;
+    function initializing() external returns (bool)   envfree;
 }
 
 /*
@@ -145,7 +145,7 @@ rule reinitializeEffects() {
     reinitialize@withrevert(n);
     bool success = !lastReverted;
 
-    assert success <=> versionBefore < n, "can only reinitialize to a latter versions";
+    assert success <=> versionBefore < n, "can only reinitialize to a later version";
     assert success => version() == n,     "reinitialize must set version() to n";
 }
 


### PR DESCRIPTION
Grammar Fix in Assertion Message

Changed: "can only reinitialize to a latter versions"
To: "can only reinitialize to a later version"
Reason: The word "latter" is incorrect in this context. "Later" is the correct term for referring to a future version in a sequence. Additionally, "versions" was changed to "version" to align with singular usage.


Wrapped the return types uint64 and bool in parentheses () to improve readability and ensure consistency with Solidity’s function return type formatting.
This change helps maintain clarity, especially when dealing with multiple return values in future modifications.
