### PR TITLE
docs: add comment explaining execution delay value in AccessManaged test

### DIFF
--- a/test/access/manager/AccessManaged.test.js
+++ b/test/access/manager/AccessManaged.test.js
@@ -65,7 +65,7 @@ describe('AccessManaged', function () {
 
     describe('when role is granted with execution delay', function () {
       beforeEach(async function () {
-        const executionDelay = 911n;
+        const executionDelay = 911n; // Arbitrary delay for testing execution delay functionality
         await this.authority.$_grantRole(this.role, this.roleMember, 0, executionDelay);
       });
 


### PR DESCRIPTION
Add explanatory comment for the 911n execution delay value used in AccessManaged tests. 