### PR TITLE
Improve error granularity of EnumerableMap behavior tests

### DIFF
--- a/test/utils/structs/EnumerableMap.behavior.js
+++ b/test/utils/structs/EnumerableMap.behavior.js
@@ -172,8 +172,12 @@ function shouldBehaveLikeMap() {
 
       it('missing value', async function () {
         await expect(this.methods.get(this.keyB))
-          .to.be.revertedWithCustomError(this.mock, 'EnumerableMapNonexistentKey')
-          .withArgs(ethers.AbiCoder.defaultAbiCoder().encode([this.keyType], [this.keyB]));
+          .to.be.revertedWithCustomError(this.mock, this.error ?? 'EnumerableMapNonexistentKey')
+          .withArgs(
+            this.key?.memory || this.value?.memory
+              ? this.keyB
+              : ethers.AbiCoder.defaultAbiCoder().encode([this.keyType], [this.keyB]),
+          );
       });
     });
 


### PR DESCRIPTION
Part of the deprecated #5558
Not included in #5568
Necessary for re-using behaviors in the community repo with variants that uses different custom error and key format.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
