### PR TITLE
Fix broken .adoc links by adding pages/ prefix in nav.adoc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,24 +1,24 @@
-* xref:index.adoc[Overview]
-* xref:wizard.adoc[Wizard]
-* xref:extending-contracts.adoc[Extending Contracts]
-* xref:upgradeable.adoc[Using with Upgrades]
+* xref:pages/index.adoc[Overview]
+* xref:pages/wizard.adoc[Wizard]
+* xref:pages/extending-contracts.adoc[Extending Contracts]
+* xref:pages/upgradeable.adoc[Using with Upgrades]
 
-* xref:backwards-compatibility.adoc[Backwards Compatibility]
+* xref:pages/backwards-compatibility.adoc[Backwards Compatibility]
 
-* xref:access-control.adoc[Access Control]
+* xref:pages/access-control.adoc[Access Control]
 
-* xref:tokens.adoc[Tokens]
-** xref:erc20.adoc[ERC-20]
-*** xref:erc20-supply.adoc[Creating Supply]
-** xref:erc721.adoc[ERC-721]
-** xref:erc1155.adoc[ERC-1155]
-** xref:erc4626.adoc[ERC-4626]
-** xref:erc6909.adoc[ERC-6909]
+* xref:pages/tokens.adoc[Tokens]
+** xref:pages/erc20.adoc[ERC-20]
+*** xref:pages/erc20-supply.adoc[Creating Supply]
+** xref:pages/erc721.adoc[ERC-721]
+** xref:pages/erc1155.adoc[ERC-1155]
+** xref:pages/erc4626.adoc[ERC-4626]
+** xref:pages/erc6909.adoc[ERC-6909]
 
-* xref:governance.adoc[Governance]
+* xref:pages/governance.adoc[Governance]
 
-* xref:utilities.adoc[Utilities]
+* xref:pages/utilities.adoc[Utilities]
 
-* xref:subgraphs::index.adoc[Subgraphs]
+* xref:subgraphs::pages/index.adoc[Subgraphs]
 
-* xref:faq.adoc[FAQ]
+* xref:pages/faq.adoc[FAQ]


### PR DESCRIPTION
This PR fixes all broken internal documentation links in docs/modules/ROOT/nav.adoc by adding the correct pages/ directory prefix.
