### PR TITLE
docs: add cross-link to ReentrancyGuard guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,5 @@ OpenZeppelin Contracts is released under the [MIT License](LICENSE).
 ## Legal
 
 Your use of this Project is governed by the terms found at www.openzeppelin.com/tos (the "Terms").
+
+> See also: ReentrancyGuard usage guide in the docs.


### PR DESCRIPTION
Minor docs cross-link for discoverability. No code changes.

## Summary by Sourcery

Documentation:
- Add link to ReentrancyGuard usage guide in README for easier navigation