### PR TITLE
gas: cache array length in ERC2771Forwarder.executeBatch

### DIFF
--- a/contracts/metatx/ERC2771Forwarder.sol
+++ b/contracts/metatx/ERC2771Forwarder.sol
@@ -168,8 +168,9 @@ contract ERC2771Forwarder is EIP712, Nonces {
 
         uint256 requestsValue;
         uint256 refundValue;
+        uint256 requestsLength = requests.length;
 
-        for (uint256 i; i < requests.length; ++i) {
+        for (uint256 i; i < requestsLength; ++i) {
             requestsValue += requests[i].value;
             bool success = _execute(requests[i], atomic);
             if (!success) {


### PR DESCRIPTION
Avoid repeated array.length calls in loop to save gas.

Cache requests.length before the loop to prevent redundant SLOAD operations on each iteration. This follows standard Solidity optimization practices and reduces gas costs, especially for batch executions with many requests.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)

## Summary by Sourcery

Enhancements:
- Cache the requests array length before executing the batch loop to optimize gas usage by preventing redundant length lookups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized batch transaction processing in the meta-transaction forwarder to reduce redundant operations, improving gas efficiency during execution.
  * No changes to external behavior: batch requests are still processed atomically, values are summed as before, and refunds for failed executions are handled unchanged.
  * No public interfaces were modified; this is a transparent performance improvement for users interacting with batch forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->