### PR TITLE
docs: fix typos and grammar in comments

### DIFF
--- a/contracts/access/extensions/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/AccessControlDefaultAdminRules.sol
@@ -364,7 +364,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
     }
 
     /**
-     * @dev Defines if an `schedule` is considered passed. For consistency purposes.
+     * @dev Defines if a `schedule` is considered passed. For consistency purposes.
      */
     function _hasSchedulePassed(uint48 schedule) private view returns (bool) {
         return schedule < block.timestamp;

--- a/contracts/access/extensions/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/AccessControlDefaultAdminRules.sol
@@ -357,7 +357,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
     ///
 
     /**
-     * @dev Defines if an `schedule` is considered set. For consistency purposes.
+     * @dev Defines if a `schedule` is considered set. For consistency purposes.
      */
     function _isScheduleSet(uint48 schedule) private pure returns (bool) {
         return schedule != 0;

--- a/contracts/access/manager/AccessManager.sol
+++ b/contracts/access/manager/AccessManager.sol
@@ -69,7 +69,7 @@ contract AccessManager is Context, Multicall, IAccessManager {
         bool closed;
     }
 
-    // Structure that stores the details for a role/account pair. This structures fit into a single slot.
+    // Structure that stores the details for a role/account pair. This structure fits into a single slot.
     struct Access {
         // Timepoint at which the user gets the permission.
         // If this is either 0 or in the future, then the role permission is not available.

--- a/contracts/account/extensions/draft-ERC7821.sol
+++ b/contracts/account/extensions/draft-ERC7821.sol
@@ -10,7 +10,7 @@ import {Account} from "../Account.sol";
 /**
  * @dev Minimal batch executor following ERC-7821.
  *
- * Only supports supports single batch mode (`0x01000000000000000000`). Does not support optional "opData".
+ * Only supports single batch mode (`0x01000000000000000000`). Does not support optional "opData".
  *
  * @custom:stateless
  */

--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -8,7 +8,7 @@ import {Context} from "../utils/Context.sol";
 /**
  * @dev Context variant with ERC-2771 support.
  *
- * WARNING: Avoid using this pattern in contracts that rely in a specific calldata length as they'll
+ * WARNING: Avoid using this pattern in contracts that rely on a specific calldata length as they'll
  * be affected by any forwarder whose `msg.data` is suffixed with the `from` address according to the ERC-2771
  * specification adding the address size in bytes (20) to the calldata size. An example of an unexpected
  * behavior could be an unintended fallback (or another function) invocation while trying to invoke the `receive`

--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -33,7 +33,7 @@ abstract contract ERC4626Fees is ERC4626 {
         return assets + _feeOnRaw(assets, _entryFeeBasisPoints());
     }
 
-    /// @dev Preview adding an exit fee on withdraw. See {IERC4626-previewWithdraw}.
+    /// @dev Preview adding an exit fee on withdrawal. See {IERC4626-previewWithdraw}.
     function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
         uint256 fee = _feeOnRaw(assets, _exitFeeBasisPoints());
         return super.previewWithdraw(assets + fee);


### PR DESCRIPTION
- Corrected article usage in AccessControlDefaultAdminRules (`a schedule` instead of `an schedule`).
- Fixed pluralization in AccessManager (`This structure fits...`).
- Removed duplicated word in ERC7821 (`supports supports` → `supports`).
- Corrected preposition in ERC2771Context (`rely on` instead of `rely in`).
- Improved wording in ERC4626Fees (`withdrawal` instead of `withdraw`).

## Summary by Sourcery

Fix grammar and typos in comments across multiple contracts

Documentation:
- Correct article usage for "schedule" comments in AccessControlDefaultAdminRules
- Fix pluralization in AccessManager comment to "structure fits"
- Remove duplicated word in ERC7821 batch mode comment
- Correct preposition to "rely on" in ERC2771Context warning
- Improve wording to "withdrawal" in ERC4626Fees preview comment