### PR TITLE
Update OpenZeppelin cryptography documentation link

### DIFF
--- a/contracts/utils/cryptography/README.adoc
+++ b/contracts/utils/cryptography/README.adoc
@@ -1,7 +1,7 @@
 = Cryptography
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/utils/cryptography
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/5.x/api/utils#cryptography
 
 A collection of contracts and libraries that implement various signature validation schemes and cryptographic primitives. These utilities enable secure authentication, multisignature operations, and advanced cryptographic operations in smart contracts.
 


### PR DESCRIPTION
Updated the link to OpenZeppelin's cryptography utilities documentation from the outdated URL to the current one (contracts/5.x/api/utils#cryptography) which contains the latest information on ECDSA, P256, RSA, MerkleProof and other cryptographic utilities.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
