### PR TITLE
docs: update EIP712 upgradeable version comment

### DIFF
--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -25,9 +25,8 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
  * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
  *
- * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain
- * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
- * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
+ * NOTE: The upgradeable version of this contract does not use an immutable cache and recomputes the domain separator
+ * each time {_domainSeparatorV4} is called. That is cheaper than accessing a cached version in cold storage.
  *
  * @custom:oz-upgrades-unsafe-allow state-variable-immutable
  */


### PR DESCRIPTION
Fixes #5607

Replaces outdated comment about the upgradeable version in EIP712 with an accurate explanation, as discussed in the issue.