### PR TITLE
docs(erc721): fix _setTokenURI xref to ERC721URIStorage

### DIFF
--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -15,7 +15,7 @@ Here's what a contract for tokenized items might look like:
 include::api:example$token/ERC721/GameItem.sol[]
 ----
 
-The xref:api:token/ERC721.adoc#ERC721URIStorage[`ERC721URIStorage`] contract is an implementation of ERC-721 that includes the metadata standard extensions (xref:api:token/ERC721.adoc#IERC721Metadata[`IERC721Metadata`]) as well as a mechanism for per-token metadata. That's where the xref:api:token/ERC721.adoc#ERC721-_setTokenURI-uint256-string-[`_setTokenURI`] method comes from: we use it to store an item's metadata.
+The xref:api:token/ERC721.adoc#ERC721URIStorage[`ERC721URIStorage`] contract is an implementation of ERC-721 that includes the metadata standard extensions (xref:api:token/ERC721.adoc#IERC721Metadata[`IERC721Metadata`]) as well as a mechanism for per-token metadata. That's where the xref:api:token/ERC721.adoc#ERC721URIStorage-_setTokenURI-uint256-string-[`_setTokenURI`] method comes from: we use it to store an item's metadata.
 
 Also note that, unlike ERC-20, ERC-721 lacks a `decimals` field, since each token is distinct and cannot be partitioned.
 


### PR DESCRIPTION
The _setTokenURI method belongs to ERC721URIStorage, not ERC721.
Updated the AsciiDoc xref in docs/modules/ROOT/pages/erc721.adoc to point to #ERC721URIStorage-_setTokenURI-uint256-string-.
Ensures the link resolves correctly in the generated 5.x API docs and matches the source code in contracts/token/ERC721/extensions/ERC721URIStorage.sol.