### PR TITLE
docs(ERC20): link ERC20Votes to governance guide minimal example

### DIFF
--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -21,7 +21,7 @@ Additionally there are multiple custom extensions, including:
 * {ERC20Capped}: enforcement of a cap to the total supply when minting tokens.
 * {ERC20Pausable}: ability to pause token transfers.
 * {ERC20FlashMint}: token level support for flash loans through the minting and burning of ephemeral tokens (standardized as ERC-3156).
-* {ERC20Votes}: support for voting and vote delegation. See the governance guide for a minimal example (with the required overrides when combining ERC20 + ERC20Permit + ERC20Votes): https://docs.openzeppelin.com/contracts/4.x/governance#token
+* {ERC20Votes}: support for voting and vote delegation. xref:governance.adoc#token[See the governance guide for a minimal example (with the required overrides when combining ERC20 + ERC20Permit + ERC20Votes)].
 * {ERC20Wrapper}: wrapper to create an ERC-20 backed by another ERC-20, with deposit and withdraw methods. Useful in conjunction with {ERC20Votes}.
 * {ERC20TemporaryApproval}: support for approvals lasting for only one transaction, as defined in ERC-7674.
 * {ERC1363}: support for calling the target of a transfer or approval, enabling code execution on the receiver within a single transaction.

--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -21,7 +21,7 @@ Additionally there are multiple custom extensions, including:
 * {ERC20Capped}: enforcement of a cap to the total supply when minting tokens.
 * {ERC20Pausable}: ability to pause token transfers.
 * {ERC20FlashMint}: token level support for flash loans through the minting and burning of ephemeral tokens (standardized as ERC-3156).
-* {ERC20Votes}: support for voting and vote delegation.
+* {ERC20Votes}: support for voting and vote delegation. See the governance guide for a minimal example (with the required overrides when combining ERC20 + ERC20Permit + ERC20Votes): https://docs.openzeppelin.com/contracts/4.x/governance#token
 * {ERC20Wrapper}: wrapper to create an ERC-20 backed by another ERC-20, with deposit and withdraw methods. Useful in conjunction with {ERC20Votes}.
 * {ERC20TemporaryApproval}: support for approvals lasting for only one transaction, as defined in ERC-7674.
 * {ERC1363}: support for calling the target of a transfer or approval, enabling code execution on the receiver within a single transaction.


### PR DESCRIPTION
### Summary
Add a direct link from the ERC20 README to the governance guide section that shows the minimal ERC20Votes example (including the required overrides when combining ERC20 + ERC20Permit + ERC20Votes).

### Why
Developers frequently land on the ERC20 README, see `{ERC20Votes}`, and miss the minimal example that lives in the governance guide. Linking it here reduces foot-guns, especially around the required `_afterTokenTransfer`, `_mint`, and `_burn` overrides.

- Minimal example with overrides (official docs): https://docs.openzeppelin.com/contracts/4.x/governance#token
- ERC20Votes warns that incorrect overrides can compromise vote accounting (see Natspec on the upgradeable variant as well).

### Scope
Docs only. No code changes.
