### PR TITLE
fix: incorrect documentation reference in ERC4626Fees._withdraw

### DIFF
--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -57,7 +57,7 @@ abstract contract ERC4626Fees is ERC4626 {
         }
     }
 
-    /// @dev Send exit fee to {_exitFeeRecipient}. See {IERC4626-_deposit}.
+    /// @dev Send exit fee to {_exitFeeRecipient}. See {IERC4626-_withdraw}.
     function _withdraw(
         address caller,
         address receiver,


### PR DESCRIPTION
Fix incorrect reference in _withdraw function documentation. The comment was incorrectly referencing {IERC4626-_deposit} instead of {IERC4626-_withdraw}. This was likely a copy-paste error from the _deposit function comment above.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
