### PR TITLE
Update Address.sol

### DIFF
--- a/.changeset/rare-otters-work.md
+++ b/.changeset/rare-otters-work.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Gas optimization: skip balance check when value == 0 in Address.functionCallWithValue

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -73,7 +73,7 @@ library Address {
      * - the called Solidity function must be `payable`.
      */
     function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
-        if (address(this).balance < value) {
+        if (value > 0 && address(this).balance < value) {
             revert Errors.InsufficientBalance(address(this).balance, value);
         }
         (bool success, bytes memory returndata) = target.call{value: value}(data);


### PR DESCRIPTION
---
name: Gas optimization: skip balance check when value == 0 in Address.functionCallWithValue
about: Improve gas efficiency in Address.sol by avoiding unnecessary balance reads
title: Gas optimization: skip balance check when value == 0 in Address.functionCallWithValue
labels: optimization
assignees: ''

---

## Description

This PR optimizes the `functionCallWithValue` function in `Address.sol` by skipping the balance check when the `value` parameter is zero. Reading `address(this).balance` is a costly operation (~100 gas), and since calls with `value == 0` never require this check to fail, this saves gas on all such calls, including those made through `functionCall`.

This optimization benefits all contracts and protocols that rely on OpenZeppelin's `Address.functionCall` for external contract calls without sending ETH.

Fixes #5685

## Changes

- Updated `functionCallWithValue` to conditionally check balance only if `value > 0`.

```solidity
function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
    if (value > 0 && address(this).balance < value) {
        revert Errors.InsufficientBalance(address(this).balance, value);
    }
    (bool success, bytes memory returndata) = target.call{value: value}(data);
    return verifyCallResultFromTarget(target, success, returndata);
}
