### PR TITLE
ci: upgrade to Node.js 24

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 22.x
+        node-version: 24.x
     - uses: actions/cache@v4
       id: cache
       with:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of  22.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)
