### PR TITLE
Remove NPM_TOKEN from release-cycle CI

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -151,10 +151,8 @@ jobs:
       - name: Publish
         run: bash scripts/release/workflow/publish.sh
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TARBALL: ${{ steps.pack.outputs.tarball }}
           TAG: ${{ steps.pack.outputs.tag }}
-          NPM_CONFIG_PROVENANCE: true
       - name: Create Github Release
         uses: actions/github-script@v8
         env:


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #5993

Trusted publisher is already configured so we wouldn't need the `NPM_TOKEN`. Also, trusted publishers get provenance automatically.

<img width="791" height="227" alt="Captura de pantalla 2025-10-21 a la(s) 10 08 44 a m" src="https://github.com/user-attachments/assets/28da8b4a-c18f-414e-a2d7-b8747bb8107d" />
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
