### PR TITLE
fix: prevent prepack from failing when no .dbg.json files exist

### DIFF
--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -17,7 +17,7 @@ env COMPILE_MODE=production npm run compile
 
 mkdirp contracts/build/contracts
 cp artifacts/contracts/**/*.json contracts/build/contracts
-rm contracts/build/contracts/*.dbg.json
+rm -f contracts/build/contracts/*.dbg.json
 node scripts/remove-ignored-artifacts.js
 
 cp README.md contracts/


### PR DESCRIPTION


### Description
- **Change**: Use `rm -f` for cleaning `*.dbg.json` in `scripts/prepack.sh`.
- **Why**: Under `set -e`, `rm` without `-f` fails when no files match, causing brittle builds.

