### PR TITLE
 Fix Grammar in Warning Message

### DIFF
--- a/scripts/checks/compare-layout.js
+++ b/scripts/checks/compare-layout.js
@@ -15,6 +15,6 @@ for (const name in oldLayout) {
       process.exitCode = 1;
     }
   } else {
-    console.log(`WARNING: ${name} is missing from the current branch`);
+    console.log(`WARNING: ${name} is missing in the current branch`);
   }
 }


### PR DESCRIPTION
File: scripts/checks/compare-layout.js

Updated Warning Message:
Before: console.log(\WARNING: ${name} is missing from the current branch`);`
After: console.log(\WARNING: ${name} is missing in the current branch`);`


Reason for Change
"Missing in" is more appropriate in this context than "missing from" when referring to the absence of an item within a defined scope (the "current branch").
This change ensures better clarity and proper grammatical structure.
