### PR TITLE
Mark stateless cryptography contracts that should not be transpiled

### DIFF
--- a/contracts/utils/cryptography/signers/draft-ERC7739.sol
+++ b/contracts/utils/cryptography/signers/draft-ERC7739.sol
@@ -22,6 +22,8 @@ import {ShortStrings} from "../../ShortStrings.sol";
  * optimize gas costs for short strings (up to 31 characters). Consider that strings longer than that will use storage,
  * which may limit the ability of the signer to be used within the ERC-4337 validation phase (due to
  * https://eips.ethereum.org/EIPS/eip-7562#storage-rules[ERC-7562 storage access rules]).
+ *
+ * @custom:stateless
  */
 abstract contract ERC7739 is AbstractSigner, EIP712, IERC1271 {
     using ERC7739Utils for *;

--- a/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol
@@ -7,6 +7,8 @@ import {IERC7913SignatureVerifier} from "../../../interfaces/IERC7913.sol";
 
 /**
  * @dev ERC-7913 signature verifier that support P256 (secp256r1) keys.
+ *
+ * @custom:stateless
  */
 contract ERC7913P256Verifier is IERC7913SignatureVerifier {
     /// @inheritdoc IERC7913SignatureVerifier

--- a/contracts/utils/cryptography/verifiers/ERC7913RSAVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913RSAVerifier.sol
@@ -7,6 +7,8 @@ import {IERC7913SignatureVerifier} from "../../../interfaces/IERC7913.sol";
 
 /**
  * @dev ERC-7913 signature verifier that support RSA keys.
+ *
+ * @custom:stateless
  */
 contract ERC7913RSAVerifier is IERC7913SignatureVerifier {
     /// @inheritdoc IERC7913SignatureVerifier


### PR DESCRIPTION
Some stateless contracts should not be transpiled.

This should be cherrypicked to be part of v5.4.
