### PR TITLE
Clarify documentation for IAccessManager.canCall

### DIFF
--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -97,7 +97,7 @@ interface IAccessManager {
      * previously set delay (not zero), then the function should return false and the caller should schedule the operation
      * for future execution.
      *
-     * If `immediate` is true, the delay can be disregarded and the operation can be immediately executed, otherwise
+     * If `allowed` is true, the delay can be disregarded and the operation can be immediately executed, otherwise
      * the operation can be executed if and only if delay is greater than 0.
      *
      * NOTE: The IAuthority interface does not include the `uint32` delay. This is an extension of that interface that


### PR DESCRIPTION
The return name is part of the ABI, so renaming it may affect some people that rely on the ABI.

Therefore I believe its simpler/cleaner to just change the documentation wording to relfect the actual name of the return value.

