### PR TITLE
scripts: specify radix=10 for parseInt in inheritance-ordering check

### DIFF
--- a/scripts/checks/inheritance-ordering.js
+++ b/scripts/checks/inheritance-ordering.js
@@ -39,9 +39,9 @@ for (const artifact of artifacts) {
       .forEach(y => {
         console.log(`Conflict between ${names[x]} and ${names[y]} detected in the following dependency chains:`);
         linearized
-          .filter(chain => chain.includes(parseInt(x)) && chain.includes(parseInt(y)))
+          .filter(chain => chain.includes(parseInt(x, 10)) && chain.includes(parseInt(y, 10)))
           .forEach(chain => {
-            const comp = chain.indexOf(parseInt(x)) < chain.indexOf(parseInt(y)) ? '>' : '<';
+            const comp = chain.indexOf(parseInt(x, 10)) < chain.indexOf(parseInt(y, 10)) ? '>' : '<';
             console.log(`- ${names[x]} ${comp} ${names[y]} in ${names[chain.find(Boolean)]}`);
             // console.log(`- ${names[x]} ${comp} ${names[y]}: ${chain.reverse().map(id => names[id]).join(', ')}`);
           });


### PR DESCRIPTION

- **Summary**: Ensure deterministic integer parsing by explicitly passing radix=10 to parseInt.
- **Rationale**: Avoids environment-dependent behavior (e.g., hex strings like `0x...`) and aligns with ESLint’s radix rule.
- **Change**: Replace `parseInt(x)`/`parseInt(y)` with `parseInt(x, 10)`/`parseInt(y, 10)` in `scripts/checks/inheritance-ordering.js`.

