### PR TITLE
fix: remove duplicate word in ERC7821 comment

### DIFF
--- a/contracts/account/extensions/draft-ERC7821.sol
+++ b/contracts/account/extensions/draft-ERC7821.sol
@@ -10,7 +10,7 @@ import {Account} from "../Account.sol";
 /**
  * @dev Minimal batch executor following ERC-7821.
  *
- * Only supports supports single batch mode (`0x01000000000000000000`). Does not support optional "opData".
+ * Only supports single batch mode (`0x01000000000000000000`). Does not support optional "opData".
  *
  * @custom:stateless
  */


### PR DESCRIPTION
Remove duplicate "supports" word in the comment describing batch mode support.
The comment now correctly reads `Only supports supports single batch mode` of `Only supports single batch mode`


#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
