### PR TITLE
Add _reentrancyGuardStorageSlot()

### DIFF
--- a/contracts/utils/ReentrancyGuardTransient.sol
+++ b/contracts/utils/ReentrancyGuardTransient.sol
@@ -44,11 +44,11 @@ abstract contract ReentrancyGuardTransient {
         }
 
         // Any calls to nonReentrant after this point will fail
-        REENTRANCY_GUARD_STORAGE.asBoolean().tstore(true);
+        _reentrancyGuardStorageSlot().asBoolean().tstore(true);
     }
 
     function _nonReentrantAfter() private {
-        REENTRANCY_GUARD_STORAGE.asBoolean().tstore(false);
+        _reentrancyGuardStorageSlot().asBoolean().tstore(false);
     }
 
     /**
@@ -56,6 +56,10 @@ abstract contract ReentrancyGuardTransient {
      * `nonReentrant` function in the call stack.
      */
     function _reentrancyGuardEntered() internal view returns (bool) {
-        return REENTRANCY_GUARD_STORAGE.asBoolean().tload();
+        return _reentrancyGuardStorageSlot().asBoolean().tload();
+    }
+
+    function _reentrancyGuardStorageSlot() internal pure virtual returns (bytes32) {
+        return REENTRANCY_GUARD_STORAGE;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-contracts/issues/5681 for ReentrancyGuardTransient.

This PR introduces a pure virtual function `_reentrancyGuardStorageSlot()` in `ReentrancyGuardTransient.sol`, mirroring the pattern used in the upgradeable [Initializable.sol](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/proxy/utils/Initializable.sol)

### Motivation

As discussed in https://github.com/OpenZeppelin/openzeppelin-contracts/issues/5681, storage slot collisions can occur when using OpenZeppelin contracts in delegatecall-based modular systems (e.g., the Diamond Standard). While this issue was originally raised in the context of upgradeable contracts, `ReentrancyGuardTransient.sol` in the non-upgradeable repo is in fact **already upgrade-safe** due to its use of a named storage slot.

Adding `_reentrancyGuardStorageSlot()` as a `pure virtual` function allows advanced users to override the default slot location safely in derived contracts, which is essential when using multiple delegatecall modules that each instantiate `ReentrancyGuardTransient`.

### Summary of Changes

* Introduced `_reentrancyGuardStorageSlot()`, marked `internal pure virtual`
* Replaced all direct uses of `REENTRANCY_GUARD_STORAGE` with calls to this new function
* No behavioral or storage layout changes; fully backward-compatible
