### PR TITLE
docs: fix some typos

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -256,7 +256,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
      * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.
      *
      * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by
-     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any
+     * `_spendAllowance` during the `transferFrom` operation sets the flag to false. This saves gas by not emitting any
      * `Approval` event during `transferFrom` operations.
      *
      * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -49,7 +49,7 @@ import {Math} from "../../../utils/math/Math.sol";
  *
  * [NOTE]
  * ====
- * When overriding this contract, some elements must to be considered:
+ * When overriding this contract, some elements must be considered:
  *
  * * When overriding the behavior of the deposit or withdraw mechanisms, it is recommended to override the internal
  * functions. Overriding {_deposit} automatically affects both {deposit} and {mint}. Similarly, overriding {_withdraw}

--- a/contracts/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/IERC20Permit.sol
@@ -45,7 +45,7 @@ interface IERC20Permit {
      * given ``owner``'s signed approval.
      *
      * IMPORTANT: The same issues {IERC20-approve} has related to transaction
-     * ordering also apply here.
+     * ordering also applies here.
      *
      * Emits an {Approval} event.
      *

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -151,7 +151,7 @@ library SafeERC20 {
      * targeting contracts.
      *
      * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.
-     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}
+     * Oppositely, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}
      * once without retrying, and relies on the returned value to be true.
      *
      * Reverts if the returned value is other than `true`.


### PR DESCRIPTION
operation set -> operation sets
must to be considered -> must to considered
ordering also apply here. -> ordering also applies here.
Opposedly -> Oppositely