### PR TITLE
fix: remove duplicate `shares` in IERC4626 function documentation

### DIFF
--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -134,7 +134,7 @@ interface IERC4626 is IERC20, IERC20Metadata {
     function previewMint(uint256 shares) external view returns (uint256 assets);
 
     /**
-     * @dev Mints exactly Vault shares to receiver by depositing amount of underlying tokens.
+     * @dev Mints exactly `shares` vault shares to `receiver` in exchange for `assets` underlyng tokens.
      *
      * - MUST emit the Deposit event.
      * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the mint

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -96,7 +96,7 @@ interface IERC4626 is IERC20, IERC20Metadata {
     function previewDeposit(uint256 assets) external view returns (uint256 shares);
 
     /**
-     * @dev Mints Vault shares to receiver by depositing exactly amount of underlying tokens.
+     * @dev Deposit `assets` underlying tokens and send the corresponding number of vault shares (`shares`) to `receiver`.
      *
      * - MUST emit the Deposit event.
      * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -134,7 +134,7 @@ interface IERC4626 is IERC20, IERC20Metadata {
     function previewMint(uint256 shares) external view returns (uint256 assets);
 
     /**
-     * @dev Mints exactly `shares` vault shares to `receiver` in exchange for `assets` underlyng tokens.
+     * @dev Mints exactly `shares` vault shares to `receiver` in exchange for `assets` underlying tokens.
      *
      * - MUST emit the Deposit event.
      * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the mint

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -96,7 +96,7 @@ interface IERC4626 is IERC20, IERC20Metadata {
     function previewDeposit(uint256 assets) external view returns (uint256 shares);
 
     /**
-     * @dev Mints shares Vault shares to receiver by depositing exactly amount of underlying tokens.
+     * @dev Mints Vault shares to receiver by depositing exactly amount of underlying tokens.
      *
      * - MUST emit the Deposit event.
      * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the
@@ -134,7 +134,7 @@ interface IERC4626 is IERC20, IERC20Metadata {
     function previewMint(uint256 shares) external view returns (uint256 assets);
 
     /**
-     * @dev Mints exactly shares Vault shares to receiver by depositing amount of underlying tokens.
+     * @dev Mints exactly Vault shares to receiver by depositing amount of underlying tokens.
      *
      * - MUST emit the Deposit event.
      * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the mint


### PR DESCRIPTION
Remove redundant `shares` word in deposit and mint function comments

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)

## Summary by Sourcery

Clean up IERC4626 interface documentation by removing redundant 'shares' in the deposit and mint function comments.

Documentation:
- Remove duplicate 'shares' word in deposit comment for previewDeposit.
- Remove duplicate 'shares' word in mint comment for previewMint.