### PR TITLE
Minimize Interface Pragmas

### DIFF
--- a/contracts/governance/utils/IVotes.sol
+++ b/contracts/governance/utils/IVotes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (governance/utils/IVotes.sol)
-pragma solidity ^0.8.20;
+pragma solidity >= 0.8.4;
 
 /**
  * @dev Common interface for {ERC20Votes}, {ERC721Votes}, and other {Votes}-enabled contracts.

--- a/contracts/interfaces/IERC1155.sol
+++ b/contracts/interfaces/IERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1155.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC1155} from "../token/ERC1155/IERC1155.sol";

--- a/contracts/interfaces/IERC1155MetadataURI.sol
+++ b/contracts/interfaces/IERC1155MetadataURI.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1155MetadataURI.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC1155MetadataURI} from "../token/ERC1155/extensions/IERC1155MetadataURI.sol";

--- a/contracts/interfaces/IERC1155Receiver.sol
+++ b/contracts/interfaces/IERC1155Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1155Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC1155Receiver} from "../token/ERC1155/IERC1155Receiver.sol";

--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/IERC1271.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.9;
 
 /**
  * @dev Interface of the ERC-1271 standard signature validation method for

--- a/contracts/interfaces/IERC1363.sol
+++ b/contracts/interfaces/IERC1363.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC20} from "./IERC20.sol";
 import {IERC165} from "./IERC165.sol";

--- a/contracts/interfaces/IERC1363Receiver.sol
+++ b/contracts/interfaces/IERC1363Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @title IERC1363Receiver

--- a/contracts/interfaces/IERC1363Spender.sol
+++ b/contracts/interfaces/IERC1363Spender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363Spender.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @title IERC1363Spender

--- a/contracts/interfaces/IERC165.sol
+++ b/contracts/interfaces/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 import {IERC165} from "../utils/introspection/IERC165.sol";

--- a/contracts/interfaces/IERC1820Implementer.sol
+++ b/contracts/interfaces/IERC1820Implementer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1820Implementer.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface for an ERC-1820 implementer, as defined in the

--- a/contracts/interfaces/IERC1820Registry.sol
+++ b/contracts/interfaces/IERC1820Registry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1820Registry.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the global ERC-1820 Registry, as defined in the

--- a/contracts/interfaces/IERC1967.sol
+++ b/contracts/interfaces/IERC1967.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1967.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev ERC-1967: Proxy Storage Slots. This interface contains the events defined in the ERC.

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 import {IERC20} from "../token/ERC20/IERC20.sol";

--- a/contracts/interfaces/IERC20Metadata.sol
+++ b/contracts/interfaces/IERC20Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC20Metadata} from "../token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/interfaces/IERC2309.sol
+++ b/contracts/interfaces/IERC2309.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC2309.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev ERC-2309: ERC-721 Consecutive Transfer Extension.

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC2612.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC20Permit} from "../token/ERC20/extensions/IERC20Permit.sol";
 

--- a/contracts/interfaces/IERC2981.sol
+++ b/contracts/interfaces/IERC2981.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC2981.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC165} from "../utils/introspection/IERC165.sol";
 

--- a/contracts/interfaces/IERC3156.sol
+++ b/contracts/interfaces/IERC3156.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC3156.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.8.20;
 
 import {IERC3156FlashBorrower} from "./IERC3156FlashBorrower.sol";
 import {IERC3156FlashLender} from "./IERC3156FlashLender.sol";

--- a/contracts/interfaces/IERC3156FlashBorrower.sol
+++ b/contracts/interfaces/IERC3156FlashBorrower.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC3156FlashBorrower.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-3156 FlashBorrower, as defined in

--- a/contracts/interfaces/IERC3156FlashLender.sol
+++ b/contracts/interfaces/IERC3156FlashLender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC3156FlashLender.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 import {IERC3156FlashBorrower} from "./IERC3156FlashBorrower.sol";
 

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/IERC4626.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC20} from "../token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "../token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/interfaces/IERC4906.sol
+++ b/contracts/interfaces/IERC4906.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC4906.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC165} from "./IERC165.sol";
 import {IERC721} from "./IERC721.sol";

--- a/contracts/interfaces/IERC5267.sol
+++ b/contracts/interfaces/IERC5267.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 interface IERC5267 {
     /**

--- a/contracts/interfaces/IERC5313.sol
+++ b/contracts/interfaces/IERC5313.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5313.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface for the Light Contract Ownership Standard.

--- a/contracts/interfaces/IERC5805.sol
+++ b/contracts/interfaces/IERC5805.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5805.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.8.4;
 
 import {IVotes} from "../governance/utils/IVotes.sol";
 import {IERC6372} from "./IERC6372.sol";

--- a/contracts/interfaces/IERC6372.sol
+++ b/contracts/interfaces/IERC6372.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC6372.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 interface IERC6372 {
     /**

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC721} from "../token/ERC721/IERC721.sol";

--- a/contracts/interfaces/IERC721Enumerable.sol
+++ b/contracts/interfaces/IERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721Enumerable.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC721Enumerable} from "../token/ERC721/extensions/IERC721Enumerable.sol";

--- a/contracts/interfaces/IERC721Metadata.sol
+++ b/contracts/interfaces/IERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC721Metadata} from "../token/ERC721/extensions/IERC721Metadata.sol";

--- a/contracts/interfaces/IERC721Receiver.sol
+++ b/contracts/interfaces/IERC721Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 import {IERC721Receiver} from "../token/ERC721/IERC721Receiver.sol";

--- a/contracts/interfaces/IERC777.sol
+++ b/contracts/interfaces/IERC777.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC777.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-777 Token standard as defined in the ERC.

--- a/contracts/interfaces/IERC777Recipient.sol
+++ b/contracts/interfaces/IERC777Recipient.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC777Recipient.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-777 Tokens Recipient standard as defined in the ERC.

--- a/contracts/interfaces/IERC777Sender.sol
+++ b/contracts/interfaces/IERC777Sender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC777Sender.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-777 Tokens Sender standard as defined in the ERC.

--- a/contracts/token/ERC1155/IERC1155.sol
+++ b/contracts/token/ERC1155/IERC1155.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (token/ERC1155/IERC1155.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC165} from "../../utils/introspection/IERC165.sol";
 

--- a/contracts/token/ERC1155/IERC1155Receiver.sol
+++ b/contracts/token/ERC1155/IERC1155Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC1155/IERC1155Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC165} from "../../utils/introspection/IERC165.sol";
 

--- a/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol
+++ b/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC1155/extensions/IERC1155MetadataURI.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC1155} from "../IERC1155.sol";
 

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-20 standard as defined in the ERC.

--- a/contracts/token/ERC20/extensions/IERC20Metadata.sol
+++ b/contracts/token/ERC20/extensions/IERC20Metadata.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC20} from "../IERC20.sol";
 

--- a/contracts/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/IERC20Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC721/IERC721.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC165} from "../../utils/introspection/IERC165.sol";
 

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC721/IERC721Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @title ERC-721 token receiver interface

--- a/contracts/token/ERC721/extensions/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/IERC721Enumerable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/extensions/IERC721Enumerable.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC721} from "../IERC721.sol";
 

--- a/contracts/token/ERC721/extensions/IERC721Metadata.sol
+++ b/contracts/token/ERC721/extensions/IERC721Metadata.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/extensions/IERC721Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.6.2;
 
 import {IERC721} from "../IERC721.sol";
 

--- a/contracts/utils/introspection/IERC165.sol
+++ b/contracts/utils/introspection/IERC165.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >= 0.5.0;
 
 /**
  * @dev Interface of the ERC-165 standard, as defined in the

--- a/scripts/maximize-pragma.js
+++ b/scripts/maximize-pragma.js
@@ -1,0 +1,119 @@
+const { exec } = require('child_process');
+const fs = require('fs');
+const { hideBin } = require('yargs/helpers');
+const { argv } = require('yargs/yargs')(hideBin(process.argv)).positional('file', {
+  type: 'string',
+  describe: 'The contract to set pragma for',
+});
+
+let solcVersionsMaxPatch = ['0.5.16', '0.6.12', '0.7.6', '0.8.29'];
+const allSolcVersions = solcVersionsMaxPatch.flatMap(minorVersion => {
+  let patchVersions = [];
+  const maxPatchVersion = parseInt(minorVersion.split('.')[2]);
+  const minorVersionWithoutPatch = minorVersion.split('.').slice(0, 2).join('.');
+  for (let i = 0; i <= maxPatchVersion; i++) {
+    patchVersions.push(`${minorVersionWithoutPatch}.${i}`);
+  }
+  return patchVersions;
+});
+
+temp('contracts/interfaces/IERC721.sol');
+
+async function main() {
+  console.log(await Promise.all(allSolcVersions.map(version => compileWithVersion(argv.file, version))));
+}
+
+async function getApplicablePragmas(file) {
+  const pragmas = await Promise.all(allSolcVersions.map(version => compileWithVersion(file, version)));
+  return pragmas;
+}
+
+async function temp(file) {
+  const sources = getFileSources(file);
+
+  console.log(mergePragmaLists(await getApplicablePragmas(file), await getParentApplicablePragmas(sources)));
+}
+
+async function getParentApplicablePragmas(parents) {
+  let pragmas;
+  for (const parent of parents) {
+    if (pragmas === undefined) {
+      pragmas = await getApplicablePragmas(parent);
+    } else {
+      pragmas = mergePragmaLists(pragmas, await getApplicablePragmas(parent));
+    }
+  }
+  return pragmas;
+}
+
+async function compileWithVersion(file, solcVersion) {
+  return new Promise(resolve => {
+    exec(`forge build ${file} --ast --use ${solcVersion} --out out/out-solc${solcVersion}`, error => {
+      if (error !== null) {
+        return resolve({ solcVersion, success: false });
+      }
+      return resolve({ solcVersion, success: true });
+    });
+  });
+}
+
+async function updateAllInterfacePragmas(newPragma) {
+  const dirPath = 'contracts/interfaces';
+  const files = fs.readdirSync(dirPath);
+  for (const file of files) {
+    if (!file.endsWith('.sol')) {
+      continue;
+    }
+    await updatePragmaWithDependencies(`${dirPath}/${file}`, newPragma);
+  }
+}
+
+function getFileSources(file) {
+  const contractName = file.split('/').at(-1);
+
+  const jsonOutput = JSON.parse(fs.readFileSync(`out/${contractName}/${contractName.split('.')[0]}.json`));
+  if (jsonOutput.metadata === undefined || jsonOutput.metadata.sources === undefined) {
+    return [];
+  }
+
+  const sources = Object.keys(
+    JSON.parse(fs.readFileSync(`out/${contractName}/${contractName.split('.')[0]}.json`)).metadata.sources,
+  );
+  return sources.filter(source => source !== file);
+}
+
+async function updatePragma(file, newPragma) {
+  let fileContent = fs.readFileSync(file, 'utf8').split('\n');
+  const pragmaLineIndex = fileContent.findIndex(line => line.startsWith('pragma solidity'));
+  fileContent[pragmaLineIndex] = `pragma solidity ${newPragma};`;
+
+  fs.writeFileSync(file, fileContent.join('\n'), 'utf8');
+  console.log(`Updated pragma in ${file}`);
+}
+
+async function updatePragmaWithDependencies(file, newPragma) {
+  updatePragma(file, newPragma);
+
+  const sources = getFileSources(file);
+
+  for (const source of sources) {
+    if (source !== file && !source.split('.').at(-1).startsWith('draft')) {
+      await updatePragmaWithDependencies(source, newPragma);
+    }
+  }
+}
+
+function mergePragmaLists(pragmaList1, pragmaList2) {
+  if (pragmaList1 === undefined || pragmaList2 === undefined) return pragmaList1 ?? pragmaList2;
+
+  let res = [];
+
+  const versions = pragmaList1.map(item => item.solcVersion);
+  for (const version of versions) {
+    const success1 = pragmaList1.find(item => item.solcVersion === version)?.success;
+    const success2 = pragmaList2.find(item => item.solcVersion === version)?.success;
+    res.push({ solcVersion: version, success: (success1 ?? false) && (success2 ?? false) });
+  }
+
+  return res;
+}


### PR DESCRIPTION
The pragmas specified on interfaces are generally way more restrictive than necessary. Given that interfaces don't actually have any related bytecode, we just need to ensure that an interface can compile with lower solc versions--we should set the pragmas to be as permissive as possible to allow consumers to use the interfaces in as many ways as possible.