### PR TITLE
Add Ownable2StepSign

### DIFF
--- a/.changeset/witty-ducks-cross.md
+++ b/.changeset/witty-ducks-cross.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': major
+---
+
+`Ownable2StepSign`: Introduce Ownable2Step extension which allows for implicit ownership acceptance via signature.

--- a/contracts/access/Ownable2StepSign.sol
+++ b/contracts/access/Ownable2StepSign.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Ownable2Step} from "./Ownable2Step.sol";
+import {ECDSA} from "../utils/cryptography/ECDSA.sol";
+import {EIP712} from "../utils/cryptography/EIP712.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * This extension of the {Ownable2Step}, which is an extension of {Ownable} contract,
+ * includes a signature protected ownership transfer mechanism,
+ * where the `newOwner` must provide a signature in order to replace the
+ * old one. This can help prevent common mistakes, such as transfers of ownership to
+ * incorrect accounts, and keep the `newOwner` wallet safer, as it can stay offline at a time.
+ * Function `transferOwnership` available through {Ownable2Step} provides a safe way of making
+ * an ownership transfer to a contract.
+ *
+ * The initial owner is specified at deployment time in the constructor for `Ownable`. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available all functions
+ * from parents (Ownable2Step and Ownable).
+ */
+abstract contract Ownable2StepSign is Ownable2Step, EIP712 {
+    /**
+     * @dev Nonce used for signatures.
+     */
+    uint256 private _nonce;
+
+    bytes32 private constant TRANSFER_OWNERSHIP_TYPEHASH =
+        keccak256("TransferOwnership(uint256 nonce,uint256 deadline)");
+
+    /**
+     * @dev Permit deadline has expired.
+     */
+    error ExpiredSignature(uint256 deadline);
+
+    /**
+     * @dev Mismatched signature.
+     */
+    error InvalidSigner(address signer, address newOwner);
+
+    constructor(string memory name) EIP712(name, "1") {}
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     * Requires a `newOwner` account's signature.
+     */
+    function transferOwnership(
+        address newOwner,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual onlyOwner {
+        if (block.timestamp > deadline) {
+            revert ExpiredSignature(deadline);
+        }
+
+        bytes32 hash = _hashTypedDataV4(keccak256(abi.encode(TRANSFER_OWNERSHIP_TYPEHASH, _useNonce(), deadline)));
+
+        address signer = ECDSA.recover(hash, v, r, s);
+        if (signer != newOwner) {
+            revert InvalidSigner(signer, newOwner);
+        }
+
+        super._transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Consumes a nonce.
+     *
+     * Returns the current value and increments nonce.
+     */
+    function _useNonce() internal virtual returns (uint256) {
+        // Flow guarantees that the nonce never overflows.
+        unchecked {
+            // It is important to do x++ and not ++x here.
+            return _nonce++;
+        }
+    }
+
+    /**
+     * @dev Returns the next unused nonce.
+     */
+    function nonce() public view virtual returns (uint256) {
+        return _nonce;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+}

--- a/test/access/Ownable2StepSign.t.sol
+++ b/test/access/Ownable2StepSign.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {Ownable2StepSign} from "@openzeppelin/contracts/access/Ownable2StepSign.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+contract Ownable2StepSignMock is Ownable2StepSign {
+    bytes32 private constant TRANSFER_OWNERSHIP_TYPEHASH =
+        keccak256("TransferOwnership(uint256 nonce,uint256 deadline)");
+
+    constructor(address initialOwner) Ownable2StepSign("Ownable2StepSign") Ownable(initialOwner) {}
+
+    function computeHash(uint256 nonce, uint256 deadline) external view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(TRANSFER_OWNERSHIP_TYPEHASH, nonce, deadline)));
+    }
+}
+
+contract Ownable2StepSignTest is Test {
+    address private constant INITIAL_OWNER = address(1);
+    Ownable2StepSignMock private ownable2StepSignMock;
+    Vm.Wallet private newOwner;
+
+    function setUp() external {
+        ownable2StepSignMock = new Ownable2StepSignMock(INITIAL_OWNER);
+        newOwner = vm.createWallet("newOwner");
+        assertEq(ownable2StepSignMock.owner(), INITIAL_OWNER);
+    }
+
+    function testTransferOwnership() public {
+        uint256 deadline = block.timestamp;
+        uint256 nonce = 0;
+
+        bytes32 hash = ownable2StepSignMock.computeHash(nonce, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newOwner, hash);
+
+        vm.prank(INITIAL_OWNER);
+        ownable2StepSignMock.transferOwnership(newOwner.addr, deadline, v, r, s);
+
+        assertEq(ownable2StepSignMock.owner(), newOwner.addr);
+        assertEq(ownable2StepSignMock.nonce(), nonce + 1);
+    }
+
+    function testTransferOwnershipDeletesPendingOwner() external {
+        vm.prank(INITIAL_OWNER);
+        ownable2StepSignMock.transferOwnership(address(2));
+        assertEq(ownable2StepSignMock.pendingOwner(), address(2));
+
+        testTransferOwnership();
+
+        assertEq(ownable2StepSignMock.pendingOwner(), address(0));
+    }
+
+    function testRevertWhenUnauthorizedCallIsMadeToTransferOwnership() external {
+        uint256 deadline = block.timestamp;
+        uint256 nonce = 0;
+        address unauthorizedCaller = address(2);
+
+        bytes32 hash = ownable2StepSignMock.computeHash(nonce, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newOwner, hash);
+
+        vm.prank(unauthorizedCaller);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, unauthorizedCaller));
+        ownable2StepSignMock.transferOwnership(newOwner.addr, deadline, v, r, s);
+    }
+
+    function testRevertTransferOwnershipWhenSignatureExpires() external {
+        uint256 deadline = block.timestamp - 1;
+        uint256 nonce = 0;
+
+        bytes32 hash = ownable2StepSignMock.computeHash(nonce, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newOwner, hash);
+
+        vm.prank(INITIAL_OWNER);
+        vm.expectRevert(abi.encodeWithSelector(Ownable2StepSign.ExpiredSignature.selector, deadline));
+        ownable2StepSignMock.transferOwnership(newOwner.addr, deadline, v, r, s);
+    }
+
+    function testRevertTransferOwnershipWhenSignatureIsInvalid() external {
+        Vm.Wallet memory falseSigner = vm.createWallet("falseSigner");
+        uint256 deadline = block.timestamp;
+        uint256 nonce = 0;
+
+        bytes32 hash = ownable2StepSignMock.computeHash(nonce, deadline);
+        // Data is valid but signed by an inadequate wallet.
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(falseSigner, hash);
+
+        vm.prank(INITIAL_OWNER);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable2StepSign.InvalidSigner.selector, falseSigner.addr, newOwner.addr)
+        );
+        ownable2StepSignMock.transferOwnership(newOwner.addr, deadline, v, r, s);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR contains an extension of `Ownable2Step`, that I found useful for the following reasons:
- Reduces the amount of needed transactions for execution of an ownership transfer from 2 to 1 (for EOAs), while keeping the same level of protection as present in `Ownable2Step`.
- Provides an additional level of safety to the `newOwner` wallet at the time of the ownership transfer, as it can stay offline and therefore reduce the potential security threats.

Ownership over the `newOwner` EOA, as well as the acceptance of ownership transfer are proved via signature.
Call for an ownership transfer must be made by the current owner (as per usual), with the signature provided by the `newOwner`.

Support for 2step ownership transfer to contracts is inherited from `Ownable2Step`.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
