### PR TITLE
chore: remove unused IERC165 import in AccessControlDefaultAdminRules

### DIFF
--- a/contracts/access/extensions/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/AccessControlDefaultAdminRules.sol
@@ -8,7 +8,6 @@ import {AccessControl, IAccessControl} from "../AccessControl.sol";
 import {SafeCast} from "../../utils/math/SafeCast.sol";
 import {Math} from "../../utils/math/Math.sol";
 import {IERC5313} from "../../interfaces/IERC5313.sol";
-import {IERC165} from "../../utils/introspection/IERC165.sol";
 
 /**
  * @dev Extension of {AccessControl} that allows specifying special rules to manage


### PR DESCRIPTION
This PR removes an unused import (`IERC165`) from AccessControlDefaultAdminRules.sol.
There are no logic or behavior changes — just a small cleanup to avoid an unused-import warning.
