### PR TITLE
Refactor SafeERC20 to save gas

### DIFF
--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -104,9 +104,8 @@ library SafeERC20 {
      */
     function forceApprove(IERC20 token, address spender, uint256 value) internal {
         if (!_safeApprove(token, spender, value, false)) {
-            if (!_safeApprove(token, spender, 0, true) || !_safeApprove(token, spender, value, true)) {
-                revert SafeERC20FailedOperation(address(token));
-            }
+            if (!_safeApprove(token, spender, 0, true)) revert SafeERC20FailedOperation(address(token));
+            if (!_safeApprove(token, spender, value, true)) revert SafeERC20FailedOperation(address(token));
         }
     }
 

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -236,7 +236,7 @@ library SafeERC20 {
                     revert(fmp, returndatasize())
                 }
                 // if the call is successful, and either
-                // - we got returndata (is that case mload(0x00) is a real false)
+                // - we got returndata (in that case mload(0x00) is a real false)
                 // - the token address doesn't have code
                 if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
                     // than the transfer is a failure

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -184,6 +184,7 @@ library SafeERC20 {
             mstore(0x24, value)
             success := call(gas(), token, 0, 0, 0x44, 0, 0x20)
             // if call success and return is true, all is good.
+            // otherwize (not success or return is not true), we need to perform further checks
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
@@ -229,6 +230,7 @@ library SafeERC20 {
             mstore(0x44, value)
             success := call(gas(), token, 0, 0, 0x64, 0, 0x20)
             // if call success and return is true, all is good.
+            // otherwize (not success or return is not true), we need to perform further checks
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
@@ -267,6 +269,7 @@ library SafeERC20 {
             mstore(0x24, value)
             success := call(gas(), token, 0, 0, 0x44, 0, 0x20)
             // if call success and return is true, all is good.
+            // otherwize (not success or return is not true), we need to perform further checks
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -191,7 +191,7 @@ library SafeERC20 {
                     revert(fmp, returndatasize())
                 }
                 // if the call is successful, and either
-                // - we got returndata (is that case mload(0x00) is a real false)
+                // - we got returndata (in that case mload(0x00) is a real false)
                 // - the token address doesn't have code
                 if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
                     // then the transfer is a failure

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -184,7 +184,7 @@ library SafeERC20 {
             mstore(0x24, value)
             success := call(gas(), token, 0, 0, 0x44, 0, 0x20)
             // if call success and return is true, all is good.
-            // otherwize (not success or return is not true), we need to perform further checks
+            // otherwise (not success or return is not true), we need to perform further checks
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
@@ -230,7 +230,7 @@ library SafeERC20 {
             mstore(0x44, value)
             success := call(gas(), token, 0, 0, 0x64, 0, 0x20)
             // if call success and return is true, all is good.
-            // otherwize (not success or return is not true), we need to perform further checks
+            // otherwise (not success or return is not true), we need to perform further checks
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
@@ -269,7 +269,7 @@ library SafeERC20 {
             mstore(0x24, value)
             success := call(gas(), token, 0, 0, 0x44, 0, 0x20)
             // if call success and return is true, all is good.
-            // otherwize (not success or return is not true), we need to perform further checks
+            // otherwise (not success or return is not true), we need to perform further checks
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -239,7 +239,7 @@ library SafeERC20 {
                 // - we got returndata (in that case mload(0x00) is a real false)
                 // - the token address doesn't have code
                 if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
-                    // than the transfer is a failure
+                    // then the transfer is a failure
                     success := 0
                 }
             }

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -190,13 +190,10 @@ library SafeERC20 {
                     returndatacopy(fmp, 0, returndatasize())
                     revert(fmp, returndatasize())
                 }
-                // if the call is successful, and either
-                // - we got returndata (in that case mload(0x00) is a real false)
-                // - the token address doesn't have code
-                if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
-                    // then the transfer is a failure
-                    success := 0
-                }
+                // if the return value is not true, then the call is only successful if:
+                // - the token address has code
+                // - the returndata is empty
+                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
             }
             mstore(0x40, fmp)
         }
@@ -236,13 +233,10 @@ library SafeERC20 {
                     returndatacopy(fmp, 0, returndatasize())
                     revert(fmp, returndatasize())
                 }
-                // if the call is successful, and either
-                // - we got returndata (in that case mload(0x00) is a real false)
-                // - the token address doesn't have code
-                if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
-                    // then the transfer is a failure
-                    success := 0
-                }
+                // if the return value is not true, then the call is only successful if:
+                // - the token address has code
+                // - the returndata is empty
+                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
             }
             mstore(0x40, fmp)
             mstore(0x60, 0)
@@ -275,13 +269,10 @@ library SafeERC20 {
                     returndatacopy(fmp, 0, returndatasize())
                     revert(fmp, returndatasize())
                 }
-                // if the call is successful, and either
-                // - we got returndata (in that case mload(0x00) is a real false)
-                // - the token address doesn't have code
-                if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
-                    // then the approval is a failure
-                    success := 0
-                }
+                // if the return value is not true, then the call is only successful if:
+                // - the token address has code
+                // - the returndata is empty
+                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
             }
             mstore(0x40, fmp)
         }

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -274,7 +274,7 @@ library SafeERC20 {
                     revert(fmp, returndatasize())
                 }
                 // if the call is successful, and either
-                // - we got returndata (is that case mload(0x00) is a real false)
+                // - we got returndata (in that case mload(0x00) is a real false)
                 // - the token address doesn't have code
                 if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
                     // then the approval is a failure

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -187,8 +187,8 @@ library SafeERC20 {
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
-                    returndatacopy(fmp, 0, returndatasize())
-                    revert(fmp, returndatasize())
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
                 // if the return value is not true, then the call is only successful if:
                 // - the token address has code
@@ -230,8 +230,8 @@ library SafeERC20 {
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
-                    returndatacopy(fmp, 0, returndatasize())
-                    revert(fmp, returndatasize())
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
                 // if the return value is not true, then the call is only successful if:
                 // - the token address has code
@@ -266,8 +266,8 @@ library SafeERC20 {
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
-                    returndatacopy(fmp, 0, returndatasize())
-                    revert(fmp, returndatasize())
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
                 // if the return value is not true, then the call is only successful if:
                 // - the token address has code

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -187,8 +187,8 @@ library SafeERC20 {
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
-                    returndatacopy(0, 0, returndatasize())
-                    revert(0, returndatasize())
+                    returndatacopy(fmp, 0, returndatasize())
+                    revert(fmp, returndatasize())
                 }
                 // if the return value is not true, then the call is only successful if:
                 // - the token address has code
@@ -230,8 +230,8 @@ library SafeERC20 {
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
-                    returndatacopy(0, 0, returndatasize())
-                    revert(0, returndatasize())
+                    returndatacopy(fmp, 0, returndatasize())
+                    revert(fmp, returndatasize())
                 }
                 // if the return value is not true, then the call is only successful if:
                 // - the token address has code
@@ -266,8 +266,8 @@ library SafeERC20 {
             if iszero(and(success, eq(mload(0x00), 1))) {
                 // if the call was a failure and bubble is enabled, bubble the error
                 if and(iszero(success), bubble) {
-                    returndatacopy(0, 0, returndatasize())
-                    revert(0, returndatasize())
+                    returndatacopy(fmp, 0, returndatasize())
+                    revert(fmp, returndatasize())
                 }
                 // if the return value is not true, then the call is only successful if:
                 // - the token address has code

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -194,7 +194,7 @@ library SafeERC20 {
                 // - we got returndata (is that case mload(0x00) is a real false)
                 // - the token address doesn't have code
                 if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
-                    // than the transfer is a failure
+                    // then the transfer is a failure
                     success := 0
                 }
             }

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -277,7 +277,7 @@ library SafeERC20 {
                 // - we got returndata (is that case mload(0x00) is a real false)
                 // - the token address doesn't have code
                 if and(success, or(gt(returndatasize(), 0), iszero(extcodesize(token)))) {
-                    // than the transfer is a failure
+                    // then the approval is a failure
                     success := 0
                 }
             }

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -31,7 +31,9 @@ library SafeERC20 {
      * non-reverting calls are assumed to be successful.
      */
     function safeTransfer(IERC20 token, address to, uint256 value) internal {
-        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));
+        if (!_safeTransfer(token, to, value, true)) {
+            revert SafeERC20FailedOperation(address(token));
+        }
     }
 
     /**
@@ -39,21 +41,23 @@ library SafeERC20 {
      * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
      */
     function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
-        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));
+        if (!_safeTransferFrom(token, from, to, value, true)) {
+            revert SafeERC20FailedOperation(address(token));
+        }
     }
 
     /**
      * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.
      */
     function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {
-        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));
+        return _safeTransfer(token, to, value, false);
     }
 
     /**
      * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.
      */
     function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {
-        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));
+        return _safeTransferFrom(token, from, to, value, false);
     }
 
     /**
@@ -99,11 +103,10 @@ library SafeERC20 {
      * set here.
      */
     function forceApprove(IERC20 token, address spender, uint256 value) internal {
-        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));
-
-        if (!_callOptionalReturnBool(token, approvalCall)) {
-            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));
-            _callOptionalReturn(token, approvalCall);
+        if (!_safeApprove(token, spender, value, false)) {
+            if (!_safeApprove(token, spender, 0, true) || !_safeApprove(token, spender, value, true)) {
+                revert SafeERC20FailedOperation(address(token));
+            }
         }
     }
 
@@ -163,50 +166,110 @@ library SafeERC20 {
     }
 
     /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
+     * @dev Imitates a Solidity `token.transfer(to, value)` call, relaxing the requirement on the return value: the
+     * return value is optional (but if data is returned, it must not be false).
      *
-     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.
-     */
-    function _callOptionalReturn(IERC20 token, bytes memory data) private {
-        uint256 returnSize;
-        uint256 returnValue;
-        assembly ("memory-safe") {
-            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)
-            // bubble errors
-            if iszero(success) {
-                let ptr := mload(0x40)
-                returndatacopy(ptr, 0, returndatasize())
-                revert(ptr, returndatasize())
-            }
-            returnSize := returndatasize()
-            returnValue := mload(0)
-        }
-
-        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {
-            revert SafeERC20FailedOperation(address(token));
-        }
-    }
-
-    /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
      * @param token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
-     *
-     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.
+     * @param to The recipient of the tokens
+     * @param value The amount of token to transfer
+     * @param bubble Behavior switch if the transfer call reverts: bubble the revert reason or return a false boolean.
      */
-    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {
+    function _safeTransfer(IERC20 token, address to, uint256 value, bool bubble) private returns (bool) {
+        bytes4 selector = IERC20.transfer.selector;
         bool success;
         uint256 returnSize;
         uint256 returnValue;
+
         assembly ("memory-safe") {
-            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)
+            let fmp := mload(0x40)
+            mstore(0x00, selector)
+            mstore(0x04, and(to, shr(96, not(0))))
+            mstore(0x24, value)
+            success := call(gas(), token, 0, 0, 0x44, 0, 0x20)
+            if and(bubble, iszero(success)) {
+                returndatacopy(fmp, 0, returndatasize())
+                revert(fmp, returndatasize())
+            }
             returnSize := returndatasize()
             returnValue := mload(0)
+            mstore(0x40, fmp)
         }
+
+        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);
+    }
+
+    /**
+     * @dev Imitates a Solidity `token.transferFrom(from, to, value)` call, relaxing the requirement on the return
+     * value: the return value is optional (but if data is returned, it must not be false).
+     *
+     * @param token The token targeted by the call.
+     * @param from The sender of the tokens
+     * @param to The recipient of the tokens
+     * @param value The amount of token to transfer
+     * @param bubble Behavior switch if the transfer call reverts: bubble the revert reason or return a false boolean.
+     */
+    function _safeTransferFrom(
+        IERC20 token,
+        address from,
+        address to,
+        uint256 value,
+        bool bubble
+    ) private returns (bool) {
+        bytes4 selector = IERC20.transferFrom.selector;
+        bool success;
+        uint256 returnSize;
+        uint256 returnValue;
+
+        assembly ("memory-safe") {
+            let fmp := mload(0x40)
+            mstore(0x00, selector)
+            mstore(0x04, and(from, shr(96, not(0))))
+            mstore(0x24, and(to, shr(96, not(0))))
+            mstore(0x44, value)
+            success := call(gas(), token, 0, 0, 0x64, 0, 0x20)
+            if and(bubble, iszero(success)) {
+                returndatacopy(fmp, 0, returndatasize())
+                revert(fmp, returndatasize())
+            }
+            returnSize := returndatasize()
+            returnValue := mload(0)
+            mstore(0x40, fmp)
+            mstore(0x60, 0)
+        }
+
+        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);
+    }
+
+    /**
+     * @dev Imitates a Solidity `token.approve(spender, value)` call, relaxing the requirement on the return value:
+     * the return value is optional (but if data is returned, it must not be false).
+     *
+     * @param token The token targeted by the call.
+     * @param spender The spender of the tokens
+     * @param value The amount of token to transfer
+     * @param bubble Behavior switch if the transfer call reverts: bubble the revert reason or return a false boolean.
+     */
+    function _safeApprove(IERC20 token, address spender, uint256 value, bool bubble) private returns (bool) {
+        bytes4 selector = IERC20.approve.selector;
+        bool success;
+        uint256 returnSize;
+        uint256 returnValue;
+
+        assembly ("memory-safe") {
+            let fmp := mload(0x40)
+            mstore(0x00, selector)
+            mstore(0x04, and(spender, shr(96, not(0))))
+            mstore(0x24, value)
+            success := call(gas(), token, 0, 0, 0x44, 0, 0x20)
+            if and(bubble, iszero(success)) {
+                returndatacopy(fmp, 0, returndatasize())
+                revert(fmp, returndatasize())
+            }
+            returnSize := returndatasize()
+            returnValue := mload(0)
+            mstore(0x40, fmp)
+        }
+
         return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);
     }
 }


### PR DESCRIPTION
This PR avoids the expensive `abi.encode` that allocates memory. It also processes the output (returnSize, returnValue) directly in assembly. The goal is to optimize the "happy path" when a token returns a true boolean.

No user-visible behavior change

Note: this is a priority for @luiz-lvj's work on OIF. Hopefully we can achieve good results.

#### Versions

- [bf140e4](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5771/commits/bf140e40a93ee94e62a568e6112a58f8aab0df68) saves ~60 gas
- [471e088](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5771/commits/471e088f5929d0b7d4f1f4c4675f384e4392a82b) saves ~170 gas 🥳

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
