### PR TITLE
test: enable some math tests to be run by halmos

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -84,3 +84,5 @@ jobs:
         run: pip install -r fv-requirements.txt
       - name: Run Halmos
         run: halmos --match-test '^symbolic|^testSymbolic' -vv
+        env:
+          HALMOS_ALLOW_DOWNLOAD: 1

--- a/test/utils/Bytes.t.sol
+++ b/test/utils/Bytes.t.sol
@@ -14,7 +14,7 @@ contract BytesTest is Test {
     }
 
     // INDEX OF
-    function testIndexOf(bytes memory buffer, bytes1 s) public pure {
+    function testSymbolicIndexOf(bytes memory buffer, bytes1 s) public pure {
         uint256 result = Bytes.indexOf(buffer, s);
 
         if (buffer.length == 0) {
@@ -48,7 +48,7 @@ contract BytesTest is Test {
         }
     }
 
-    function testLastIndexOf(bytes memory buffer, bytes1 s) public pure {
+    function testSymbolicLastIndexOf(bytes memory buffer, bytes1 s) public pure {
         uint256 result = Bytes.lastIndexOf(buffer, s);
 
         if (buffer.length == 0) {

--- a/test/utils/math/Math.t.sol
+++ b/test/utils/math/Math.t.sol
@@ -12,7 +12,7 @@ contract MathTest is Test {
     }
 
     // ADD512 & MUL512
-    function testAdd512(uint256 a, uint256 b) public pure {
+    function testSymbolicAdd512(uint256 a, uint256 b) public pure {
         (uint256 high, uint256 low) = Math.add512(a, b);
 
         // test against tryAdd
@@ -60,7 +60,8 @@ contract MathTest is Test {
     }
 
     // CEILDIV
-    function testCeilDiv(uint256 a, uint256 b) public pure {
+    /// @custom:halmos --solver cvc5-int
+    function testSymbolicCeilDiv(uint256 a, uint256 b) public pure {
         vm.assume(b > 0);
 
         uint256 result = Math.ceilDiv(a, b);
@@ -112,17 +113,18 @@ contract MathTest is Test {
         _testInvMod(value, p, true);
     }
 
-    function testInvMod2(uint256 seed) public pure {
+    function testSymbolicInvMod2(uint256 seed) public pure {
         uint256 p = 2; // prime
         _testInvMod(bound(seed, 1, p - 1), p, false);
     }
 
-    function testInvMod17(uint256 seed) public pure {
+    function testSymbolicInvMod17(uint256 seed) public pure {
         uint256 p = 17; // prime
         _testInvMod(bound(seed, 1, p - 1), p, false);
     }
 
-    function testInvMod65537(uint256 seed) public pure {
+    /// @custom:halmos --solver bitwuzla-abs
+    function testSymbolicInvMod65537(uint256 seed) public pure {
         uint256 p = 65537; // prime
         _testInvMod(bound(seed, 1, p - 1), p, false);
     }

--- a/test/utils/math/SignedMath.t.sol
+++ b/test/utils/math/SignedMath.t.sol
@@ -48,7 +48,8 @@ contract SignedMathTest is Test {
     }
 
     // 2. more complex test, full int256 range
-    function testAverage2(int256 a, int256 b) public pure {
+    /// @custom:halmos --solver-timeout-assertion 0
+    function testSymbolicAverage2(int256 a, int256 b) public pure {
         (int256 result, int256 min, int256 max) = (
             SignedMath.average(a, b),
             SignedMath.min(a, b),


### PR DESCRIPTION
Some of the math library tests are also run by halmos for verification. With the recent switch in halmos's default SMT solver from Z3 to Yices, a few more tests can now be verified as well.

The following additional tests are now supported by halmos (>=v0.3.3):
(Most of these run quickly, except testAverage2, which takes ~100s locally, and ~200s in GitHub CI.)

Math.t.sol:
- testAdd512
- testCeilDiv (requires `--solver cvc5-int`)
- testInvMod2
- testInvMod17
- testInvMod65537 (requires `--solver bitwuzla-abs`)

SignedMath.t.sol:
- testAverage2 (requires `--solver-timeout-assertion 0`)

Bytes.t.sol:
- testIndexOf (the first variant with two parameters)
- testLastIndexOf (the first variant with two parameters)


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
