### PR TITLE
docs: remove crowdsales in 'README.md'

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To keep your system secure, you should **always** use the installed code as-is, 
 The guides in the [documentation site](https://docs.openzeppelin.com/contracts) will teach about different concepts, and how to use the related contracts that OpenZeppelin Contracts provides:
 
 * [Access Control](https://docs.openzeppelin.com/contracts/access-control): decide who can perform each of the actions on your system.
-* [Tokens](https://docs.openzeppelin.com/contracts/tokens): create tradeable assets or collectives, and distribute them via [Crowdsales](https://docs.openzeppelin.com/contracts/crowdsales).
+* [Tokens](https://docs.openzeppelin.com/contracts/tokens): create tradeable assets or collectives.
 * [Utilities](https://docs.openzeppelin.com/contracts/utilities): generic useful tools including non-overflowing math, signature verification, and trustless paying systems.
 
 The [full API](https://docs.openzeppelin.com/contracts/api/token/ERC20) is also thoroughly documented, and serves as a great reference when developing your smart contract application. You can also ask for help or follow Contracts' development in the [community forum](https://forum.openzeppelin.com).


### PR DESCRIPTION
Hi! I removes the outdated reference to Crowdsales in the README. Since Crowdsales are no longer maintained, this change helps keep the documentation accurate and up to date. ref: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2116


---

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)