### PR TITLE
docs: fix typos and grammar in Solidity source comments

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721Consecutive.sol
+++ b/contracts/token/ERC721/extensions/ERC721Consecutive.sol
@@ -20,7 +20,7 @@ import {Checkpoints} from "../../../utils/structs/Checkpoints.sol";
  * regained after construction. During construction, only batch minting is allowed.
  *
  * IMPORTANT: This extension does not call the {_update} function for tokens minted in batch. Any logic added to this
- * function through overrides will not be triggered when token are minted in batch. You may want to also override
+ * function through overrides will not be triggered when tokens are minted in batch. You may want to also override
  * {_increaseBalance} or {_mintConsecutive} to account for these mints.
  *
  * IMPORTANT: When overriding {_mintConsecutive}, be careful about call ordering. {ownerOf} may return invalid

--- a/contracts/token/ERC721/utils/ERC721Utils.sol
+++ b/contracts/token/ERC721/utils/ERC721Utils.sol
@@ -7,7 +7,7 @@ import {IERC721Receiver} from "../IERC721Receiver.sol";
 import {IERC721Errors} from "../../../interfaces/draft-IERC6093.sol";
 
 /**
- * @dev Library that provide common ERC-721 utility functions.
+ * @dev Library that provides common ERC-721 utility functions.
  *
  * See https://eips.ethereum.org/EIPS/eip-721[ERC-721].
  *

--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -137,7 +137,7 @@ library Bytes {
 
     /**
      * @dev Reverses the byte order of a bytes32 value, converting between little-endian and big-endian.
-     * Inspired in https://graphics.stanford.edu/~seander/bithacks.html#ReverseParallel[Reverse Parallel]
+     * Inspired by https://graphics.stanford.edu/~seander/bithacks.html#ReverseParallel[Reverse Parallel]
      */
     function reverseBytes32(bytes32 value) internal pure returns (bytes32) {
         value = // swap bytes

--- a/contracts/utils/draft-InteroperableAddress.sol
+++ b/contracts/utils/draft-InteroperableAddress.sol
@@ -21,7 +21,7 @@ library InteroperableAddress {
     /**
      * @dev Format an ERC-7930 interoperable address (version 1) from its components `chainType`, `chainReference`
      * and `addr`. This is a generic function that supports any chain type, chain reference and address supported by
-     * ERC-7390, including interoperable addresses with empty chain reference or empty address.
+     * ERC-7930, including interoperable addresses with empty chain reference or empty address.
      */
     function formatV1(
         bytes2 chainType,

--- a/contracts/utils/structs/CircularBuffer.sol
+++ b/contracts/utils/structs/CircularBuffer.sol
@@ -21,7 +21,7 @@ import {Panic} from "../Panic.sol";
  * - inclusion ({includes}): O(N) (worst case)
  * - reset ({clear}): O(1)
  *
- * * The struct is called `Bytes32CircularBuffer`. Other types can be cast to and from `bytes32`. This data structure
+ * The struct is called `Bytes32CircularBuffer`. Other types can be cast to and from `bytes32`. This data structure
  * can only be used in storage, and not in memory.
  *
  * Example usage:

--- a/contracts/utils/types/Time.sol
+++ b/contracts/utils/types/Time.sol
@@ -37,7 +37,7 @@ library Time {
     // ==================================================== Delay =====================================================
     /**
      * @dev A `Delay` is a uint32 duration that can be programmed to change value automatically at a given point in the
-     * future. The "effect" timepoint describes when the transitions happen from the "old" value to the "new" value.
+     * future. The "effect" timepoint describes when the transition happens from the "old" value to the "new" value.
      * This allows updating the delay applied to some operation while keeping some guarantees.
      *
      * In particular, the {update} function guarantees that if the delay is reduced, the old delay still applies for

--- a/contracts/utils/types/Time.sol
+++ b/contracts/utils/types/Time.sol
@@ -37,7 +37,7 @@ library Time {
     // ==================================================== Delay =====================================================
     /**
      * @dev A `Delay` is a uint32 duration that can be programmed to change value automatically at a given point in the
-     * future. The "effect" timepoint describes when the transitions happens from the "old" value to the "new" value.
+     * future. The "effect" timepoint describes when the transitions happen from the "old" value to the "new" value.
      * This allows updating the delay applied to some operation while keeping some guarantees.
      *
      * In particular, the {update} function guarantees that if the delay is reduced, the old delay still applies for


### PR DESCRIPTION
- ERC721Consecutive.sol: corrected grammar in _update function note (token are → tokens are).

- ERC721Utils.sol: fixed docstring wording (provide → provides).

- Bytes.sol: corrected phrasing (Inspired in → Inspired by).

- draft-InteroperableAddress.sol: fixed standard reference (ERC-7390 → ERC-7930).

- CircularBuffer.sol: removed redundant asterisk in doc comment.

- Time.sol: corrected grammar (transitions happens → transitions happen).


#### PR Checklist

- [x] Documentation

## Summary by Sourcery

Fix typos, grammar, and wording in Solidity source comments across multiple contracts to improve documentation accuracy.

Documentation:
- Correct grammar in the _update function note in ERC721Consecutive ("token are" → "tokens are").
- Change "provide" to "provides" in the ERC721Utils library docstring.
- Update phrasing in Bytes library comment ("Inspired in" → "Inspired by").
- Fix standard reference in InteroperableAddress from ERC-7390 to ERC-7930.
- Remove a redundant asterisk in the CircularBuffer struct comment.
- Correct grammar in the Time library comment ("transitions happens" → "transitions happen").