### PR TITLE
Fix memory pointer alignment in LowLevelCall.returnData()

### DIFF
--- a/contracts/utils/LowLevelCall.sol
+++ b/contracts/utils/LowLevelCall.sol
@@ -105,7 +105,7 @@ library LowLevelCall {
             result := mload(0x40)
             mstore(result, returndatasize())
             returndatacopy(add(result, 0x20), 0x00, returndatasize())
-            mstore(0x40, add(result, add(0x20, returndatasize())))
+            mstore(0x40, add(add(result, 0x20), and(add(returndatasize(), 0x1f), not(0x1f))))
         }
     }
 


### PR DESCRIPTION

## Summary
Fixes memory pointer alignment issue in `LowLevelCall.returnData()` function.

## Problem
The free memory pointer at `0x40` was not aligned to 32-byte boundary, which violates Solidity ABI expectations and can cause incorrect subsequent allocations.

## Solution
- Align free memory pointer to 32-byte boundary using bitwise operations
