### PR TITLE
Mark ERC7913WebAuthnVerifier as stateless

### DIFF
--- a/contracts/mocks/Stateless.sol
+++ b/contracts/mocks/Stateless.sol
@@ -33,6 +33,7 @@ import {ERC4337Utils} from "../account/utils/draft-ERC4337Utils.sol";
 import {ERC7579Utils} from "../account/utils/draft-ERC7579Utils.sol";
 import {ERC7913P256Verifier} from "../utils/cryptography/verifiers/ERC7913P256Verifier.sol";
 import {ERC7913RSAVerifier} from "../utils/cryptography/verifiers/ERC7913RSAVerifier.sol";
+import {ERC7913WebAuthnVerifier} from "../utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol";
 import {Heap} from "../utils/structs/Heap.sol";
 import {InteroperableAddress} from "../utils/draft-InteroperableAddress.sol";
 import {LowLevelCall} from "../utils/LowLevelCall.sol";

--- a/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
@@ -16,6 +16,8 @@ import {IERC7913SignatureVerifier} from "../../../interfaces/IERC7913.sol";
  * WebAuthn checks: type validation, challenge matching, and cryptographic signature verification.
  *
  * NOTE: Wallets that may require default P256 validation may install a P256 verifier separately.
+ *
+ * @custom:stateless
  */
 contract ERC7913WebAuthnVerifier is IERC7913SignatureVerifier {
     /// @inheritdoc IERC7913SignatureVerifier


### PR DESCRIPTION
This should be merged into master then cherrypicked onto release-v5.5

Since this is a new contract that was first released in v5.5.0-rc.0, we don't need a changelog entry
