### PR TITLE
docs: make note visible and fix broken link

### DIFF
--- a/contracts/account/README.adoc
+++ b/contracts/account/README.adoc
@@ -1,6 +1,7 @@
 = Account
+
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/account
+NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/5.x/api/account#account
 
 This directory includes contracts to build accounts for ERC-4337. These include:
 


### PR DESCRIPTION
[.readme-notice] - is visible now, and also fixed broken https://docs.openzeppelin.com/contracts/api/account link
this works - https://docs.openzeppelin.com/contracts/5.x/api/account#account