### PR TITLE
Correct grammar typo

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -39,7 +39,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     /**
      * @dev Sets the values for {name} and {symbol}.
      *
-     * All two of these values are immutable: they can only be set once during
+     * Both of these values are immutable: they can only be set once during
      * construction.
      */
     constructor(string memory name_, string memory symbol_) {


### PR DESCRIPTION
#### **Description**  
This pull request corrects a minor grammar typo in the `ERC20.sol` file. No functional changes were made.  

#### **PR Checklist**  
- [ ] Tests
- [x] Documentation
- [ ] Changeset entry