### PR TITLE
Implement ERC-7821 calldata compression in ERC7579Utils

### DIFF
--- a/contracts/account/utils/draft-ERC7579Utils.sol
+++ b/contracts/account/utils/draft-ERC7579Utils.sol
@@ -218,7 +218,9 @@ library ERC7579Utils {
         uint256 value,
         bytes calldata data
     ) private returns (bytes memory) {
-        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        (bool success, bytes memory returndata) = (target == address(0) ? address(this) : target).call{value: value}(
+            data
+        );
         return _validateExecutionMode(index, execType, success, returndata);
     }
 
@@ -229,7 +231,7 @@ library ERC7579Utils {
         address target,
         bytes calldata data
     ) private returns (bytes memory) {
-        (bool success, bytes memory returndata) = target.delegatecall(data);
+        (bool success, bytes memory returndata) = (target == address(0) ? address(this) : target).delegatecall(data);
         return _validateExecutionMode(index, execType, success, returndata);
     }
 

--- a/test/account/utils/draft-ERC7579Utils.test.js
+++ b/test/account/utils/draft-ERC7579Utils.test.js
@@ -2,14 +2,14 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const {
+  CALL_TYPE_CALL,
+  CALL_TYPE_BATCH,
+  CALL_TYPE_DELEGATE,
   EXEC_TYPE_DEFAULT,
   EXEC_TYPE_TRY,
   encodeSingle,
   encodeBatch,
   encodeDelegate,
-  CALL_TYPE_CALL,
-  CALL_TYPE_BATCH,
-  CALL_TYPE_DELEGATE,
   encodeMode,
 } = require('../../helpers/erc7579');
 const { selector } = require('../../helpers/methods');
@@ -28,6 +28,14 @@ const fixture = async () => {
 describe('ERC7579Utils', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
+  });
+
+  it('constants', async function () {
+    await expect(this.utils.$CALLTYPE_SINGLE()).to.eventually.equal(CALL_TYPE_CALL);
+    await expect(this.utils.$CALLTYPE_BATCH()).to.eventually.equal(CALL_TYPE_BATCH);
+    await expect(this.utils.$CALLTYPE_DELEGATECALL()).to.eventually.equal(CALL_TYPE_DELEGATE);
+    await expect(this.utils.$EXECTYPE_DEFAULT()).to.eventually.equal(EXEC_TYPE_DEFAULT);
+    await expect(this.utils.$EXECTYPE_TRY()).to.eventually.equal(EXEC_TYPE_TRY);
   });
 
   describe('execSingle', function () {


### PR DESCRIPTION
ERC-7821 implementation uses the ERC7579Utils library. While ERC-7821 looks like a subset of ERC-7579, it includes a [specific design choice to help compress calldata](https://eips.ethereum.org/EIPS/eip-7821#replacing-address0-with-addressthis) that is not strictly part of ERC-7579.

When asked if it would be fine to add this mechanism to ERC-7579, Konrad (ERC-7579 authors) says:
> Hadrien Croubois, [21/03/2025 09:56]
> [...]. Since we are using the same library for 7821 and 7579 implementations, I was wondering if it would be ok to add the same behavior to 7579.
>> Konrad | rhinestone, [21/03/2025 22:51]
>> I dont see a problem with this but one point to note is that this will cause differing behaviour to existing accounts, so you can't really rely on that feature working across accounts

This PR adds the target rewrite mechanism to be used in both 7821 (where it is required) and 7579 (where is is not mandated, but also not a problem).

---

No need for a changeset entry if this is part of 5.3 audit fixes (unreleased feature).

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Changeset entry (run `npx changeset add`)
