### PR TITLE
docs: document the non-zero delay enforcement

### DIFF
--- a/contracts/access/extensions/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/AccessControlDefaultAdminRules.sol
@@ -24,6 +24,7 @@ import {IERC165} from "../../utils/introspection/ERC165.sol";
  * * Enforces a 2-step process to transfer the `DEFAULT_ADMIN_ROLE` to another account.
  * * Enforces a configurable delay between the two steps, with the ability to cancel before the transfer is accepted.
  * * The delay can be changed by scheduling, see {changeDefaultAdminDelay}.
+ * * There must be a non-zero delay between the default admin role's transfer and acceptance.
  * * It is not possible to use another role to manage the `DEFAULT_ADMIN_ROLE`.
  *
  * Example usage:

--- a/contracts/access/extensions/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/AccessControlDefaultAdminRules.sol
@@ -24,7 +24,7 @@ import {IERC165} from "../../utils/introspection/ERC165.sol";
  * * Enforces a 2-step process to transfer the `DEFAULT_ADMIN_ROLE` to another account.
  * * Enforces a configurable delay between the two steps, with the ability to cancel before the transfer is accepted.
  * * The delay can be changed by scheduling, see {changeDefaultAdminDelay}.
- * * There must be a non-zero delay between the default admin role's transfer and acceptance.
+ * * Role transfers must wait at least one block after scheduling before it can be accepted.
  * * It is not possible to use another role to manage the `DEFAULT_ADMIN_ROLE`.
  *
  * Example usage:


### PR DESCRIPTION
Fixes #5666

* Adds a documentation comment to expose the non-zero delay requirement for the default admin role transfer.


#### PR Checklist

- [X] Tests
- [X] Documentation
- [ ] Changeset entry (run `npx changeset add`)
