### PR TITLE
Clarify how ECDSA signatures are parsed

### DIFF
--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -207,7 +207,12 @@ library ECDSA {
 
     /**
      * @dev Parse a signature into its `v`, `r` and `s` components. Supports 65-byte and 64-byte (ERC-2098)
-     * formats. Returns (0,0,0) for invalid signatures. Consider skipping {tryRecover} or {recover} if so.
+     * formats. Returns (0,0,0) for invalid signatures.
+     *
+     * For 64-byte signatures, `v` is automatically normalized to 27 or 28.
+     * For 65-byte signatures, `v` is returned as-is and MUST already be 27 or 28 for use with ecrecover.
+     *
+     * Consider validating the result before use, or use {tryRecover}/{recover} which perform full validation.
      */
     function parse(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         assembly ("memory-safe") {


### PR DESCRIPTION
Add clarification about how signatures are parsed depending on the length of the bytes buffer.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
