### PR TITLE
docs: fix typos in Solidity comments and documentation

### DIFF
--- a/contracts/governance/extensions/GovernorStorage.sol
+++ b/contracts/governance/extensions/GovernorStorage.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.24;
 import {Governor} from "../Governor.sol";
 
 /**
- * @dev Extension of {Governor} that implements storage of proposal details. This modules also provides primitives for
+ * @dev Extension of {Governor} that implements storage of proposal details. This module also provides primitives for
  * the enumerability of proposals.
  *
  * Use cases for this module include:

--- a/contracts/interfaces/IERC3156FlashLender.sol
+++ b/contracts/interfaces/IERC3156FlashLender.sol
@@ -11,7 +11,7 @@ import {IERC3156FlashBorrower} from "./IERC3156FlashBorrower.sol";
  */
 interface IERC3156FlashLender {
     /**
-     * @dev The amount of currency available to be lended.
+     * @dev The amount of currency available to be lent.
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -263,7 +263,7 @@ Some use cases require more powerful data structures than arrays and mappings of
 - xref:api:utils.adoc#EnumerableSet[`EnumerableSet`]: A https://en.wikipedia.org/wiki/Set_(abstract_data_type)[set] with enumeration capabilities.
 - xref:api:utils.adoc#EnumerableMap[`EnumerableMap`]: A `mapping` variant with enumeration capabilities.
 - xref:api:utils.adoc#MerkleTree[`MerkleTree`]: An on-chain https://wikipedia.org/wiki/Merkle_Tree[Merkle Tree] with helper functions.
-- xref:api:utils.adoc#Heap.sol[`Heap`]: A https://en.wikipedia.org/wiki/Binary_heap[binary heap] to store elements with priority defined by a compartor function.
+- xref:api:utils.adoc#Heap.sol[`Heap`]: A https://en.wikipedia.org/wiki/Binary_heap[binary heap] to store elements with priority defined by a comparator function.
 
 The `Enumerable*` structures are similar to mappings in that they store and remove elements in constant time and don't allow for repeated entries, but they also support _enumeration_, which means you can easily query all stored entries both on and off-chain.
 


### PR DESCRIPTION
- Corrected "modules" → "module" in GovernorStorage.sol docstring.  
- Corrected "lended" → "lent" in IERC3156FlashLender.sol.  
- Corrected "compartor" → "comparator" in utilities.adoc.

## Summary by Sourcery

Fix typos in Solidity contract comments and documentation

Documentation:
- Correct 'modules' to 'module' in GovernorStorage.sol docstring
- Correct 'lended' to 'lent' in IERC3156FlashLender.sol comment
- Correct 'compartor' to 'comparator' in utilities.adoc