### PR TITLE
docs(interfaces): deprecate ERC1155InvalidApprover in IERC1155Errors

### DIFF
--- a/contracts/interfaces/draft-IERC6093.sol
+++ b/contracts/interfaces/draft-IERC6093.sol
@@ -141,13 +141,6 @@ interface IERC1155Errors {
     error ERC1155MissingApprovalForAll(address operator, address owner);
 
     /**
-     * @dev Non-standard for ERC-1155. ERC-1155 only defines operator-wide approvals via {setApprovalForAll}.
-     * @deprecated Non-standard for ERC-1155; use {ERC1155InvalidOperator} or {ERC1155MissingApprovalForAll} instead.
-     * @param approver Address initiating an approval operation.
-     */
-    error ERC1155InvalidApprover(address approver);
-
-    /**
      * @dev Indicates a failure with the `operator` to be approved. Used in approvals.
      * @param operator Address that may be allowed to operate on tokens without being their owner.
      */


### PR DESCRIPTION
This change deprecates the ERC1155InvalidApprover error in contracts/interfaces/draft-IERC6093.sol, clarifying it is non-standard for ERC-1155 which only defines operator-wide approvals via setApprovalForAll. The error is unused across the codebase and not part of ERC-6093’s canonical ERC-1155 set. The comment now directs users to ERC1155InvalidOperator and ERC1155MissingApprovalForAll to avoid confusion and align with the spec without introducing behavioral changes.