### PR TITLE
Enable Foundry linter

### DIFF
--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -10,6 +10,7 @@ import {Context} from "../../utils/Context.sol";
 import {Multicall} from "../../utils/Multicall.sol";
 import {Math} from "../../utils/math/Math.sol";
 import {Time} from "../../utils/types/Time.sol";
+import {Hashes} from "../../utils/cryptography/Hashes.sol";
 
 /**
  * @dev AccessManager is a central contract to store the permissions of a system.
@@ -735,6 +736,6 @@ contract AccessManager is Context, Multicall, IAccessManager {
      * @dev Hashing function for execute protection
      */
     function _hashExecutionId(address target, bytes4 selector) private pure returns (bytes32) {
-        return keccak256(abi.encode(target, selector));
+        return Hashes.efficientKeccak256(bytes32(uint256(uint160(target))), selector);
     }
 }

--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -19,7 +19,6 @@ import {ERC7579Utils, Mode, CallType, ExecType} from "../../account/utils/draft-
 import {EnumerableSet} from "../../utils/structs/EnumerableSet.sol";
 import {Bytes} from "../../utils/Bytes.sol";
 import {Packing} from "../../utils/Packing.sol";
-import {Address} from "../../utils/Address.sol";
 import {Calldata} from "../../utils/Calldata.sol";
 import {Account} from "../Account.sol";
 

--- a/contracts/mocks/account/AccountMock.sol
+++ b/contracts/mocks/account/AccountMock.sol
@@ -7,7 +7,6 @@ import {AccountERC7579} from "../../account/extensions/draft-AccountERC7579.sol"
 import {AccountERC7579Hooked} from "../../account/extensions/draft-AccountERC7579Hooked.sol";
 import {ERC721Holder} from "../../token/ERC721/utils/ERC721Holder.sol";
 import {ERC1155Holder} from "../../token/ERC1155/utils/ERC1155Holder.sol";
-import {ERC4337Utils} from "../../account/utils/draft-ERC4337Utils.sol";
 import {ERC7739} from "../../utils/cryptography/signers/draft-ERC7739.sol";
 import {ERC7821} from "../../account/extensions/draft-ERC7821.sol";
 import {MODULE_TYPE_VALIDATOR} from "../../interfaces/draft-IERC7579.sol";

--- a/contracts/mocks/governance/GovernorNoncesKeyedMock.sol
+++ b/contracts/mocks/governance/GovernorNoncesKeyedMock.sol
@@ -6,7 +6,6 @@ import {Governor, Nonces} from "../../governance/Governor.sol";
 import {GovernorSettings} from "../../governance/extensions/GovernorSettings.sol";
 import {GovernorCountingSimple} from "../../governance/extensions/GovernorCountingSimple.sol";
 import {GovernorVotesQuorumFraction} from "../../governance/extensions/GovernorVotesQuorumFraction.sol";
-import {GovernorProposalGuardian} from "../../governance/extensions/GovernorProposalGuardian.sol";
 import {GovernorNoncesKeyed} from "../../governance/extensions/GovernorNoncesKeyed.sol";
 
 abstract contract GovernorNoncesKeyedMock is

--- a/contracts/mocks/token/ERC20BridgeableMock.sol
+++ b/contracts/mocks/token/ERC20BridgeableMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.20;
 
-import {ERC20, ERC20Bridgeable} from "../../token/ERC20/extensions/draft-ERC20Bridgeable.sol";
+import {ERC20Bridgeable} from "../../token/ERC20/extensions/draft-ERC20Bridgeable.sol";
 
 abstract contract ERC20BridgeableMock is ERC20Bridgeable {
     address private _bridge;

--- a/contracts/mocks/token/ERC20NoReturnMock.sol
+++ b/contracts/mocks/token/ERC20NoReturnMock.sol
@@ -6,6 +6,7 @@ import {ERC20} from "../../token/ERC20/ERC20.sol";
 
 abstract contract ERC20NoReturnMock is ERC20 {
     function transfer(address to, uint256 amount) public override returns (bool) {
+        // forge-lint: disable-next-line(erc20-unchecked-transfer)
         super.transfer(to, amount);
         assembly {
             return(0, 0)
@@ -13,6 +14,7 @@ abstract contract ERC20NoReturnMock is ERC20 {
     }
 
     function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        // forge-lint: disable-next-line(erc20-unchecked-transfer)
         super.transferFrom(from, to, amount);
         assembly {
             return(0, 0)

--- a/contracts/mocks/utils/cryptography/ERC7739Mock.sol
+++ b/contracts/mocks/utils/cryptography/ERC7739Mock.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import {ECDSA} from "../../../utils/cryptography/ECDSA.sol";
 import {ERC7739} from "../../../utils/cryptography/signers/draft-ERC7739.sol";
 import {SignerECDSA} from "../../../utils/cryptography/signers/SignerECDSA.sol";
 import {SignerP256} from "../../../utils/cryptography/signers/SignerP256.sol";

--- a/contracts/token/ERC721/extensions/ERC721Wrapper.sol
+++ b/contracts/token/ERC721/extensions/ERC721Wrapper.sol
@@ -36,7 +36,7 @@ abstract contract ERC721Wrapper is ERC721, IERC721Receiver {
             // This is an "unsafe" transfer that doesn't call any hook on the receiver. With underlying() being trusted
             // (by design of this contract) and no other contracts expected to be called from there, we are safe.
             // slither-disable-next-line reentrancy-no-eth
-            underlying().transferFrom(_msgSender(), address(this), tokenId);
+            underlying().transferFrom(_msgSender(), address(this), tokenId); // forge-lint: disable-line(erc20-unchecked-transfer)
             _safeMint(account, tokenId);
         }
 

--- a/contracts/utils/cryptography/draft-ERC7739Utils.sol
+++ b/contracts/utils/cryptography/draft-ERC7739Utils.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.20;
 
 import {Calldata} from "../Calldata.sol";
+import {Hashes} from "./Hashes.sol";
 
 /**
  * @dev Utilities to process https://ercs.ethereum.org/ERCS/erc-7739[ERC-7739] typed data signatures
@@ -101,7 +102,7 @@ library ERC7739Utils {
      * This is used to simulates the `personal_sign` RPC method in the context of smart contracts.
      */
     function personalSignStructHash(bytes32 contents) internal pure returns (bytes32) {
-        return keccak256(abi.encode(PERSONAL_SIGN_TYPEHASH, contents));
+        return Hashes.efficientKeccak256(PERSONAL_SIGN_TYPEHASH, contents);
     }
 
     /**

--- a/contracts/utils/cryptography/signers/draft-ERC7739.sol
+++ b/contracts/utils/cryptography/signers/draft-ERC7739.sol
@@ -8,7 +8,6 @@ import {EIP712} from "../EIP712.sol";
 import {ERC7739Utils} from "../draft-ERC7739Utils.sol";
 import {IERC1271} from "../../../interfaces/IERC1271.sol";
 import {MessageHashUtils} from "../MessageHashUtils.sol";
-import {ShortStrings} from "../../ShortStrings.sol";
 
 /**
  * @dev Validates signatures wrapping the message hash in a nested EIP712 type. See {ERC7739Utils}.

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,10 @@ test = 'test'
 cache_path  = 'cache_forge'
 fs_permissions = [{ access = "read", path = "./node_modules/hardhat-predeploy/bin" }]
 
+[lint]
+exclude_lints = ["mixed-case-function", "asm-keccak256", "screaming-snake-case-immutable", "incorrect-shift", "mixed-case-variable"]
+ignore = ["./contracts/interfaces/**/*.sol", "./contracts/mocks/Stateless.sol"]
+
 [fuzz]
 runs = 5000
 max_test_rejects = 150000

--- a/test/token/ERC721/extensions/ERC721Consecutive.t.sol
+++ b/test/token/ERC721/extensions/ERC721Consecutive.t.sol
@@ -16,7 +16,7 @@ function toSingleton(address account) pure returns (address[] memory) {
 
 contract ERC721ConsecutiveTarget is StdUtils, ERC721Consecutive {
     uint96 private immutable _offset;
-    uint256 public totalMinted = 0;
+    uint256 private _totalMinted = 0;
 
     constructor(address[] memory receivers, uint256[] memory batches, uint256 startingId) ERC721("", "") {
         _offset = uint96(startingId);
@@ -24,8 +24,12 @@ contract ERC721ConsecutiveTarget is StdUtils, ERC721Consecutive {
             address receiver = receivers[i % receivers.length];
             uint96 batchSize = uint96(bound(batches[i], 0, _maxBatchSize()));
             _mintConsecutive(receiver, batchSize);
-            totalMinted += batchSize;
+            _totalMinted += batchSize;
         }
+    }
+
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted;
     }
 
     function burn(uint256 tokenId) public {
@@ -138,6 +142,7 @@ contract ERC721ConsecutiveTest is Test {
         assertEq(token.balanceOf(accounts[1]), batches[1]);
 
         vm.prank(accounts[0]);
+        // forge-lint: disable-next-line(erc20-unchecked-transfer)
         token.transferFrom(accounts[0], accounts[1], tokenId0);
 
         assertEq(token.ownerOf(tokenId0), accounts[1]);
@@ -146,6 +151,7 @@ contract ERC721ConsecutiveTest is Test {
         assertEq(token.balanceOf(accounts[1]), batches[1] + 1);
 
         vm.prank(accounts[1]);
+        // forge-lint: disable-next-line(erc20-unchecked-transfer)
         token.transferFrom(accounts[1], accounts[0], tokenId1);
 
         assertEq(token.ownerOf(tokenId0), accounts[1]);


### PR DESCRIPTION
There's a new [linter](https://getfoundry.sh/forge/linting/) included in a recent release of Foundry and I think it's good to give it a try.

Currently, the following lint rules are excluded:

- `mixed-case-function`: We have multiple legitimate cases, for example all the Packing library is `extract_xx_xx`. Also there are functions that are standard like `COUNTING_MODE()`
- `asm-keccak256`: This one is useful but has multiple false positives. For example, `keccak256(bytes memory)` still suggest using inline assembly when I think it's equivalent. Similarly, for hashes of more than 2 arguments, which no longer can be fit within scratch space, so they allocate memory regardless. Some suggestions were true, for those I'm using the Hashes library
- `screaming-snake-case-immutable`: We don't do this, and I particularly dislike it.
- `incorrect-shift`: Also, multiple false positives for legitimate cases. I think these must come from testing and not from linting
- `mixed-case-variable`: Similar rationale to `mixed-case-function`

Also, I'm ignoring the following patterns:

- `"./contracts/interfaces/**/*.sol"`: Interfaces have unused imports, this eliminates the need of adding `forge-lint: disable-next-line`
- "./contracts/mocks/Stateless.sol": Unused imports too.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
