### PR TITLE
fix the check for non-canonical s to be valid after ethers: 6.15.0

### DIFF
--- a/test/utils/cryptography/ECDSA.test.js
+++ b/test/utils/cryptography/ECDSA.test.js
@@ -243,6 +243,10 @@ describe('ECDSA', function () {
       const s = ethers.dataSlice(highSSignature, 32, 64);
       const v = ethers.dataSlice(highSSignature, 64, 65);
 
+      // In ethers v6.15.0+, the library no longer throws 'non-canonical s' error for high-s signatures. This
+      // assertion verifies we are in fact dealing with a high-s value that the ECDSA library should reject.
+      expect(ethers.toBigInt(s)).to.be.gt(secp256k1.CURVE.n / 2n);
+
       await expect(this.mock.$recover(message, highSSignature))
         .to.be.revertedWithCustomError(this.mock, 'ECDSAInvalidSignatureS')
         .withArgs(s);
@@ -252,9 +256,6 @@ describe('ECDSA', function () {
       await expect(this.mock.getFunction('$recover(bytes32,uint8,bytes32,bytes32)')(TEST_MESSAGE, v, r, s))
         .to.be.revertedWithCustomError(this.mock, 'ECDSAInvalidSignatureS')
         .withArgs(s);
-      // In ethers v6.15.0+, the library no longer throws 'non-canonical s' error for high-s signatures,
-      // but the canonical check is still enforced. This assertion verifies s is in the lower half of the curve order.
-      expect(ethers.toBigInt(s)).to.be.smallerThanOrEqual(secp256k1.CURVE.n / 2n);
     });
   });
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #5977 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
For seamless transition to the newer version of `ethers` I have mimicked the check of S from the version 6.14.0. Now the test passes with both versions of ethers, but in the future we might want to use `isValid` for the same purpose


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
