### PR TITLE
Revert #5663 changes that were missed in #5696

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,8 +118,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
-      ## TODO: Remove when EIP-7702 authorizations are enabled in latest non-beta ethers version
-      - run: rm package-lock.json package.json # Dependencies already installed
       - uses: crytic/slither-action@v0.4.1
 
   codespell:


### PR DESCRIPTION
- #5663 added dependency to ethers 6.13.6-beta.1, and changed github action to workaround some issue (with beta release). The gihub actions were marked for removal
- #5668 updated ethers to a stable version that supports 7702, without removing the changes to the github action
- #5696 removed part of the github action changes introduced in #5663, but missed some.

This is removing what is left.
