### PR TITLE
docs(account/AccountERC7579): clarify ERC-1271 behavior and no native fallback

### DIFF
--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -205,9 +205,10 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
      * if the module specified by the first 20 bytes of the nonce key is installed. Falls back to
      * {Account-_validateUserOp} otherwise.
      *
-     * Note: this contract disables raw signature validation (see {_rawSignatureValidation}), so unless
-     * overridden or complemented via multiple inheritance, the fallback path to {Account-_validateUserOp}
-     * will not succeed by itself.
+     * Note: if no installed validation module is extracted from the user operation, this function
+     * defers to {Account-_validateUserOp}, which performs a {_rawSignatureValidation} check. This contract
+     * overrides {_rawSignatureValidation} to always return `false`. Projects that require native/raw
+     * validation should override {_rawSignatureValidation} or compose with another extension that provides it.
      *
      * See {_extractUserOpValidator} for the module extraction logic.
      */


### PR DESCRIPTION
This change updates isValidSignature documentation to reflect the actual behavior: validation is delegated exclusively to installed ERC-7579 validator modules and returns 0xffffffff when none validate; native/raw signature validation is disabled by default in this extension. The _validateUserOp comment is also clarified to note that while it falls back to {Account-_validateUserOp}, raw validation is disabled here, so the fallback will not succeed unless overridden or composed with other extensions (e.g., ERC-7739). These updates remove confusing guidance that suggested a native fallback existed, aligning docs with the implemented and intended behavior.

## Summary by Sourcery

Clarify in AccountERC7579 that ERC-1271 signature validation is exclusively delegated to installed validator modules with no native/raw fallback by default, and update _validateUserOp comments accordingly

Documentation:
- Clarify ERC-1271 implementation in isValidSignature to delegate solely to IERC7579Validator modules and return 0xffffffff when none validate, disabling native/raw signature validation by default
- Update _validateUserOp comment to note that raw signature validation is disabled and its fallback to Account-_validateUserOp will not succeed unless overridden or composed with other extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how signature validation delegates to installed validator modules and the expected fallback behavior when none approve.
  * Noted that native/raw signature checks are disabled by default and must be explicitly enabled or composed via compatible extensions.
  * Added guidance on multiple-inheritance scenarios, including resolution order considerations when combining extensions.
  * Updated user operation validation notes to reflect the default behavior and when overrides/composition are required for raw signature handling.
  * No public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->