### PR TITLE
feat: add ERC7572 interface for contracts that expose contract level metadata

### DIFF
--- a/.changeset/fluffy-bananas-add.md
+++ b/.changeset/fluffy-bananas-add.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Add draft ERC-7572 interface

--- a/contracts/interfaces/draft-IERC7572.sol
+++ b/contracts/interfaces/draft-IERC7572.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.3.0) (interfaces/draft-IERC7572.sol)
+
+pragma solidity ^0.8.20;
+
+/// @title ERC-7572 Contract Level Metadata
+/// @dev Required interface of an ERC-7572 compliant contract, as defined in the
+/// https://eips.ethereum.org/EIPS/eip-7572[ERC].
+interface IERC7572 {
+
+  /// @dev This event should be emitted on updates to the contract metadata 
+  /// to indicate to offchain indexers that they should query the contract
+  /// for the latest URI.
+  event ContractURIUpdated();
+
+  /// @dev Returns an offchain resource for contract metadata or onchain JSON
+  /// data string (data:application/json;utf8,{}).
+  function contractURI() external view returns (string memory);
+}


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
This PR introduces the interface for [draft ERC-7572](https://eips.ethereum.org/EIPS/eip-7572) to the set of interfaces in the package.

<!-- Include any context necessary for understanding the PR's purpose. -->
This interface is useful for contracts (particularly tokens) that wish to expose a set of metadata for the contract including icon, banner image, description, external url, etc. 

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests (No tests are necessary as this is purely an interface spec)
- [x] Documentation (Natspec documentation is applied to the added interface)
- [x] Changeset entry (run `npx changeset add`)
