### PR TITLE
Prevent revert in isModuleInstalled for fallback modules on short additionalContext

### DIFF
--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -149,7 +149,13 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
     ) public view virtual returns (bool) {
         if (moduleTypeId == MODULE_TYPE_VALIDATOR) return _validators.contains(module);
         if (moduleTypeId == MODULE_TYPE_EXECUTOR) return _executors.contains(module);
-        if (moduleTypeId == MODULE_TYPE_FALLBACK) return _fallbacks[bytes4(additionalContext[0:4])] == module;
+        if (moduleTypeId == MODULE_TYPE_FALLBACK) {
+            // For fallback modules, the additionalContext is expected to start with a 4-byte selector.
+            // Per IERC7579ModuleConfig spec, this function MUST return true/false and not revert.
+            // Treat malformed context (< 4 bytes) as "not installed" to avoid out-of-bounds slice reverts.
+            if (additionalContext.length < 4) return false;
+            return _fallbacks[bytes4(additionalContext[0:4])] == module;
+        }
         return false;
     }
 


### PR DESCRIPTION
This change adds a length check before slicing additionalContext[0:4] in isModuleInstalled for fallback modules. The ERC-7579 IERC7579ModuleConfig.isModuleInstalled requires returning true/false rather than reverting. Previously, providing fewer than 4 bytes caused an out-of-bounds slice and a revert. Now, malformed context returns false, aligning behavior with the spec and avoiding unexpected reverts in external status queries.