### PR TITLE
scripts: avoid module shadowing by renaming `readJSON` param in remove-ignored-artifacts

### DIFF
--- a/scripts/remove-ignored-artifacts.js
+++ b/scripts/remove-ignored-artifacts.js
@@ -6,8 +6,8 @@ const fs = require('fs');
 const path = require('path');
 const match = require('micromatch');
 
-function readJSON(path) {
-  return JSON.parse(fs.readFileSync(path));
+unction readJSON(filePath) {
+  return JSON.parse(fs.readFileSync(filePath));
 }
 
 const pkgFiles = readJSON('package.json').files;


### PR DESCRIPTION


### Description
- **Summary**: Rename `readJSON` parameter from `path` to `filePath` to avoid shadowing Node’s `path` module.
- **Rationale**: Prevents name shadowing that can confuse readers and risk subtle bugs; improves clarity.
- **Change**: Update `scripts/remove-ignored-artifacts.js` to use `readJSON(filePath)` instead of `readJSON(path)`.
