### PR TITLE
Prevent zero-value transferFrom calls to block unsolicited USDT spam transfers

### DIFF
--- a/contracts/interfaces/draft-IERC6093.sol
+++ b/contracts/interfaces/draft-IERC6093.sol
@@ -37,6 +37,14 @@ interface IERC20Errors {
     error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
 
     /**
+     * @dev Indicates that a `transferFrom` call attempted to move zero tokens.
+     * This implementation disallows zero-value transfers via {transferFrom} to prevent
+     * unsolicited event emissions.
+     * @param spender Address that attempted to spend on behalf of the token owner.
+     */
+    error ERC20ZeroTransferFromNotAllowed(address spender);
+
+    /**
      * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.
      * @param approver Address initiating an approval operation.
      */

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -294,9 +294,14 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     function _spendAllowance(address owner, address spender, uint256 value) internal virtual {
         uint256 currentAllowance = allowance(owner, spender);
         if (currentAllowance < type(uint256).max) {
+            if(value == 0){
+                revert ERC20ZeroTransferFromNotAllowed(spender);
+            }
+            
             if (currentAllowance < value) {
                 revert ERC20InsufficientAllowance(spender, currentAllowance, value);
             }
+            
             unchecked {
                 _approve(owner, spender, currentAllowance - value, false);
             }


### PR DESCRIPTION
**Problem**

In the current ERC20 implementation, transferFrom with amount = 0 is allowed.
Because the ERC20 standard does not require allowance checks for zero values, any external account can call:

`usdt.transferFrom(victimWallet, attackerWallet, 0);`

This succeeds without approval and emits a Transfer(from, to, 0) event.
As a result:

- Wallets (including fee wallets) appear to have “OUT” transfers of 0 tokens.
- Block explorers (like BscScan) show misleading history logs.
- This behavior enables spam attacks where attackers flood wallets with fake “0 USDT transfers” to confuse users.


**Solution**

This PR modifies the ERC20 implementation to explicitly forbid zero-value transfers via transferFrom.

- Introduced a new custom error:

`error ERC20ZeroTransferFromNotAllowed(address spender);`

- Updated _spendAllowance to revert with this error when value == 0.
- Nonzero transferFrom calls remain unaffected.
- Direct transfer(…, 0) calls are still permitted for ERC20 spec compliance.

**Impact**

- Prevents unsolicited zero-value transferFrom calls.
- Eliminates spam “OUT 0 token” events from user wallets.
- Provides a clear and explicit revert reason to integrators via the new error.
