### PR TITLE
docs: fix incorrect ERC standard references and URL formatting

### DIFF
--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -103,7 +103,7 @@ interface IEntryPointNonces {
  *
  * The EntryPoint must implement the following API to let entities like paymasters have a stake,
  * and thus have more flexibility in their storage access
- * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttling-banning-for-global-entities[reputation, throttling and banning.])
+ * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-global-entities[reputation, throttling and banning.])
  */
 interface IEntryPointStake {
     /**

--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -103,7 +103,7 @@ interface IEntryPointNonces {
  *
  * The EntryPoint must implement the following API to let entities like paymasters have a stake,
  * and thus have more flexibility in their storage access
- * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-global-entities[reputation, throttling and banning.])
+ * (see https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttling-banning-for-global-entities[reputation, throttling and banning.])
  */
 interface IEntryPointStake {
     /**

--- a/contracts/interfaces/draft-IERC6093.sol
+++ b/contracts/interfaces/draft-IERC6093.sol
@@ -55,7 +55,7 @@ interface IERC20Errors {
  */
 interface IERC721Errors {
     /**
-     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.
+     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-721.
      * Used in balance queries.
      * @param owner Address of the current owner of a token.
      */


### PR DESCRIPTION
Fix incorrect ERC-20 reference to ERC-721 in IERC721Errors comment
Add missing hyphen in EIP-4337 URL `throttlingbanning` -> `throttling-banning`


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)

## Summary by Sourcery

Fix documentation inaccuracies by correcting the ERC standard reference and URL formatting in interface comments.

Documentation:
- Correct the ERC-20 reference to ERC-721 in the IERC721Errors comment.
- Add a missing hyphen in the EIP-4337 URL for throttling-banning in draft-IERC4337.sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified interface documentation by correcting terminology to “throttling-banning” and updating an example to reference ERC‑721 instead of ERC‑20, improving accuracy and readability for integrators.
  * No behavioral, API, or type signature changes; functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->