### PR TITLE
Use the "dev" tag for new releases

### DIFF
--- a/scripts/release/workflow/pack.sh
+++ b/scripts/release/workflow/pack.sh
@@ -10,7 +10,7 @@ dist_tag() {
   if [ "$PRERELEASE" = "true" ]; then
     echo "next"
   elif npx semver -r ">$LATEST_NPM_VERSION" "$PACKAGE_JSON_VERSION" > /dev/null; then
-    echo "latest"
+    echo "dev"
   else
     # This is a patch for an older version
     # npm can't publish without a tag


### PR DESCRIPTION
### Overview

Use a dual tag: `latest` + `dev`

```mermaid
graph LR
  5.3["5.3 (audited)"] --dev--> 5.4["5.4 (audited)"] --dev--> 5.5["5.5 (unaudited)"] --dev--> 5.6["5.6 (unaudited)"] --dev--> 5.7["5.7 (audited)"] --dev--> 5.8["5.8 (unaudited)"]
  5.3 --latest--> 5.4 --latest--> 5.7
  
```

At each point, `dev` points to the latest version (audited or not), which `latest` (which npm serves by default) points to the latest audited version. 

If the latest version was audited, then both `latest` and `dev` will point to the same version.

### How does the users get the package

If a user wants to get the latest audited release:

- `npm i @openzeppelin/contracts`
- `npm i @openzeppelin/contracts@latest`

If a user wants to get the latest release (audited or not):

- `npm i @openzeppelin/contracts@dev`

If a user wants to get the latest release candidate (might not exist, might correspond to an unaudited version):

- `npm i @openzeppelin/contracts@next`

### Changes to the release process

- (automatic) release next version with with dev tag instead of latest <= **THIS PR**
- (manual) move the latest tag when an audited release is published

## Summary by Sourcery

Build:
- Change release script to tag new packages as ‘dev’ instead of ‘latest’