### PR TITLE
`ERC2771Context` gas improvements

### DIFF
--- a/.changeset/shy-insects-enjoy.md
+++ b/.changeset/shy-insects-enjoy.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+optimize ERC2771Context

--- a/.changeset/shy-insects-enjoy.md
+++ b/.changeset/shy-insects-enjoy.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-optimize ERC2771Context

--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -55,7 +55,7 @@ abstract contract ERC2771Context is Context {
     function _msgSender() internal view virtual override returns (address) {
         uint256 calldataLength = msg.data.length;
         uint256 contextSuffixLength = _contextSuffixLength();
-        if (isTrustedForwarder(msg.sender) && calldataLength >= contextSuffixLength) {
+        if (calldataLength >= contextSuffixLength && isTrustedForwarder(msg.sender)) {
             return address(bytes20(msg.data[calldataLength - contextSuffixLength:]));
         } else {
             return super._msgSender();
@@ -70,7 +70,7 @@ abstract contract ERC2771Context is Context {
     function _msgData() internal view virtual override returns (bytes calldata) {
         uint256 calldataLength = msg.data.length;
         uint256 contextSuffixLength = _contextSuffixLength();
-        if (isTrustedForwarder(msg.sender) && calldataLength >= contextSuffixLength) {
+        if (calldataLength >= contextSuffixLength && isTrustedForwarder(msg.sender)) {
             return msg.data[:calldataLength - contextSuffixLength];
         } else {
             return super._msgData();

--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -56,7 +56,9 @@ abstract contract ERC2771Context is Context {
         uint256 calldataLength = msg.data.length;
         uint256 contextSuffixLength = _contextSuffixLength();
         if (calldataLength >= contextSuffixLength && isTrustedForwarder(msg.sender)) {
-            return address(bytes20(msg.data[calldataLength - contextSuffixLength:]));
+            unchecked {
+                return address(bytes20(msg.data[calldataLength - contextSuffixLength:]));
+            }
         } else {
             return super._msgSender();
         }
@@ -71,7 +73,9 @@ abstract contract ERC2771Context is Context {
         uint256 calldataLength = msg.data.length;
         uint256 contextSuffixLength = _contextSuffixLength();
         if (calldataLength >= contextSuffixLength && isTrustedForwarder(msg.sender)) {
-            return msg.data[:calldataLength - contextSuffixLength];
+            unchecked {
+                return msg.data[:calldataLength - contextSuffixLength];
+            }
         } else {
             return super._msgData();
         }


### PR DESCRIPTION
Two small changes to `ERC2771Context`:
* check `calldataLength >= contextSuffixLength` before calling `isTrustedForwarder(msg.sender)` so that the condition can short-circuit (useful in the event that `trustedForwarder` is overridden to use storage)
* add `

While I'm here, I'm wondering why the function doesn't revert if `calldataLength >= contextSuffixLength` is `false` but `isTrustedForwarder(msg.sender)` is `true`.  It might seem kind to allow the transaction to through on behalf of the forwarder.  But what if they get used to this convenience and try to call a function with a data signature longer than the 20-byte suffix?  That could have negative consequences, as an invalid message sender would be extracted from the function's un-suffixed calldata.  The forwarder must therefore compare any function's expected calldata length to the suffix length before calling it, ruling out any functions with `bytes` or `string`.  This is not a good interface, so `isTrustedForwarder(msg.sender) && calldataLength < contextSuffixLength` should revert.  A forwarder who wants to call a function normally should encode their own address as the calldata suffix.
