### PR TITLE
docs: fix P256 example functions to be view instead of pure

### DIFF
--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -46,7 +46,7 @@ function _verify(
     bytes32 s,
     bytes32 qx,
     bytes32 qy
-) internal pure returns (bool) {
+) internal view returns (bool) {
     return data.verify(data, r, s, qx, qy);
 }
 ----
@@ -63,7 +63,7 @@ function _verify(
     bytes32 s,
     bytes32 qx,
     bytes32 qy
-) internal pure returns (bool) {
+) internal view returns (bool) {
     // Will only call the precompile at address(0x100)
     return data.verifyNative(data, r, s, qx, qy);
 }


### PR DESCRIPTION
Updated P256 example function signatures  from internal pure to internal view.
Reason: P256.verify and P256.verifyNative are view functions