### PR TITLE
test(governance): normalize BigInt usage in tests and fix minor inconsistencies

### DIFF
--- a/test/governance/Governor.test.js
+++ b/test/governance/Governor.test.js
@@ -682,7 +682,7 @@ describe('Governor', function () {
 
           await expect(this.helper.propose())
             .to.be.revertedWithCustomError(this.mock, 'GovernorInvalidProposalLength')
-            .withArgs(0, 0, 0);
+            .withArgs(0n, 0n, 0n);
         });
 
         it('mismatch #1', async function () {
@@ -696,7 +696,7 @@ describe('Governor', function () {
           );
           await expect(this.helper.propose())
             .to.be.revertedWithCustomError(this.mock, 'GovernorInvalidProposalLength')
-            .withArgs(0, 1, 1);
+            .withArgs(0n, 1n, 1n);
         });
 
         it('mismatch #2', async function () {
@@ -710,7 +710,7 @@ describe('Governor', function () {
           );
           await expect(this.helper.propose())
             .to.be.revertedWithCustomError(this.mock, 'GovernorInvalidProposalLength')
-            .withArgs(1, 1, 0);
+            .withArgs(1n, 1n, 0n);
         });
 
         it('mismatch #3', async function () {
@@ -724,7 +724,7 @@ describe('Governor', function () {
           );
           await expect(this.helper.propose())
             .to.be.revertedWithCustomError(this.mock, 'GovernorInvalidProposalLength')
-            .withArgs(1, 0, 1);
+            .withArgs(1n, 0n, 1n);
         });
       });
 

--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -739,7 +739,7 @@ describe('TimelockController', function () {
                   ),
               )
                 .to.be.revertedWithCustomError(this.mock, 'TimelockInvalidOperationLength')
-                .withArgs(0, this.operation.payloads.length, this.operation.values.length);
+                .withArgs(0n, this.operation.payloads.length, this.operation.values.length);
             });
 
             it('length mismatch #2', async function () {
@@ -1152,7 +1152,7 @@ describe('TimelockController', function () {
     it('call payable with eth', async function () {
       const operation = genOperation(
         this.callreceivermock,
-        1,
+        1n,
         this.callreceivermock.interface.encodeFunctionData('mockFunction'),
         ethers.ZeroHash,
         '0x5ab73cd33477dcd36c1e05e28362719d0ed59a7b9ff14939de63a43073dc1f44',
@@ -1170,7 +1170,7 @@ describe('TimelockController', function () {
       await this.mock
         .connect(this.executor)
         .execute(operation.target, operation.value, operation.data, operation.predecessor, operation.salt, {
-          value: 1,
+          value: 1n,
         });
 
       expect(await ethers.provider.getBalance(this.mock)).to.equal(0n);
@@ -1264,7 +1264,7 @@ describe('TimelockController', function () {
         await this.token.connect(this.other).safeTransferFrom(
           this.other,
           this.mock,
-          ...Object.entries(tokenIds)[0n], // id + amount
+          ...Object.entries(tokenIds)[0], // id + amount
           '0x',
         );
       });

--- a/test/governance/extensions/GovernorCountingOverridable.test.js
+++ b/test/governance/extensions/GovernorCountingOverridable.test.js
@@ -93,7 +93,7 @@ describe('GovernorCountingOverridable', function () {
         expect(await ethers.provider.getBalance(this.receiver)).to.equal(value);
       });
 
-      describe('cast override vote', async function () {
+      describe('cast override vote', function () {
         beforeEach(async function () {
           // user 1 -(delegate 10 tokens)-> user 2
           // user 2 -(delegate 7 tokens)-> user 2

--- a/test/governance/extensions/GovernorSequentialProposalId.test.js
+++ b/test/governance/extensions/GovernorSequentialProposalId.test.js
@@ -167,7 +167,7 @@ describe('GovernorSequentialProposalId', function () {
         await this.helper.connect(this.proposer).propose();
         await expect(this.helper.connect(this.proposer).propose())
           .to.be.revertedWithCustomError(this.mock, 'GovernorUnexpectedProposalState')
-          .withArgs(await this.proposal.id, 0, ethers.ZeroHash);
+          .withArgs(await this.proposal.id, 0n, ethers.ZeroHash);
       });
 
       it('nominal workflow', async function () {

--- a/test/governance/utils/Votes.behavior.js
+++ b/test/governance/utils/Votes.behavior.js
@@ -65,7 +65,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
 
         expect(await this.votes.delegates(this.alice)).to.equal(this.alice);
         expect(await this.votes.getVotes(this.alice)).to.equal(weight);
-        expect(await this.votes.getVotes(this.bob)).to.equal(0);
+        expect(await this.votes.getVotes(this.bob)).to.equal(0n);
 
         const tx = await this.votes.connect(this.alice).delegate(this.bob);
         const timepoint = await time.clockFromReceipt[mode](tx);
@@ -74,9 +74,9 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
           .to.emit(this.votes, 'DelegateChanged')
           .withArgs(this.alice, this.alice, this.bob)
           .to.emit(this.votes, 'DelegateVotesChanged')
-          .withArgs(this.alice, weight, 0)
+          .withArgs(this.alice, weight, 0n)
           .to.emit(this.votes, 'DelegateVotesChanged')
-          .withArgs(this.bob, 0, weight);
+          .withArgs(this.bob, 0n, weight);
 
         expect(await this.votes.delegates(this.alice)).to.equal(this.bob);
         expect(await this.votes.getVotes(this.alice)).to.equal(0n);
@@ -117,7 +117,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
             .to.emit(this.votes, 'DelegateChanged')
             .withArgs(this.delegator, ethers.ZeroAddress, this.delegatee)
             .to.emit(this.votes, 'DelegateVotesChanged')
-            .withArgs(this.delegatee, 0, weight);
+            .withArgs(this.delegatee, 0n, weight);
 
           expect(await this.votes.delegates(this.delegator.address)).to.equal(this.delegatee);
           expect(await this.votes.getVotes(this.delegator.address)).to.equal(0n);
@@ -187,7 +187,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
 
           await expect(this.votes.delegateBySig(this.delegatee, nonce + 1n, ethers.MaxUint256, v, r, s))
             .to.be.revertedWithCustomError(this.votes, 'InvalidAccountNonce')
-            .withArgs(this.delegator, 0);
+            .withArgs(this.delegator, 0n);
         });
 
         it('rejects expired permit', async function () {
@@ -217,7 +217,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
       });
 
       it('reverts if block number >= current block', async function () {
-        const timepoint = 5e10;
+        const timepoint = 50_000_000_000n;
         const clock = await this.votes.clock();
         await expect(this.votes.getPastTotalSupply(timepoint))
           .to.be.revertedWithCustomError(this.votes, 'ERC5805FutureLookup')
@@ -257,7 +257,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
         t4.timepoint = await time.clockFromReceipt[mode](t4);
         t5.timepoint = await time.clockFromReceipt[mode](t5);
 
-        expect(await this.votes.getPastTotalSupply(t0.timepoint - 1n)).to.equal(0);
+        expect(await this.votes.getPastTotalSupply(t0.timepoint - 1n)).to.equal(0n);
         expect(await this.votes.getPastTotalSupply(t0.timepoint)).to.equal(weight[0]);
         expect(await this.votes.getPastTotalSupply(t0.timepoint + 1n)).to.equal(weight[0]);
         expect(await this.votes.getPastTotalSupply(t1.timepoint)).to.equal(weight[0] + weight[1]);
@@ -268,7 +268,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
         expect(await this.votes.getPastTotalSupply(t3.timepoint + 1n)).to.equal(weight[0] + weight[2]);
         expect(await this.votes.getPastTotalSupply(t4.timepoint)).to.equal(weight[2]);
         expect(await this.votes.getPastTotalSupply(t4.timepoint + 1n)).to.equal(weight[2]);
-        expect(await this.votes.getPastTotalSupply(t5.timepoint)).to.equal(0);
+        expect(await this.votes.getPastTotalSupply(t5.timepoint)).to.equal(0n);
         await expect(this.votes.getPastTotalSupply(t5.timepoint + 1n))
           .to.be.revertedWithCustomError(this.votes, 'ERC5805FutureLookup')
           .withArgs(t5.timepoint + 1n, t5.timepoint + 1n);
@@ -287,7 +287,7 @@ function shouldBehaveLikeVotes(tokens, { mode = 'blocknumber', fungible = true }
       describe('getPastVotes', function () {
         it('reverts if block number >= current block', async function () {
           const clock = await this.votes.clock();
-          const timepoint = 5e10; // far in the future
+          const timepoint = 50_000_000_000n; // far in the future
           await expect(this.votes.getPastVotes(this.bob, timepoint))
             .to.be.revertedWithCustomError(this.votes, 'ERC5805FutureLookup')
             .withArgs(timepoint, clock);


### PR DESCRIPTION
#### Problem
Several governance-related test files used inconsistent numeric literal types in assertions and event argument checks:
- Mixed `Number` and `BigInt` values in `.withArgs()` and `expect(...).to.equal(...)` for `uint256`-typed values caused type mismatches and potential brittle comparisons.
- Some literals like `5e10` were not using `n` suffix for `BigInt`.
- A non-idiomatic index `[0n]` was used for `Object.entries(...)` instead of `[0]`.
- Minor unnecessary `async` in `describe` blocks.

#### Summary of Changes
- Replaced all numeric literals representing `uint256` values with proper `BigInt` (`0n`, `1n`, `50_000_000_000n`, etc.).
- Updated `.withArgs(...)` calls to ensure argument types match contract ABI expectations (BigInt for `uint256`).
- Changed `5e10` to `50_000_000_000n` for clarity and correct type.
- Fixed `[0n]` index to `[0]` for array access.
- Removed unused `async` keyword in `describe` block.

#### Affected Files
- `test/governance/utils/Votes.behavior.js`
- `test/governance/Governor.test.js`
- `test/governance/TimelockController.test.js`
- `test/governance/extensions/GovernorSequentialProposalId.test.js`
- `test/governance/extensions/GovernorCountingOverridable.test.js`

#### Impact
- Improves test reliability by eliminating implicit type coercion between `Number` and `BigInt`.
- Maintains consistency across governance test suite.
- **Tests-only change; no production code touched.**
```
