### PR TITLE
Preserve EVM semantics in ERC7579Utils: remove zero-address rewrite in calls

### DIFF
--- a/contracts/account/utils/draft-ERC7579Utils.sol
+++ b/contracts/account/utils/draft-ERC7579Utils.sol
@@ -218,9 +218,8 @@ library ERC7579Utils {
         uint256 value,
         bytes calldata data
     ) private returns (bytes memory) {
-        (bool success, bytes memory returndata) = (target == address(0) ? address(this) : target).call{value: value}(
-            data
-        );
+        // Do not rewrite zero address to self; preserve EVM semantics for value transfers
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
         return _validateExecutionMode(index, execType, success, returndata);
     }
 
@@ -231,7 +230,8 @@ library ERC7579Utils {
         address target,
         bytes calldata data
     ) private returns (bytes memory) {
-        (bool success, bytes memory returndata) = (target == address(0) ? address(this) : target).delegatecall(data);
+        // Do not rewrite zero address to self; preserve EVM semantics; let delegatecall fail naturally
+        (bool success, bytes memory returndata) = target.delegatecall(data);
         return _validateExecutionMode(index, execType, success, returndata);
     }
 


### PR DESCRIPTION


### PR Description
- **What**: Stop rewriting `address(0)` to `address(this)` in `ERC7579Utils._call` and `_delegatecall`. Added brief comments explaining the rationale.
- **Why**: Preserves standard EVM semantics (e.g., ETH transfers to `address(0)`), avoids surprising self-calls, and reduces unintended reentrancy surface.
- **Changes**
  - `contracts/account/utils/draft-ERC7579Utils.sol`
    - `_call`: use `target.call{value: value}(data)` directly
    - `_delegatecall`: use `target.delegatecall(data)` directly
    - Comments added in English
- **Behavioral impact**: If any caller relied on `address(0)` meaning self-call, they must now pass `address(this)` explicitly.
- **Security**: Removes an implicit self-call pathway and restores expected call semantics.
