### PR TITLE
Add missing `id-token: write` permission in release pipeline

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -131,6 +131,7 @@ jobs:
     environment: npm
     permissions:
       contents: write
+      id-token: write
     if: needs.state.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -153,6 +154,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TARBALL: ${{ steps.pack.outputs.tarball }}
           TAG: ${{ steps.pack.outputs.tag }}
+          NPM_CONFIG_PROVENANCE: true
       - name: Create Github Release
         uses: actions/github-script@v7
         env:

--- a/scripts/release/workflow/publish.sh
+++ b/scripts/release/workflow/publish.sh
@@ -9,7 +9,7 @@ PACKAGE_JSON_VERSION="$(tar xfO "$TARBALL" package/package.json | jq -r .version
 echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 # Actual publish
-npm publish --provenance "$TARBALL" --tag "$TAG"
+npm publish "$TARBALL" --tag "$TAG"
 
 # Clean up tags
 delete_tag() {


### PR DESCRIPTION
This PR addresses https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5644#pullrequestreview-2783361729:
- Give the CI pipeline the permission to mint an OIDC token,
- Put the provenance flag into the environmental variable.