### PR TITLE
Remove unused named return from supportsExecutionMode in ERC7821

### DIFF
--- a/contracts/account/extensions/draft-ERC7821.sol
+++ b/contracts/account/extensions/draft-ERC7821.sol
@@ -35,7 +35,7 @@ abstract contract ERC7821 is IERC7821 {
     }
 
     /// @inheritdoc IERC7821
-    function supportsExecutionMode(bytes32 mode) public view virtual returns (bool result) {
+    function supportsExecutionMode(bytes32 mode) public view virtual returns (bool) {
         (CallType callType, ExecType execType, ModeSelector modeSelector, ) = Mode.wrap(mode).decodeMode();
         return
             callType == ERC7579Utils.CALLTYPE_BATCH &&


### PR DESCRIPTION

Replace returns (bool result) with returns (bool) in contracts/account/extensions/draft-ERC7821.sol to align with project style and avoid unused named return variables. No functional changes; ABI and behavior remain the same.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
