### PR TITLE
Make Certora spec matching recursive

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -38,7 +38,11 @@ jobs:
         run: |
           if [[ ${{ github.event_name }} = 'pull_request' ]];
           then
-            RESULT=$(git diff ${{ github.event.pull_request.head.sha }}..${{ github.event.pull_request.base.sha }} --name-only certora/specs/*.spec | while IFS= read -r file; do [[ -f $file ]] && basename "${file%.spec}"; done | tr "\n" " ")
+            RESULT=$(git diff ${{ github.event.pull_request.head.sha }}..${{ github.event.pull_request.base.sha }} --name-only -- ':(glob)certora/specs/**/*.spec' | while IFS= read -r file; do [[ -f "$file" ]] && basename "${file%.spec}"; done | tr "\n" " ")
+            if [[ -z "$RESULT" ]]; then
+              echo "No .spec changes detected under certora/specs/**; running all specs." >> "$GITHUB_STEP_SUMMARY"
+              RESULT='--all'
+            fi
           else
             RESULT='--all'
           fi


### PR DESCRIPTION
This PR updates formal-verification to detect .spec changes recursively using Git pathspec:

- Before: certora/specs/*.spec (top-level only) → silently misses helpers/ and methods/
- After: -- ':(glob)certora/specs/**/*.spec' (recursive) + fallback to --all when no matches
- Adds a clear Step Summary note when no .spec changes are detected