### PR TITLE
ECDSA: add parse and tryParse

### DIFF
--- a/.changeset/plain-times-itch.md
+++ b/.changeset/plain-times-itch.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ECDSA`: Add `parse` and `parseCalldata` to parse bytes signatures of length 65 or 64 (eip-2098) into its v,r,s components.

--- a/.changeset/plain-times-itch.md
+++ b/.changeset/plain-times-itch.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`ECDSA`: Add `parse` and `parseCalldata` to parse bytes signatures of length 65 or 64 (eip-2098) into its v,r,s components.
+`ECDSA`: Add `parse` and `parseCalldata` to parse bytes signatures of length 65 or 64 (erc-2098) into its v,r,s components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Update minimum pragma to 0.8.24 in `Votes`, `VotesExtended`, `ERC20Votes`, `Strings`, `ERC1155URIStorage`, `MessageHashUtils`, `ERC721URIStorage`, `ERC721Votes`, `ERC721Wrapper`, `ERC721Burnable`, `ERC721Consecutive`, `ERC721Enumerable`, `ERC721Pausable`, `ERC721Royalty`, `ERC721Wrapper`, `EIP712`, and `ERC7739`. ([#5726](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5726))
 
+### Deprecation
+
+- `ECDSA` signature malleability protection is partly deprecated. See documentation for more details.
+
 ## 5.4.0 (2025-07-17)
 
 ### Breaking changes

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -212,7 +212,7 @@ library ECDSA {
      * @dev Parse a signature into its `v`, `r` and `s` components. Supports both 65 bytes and 64 bytes (eip-2098)
      * signature formats. Returns 0, 0, 0 is the signature is not in a proper format.
      */
-    function parse(bytes memory signature) internal pure returns (int8 v, bytes32 r, bytes32 s) {
+    function parse(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         assembly ("memory-safe") {
             // Check the signature length
             switch mload(signature)
@@ -240,7 +240,7 @@ library ECDSA {
     /**
      * @dev Variant of {parse} that takes a signature in calldata
      */
-    function parseCalldata(bytes calldata signature) internal pure returns (int8 v, bytes32 r, bytes32 s) {
+    function parseCalldata(bytes calldata signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         assembly ("memory-safe") {
             // Check the signature length
             switch signature.length

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -43,11 +43,9 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
-     * NOTE: This function protects against malleability by only supporting 65 bytes long signatures, and rejecting
-     * EIP-2098 short signatures. This guarantee is DEPRECATED and will be removed in the next major release (v6.0).
-     * Developers SHOULD NOT use signatures as unique identifiers. If an operation must be marked as consumed to
-     * prevent replayability, either the `hash` (or the `hash`/`recovered` pair if multiple accounts are to sign the
-     * same hash) should be invalidated. Nonces are also a viable solution.
+     * NOTE: This function only supports 65-byte signatures. ERC-2098 short signatures are rejected. This restriction
+     * is DEPRECATED and will be removed in v6.0. Developers SHOULD NOT use signatures as unique identifiers; use hash
+     * invalidation or nonces for replay protection.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that
@@ -112,11 +110,9 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
-     * NOTE: This function protects against malleability by only supporting 65 bytes long signatures, and rejecting
-     * EIP-2098 short signatures. This guarantee is DEPRECATED and will be removed in the next major release (v6.0).
-     * Developers SHOULD NOT use signatures as unique identifiers. If an operation must be marked as consumed to
-     * prevent replayability, either the `hash` (or the `hash`/`recovered` pair if multiple accounts are to sign the
-     * same hash) should be invalidated. Nonces are also a viable solution.
+     * NOTE: This function only supports 65-byte signatures. ERC-2098 short signatures are rejected. This restriction
+     * is DEPRECATED and will be removed in v6.0. Developers SHOULD NOT use signatures as unique identifiers; use hash
+     * invalidation or nonces for replay protection.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that
@@ -209,7 +205,7 @@ library ECDSA {
     }
 
     /**
-     * @dev Parse a signature into its `v`, `r` and `s` components. Supports both 65 bytes and 64 bytes (eip-2098)
+     * @dev Parse a signature into its `v`, `r` and `s` components. Supports both 65 bytes and 64 bytes (erc-2098)
      * signature formats. Returns 0, 0, 0 is the signature is not in a proper format.
      */
     function parse(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -43,12 +43,11 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
-     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signatures, and
-     * rejecting eip-2098 short signatures. While this guarantee is still present, it is DEPRECATED and will be
-     * removed in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an
-     * operation must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered`
-     * pair if multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution.
-     * Marking the signatures as consumed is very strongly discouraged.
+     * NOTE: This function protects against malleability by only supporting 65 bytes long signatures, and rejecting
+     * EIP-2098 short signatures. This guarantee is DEPRECATED and will be removed in the next major release (v6.0).
+     * Developers SHOULD NOT use signatures as unique identifiers. If an operation must be marked as consumed to
+     * prevent replayability, either the `hash` (or the `hash`/`recovered` pair if multiple accounts are to sign the
+     * same hash) should be invalidated. Nonces are also a viable solution.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that
@@ -113,12 +112,11 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
-     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signatures, and
-     * rejecting eip-2098 short signatures. While this guarantee is still present, it is DEPRECATED and will be
-     * removed in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an
-     * operation must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered`
-     * pair if multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution.
-     * Marking the signatures as consumed is very strongly discouraged.
+     * NOTE: This function protects against malleability by only supporting 65 bytes long signatures, and rejecting
+     * EIP-2098 short signatures. This guarantee is DEPRECATED and will be removed in the next major release (v6.0).
+     * Developers SHOULD NOT use signatures as unique identifiers. If an operation must be marked as consumed to
+     * prevent replayability, either the `hash` (or the `hash`/`recovered` pair if multiple accounts are to sign the
+     * same hash) should be invalidated. Nonces are also a viable solution.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -43,7 +43,7 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
-     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signature, and
+     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signatures, and
      * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
      * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an operation
      * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
@@ -113,7 +113,7 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
-     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signature, and
+     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signatures, and
      * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
      * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an operation
      * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -205,8 +205,8 @@ library ECDSA {
     }
 
     /**
-     * @dev Parse a signature into its `v`, `r` and `s` components. Supports both 65 bytes and 64 bytes (erc-2098)
-     * signature formats. Returns 0, 0, 0 is the signature is not in a proper format.
+     * @dev Parse a signature into its `v`, `r` and `s` components. Supports 65-byte and 64-byte (ERC-2098)
+     * formats. Returns (0,0,0) for invalid signatures. Consider skipping {tryRecover} or {recover} if so.
      */
     function parse(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         assembly ("memory-safe") {

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -44,11 +44,11 @@ library ECDSA {
      * half order, and the `v` value to be either 27 or 28.
      *
      * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signatures, and
-     * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
-     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an operation
-     * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
-     * multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution. Marking
-     * signatures as consumed is very strongly discouraged.
+     * rejecting eip-2098 short signatures. While this guarantee is still present, it is DEPRECATED and will be
+     * removed in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an
+     * operation must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered`
+     * pair if multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution.
+     * Marking the signatures as consumed is very strongly discouraged.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that
@@ -114,11 +114,11 @@ library ECDSA {
      * half order, and the `v` value to be either 27 or 28.
      *
      * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signatures, and
-     * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
-     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an operation
-     * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
-     * multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution. Marking
-     * signatures as consumed is very strongly discouraged.
+     * rejecting eip-2098 short signatures. While this guarantee is still present, it is DEPRECATED and will be
+     * removed in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an
+     * operation must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered`
+     * pair if multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution.
+     * Marking the signatures as consumed is very strongly discouraged.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -43,6 +43,13 @@ library ECDSA {
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
      *
+     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signature, and
+     * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
+     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifier. If an operation
+     * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
+     * multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution. Marking
+     * signatures as consumed is very strongly discouraged.
+     *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that
      * recover to arbitrary addresses for non-hashed data. A safe way to ensure
@@ -105,6 +112,13 @@ library ECDSA {
      * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:
      * this function rejects them by requiring the `s` value to be in the lower
      * half order, and the `v` value to be either 27 or 28.
+     *
+     * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signature, and
+     * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
+     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifier. If an operation
+     * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
+     * multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution. Marking
+     * signatures as consumed is very strongly discouraged.
      *
      * IMPORTANT: `hash` _must_ be the result of a hash operation for the
      * verification to be secure: it is possible to craft signatures that

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -45,7 +45,7 @@ library ECDSA {
      *
      * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signature, and
      * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
-     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifier. If an operation
+     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an operation
      * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
      * multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution. Marking
      * signatures as consumed is very strongly discouraged.
@@ -115,7 +115,7 @@ library ECDSA {
      *
      * NOTE: This function also prevents signature malleability by only supporting 65 bytes long signature, and
      * rejecting eip-2098 short signature. While this guarantee is still present, it is DEPRECATED and will be removed
-     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifier. If an operation
+     * in the next major release (v6.0). Developers SHOULD NOT use signatures as unique identifiers. If an operation
      * must me marked as consumed to prevent replayability, either the `hash` (or the `hash`/`recovered` pair if
      * multiple accounts are to sign the same hash) should be invalidated. Nonces are also a viable solution. Marking
      * signatures as consumed is very strongly discouraged.


### PR DESCRIPTION
Following discussion with @frangio, we believe that this could be usefull for someone that wants to re-implement `isValidSignatureNow` in a way taht supports both 65 and 64 bytes signatures.

We should add this support nativelly in v6.0, but for the same reason as the one mentioned in [this GHSA](https://github.com/OpenZeppelin/openzeppelin-contracts/security/advisories/GHSA-4h98-2769-gh6h) this is not a change that should happen in a minor release.

```solidity
function isValidSignatureNow64or65(address signer, bytes32 hash, bytes memory signature) internal view returns (bool) {
        if (signer.code.length == 0) {
            (uint8 v, bytes32 r, bytes32 s) = ECDSA.parse(signature);
            (address recovered, ECDSA.RecoverError err, ) = ECDSA.tryRecover(hash, v, r, s);
            return err == ECDSA.RecoverError.NoError && recovered == signer;
        } else {
            return isValidERC1271SignatureNow(signer, hash, signature);
        }
    }
```

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
