### PR TITLE
docs: fix grammar and typos across multiple pages 

### DIFF
--- a/docs/modules/ROOT/pages/access-control.adoc
+++ b/docs/modules/ROOT/pages/access-control.adoc
@@ -123,7 +123,7 @@ There is an additional feature built on top of `AccessControl`: giving the execu
 
 At this point, with both a proposer and an executor assigned, the timelock can perform operations.
 
-An optional next step is for the deployer to renounce its administrative privileges and leave the timelock self-administered. If the deployer decides to do so, all further maintenance, including assigning new proposers/schedulers or changing the timelock duration will have to follow the timelock workflow. This links the governance of the timelock to the governance of contracts attached to the timelock, and enforce a delay on timelock maintenance operations.
+An optional next step is for the deployer to renounce its administrative privileges and leave the timelock self-administered. If the deployer decides to do so, all further maintenance, including assigning new proposers/schedulers or changing the timelock duration will have to follow the timelock workflow. This links the governance of the timelock to the governance of contracts attached to the timelock, and enforces a delay on timelock maintenance operations.
 
 WARNING: If the deployer renounces administrative rights in favour of timelock itself, assigning new proposers or executors will require a timelocked operation. This means that if the accounts in charge of any of these two roles become unavailable, then the entire contract (and any contract it controls) becomes locked indefinitely.
 

--- a/docs/modules/ROOT/pages/account-abstraction.adoc
+++ b/docs/modules/ROOT/pages/account-abstraction.adoc
@@ -1,6 +1,6 @@
 = Account Abstraction
 
-Unlike Externally Owned Accounts (EOAs), smart contracts may contain arbitrary verification logic based on authentication mechanisms different to Ethereum's native xref:api:utils.adoc#ECDSA[ECDSA] and have execution advantages such as batching or gas sponsorship. To leverage these properties of smart contracts, the community has widely adopted https://eips.ethereum.org/EIPS/eip-4337[ERC-4337], a standard to process user operations through an alternative mempool.
+Unlike Externally Owned Accounts (EOAs), smart contracts may contain arbitrary verification logic based on authentication mechanisms different from Ethereum's native xref:api:utils.adoc#ECDSA[ECDSA] and have execution advantages such as batching or gas sponsorship. To leverage these properties of smart contracts, the community has widely adopted https://eips.ethereum.org/EIPS/eip-4337[ERC-4337], a standard to process user operations through an alternative mempool.
 
 The library provides multiple contracts for Account Abstraction following this standard as it enables more flexible and user-friendly interactions with applications. Account Abstraction use cases include wallets in novel contexts (e.g. embedded wallets), more granular configuration of accounts, and recovery mechanisms. 
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -82,7 +82,7 @@ function isValidSignature(bytes32 hash, bytes calldata signature) public view ov
 }
 ----
 
-IMPORTANT: We recommend using xref:api:utils/cryptography.adoc#ERC7739[ERC7739] to avoid replayability across accounts. This defensive rehashing mechanism that prevents signatures for this account to be replayed in another account controlled by the same signer. See xref:accounts.adoc#erc_7739_signatures[ERC-7739 signatures].
+IMPORTANT: We recommend using xref:api:utils/cryptography.adoc#ERC7739[ERC7739] to avoid replayability across accounts. This defensive rehashing mechanism that prevents signatures for this account from being replayed in another account controlled by the same signer. See xref:accounts.adoc#erc_7739_signatures[ERC-7739 signatures].
 
 === Batched execution
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -82,7 +82,7 @@ function isValidSignature(bytes32 hash, bytes calldata signature) public view ov
 }
 ----
 
-IMPORTANT: We recommend using xref:api:utils/cryptography.adoc#ERC7739[ERC7739] to avoid replayability across accounts. This defensive rehashing mechanism that prevents signatures for this account from being replayed in another account controlled by the same signer. See xref:accounts.adoc#erc_7739_signatures[ERC-7739 signatures].
+IMPORTANT: We recommend using xref:api:utils/cryptography.adoc#ERC7739[ERC7739] to avoid replayability across accounts. This defensive rehashing mechanism prevents signatures for this account from being replayed in another account controlled by the same signer. See xref:accounts.adoc#erc_7739_signatures[ERC-7739 signatures].
 
 === Batched execution
 

--- a/docs/modules/ROOT/pages/eoa-delegation.adoc
+++ b/docs/modules/ROOT/pages/eoa-delegation.adoc
@@ -1,6 +1,6 @@
 = EOA Delegation
 
-https://eips.ethereum.org/EIPS/eip-7702[EIP-7702] introduces a new transaction type (`0x4`) that grants https://ethereum.org/en/developers/docs/accounts/[Externally Owned Accounts (EOAs)] the ability to delegate execution to an smart contract. This is particularly useful to enable traditional EVM accounts to:
+https://eips.ethereum.org/EIPS/eip-7702[EIP-7702] introduces a new transaction type (`0x4`) that grants https://ethereum.org/en/developers/docs/accounts/[Externally Owned Accounts (EOAs)] the ability to delegate execution to a smart contract. This is particularly useful to enable traditional EVM accounts to:
 
 * Batch multiple operations in a single transaction (e.g. xref:api:token/ERC20.adoc#IERC20-approve-address-uint256-[`approve`] + xref:api:token/ERC20.adoc#IERC20-transfer-address-uint256-[`transfer`], yey!)
 * Sponsoring transactions for other users.

--- a/docs/modules/ROOT/pages/erc6909.adoc
+++ b/docs/modules/ROOT/pages/erc6909.adoc
@@ -14,7 +14,7 @@ There are three main changes from ERC-1155 which are as follows:
 
 == Constructing an ERC-6909 Token Contract
 
-We'll use ERC-6909 to track multiple items in a game, each having their own unique attributes. All item types will by minted to the deployer of the contract, which we can later transfer to players. We'll also use the xref:api:token/ERC6909.adoc#ERC6909Metadata[`ERC6909Metadata`] extension to add decimals to our fungible items (the vanilla ERC-6909 implementation does not have decimals).
+We'll use ERC-6909 to track multiple items in a game, each having their own unique attributes. All item types will be minted to the deployer of the contract, which we can later transfer to players. We'll also use the xref:api:token/ERC6909.adoc#ERC6909Metadata[`ERC6909Metadata`] extension to add decimals to our fungible items (the vanilla ERC-6909 implementation does not have decimals).
 
 For simplicity, we will mint all items in the constructor--however, minting functionality could be added to the contract to mint on demand to players.
 

--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -6,7 +6,7 @@ ERC-721 is a more complex standard than ERC-20, with multiple optional extension
 
 == Constructing an ERC-721 Token Contract
 
-We'll use ERC-721 to track items in our game, which will each have their own unique attributes. Whenever one is to be awarded to a player, it will be minted and sent to them. Players are free to keep their token or trade it with other people as they see fit, as they would any other asset on the blockchain!  Please note any account can call `awardItem` to mint items.  To restrict what accounts can mint items we can add xref:access-control.adoc[Access Control].
+We'll use ERC-721 to track items in our game, which will each have their own unique attributes. Whenever one is to be awarded to a player, it will be minted and sent to them. Players are free to keep their token or trade it with other people as they see fit, as they would any other asset on the blockchain!  Please note that any account can call `awardItem` to mint items.  To restrict what accounts can mint items we can add xref:access-control.adoc[Access Control].
 
 Here's what a contract for tokenized items might look like:
 


### PR DESCRIPTION
- governance: corrected verb tense ("enforce → enforces").  
- account-abstraction.adoc: use "different from" instead of "different to".  
- accounts.adoc: fix grammar ("to be replayed → from being replayed").  
- eoa-delegation.adoc: fix article usage ("an smart contract → a smart contract").  
- erc6909.adoc: fix grammar ("will by minted → will be minted").  
- erc721.adoc: clarify sentence with "Please note that any account…".

## Summary by Sourcery

Fix various grammar issues and typos across multiple documentation pages

Documentation:
- Correct verb tense from “enforce” to “enforces” in access-control docs
- Replace “different to” with “different from” in account-abstraction docs
- Amend grammar from “to be replayed” to “from being replayed” in accounts docs
- Fix article usage to “a smart contract” in eoa-delegation docs
- Correct typo “will by minted” to “will be minted” in erc6909 docs
- Clarify account-related sentence in erc721 docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar and wording across pages:
    - Access Control: “enforces a delay” (singular agreement).
    - Account Abstraction: “different from Ethereum’s native”.
    - Accounts: ERC-7739 note clarified (“from being replayed”).
    - ERC-6909: “will be minted”.
    - ERC-721: “Please note that…”.
  * EOA Delegation: fixed article (“a smart contract”) and added a benefit bullet on privilege de-escalation (e.g., sub-keys with limited permissions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->