### PR TITLE
polishing docs: error fixes for clarity

### DIFF
--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -123,7 +123,7 @@ interface IAccessManager {
 
     /**
      * @dev Minimum setback for all delay updates, with the exception of execution delays. It
-     * can be increased without setback (and reset via {revokeRole} in the case event of an
+     * can be increased without setback (and reset via {revokeRole} in the event of an
      * accidental increase). Defaults to 5 days.
      */
     function minSetback() external view returns (uint32);
@@ -170,7 +170,7 @@ interface IAccessManager {
 
     /**
      * @dev Get the access details for a given account for a given role. These details include the timepoint at which
-     * membership becomes active, and the delay applied to all operation by this user that requires this permission
+     * membership becomes active, and the delay applied to all operations by this user that requires this permission
      * level.
      *
      * Returns:
@@ -376,7 +376,7 @@ interface IAccessManager {
      * @dev Consume a scheduled operation targeting the caller. If such an operation exists, mark it as consumed
      * (emit an {OperationExecuted} event and clean the state). Otherwise, throw an error.
      *
-     * This is useful for contract that want to enforce that calls targeting them were scheduled on the manager,
+     * This is useful for contracts that want to enforce that calls targeting them were scheduled on the manager,
      * with all the verifications that it implies.
      *
      * Emit a {OperationExecuted} event.

--- a/contracts/account/utils/EIP7702Utils.sol
+++ b/contracts/account/utils/EIP7702Utils.sol
@@ -12,7 +12,7 @@ library EIP7702Utils {
     bytes3 internal constant EIP7702_PREFIX = 0xef0100;
 
     /**
-     * @dev Returns the address of the delegate if `account` as an EIP-7702 delegation setup, or address(0) otherwise.
+     * @dev Returns the address of the delegate if `account` has an EIP-7702 delegation setup, or address(0) otherwise.
      */
     function fetchDelegate(address account) internal view returns (address) {
         bytes23 delegation = bytes23(account.code);


### PR DESCRIPTION
contracts/access/manager/IAccessManager.sol
`in the case event` - `in the event`
`to all operation` - `to all operations`
`for contract` - `for contracts`

contracts/account/utils/EIP7702Utils.sol
`as an EIP-7702` - `has an EIP-7702`

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
