### PR TITLE
draft-IERC4337: split EntryPoint interfaces into `IEntryPointStake` and `IEntryPointDeposit` [WIP]

### DIFF
--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -107,21 +107,6 @@ interface IEntryPointNonces {
  */
 interface IEntryPointStake {
     /**
-     * @dev Returns the balance of the account.
-     */
-    function balanceOf(address account) external view returns (uint256);
-
-    /**
-     * @dev Deposits `msg.value` to the account.
-     */
-    function depositTo(address account) external payable;
-
-    /**
-     * @dev Withdraws `withdrawAmount` from the account to `withdrawAddress`.
-     */
-    function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external;
-
-    /**
      * @dev Adds stake to the account with an unstake delay of `unstakeDelaySec`.
      */
     function addStake(uint32 unstakeDelaySec) external payable;
@@ -138,11 +123,42 @@ interface IEntryPointStake {
 }
 
 /**
+ * @dev Handle deposit management for entities (i.e. accounts, paymasters).
+ *
+ * The paymaster must have a deposit, which the EntryPoint will charge UserOperation costs from.
+ * The deposit (for paying gas fees) is separate from the stake (which is locked).
+ *
+ * The EntryPoint must implement the following interface to allow Paymasters (and optionally Accounts)
+ * to manage their deposit.
+ */
+interface IEntryPointDeposit {
+    /**
+     * @dev Returns the balance of the account.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Deposits `msg.value` to the account.
+     */
+    function depositTo(address account) external payable;
+
+    /**
+     * @dev Withdraws `withdrawAmount` from the account to `withdrawAddress`.
+     */
+    function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external;
+
+    /**
+     * @dev Add to the deposit of the calling account
+     */
+    receive() external payable;
+}
+
+/**
  * @dev Entry point for user operations.
  *
  * User operations are validated and executed by this contract.
  */
-interface IEntryPoint is IEntryPointNonces, IEntryPointStake {
+interface IEntryPoint is IEntryPointNonces, IEntryPointStake, IEntryPointDeposit {
     /**
      * @dev A user operation at `opIndex` failed with `reason`.
      */

--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -99,30 +99,6 @@ interface IEntryPointNonces {
 }
 
 /**
- * @dev Handle stake management for entities (i.e. accounts, paymasters, factories).
- *
- * The EntryPoint must implement the following API to let entities like paymasters have a stake,
- * and thus have more flexibility in their storage access
- * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-global-entities[reputation, throttling and banning.])
- */
-interface IEntryPointStake {
-    /**
-     * @dev Adds stake to the account with an unstake delay of `unstakeDelaySec`.
-     */
-    function addStake(uint32 unstakeDelaySec) external payable;
-
-    /**
-     * @dev Unlocks the stake of the account.
-     */
-    function unlockStake() external;
-
-    /**
-     * @dev Withdraws the stake of the account to `withdrawAddress`.
-     */
-    function withdrawStake(address payable withdrawAddress) external;
-}
-
-/**
  * @dev Handle deposit management for entities (i.e. accounts, paymasters).
  *
  * The paymaster must have a deposit, which the EntryPoint will charge UserOperation costs from.
@@ -151,6 +127,30 @@ interface IEntryPointDeposit {
      * @dev Add to the deposit of the calling account
      */
     receive() external payable;
+}
+
+/**
+ * @dev Handle stake management for entities (i.e. accounts, paymasters, factories).
+ *
+ * The EntryPoint must implement the following API to let entities like paymasters have a stake,
+ * and thus have more flexibility in their storage access
+ * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-global-entities[reputation, throttling and banning.])
+ */
+interface IEntryPointStake {
+    /**
+     * @dev Adds stake to the account with an unstake delay of `unstakeDelaySec`.
+     */
+    function addStake(uint32 unstakeDelaySec) external payable;
+
+    /**
+     * @dev Unlocks the stake of the account.
+     */
+    function unlockStake() external;
+
+    /**
+     * @dev Withdraws the stake of the account to `withdrawAddress`.
+     */
+    function withdrawStake(address payable withdrawAddress) external;
 }
 
 /**

--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -122,11 +122,6 @@ interface IEntryPointDeposit {
      * @dev Withdraws `withdrawAmount` from the account to `withdrawAddress`.
      */
     function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external;
-
-    /**
-     * @dev Add to the deposit of the calling account
-     */
-    receive() external payable;
 }
 
 /**


### PR DESCRIPTION
Currently, IEntryPointStake contains both the methods defined in the ERC for managing stakes and also for managing deposits, whose fundamental difference would be better reflected by this new interface organization.

The ERC-4337 specification explicitly states: _["the deposit (for paying gas fees) is separate from the stake (which is locked)" ](https://eips.ethereum.org/EIPS/eip-4337#entrypoint-interface:~:text=The%20deposit%20(for%20paying%20gas%20fees)%20is%20separate%20from%20the%20stake)_

Note that there are Paymasters which require the IEntryPointDeposit interface (obligatory part of the standard) but may not require the IEntryPointStake interface, which is optional. The new interface organization allows paymaster builders to import only the interface components they need.