### PR TITLE
fix(docs): Correct bugs and improve template helper `properties.js`

### DIFF
--- a/docs/templates/properties.js
+++ b/docs/templates/properties.js
@@ -35,7 +35,7 @@ module.exports.fullname = function fullname({ item }) {
 
 module.exports.inheritance = function ({ item, build }) {
   if (!isNodeType('ContractDefinition', item)) {
-    throw new Error('used inherited-items on non-contract');
+    throw new Error('inheritance modifier used on non-contract');
   }
 
   return item.linearizedBaseContracts
@@ -65,14 +65,14 @@ module.exports['has-internal-variables'] = function ({ item }) {
 
 module.exports.functions = function ({ item }) {
   return [
-    ...[...findAll('FunctionDefinition', item)].filter(f => f.visibility !== 'private'),
-    ...[...findAll('VariableDeclaration', item)].filter(f => f.visibility === 'public'),
+    ...findAll('FunctionDefinition', item).filter(f => f.visibility !== 'private'),
+    ...findAll('VariableDeclaration', item).filter(f => f.visibility === 'public'),
   ];
 };
 
 module.exports.returns2 = function ({ item }) {
   if (isNodeType('VariableDeclaration', item)) {
-    return [{ type: item.typeDescriptions.typeString }];
+    return [{ type: item.typeName.typeDescriptions.typeString }];
   } else {
     return item.returns;
   }


### PR DESCRIPTION
1.  Bug Fix in `returns2` helper:
    -   Fixed a `TypeError` by correcting the property access for `VariableDeclaration` nodes.
    -   **Before:** `item.typeDescriptions.typeString` (incorrect)
    -   **After:** `item.typeName.typeDescriptions.typeString` (correct)

2.  Improved Error Message in `inheritance` helper:
    -   Clarified the error message to be more descriptive and accurate.
    -   **Before:** `used inherited-items on non-contract`
    -   **After:** `inheritance modifier used on non-contract`

3.  Code Refactoring in `functions` helper:
    -   Removed a redundant array spread `[...[...findAll()]]`. `findAll()` already returns an iterable that can be filtered directly. 



#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests (No new tests needed as this fixes existing template logic)
- [x] Documentation (Changes are internal to the doc generator)
- [ ] Changeset entry (run `npx changeset add`)