### PR TITLE
Refactor Blockhash lib

### DIFF
--- a/contracts/utils/Blockhash.sol
+++ b/contracts/utils/Blockhash.sol
@@ -32,7 +32,7 @@ library Blockhash {
             distance = current - blockNumber;
         }
 
-        return distance > 256 && distance < 8192 ? _historyStorageCall(blockNumber) : blockhash(blockNumber);
+        return distance < 257 ? blockhash(blockNumber) : _historyStorageCall(blockNumber);
     }
 
     /// @dev Internal function to query the EIP-2935 history storage contract.


### PR DESCRIPTION
Looking at #5642, I noticed that the if statement was quite complexe. It comes with an implicit expectation that the static call (right part of the if) is executed BEFORE the returndatasize (left part of the if). While that expectation might be correct today, I'm not sure the compiler garantees it will stay that way.

Considering that the if does not trigger a revert if the staticcall fails, I believe the proposed version is just as effective, and IMO easier to read. All tests (unit and fuzzing) pass just fine.

Given that an MSTORE is just 3 gas, this version is also cheaper !


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
