### PR TITLE
Reduce the size of memory pointers

### DIFF
--- a/contracts/utils/Memory.sol
+++ b/contracts/utils/Memory.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.20;
  * guidelines for https://docs.soliditylang.org/en/v0.8.20/assembly.html#memory-safety[Memory Safety].
  */
 library Memory {
-    type Pointer is bytes32;
+    type Pointer is bytes8;
 
     /// @dev Returns a `Pointer` to the current free `Pointer`.
     function getFreeMemoryPointer() internal pure returns (Pointer ptr) {
@@ -32,13 +32,13 @@ library Memory {
         }
     }
 
-    /// @dev `Pointer` to `bytes32`. Expects a pointer to a properly ABI-encoded `bytes` object.
-    function asBytes32(Pointer ptr) internal pure returns (bytes32) {
+    /// @dev `Pointer` to `bytes8`. Expects a pointer to a properly ABI-encoded `bytes` object.
+    function asBytes8(Pointer ptr) internal pure returns (bytes8) {
         return Pointer.unwrap(ptr);
     }
 
-    /// @dev `bytes32` to `Pointer`. Expects a pointer to a properly ABI-encoded `bytes` object.
-    function asPointer(bytes32 value) internal pure returns (Pointer) {
+    /// @dev `bytes8` to `Pointer`. Expects a pointer to a properly ABI-encoded `bytes` object.
+    function asPointer(bytes8 value) internal pure returns (Pointer) {
         return Pointer.wrap(value);
     }
 }


### PR DESCRIPTION
In some cases we may want to have multiple Memory.Pointer in the same structure for representing multiple temporary objects in memory. Using a bytes32 work, but makes these objects larger, leading to higher memory usage (and expension cost).

The use of a bytes32 for representing a memory pointer is really not necessary. In practice a bytes4 would definitelly be enough. The maximum value of a bytes4 object is `0xffffffff`. 

For conctext, if someone wanted to write to memory at offset `0xffffffff` the memory expension cost alone would be `35_184_775_266_310`.

---

Note: the Memory library was not released yet, so this is NOT a breaking change if we include it in the next release.

## Summary by Sourcery

Reduce Memory.Pointer size to lower memory usage and costs

Enhancements:
- Change Memory.Pointer underlying type from bytes32 to bytes8
- Update pointer conversion functions to asBytes8/asPointer signatures accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated memory pointer representation to a more compact format and aligned the public API accordingly. Integrations using the previous format may require minor updates. No functional behavior changes expected.

- Documentation
  - Refreshed references and examples to reflect the new pointer format and current API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->