### PR TITLE
Minimize Solidity pragma versions for interface compatibility

### DIFF
--- a/contracts/access/IAccessControl.sol
+++ b/contracts/access/IAccessControl.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (access/IAccessControl.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 /**
  * @dev External interface of AccessControl declared to support ERC-165 detection.

--- a/contracts/access/extensions/IAccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/IAccessControlDefaultAdminRules.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (access/extensions/IAccessControlDefaultAdminRules.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 import {IAccessControl} from "../IAccessControl.sol";
 

--- a/contracts/access/extensions/IAccessControlEnumerable.sol
+++ b/contracts/access/extensions/IAccessControlEnumerable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (access/extensions/IAccessControlEnumerable.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 import {IAccessControl} from "../IAccessControl.sol";
 

--- a/contracts/access/manager/IAccessManaged.sol
+++ b/contracts/access/manager/IAccessManaged.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (access/manager/IAccessManaged.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 interface IAccessManaged {
     /**

--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (access/manager/IAccessManager.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 interface IAccessManager {
     /**

--- a/contracts/access/manager/IAuthority.sol
+++ b/contracts/access/manager/IAuthority.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (access/manager/IAuthority.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev Standard interface for permissioning originally defined in Dappsys.

--- a/contracts/account/extensions/AccountERC7579.sol
+++ b/contracts/account/extensions/AccountERC7579.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {PackedUserOperation} from "../../interfaces/draft-IERC4337.sol";
 import {IERC1271} from "../../interfaces/IERC1271.sol";

--- a/contracts/account/extensions/AccountERC7579Hooked.sol
+++ b/contracts/account/extensions/AccountERC7579Hooked.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {IERC7579Hook, MODULE_TYPE_HOOK} from "../../interfaces/draft-IERC7579.sol";
 import {ERC7579Utils, Mode} from "../../account/utils/draft-ERC7579Utils.sol";

--- a/contracts/governance/IGovernor.sol
+++ b/contracts/governance/IGovernor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (governance/IGovernor.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 import {IERC165} from "../interfaces/IERC165.sol";
 import {IERC6372} from "../interfaces/IERC6372.sol";

--- a/contracts/governance/utils/IVotes.sol
+++ b/contracts/governance/utils/IVotes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (governance/utils/IVotes.sol)
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 /**
  * @dev Common interface for {ERC20Votes}, {ERC721Votes}, and other {Votes}-enabled contracts.

--- a/contracts/interfaces/IERC1155.sol
+++ b/contracts/interfaces/IERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1155.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC1155} from "../token/ERC1155/IERC1155.sol";

--- a/contracts/interfaces/IERC1155MetadataURI.sol
+++ b/contracts/interfaces/IERC1155MetadataURI.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1155MetadataURI.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC1155MetadataURI} from "../token/ERC1155/extensions/IERC1155MetadataURI.sol";

--- a/contracts/interfaces/IERC1155Receiver.sol
+++ b/contracts/interfaces/IERC1155Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1155Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC1155Receiver} from "../token/ERC1155/IERC1155Receiver.sol";

--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/IERC1271.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface of the ERC-1271 standard signature validation method for
@@ -13,5 +13,5 @@ interface IERC1271 {
      * @param hash      Hash of the data to be signed
      * @param signature Signature byte array associated with `hash`
      */
-    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue);
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue);
 }

--- a/contracts/interfaces/IERC1363.sol
+++ b/contracts/interfaces/IERC1363.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC20} from "./IERC20.sol";
 import {IERC165} from "./IERC165.sol";

--- a/contracts/interfaces/IERC1363Receiver.sol
+++ b/contracts/interfaces/IERC1363Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @title IERC1363Receiver

--- a/contracts/interfaces/IERC1363Spender.sol
+++ b/contracts/interfaces/IERC1363Spender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363Spender.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @title IERC1363Spender

--- a/contracts/interfaces/IERC165.sol
+++ b/contracts/interfaces/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 import {IERC165} from "../utils/introspection/IERC165.sol";

--- a/contracts/interfaces/IERC1820Implementer.sol
+++ b/contracts/interfaces/IERC1820Implementer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1820Implementer.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev Interface for an ERC-1820 implementer, as defined in the

--- a/contracts/interfaces/IERC1820Registry.sol
+++ b/contracts/interfaces/IERC1820Registry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1820Registry.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface of the global ERC-1820 Registry, as defined in the

--- a/contracts/interfaces/IERC1967.sol
+++ b/contracts/interfaces/IERC1967.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC1967.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.11;
 
 /**
  * @dev ERC-1967: Proxy Storage Slots. This interface contains the events defined in the ERC.

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 import {IERC20} from "../token/ERC20/IERC20.sol";

--- a/contracts/interfaces/IERC20Metadata.sol
+++ b/contracts/interfaces/IERC20Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC20Metadata} from "../token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/interfaces/IERC2309.sol
+++ b/contracts/interfaces/IERC2309.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC2309.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.11;
 
 /**
  * @dev ERC-2309: ERC-721 Consecutive Transfer Extension.

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC2612.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC20Permit} from "../token/ERC20/extensions/IERC20Permit.sol";
 

--- a/contracts/interfaces/IERC2981.sol
+++ b/contracts/interfaces/IERC2981.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC2981.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC165} from "../utils/introspection/IERC165.sol";
 

--- a/contracts/interfaces/IERC3156.sol
+++ b/contracts/interfaces/IERC3156.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC3156.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 import {IERC3156FlashBorrower} from "./IERC3156FlashBorrower.sol";
 import {IERC3156FlashLender} from "./IERC3156FlashLender.sol";

--- a/contracts/interfaces/IERC3156FlashBorrower.sol
+++ b/contracts/interfaces/IERC3156FlashBorrower.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC3156FlashBorrower.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface of the ERC-3156 FlashBorrower, as defined in

--- a/contracts/interfaces/IERC3156FlashLender.sol
+++ b/contracts/interfaces/IERC3156FlashLender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC3156FlashLender.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 import {IERC3156FlashBorrower} from "./IERC3156FlashBorrower.sol";
 

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/IERC4626.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC20} from "../token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "../token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/interfaces/IERC4906.sol
+++ b/contracts/interfaces/IERC4906.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC4906.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC165} from "./IERC165.sol";
 import {IERC721} from "./IERC721.sol";

--- a/contracts/interfaces/IERC5267.sol
+++ b/contracts/interfaces/IERC5267.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 interface IERC5267 {
     /**

--- a/contracts/interfaces/IERC5313.sol
+++ b/contracts/interfaces/IERC5313.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5313.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev Interface for the Light Contract Ownership Standard.

--- a/contracts/interfaces/IERC5805.sol
+++ b/contracts/interfaces/IERC5805.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5805.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 import {IVotes} from "../governance/utils/IVotes.sol";
 import {IERC6372} from "./IERC6372.sol";

--- a/contracts/interfaces/IERC6372.sol
+++ b/contracts/interfaces/IERC6372.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC6372.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 interface IERC6372 {
     /**

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC721} from "../token/ERC721/IERC721.sol";

--- a/contracts/interfaces/IERC721Enumerable.sol
+++ b/contracts/interfaces/IERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721Enumerable.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC721Enumerable} from "../token/ERC721/extensions/IERC721Enumerable.sol";

--- a/contracts/interfaces/IERC721Metadata.sol
+++ b/contracts/interfaces/IERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC721Metadata} from "../token/ERC721/extensions/IERC721Metadata.sol";

--- a/contracts/interfaces/IERC721Receiver.sol
+++ b/contracts/interfaces/IERC721Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC721Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 import {IERC721Receiver} from "../token/ERC721/IERC721Receiver.sol";

--- a/contracts/interfaces/IERC777.sol
+++ b/contracts/interfaces/IERC777.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC777.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface of the ERC-777 Token standard as defined in the ERC.

--- a/contracts/interfaces/IERC777Recipient.sol
+++ b/contracts/interfaces/IERC777Recipient.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC777Recipient.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface of the ERC-777 Tokens Recipient standard as defined in the ERC.

--- a/contracts/interfaces/IERC777Sender.sol
+++ b/contracts/interfaces/IERC777Sender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC777Sender.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface of the ERC-777 Tokens Sender standard as defined in the ERC.

--- a/contracts/interfaces/IERC7821.sol
+++ b/contracts/interfaces/IERC7821.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Interface for minimal batch executor.

--- a/contracts/interfaces/IERC7913.sol
+++ b/contracts/interfaces/IERC7913.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity >=0.5.0;
 
 /**
  * @dev Signature verifier interface.

--- a/contracts/interfaces/draft-IERC1822.sol
+++ b/contracts/interfaces/draft-IERC1822.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC1822.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev ERC-1822: Universal Upgradeable Proxy Standard (UUPS) documents a method for upgradeability through a simplified

--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/draft-IERC4337.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 /**
  * @dev A https://github.com/ethereum/ercs/blob/master/ERCS/erc-4337.md#useroperation[user operation] is composed of the following elements:

--- a/contracts/interfaces/draft-IERC6093.sol
+++ b/contracts/interfaces/draft-IERC6093.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 /**
  * @dev Standard ERC-20 Errors

--- a/contracts/interfaces/draft-IERC6909.sol
+++ b/contracts/interfaces/draft-IERC6909.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/draft-IERC6909.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC165} from "../utils/introspection/IERC165.sol";
 

--- a/contracts/interfaces/draft-IERC7579.sol
+++ b/contracts/interfaces/draft-IERC7579.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (interfaces/draft-IERC7579.sol)
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.4;
 
 import {PackedUserOperation} from "./draft-IERC4337.sol";
 

--- a/contracts/interfaces/draft-IERC7674.sol
+++ b/contracts/interfaces/draft-IERC7674.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC7674.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC20} from "./IERC20.sol";
 

--- a/contracts/proxy/ERC1967/ERC1967Utils.sol
+++ b/contracts/proxy/ERC1967/ERC1967Utils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.2.0) (proxy/ERC1967/ERC1967Utils.sol)
 
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.21;
 
 import {IBeacon} from "../beacon/IBeacon.sol";
 import {IERC1967} from "../../interfaces/IERC1967.sol";

--- a/contracts/proxy/beacon/IBeacon.sol
+++ b/contracts/proxy/beacon/IBeacon.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (proxy/beacon/IBeacon.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev This is the interface that {BeaconProxy} expects of its beacon.

--- a/contracts/token/ERC1155/IERC1155.sol
+++ b/contracts/token/ERC1155/IERC1155.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.3.0) (token/ERC1155/IERC1155.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC165} from "../../utils/introspection/IERC165.sol";
 

--- a/contracts/token/ERC1155/IERC1155Receiver.sol
+++ b/contracts/token/ERC1155/IERC1155Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC1155/IERC1155Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC165} from "../../utils/introspection/IERC165.sol";
 

--- a/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol
+++ b/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC1155/extensions/IERC1155MetadataURI.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC1155} from "../IERC1155.sol";
 

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev Interface of the ERC-20 standard as defined in the ERC.

--- a/contracts/token/ERC20/extensions/IERC20Metadata.sol
+++ b/contracts/token/ERC20/extensions/IERC20Metadata.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC20} from "../IERC20.sol";
 

--- a/contracts/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/IERC20Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC721/IERC721.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC165} from "../../utils/introspection/IERC165.sol";
 

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (token/ERC721/IERC721Receiver.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.5.0;
 
 /**
  * @title ERC-721 token receiver interface

--- a/contracts/token/ERC721/extensions/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/IERC721Enumerable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/extensions/IERC721Enumerable.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC721} from "../IERC721.sol";
 

--- a/contracts/token/ERC721/extensions/IERC721Metadata.sol
+++ b/contracts/token/ERC721/extensions/IERC721Metadata.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/extensions/IERC721Metadata.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.2;
 
 import {IERC721} from "../IERC721.sol";
 

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {AbstractSigner} from "./AbstractSigner.sol";
 import {SignatureChecker} from "../SignatureChecker.sol";

--- a/contracts/utils/introspection/IERC165.sol
+++ b/contracts/utils/introspection/IERC165.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.4.16;
 
 /**
  * @dev Interface of the ERC-165 standard, as defined in the

--- a/contracts/vendor/compound/ICompoundTimelock.sol
+++ b/contracts/vendor/compound/ICompoundTimelock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (vendor/compound/ICompoundTimelock.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.6.9;
 
 /**
  * https://github.com/compound-finance/compound-protocol/blob/master/contracts/Timelock.sol[Compound timelock] interface


### PR DESCRIPTION
Takes just the pragma changes from https://github.com/arr00/openzeppelin-contracts/pull/2