### PR TITLE
fix(readme): update OpenZeppelin Defender link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 :mage: **Not sure how to get started?** Check out [Contracts Wizard](https://wizard.openzeppelin.com/) — an interactive smart contract generator.
 
-:building_construction: **Want to scale your decentralized application?** Check out [OpenZeppelin Defender](https://openzeppelin.com/defender) — a mission-critical developer security platform to code, audit, deploy, monitor, and operate with confidence.
+:building_construction: **Want to scale your decentralized application?** Check out [OpenZeppelin Defender](https://defender.openzeppelin.com/) — a mission-critical developer security platform to code, audit, deploy, monitor, and operate with confidence.
 
 > [!IMPORTANT]
 > OpenZeppelin Contracts uses semantic versioning to communicate backwards compatibility of its API and storage layout. For upgradeable contracts, the storage layout of different major versions should be assumed incompatible, for example, it is unsafe to upgrade from 4.9.3 to 5.0.0. Learn more at [Backwards Compatibility](https://docs.openzeppelin.com/contracts/backwards-compatibility).


### PR DESCRIPTION
README.md: replaced outdated https://openzeppelin.com/defender link with the correct https://defender.openzeppelin.com/.