### PR TITLE
Fix release tag commit

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -155,8 +155,6 @@ jobs:
           TARBALL: ${{ steps.pack.outputs.tarball }}
           TAG: ${{ steps.pack.outputs.tag }}
           NPM_CONFIG_PROVENANCE: true
-      - name: Add release commit to env
-        run: echo "RELEASE_COMMIT=$(git log -1 --format=%H)" >> "${GITHUB_ENV}"
       - name: Create Github Release
         uses: actions/github-script@v8
         env:

--- a/scripts/release/workflow/github-release.js
+++ b/scripts/release/workflow/github-release.js
@@ -5,17 +5,11 @@ const { version } = require(join(__dirname, '../../../package.json'));
 module.exports = async ({ github, context }) => {
   const changelog = readFileSync('CHANGELOG.md', 'utf8');
 
-  const releaseCommit = process.env.RELEASE_COMMIT;
-  if (!releaseCommit) {
-    console.error('`RELEASE_COMMIT` env var is required.');
-    process.exit(1);
-  }
-
   await github.rest.repos.createRelease({
     owner: context.repo.owner,
     repo: context.repo.repo,
     tag_name: `v${version}`,
-    target_commitish: releaseCommit,
+    target_commitish: context.sha,
     body: extractSection(changelog, version),
     prerelease: process.env.PRERELEASE === 'true',
   });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #4699 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
The `github.ref_name` happens to be empty, which makes `target_commitish` empty.
If `target_commitish` is empty, it defaults to the repository's default branch (here master), hence the release tag, created during _Create Release_ Github API call, is attached to the wrong commit. ([See create-a-release](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)).

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
 - [Release tag](https://github.com/james-toussaint/openzeppelin-contracts/releases/tag/v5.4.0) is attached to the [latest commit of the branch being built by the release job](https://github.com/james-toussaint/openzeppelin-contracts/commits/fix/release-tag-commit-test/).
 - [Test diff compared to current branch parent commit](https://github.com/james-toussaint/openzeppelin-contracts/compare/1cf13771092c83a060eaef0f8809493fb4c04eb1...james-toussaint:openzeppelin-contracts:fix/release-tag-commit-test)

- [ ] Documentation
