### PR TITLE
chore: fix typos and clarify role naming  

### DIFF
--- a/test/access/AccessControl.behavior.js
+++ b/test/access/AccessControl.behavior.js
@@ -464,7 +464,7 @@ function shouldBehaveLikeAccessControlDefaultAdminRules() {
           // Wait until schedule + fromSchedule
           await time.increaseTo.timestamp(this.acceptSchedule + fromSchedule, false);
 
-          // defaultAdmin changes its mind and begin again to another address
+          // defaultAdmin changes its mind and begins again to another address
           await expect(this.mock.connect(this.defaultAdmin).beginDefaultAdminTransfer(this.other)).to.emit(
             this.mock,
             'DefaultAdminTransferCanceled', // Cancellation is always emitted since it was never accepted

--- a/test/access/manager/AccessManager.behavior.js
+++ b/test/access/manager/AccessManager.behavior.js
@@ -42,7 +42,7 @@ function shouldBehaveLikeDelayedAdminOperation() {
               .to.be.revertedWithCustomError(this.target, 'AccessManagerUnauthorizedAccount')
               .withArgs(
                 this.caller,
-                this.roles.ADMIN.id, // Although PUBLIC is required, target function role doesn't apply to admin ops
+                this.roles.ADMIN.id, // Although PUBLIC_ROLE is required, target function role doesn't apply to admin ops
               );
           });
         },

--- a/test/account/utils/draft-ERC7579Utils.t.sol
+++ b/test/account/utils/draft-ERC7579Utils.t.sol
@@ -372,7 +372,7 @@ contract ERC7579UtilsTest is Test {
         // <missing data>
         bytes memory invalidDeeply = abi.encode(32, 1, 32, _recipient1, 42, 96);
         this.callDecodeBatch(invalidDeeply);
-        // Note that this is ok because we don't return the value. Returning it would introduce a check that would fails.
+        // Note that this is ok because we don't return the value. Returning it would introduce a check that would fail.
         this.callDecodeBatchAndGetFirst(invalidDeeply);
         vm.expectRevert();
         this.callDecodeBatchAndGetFirstBytes(invalidDeeply);


### PR DESCRIPTION
- AccessControl.behavior.js: corrected grammar ("begin → begins").  
- AccessManager.behavior.js: updated comment to use `PUBLIC_ROLE` for clarity.  
- ERC7579Utils.t.sol: fixed typo in comment ("fails → fail").

## Summary by Sourcery

Fix typos in test comments and clarify role naming for access control tests

Chores:
- Correct the comment tense from "begin" to "begins" in AccessControl behavior tests
- Update AccessManager behavior test comment to use PUBLIC_ROLE for clarity
- Fix typo from "fails" to "fail" in ERC7579Utils solidity test comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Corrected grammar and terminology in test comments to improve clarity; no changes to test behavior, assertions, or outcomes.
- Documentation
  - Improved inline notes within test suites for readability and consistency.
- Style
  - Minor wording refinements (e.g., singular/plural agreement and role naming) in comments.
- Chores
  - Non-functional cleanup of test comment text. No user-facing or runtime changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->