### PR TITLE
Add SimpleMintableToken contract for learning

### DIFF
--- a/SimpleMintableToken.sol
+++ b/SimpleMintableToken.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract SimpleMintableToken is ERC20 {
+    constructor() ERC20("SimpleMintableToken", "SMT") {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}


### PR DESCRIPTION
Hi! First-time contributor here. This PR adds a very basic ERC-20 token contract with minting functionality, intended for educational purposes. 

It uses OpenZeppelin's ERC20 implementation to help beginners understand how to create and deploy a token. 

No new features are being added to the main library—this is purely an example for learning.
