### PR TITLE
Make ESLint config compatible with Node 18/20

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,9 @@ import { includeIgnoreFile } from '@eslint/compat';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default [
   js.configs.recommended,
@@ -22,5 +25,5 @@ export default [
       },
     },
   },
-  includeIgnoreFile(path.resolve(import.meta.dirname, '.gitignore')),
+  includeIgnoreFile(path.resolve(__dirname, '.gitignore')),
 ];


### PR DESCRIPTION

- **What**: Replace `import.meta.dirname` with `fileURLToPath(import.meta.url)` to resolve `.gitignore` path in `eslint.config.mjs`.
- **Why**: `import.meta.dirname` is Node 22+ only; it breaks linting on LTS Node 18/20 and in CI.

