### PR TITLE
Expose binary lookup functions in Checkpoint

### DIFF
--- a/.changeset/three-banks-sing.md
+++ b/.changeset/three-banks-sing.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Rollback previous commit & added wrapper functions instead

--- a/.changeset/tidy-birds-happen.md
+++ b/.changeset/tidy-birds-happen.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Expose binary lookup functions in Checkpoint

--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -50,8 +50,24 @@ library Checkpoints {
      */
     function lowerLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = lowerBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
         return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+    }
+
+    /**
+     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
+     * `high`.
+     *
+     * WARNING: `high` should not be greater than the array's length.
+     */
+    function lowerBinaryLookup(
+        Trace224 storage self,
+        uint32 key,
+        uint256 low,
+        uint256 high
+    ) internal view returns (uint256) {
+        return _lowerBinaryLookup(self._checkpoints, key, low, high);
     }
 
     /**
@@ -60,7 +76,7 @@ library Checkpoints {
      */
     function upperLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = upperBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 
@@ -86,9 +102,25 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
 
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+    }
+
+    /**
+     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
+     * `high`.
+     *
+     * WARNING: `high` should not be greater than the array's length.
+     */
+    function upperBinaryLookup(
+        Trace224 storage self,
+        uint32 key,
+        uint256 low,
+        uint256 high
+    ) internal view returns (uint256) {
+        return _upperBinaryLookup(self._checkpoints, key, low, high);
     }
 
     /**
@@ -168,12 +200,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function upperBinaryLookup(
+    function _upperBinaryLookup(
         Checkpoint224[] storage self,
         uint32 key,
         uint256 low,
         uint256 high
-    ) internal view returns (uint256) {
+    ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key > key) {
@@ -192,12 +224,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function lowerBinaryLookup(
+    function _lowerBinaryLookup(
         Checkpoint224[] storage self,
         uint32 key,
         uint256 low,
         uint256 high
-    ) internal view returns (uint256) {
+    ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key < key) {
@@ -253,8 +285,24 @@ library Checkpoints {
      */
     function lowerLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = lowerBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
         return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+    }
+
+    /**
+     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
+     * `high`.
+     *
+     * WARNING: `high` should not be greater than the array's length.
+     */
+    function lowerBinaryLookup(
+        Trace208 storage self,
+        uint48 key,
+        uint256 low,
+        uint256 high
+    ) internal view returns (uint256) {
+        return _lowerBinaryLookup(self._checkpoints, key, low, high);
     }
 
     /**
@@ -263,7 +311,7 @@ library Checkpoints {
      */
     function upperLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = upperBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 
@@ -289,9 +337,25 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
 
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+    }
+
+    /**
+     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
+     * `high`.
+     *
+     * WARNING: `high` should not be greater than the array's length.
+     */
+    function upperBinaryLookup(
+        Trace208 storage self,
+        uint48 key,
+        uint256 low,
+        uint256 high
+    ) internal view returns (uint256) {
+        return _upperBinaryLookup(self._checkpoints, key, low, high);
     }
 
     /**
@@ -371,12 +435,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function upperBinaryLookup(
+    function _upperBinaryLookup(
         Checkpoint208[] storage self,
         uint48 key,
         uint256 low,
         uint256 high
-    ) internal view returns (uint256) {
+    ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key > key) {
@@ -395,12 +459,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function lowerBinaryLookup(
+    function _lowerBinaryLookup(
         Checkpoint208[] storage self,
         uint48 key,
         uint256 low,
         uint256 high
-    ) internal view returns (uint256) {
+    ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key < key) {
@@ -456,8 +520,24 @@ library Checkpoints {
      */
     function lowerLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = lowerBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
         return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+    }
+
+    /**
+     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
+     * `high`.
+     *
+     * WARNING: `high` should not be greater than the array's length.
+     */
+    function lowerBinaryLookup(
+        Trace160 storage self,
+        uint96 key,
+        uint256 low,
+        uint256 high
+    ) internal view returns (uint256) {
+        return _lowerBinaryLookup(self._checkpoints, key, low, high);
     }
 
     /**
@@ -466,7 +546,7 @@ library Checkpoints {
      */
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = upperBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 
@@ -492,9 +572,25 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
 
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+    }
+
+    /**
+     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
+     * `high`.
+     *
+     * WARNING: `high` should not be greater than the array's length.
+     */
+    function upperBinaryLookup(
+        Trace160 storage self,
+        uint96 key,
+        uint256 low,
+        uint256 high
+    ) internal view returns (uint256) {
+        return _upperBinaryLookup(self._checkpoints, key, low, high);
     }
 
     /**
@@ -574,12 +670,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function upperBinaryLookup(
+    function _upperBinaryLookup(
         Checkpoint160[] storage self,
         uint96 key,
         uint256 low,
         uint256 high
-    ) internal view returns (uint256) {
+    ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key > key) {
@@ -598,12 +694,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function lowerBinaryLookup(
+    function _lowerBinaryLookup(
         Checkpoint160[] storage self,
         uint96 key,
         uint256 low,
         uint256 high
-    ) internal view returns (uint256) {
+    ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key < key) {

--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -50,7 +50,7 @@ library Checkpoints {
      */
     function lowerLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = lowerBinaryLookup(self._checkpoints, key, 0, len);
         return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
     }
 
@@ -60,7 +60,7 @@ library Checkpoints {
      */
     function upperLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = upperBinaryLookup(self._checkpoints, key, 0, len);
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 
@@ -86,7 +86,7 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 pos = upperBinaryLookup(self._checkpoints, key, low, high);
 
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
@@ -168,12 +168,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function _upperBinaryLookup(
+    function upperBinaryLookup(
         Checkpoint224[] storage self,
         uint32 key,
         uint256 low,
         uint256 high
-    ) private view returns (uint256) {
+    ) internal view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key > key) {
@@ -192,12 +192,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function _lowerBinaryLookup(
+    function lowerBinaryLookup(
         Checkpoint224[] storage self,
         uint32 key,
         uint256 low,
         uint256 high
-    ) private view returns (uint256) {
+    ) internal view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key < key) {
@@ -253,7 +253,7 @@ library Checkpoints {
      */
     function lowerLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = lowerBinaryLookup(self._checkpoints, key, 0, len);
         return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
     }
 
@@ -263,7 +263,7 @@ library Checkpoints {
      */
     function upperLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = upperBinaryLookup(self._checkpoints, key, 0, len);
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 
@@ -289,7 +289,7 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 pos = upperBinaryLookup(self._checkpoints, key, low, high);
 
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
@@ -371,12 +371,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function _upperBinaryLookup(
+    function upperBinaryLookup(
         Checkpoint208[] storage self,
         uint48 key,
         uint256 low,
         uint256 high
-    ) private view returns (uint256) {
+    ) internal view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key > key) {
@@ -395,12 +395,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function _lowerBinaryLookup(
+    function lowerBinaryLookup(
         Checkpoint208[] storage self,
         uint48 key,
         uint256 low,
         uint256 high
-    ) private view returns (uint256) {
+    ) internal view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key < key) {
@@ -456,7 +456,7 @@ library Checkpoints {
      */
     function lowerLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = lowerBinaryLookup(self._checkpoints, key, 0, len);
         return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
     }
 
@@ -466,7 +466,7 @@ library Checkpoints {
      */
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        uint256 pos = upperBinaryLookup(self._checkpoints, key, 0, len);
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
 
@@ -492,7 +492,7 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 pos = upperBinaryLookup(self._checkpoints, key, low, high);
 
         return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
     }
@@ -574,12 +574,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function _upperBinaryLookup(
+    function upperBinaryLookup(
         Checkpoint160[] storage self,
         uint96 key,
         uint256 low,
         uint256 high
-    ) private view returns (uint256) {
+    ) internal view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key > key) {
@@ -598,12 +598,12 @@ library Checkpoints {
      *
      * WARNING: `high` should not be greater than the array's length.
      */
-    function _lowerBinaryLookup(
+    function lowerBinaryLookup(
         Checkpoint160[] storage self,
         uint96 key,
         uint256 low,
         uint256 high
-    ) private view returns (uint256) {
+    ) internal view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
             if (_unsafeAccess(self, mid)._key < key) {

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -55,8 +55,24 @@ function push(
  */
 function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
-    uint256 pos = lowerBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
+    uint256 pos = _lowerBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
     return pos == len ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos).${opts.valueFieldName};
+}
+
+/**
+ * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or \`high\`
+ * if there is none. \`low\` and \`high\` define a section where to do the search, with inclusive \`low\` and exclusive
+ * \`high\`.
+ *
+ * WARNING: \`high\` should not be greater than the array's length.
+ */
+function lowerBinaryLookup(
+    ${opts.historyTypeName} storage self,
+    ${opts.keyTypeName} key,
+    uint256 low,
+    uint256 high
+) internal view returns (uint256) {
+    return _lowerBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 }
 
 /**
@@ -65,7 +81,7 @@ function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
  */
 function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
-    uint256 pos = upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
+    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
     return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
 }
 
@@ -91,9 +107,25 @@ function upperLookupRecent(${opts.historyTypeName} storage self, ${opts.keyTypeN
         }
     }
 
-    uint256 pos = upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
+    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 
     return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
+}
+
+/**
+ * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or \`high\`
+ * if there is none. \`low\` and \`high\` define a section where to do the search, with inclusive \`low\` and exclusive
+ * \`high\`.
+ *
+ * WARNING: \`high\` should not be greater than the array's length.
+ */
+function upperBinaryLookup(
+    ${opts.historyTypeName} storage self,
+    ${opts.keyTypeName} key,
+    uint256 low,
+    uint256 high
+) internal view returns (uint256) {
+    return _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 }
 
 /**
@@ -173,12 +205,12 @@ function _insert(
  *
  * WARNING: \`high\` should not be greater than the array's length.
  */
-function upperBinaryLookup(
+function _upperBinaryLookup(
     ${opts.checkpointTypeName}[] storage self,
     ${opts.keyTypeName} key,
     uint256 low,
     uint256 high
-) internal view returns (uint256) {
+) private view returns (uint256) {
     while (low < high) {
         uint256 mid = Math.average(low, high);
         if (_unsafeAccess(self, mid).${opts.keyFieldName} > key) {
@@ -197,12 +229,12 @@ function upperBinaryLookup(
  *
  * WARNING: \`high\` should not be greater than the array's length.
  */
-function lowerBinaryLookup(
+function _lowerBinaryLookup(
     ${opts.checkpointTypeName}[] storage self,
     ${opts.keyTypeName} key,
     uint256 low,
     uint256 high
-) internal view returns (uint256) {
+) private view returns (uint256) {
     while (low < high) {
         uint256 mid = Math.average(low, high);
         if (_unsafeAccess(self, mid).${opts.keyFieldName} < key) {

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -55,7 +55,7 @@ function push(
  */
 function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
-    uint256 pos = _lowerBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
+    uint256 pos = lowerBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
     return pos == len ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos).${opts.valueFieldName};
 }
 
@@ -65,7 +65,7 @@ function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
  */
 function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
-    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
+    uint256 pos = upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
     return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
 }
 
@@ -91,7 +91,7 @@ function upperLookupRecent(${opts.historyTypeName} storage self, ${opts.keyTypeN
         }
     }
 
-    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
+    uint256 pos = upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 
     return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
 }
@@ -173,12 +173,12 @@ function _insert(
  *
  * WARNING: \`high\` should not be greater than the array's length.
  */
-function _upperBinaryLookup(
+function upperBinaryLookup(
     ${opts.checkpointTypeName}[] storage self,
     ${opts.keyTypeName} key,
     uint256 low,
     uint256 high
-) private view returns (uint256) {
+) internal view returns (uint256) {
     while (low < high) {
         uint256 mid = Math.average(low, high);
         if (_unsafeAccess(self, mid).${opts.keyFieldName} > key) {
@@ -197,12 +197,12 @@ function _upperBinaryLookup(
  *
  * WARNING: \`high\` should not be greater than the array's length.
  */
-function _lowerBinaryLookup(
+function lowerBinaryLookup(
     ${opts.checkpointTypeName}[] storage self,
     ${opts.keyTypeName} key,
     uint256 low,
     uint256 high
-) private view returns (uint256) {
+) internal view returns (uint256) {
     while (low < high) {
         uint256 mid = Math.average(low, high);
         if (_unsafeAccess(self, mid).${opts.keyFieldName} < key) {


### PR DESCRIPTION
Fixes #5608

## Changes

1. Added `upperBinaryLookup` function
2. Added `lowerBinaryLookup` function

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
