### PR TITLE
 remove $ prompt symbols from installation commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install @openzeppelin/contracts
 > Foundry installs the latest version initially, but subsequent `forge update` commands will use the `master` branch.
 
 ```
-$ forge install OpenZeppelin/openzeppelin-contracts
+forge install OpenZeppelin/openzeppelin-contracts
 ```
 
 Add `@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/` in `remappings.txt.`


### PR DESCRIPTION

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #5638

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR removes the `$` prompt symbols from the installation commands in the README to make them directly copy-pasteable. When users try to copy-paste commands that start with `$`, they need to manually remove this character, which creates an unnecessary inconvenience.

Changes:
- Removed `$` from `npm install @openzeppelin/contracts` command
- Removed `$` from `forge install OpenZeppelin/openzeppelin-contracts` command

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests (N/A - documentation change only)
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)

