### PR TITLE
Updated `SignatureChecker` NatSpec to better reflect EIP-7702 behavior

### DIFF
--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -13,8 +13,8 @@ import {IERC1271} from "../../interfaces/IERC1271.sol";
  */
 library SignatureChecker {
     /**
-     * @dev Checks if a signature is valid for a given signer and data hash. If the signer is a smart contract, the
-     * signature is validated against that smart contract using ERC-1271, otherwise it's validated using `ECDSA.recover`.
+     * @dev Checks if a signature is valid for a given signer and data hash. If the signer has code, the
+     * signature is validated against it using ERC-1271, otherwise it's validated using `ECDSA.recover`.
      *
      * NOTE: Unlike ECDSA signatures, contract signatures are revocable, and the outcome of this function can thus
      * change through time. It could return true at block N and false at block N+1 (or the opposite).


### PR DESCRIPTION
As already acknowledged in PR https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4951 and issue https://github.com/OpenZeppelin/openzeppelin-contracts/issues/4855, `SignatureChecker.isValidSignatureNow` validates signatures via `ERC-1271` instead of `ECDSA recover` for any signer that has code. This is enforced by design and the justification can found in the mentioned issue.

This NatSpec slight change has the objective of making it more explicit in the context of [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) EOA's delegations, where the EOA get's Smart Contract code associated, and therefore `ERC-1271` verifications apply.