### PR TITLE
Fix bug in Bytes.lastIndexOf when array is empty and position is not 2²⁵⁶-1

### DIFF
--- a/.changeset/witty-hats-flow.md
+++ b/.changeset/witty-hats-flow.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`Bytes`: Fix an issue when calling `lastIndexOf(bytes,byte,uint256)` with an empty buffer and a lookup position that is not 2²⁵⁶-1.
+`Bytes`: Fix `lastIndexOf(bytes,byte,uint256)` with empty buffers and finite position to correctly return `type(uint256).max` instead of accessing uninitialized memory sections.

--- a/.changeset/witty-hats-flow.md
+++ b/.changeset/witty-hats-flow.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`Bytes`: Fix an issue when calling `lastIndexOf(bytes,byte,uint256)` with an empty buffer and a lookup position that is not 2²⁵⁶-1.

--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -58,10 +58,12 @@ library Bytes {
     function lastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) internal pure returns (uint256) {
         unchecked {
             uint256 length = buffer.length;
-            // NOTE here we cannot do `i = Math.min(pos + 1, length)` because `pos + 1` could overflow
-            for (uint256 i = Math.min(pos, length - 1) + 1; i > 0; --i) {
-                if (bytes1(_unsafeReadBytesOffset(buffer, i - 1)) == s) {
-                    return i - 1;
+            if (length > 0) {
+                // NOTE here we cannot do `i = Math.min(pos + 1, length)` because `pos + 1` could overflow
+                for (uint256 i = Math.min(pos, length - 1) + 1; i > 0; --i) {
+                    if (bytes1(_unsafeReadBytesOffset(buffer, i - 1)) == s) {
+                        return i - 1;
+                    }
                 }
             }
             return type(uint256).max;

--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -58,12 +58,10 @@ library Bytes {
     function lastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) internal pure returns (uint256) {
         unchecked {
             uint256 length = buffer.length;
-            if (length > 0) {
-                // NOTE here we cannot do `i = Math.min(pos + 1, length)` because `pos + 1` could overflow
-                for (uint256 i = Math.min(pos, length - 1) + 1; i > 0; --i) {
-                    if (bytes1(_unsafeReadBytesOffset(buffer, i - 1)) == s) {
-                        return i - 1;
-                    }
+            uint256 end = Math.ternary(pos == type(uint256).max, length, Math.min(pos + 1, length));
+            for (uint256 i = end; i > 0; --i) {
+                if (bytes1(_unsafeReadBytesOffset(buffer, i - 1)) == s) {
+                    return i - 1;
                 }
             }
             return type(uint256).max;

--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -57,7 +57,8 @@ library Bytes {
      */
     function lastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) internal pure returns (uint256) {
         unchecked {
-            for (uint256 i = Math.min(Math.saturatingAdd(pos, 1), buffer.length); i > 0; --i) {
+            uint256 length = buffer.length;
+            for (uint256 i = Math.min(Math.saturatingAdd(pos, 1), length); i > 0; --i) {
                 if (bytes1(_unsafeReadBytesOffset(buffer, i - 1)) == s) {
                     return i - 1;
                 }

--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -57,9 +57,7 @@ library Bytes {
      */
     function lastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) internal pure returns (uint256) {
         unchecked {
-            uint256 length = buffer.length;
-            uint256 end = Math.ternary(pos == type(uint256).max, length, Math.min(pos + 1, length));
-            for (uint256 i = end; i > 0; --i) {
+            for (uint256 i = Math.min(Math.saturatingAdd(pos, 1), buffer.length); i > 0; --i) {
                 if (bytes1(_unsafeReadBytesOffset(buffer, i - 1)) == s) {
                     return i - 1;
                 }

--- a/test/utils/Bytes.t.sol
+++ b/test/utils/Bytes.t.sol
@@ -11,7 +11,20 @@ contract BytesTest is Test {
 
     // INDEX OF
     function testIndexOf(bytes memory buffer, bytes1 s) public pure {
-        testIndexOf(buffer, s, 0);
+        uint256 result = Bytes.indexOf(buffer, s);
+
+        if (buffer.length == 0) {
+            // Case 0: buffer is empty
+            assertEq(result, type(uint256).max);
+        } else if (result == type(uint256).max) {
+            // Case 1: search value could not be found
+            for (uint256 i = 0; i < buffer.length; ++i) assertNotEq(buffer[i], s);
+        } else {
+            // Case 2: search value was found
+            assertEq(buffer[result], s);
+            // search value is not present anywhere before the found location
+            for (uint256 i = 0; i < result; ++i) assertNotEq(buffer[i], s);
+        }
     }
 
     function testIndexOf(bytes memory buffer, bytes1 s, uint256 pos) public pure {
@@ -32,7 +45,20 @@ contract BytesTest is Test {
     }
 
     function testLastIndexOf(bytes memory buffer, bytes1 s) public pure {
-        testLastIndexOf(buffer, s, 0);
+        uint256 result = Bytes.lastIndexOf(buffer, s);
+
+        if (buffer.length == 0) {
+            // Case 0: buffer is empty
+            assertEq(result, type(uint256).max);
+        } else if (result == type(uint256).max) {
+            // Case 1: search value could not be found
+            for (uint256 i = 0; i < buffer.length; ++i) assertNotEq(buffer[i], s);
+        } else {
+            // Case 2: search value was found
+            assertEq(buffer[result], s);
+            // search value is not present anywhere after the found location
+            for (uint256 i = result + 1; i < buffer.length; ++i) assertNotEq(buffer[i], s);
+        }
     }
 
     function testLastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) public pure {

--- a/test/utils/Bytes.t.sol
+++ b/test/utils/Bytes.t.sol
@@ -17,10 +17,18 @@ contract BytesTest is Test {
     function testIndexOf(bytes memory buffer, bytes1 s, uint256 pos) public pure {
         uint256 result = Bytes.indexOf(buffer, s, pos);
 
-        // The search value should not me present between `pos` (included) and `result` excluded.
-        // Do not search after the end of the buffer
-        for (uint256 i = pos; i < Math.min(result, buffer.length); ++i) assertNotEq(buffer[i], s);
-        if (result != type(uint256).max) assertEq(buffer[result], s);
+        if (buffer.length == 0) {
+            // Case 0: buffer is empty
+            assertEq(result, type(uint256).max);
+        } else if (result == type(uint256).max) {
+            // Case 1: search value could not be found
+            for (uint256 i = pos; i < buffer.length; ++i) assertNotEq(buffer[i], s);
+        } else {
+            // Case 2: search value was found
+            assertEq(buffer[result], s);
+            // search value is not present anywhere before the found location
+            for (uint256 i = pos; i < result; ++i) assertNotEq(buffer[i], s);
+        }
     }
 
     function testLastIndexOf(bytes memory buffer, bytes1 s) public pure {
@@ -30,13 +38,18 @@ contract BytesTest is Test {
     function testLastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) public pure {
         uint256 result = Bytes.lastIndexOf(buffer, s, pos);
 
-        // Case found: the search value should not be present between `result` (excluded) and `pos` (included)
-        // Case not found: the search value should not be present anywhere before `pos` (included)
-        unchecked {
-            // using unchecked gives us `result + 1 == 0` in the "not found" case
-            for (uint256 i = result + 1; i < Math.min(pos + 1, buffer.length); ++i) assertNotEq(buffer[i], s);
+        if (buffer.length == 0) {
+            // Case 0: buffer is empty
+            assertEq(result, type(uint256).max);
+        } else if (result == type(uint256).max) {
+            // Case 1: search value could not be found
+            for (uint256 i = 0; i <= Math.min(pos, buffer.length - 1); ++i) assertNotEq(buffer[i], s);
+        } else {
+            // Case 2: search value was found
+            assertEq(buffer[result], s);
+            // search value is not present anywhere after the found location
+            for (uint256 i = result + 1; i <= Math.min(pos, buffer.length - 1); ++i) assertNotEq(buffer[i], s);
         }
-        if (result != type(uint256).max) assertEq(buffer[result], s);
     }
 
     // SLICES

--- a/test/utils/Bytes.t.sol
+++ b/test/utils/Bytes.t.sol
@@ -9,6 +9,37 @@ import {Bytes} from "@openzeppelin/contracts/utils/Bytes.sol";
 contract BytesTest is Test {
     using Bytes for bytes;
 
+    // INDEX OF
+    function testIndexOf(bytes memory buffer, bytes1 s) public pure {
+        testIndexOf(buffer, s, 0);
+    }
+
+    function testIndexOf(bytes memory buffer, bytes1 s, uint256 pos) public pure {
+        uint256 result = Bytes.indexOf(buffer, s, pos);
+
+        // The search value should not me present between `pos` (included) and `result` excluded.
+        // Do not search after the end of the buffer
+        for (uint256 i = pos; i < Math.min(result, buffer.length); ++i) assertNotEq(buffer[i], s);
+        if (result != type(uint256).max) assertEq(buffer[result], s);
+    }
+
+    function testLastIndexOf(bytes memory buffer, bytes1 s) public pure {
+        testLastIndexOf(buffer, s, 0);
+    }
+
+    function testLastIndexOf(bytes memory buffer, bytes1 s, uint256 pos) public pure {
+        uint256 result = Bytes.lastIndexOf(buffer, s, pos);
+
+        // Case found: the search value should not be present between `result` (excluded) and `pos` (included)
+        // Case not found: the search value should not be present anywhere before `pos` (included)
+        unchecked {
+            // using unchecked gives us `result + 1 == 0` in the "not found" case
+            for (uint256 i = result + 1; i < Math.min(pos + 1, buffer.length); ++i) assertNotEq(buffer[i], s);
+        }
+        if (result != type(uint256).max) assertEq(buffer[result], s);
+    }
+
+    // SLICES
     function testSliceWithStartOnly(bytes memory buffer, uint256 start) public pure {
         bytes memory originalBuffer = bytes.concat(buffer);
         bytes memory result = buffer.slice(start);

--- a/test/utils/Bytes.test.js
+++ b/test/utils/Bytes.test.js
@@ -28,39 +28,55 @@ describe('Bytes', function () {
 
   describe('indexOf', function () {
     it('first', async function () {
-      expect(await this.mock.$indexOf(lorem, ethers.toBeHex(present))).to.equal(lorem.indexOf(present));
+      await expect(this.mock.$indexOf(lorem, ethers.toBeHex(present))).to.eventually.equal(lorem.indexOf(present));
     });
 
     it('from index', async function () {
       for (const start in Array(lorem.length + 10).fill()) {
         const index = lorem.indexOf(present, start);
         const result = index === -1 ? ethers.MaxUint256 : index;
-        expect(await this.mock.$indexOf(lorem, ethers.toBeHex(present), ethers.Typed.uint256(start))).to.equal(result);
+        await expect(
+          this.mock.$indexOf(lorem, ethers.toBeHex(present), ethers.Typed.uint256(start)),
+        ).to.eventually.equal(result);
       }
     });
 
     it('absent', async function () {
-      expect(await this.mock.$indexOf(lorem, ethers.toBeHex(absent))).to.equal(ethers.MaxUint256);
+      await expect(this.mock.$indexOf(lorem, ethers.toBeHex(absent))).to.eventually.equal(ethers.MaxUint256);
+    });
+
+    it('empty buffer', async function () {
+      await expect(this.mock.$indexOf('0x', '0x00')).to.eventually.equal(ethers.MaxUint256);
+      await expect(this.mock.$indexOf('0x', '0x00', ethers.Typed.uint256(17))).to.eventually.equal(ethers.MaxUint256);
     });
   });
 
   describe('lastIndexOf', function () {
     it('first', async function () {
-      expect(await this.mock.$lastIndexOf(lorem, ethers.toBeHex(present))).to.equal(lorem.lastIndexOf(present));
+      await expect(this.mock.$lastIndexOf(lorem, ethers.toBeHex(present))).to.eventually.equal(
+        lorem.lastIndexOf(present),
+      );
     });
 
     it('from index', async function () {
       for (const start in Array(lorem.length + 10).fill()) {
         const index = lorem.lastIndexOf(present, start);
         const result = index === -1 ? ethers.MaxUint256 : index;
-        expect(await this.mock.$lastIndexOf(lorem, ethers.toBeHex(present), ethers.Typed.uint256(start))).to.equal(
-          result,
-        );
+        await expect(
+          this.mock.$lastIndexOf(lorem, ethers.toBeHex(present), ethers.Typed.uint256(start)),
+        ).to.eventually.equal(result);
       }
     });
 
     it('absent', async function () {
-      expect(await this.mock.$lastIndexOf(lorem, ethers.toBeHex(absent))).to.equal(ethers.MaxUint256);
+      await expect(this.mock.$lastIndexOf(lorem, ethers.toBeHex(absent))).to.eventually.equal(ethers.MaxUint256);
+    });
+
+    it('empty buffer', async function () {
+      await expect(this.mock.$lastIndexOf('0x', '0x00')).to.eventually.equal(ethers.MaxUint256);
+      await expect(this.mock.$lastIndexOf('0x', '0x00', ethers.Typed.uint256(17))).to.eventually.equal(
+        ethers.MaxUint256,
+      );
     });
   });
 
@@ -73,8 +89,8 @@ describe('Bytes', function () {
       })) {
         it(descr, async function () {
           const result = ethers.hexlify(lorem.slice(start));
-          expect(await this.mock.$slice(lorem, start)).to.equal(result);
-          expect(await this.mock.$splice(lorem, start)).to.equal(result);
+          await expect(this.mock.$slice(lorem, start)).to.eventually.equal(result);
+          await expect(this.mock.$splice(lorem, start)).to.eventually.equal(result);
         });
       }
     });
@@ -89,8 +105,8 @@ describe('Bytes', function () {
       })) {
         it(descr, async function () {
           const result = ethers.hexlify(lorem.slice(start, end));
-          expect(await this.mock.$slice(lorem, start, ethers.Typed.uint256(end))).to.equal(result);
-          expect(await this.mock.$splice(lorem, start, ethers.Typed.uint256(end))).to.equal(result);
+          await expect(this.mock.$slice(lorem, start, ethers.Typed.uint256(end))).to.eventually.equal(result);
+          await expect(this.mock.$splice(lorem, start, ethers.Typed.uint256(end))).to.eventually.equal(result);
         });
       }
     });


### PR DESCRIPTION
Fix bug introduced in #5252 (v5.2)

#### Bug description

If the `buffer` is empty and if `pos` is not `type(uint256).max`
  - in the computation of `Math.min(pos, length - 1) + 1`, `length-1` overflow and return `2²⁵⁶-1`.
  - taking the min between `pos` and that will return something that is NOT `2²⁵⁶-1`.
  - adding 1 to it will NOT return 0.
  - the loop will start at a non-0 index, and try to access data when the buffer is actually empty.

This will return unpredictable results, if s can be found after the buffer. For example, if the memory after the is clean (zero) and you do `lastIndexOf('0x', '0x00', 17)` ... it will return 17 instead of the expected 2²⁵⁶-1 (not found)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
