### PR TITLE
docs(IAccessManager): document locked roles for label/admin/guardian/grantDelay

### DIFF
--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -196,6 +196,7 @@ interface IAccessManager {
      * Requirements:
      *
      * - the caller must be a global admin
+     * - `roleId` must not be the `ADMIN_ROLE` or `PUBLIC_ROLE`
      *
      * Emits a {RoleLabel} event.
      */
@@ -254,6 +255,10 @@ interface IAccessManager {
      * Requirements:
      *
      * - the caller must be a global admin
+     * - `roleId` must not be the `ADMIN_ROLE` or `PUBLIC_ROLE`
+     *
+     * NOTE: Setting `admin` to the `PUBLIC_ROLE` is allowed, but the target `roleId` itself
+     * must not be a locked role (`ADMIN_ROLE` or `PUBLIC_ROLE`).
      *
      * Emits a {RoleAdminChanged} event
      */
@@ -265,6 +270,10 @@ interface IAccessManager {
      * Requirements:
      *
      * - the caller must be a global admin
+     * - `roleId` must not be the `ADMIN_ROLE` or `PUBLIC_ROLE`
+     *
+     * NOTE: Setting `guardian` to the `PUBLIC_ROLE` is allowed, but the target `roleId` itself
+     * must not be a locked role (`ADMIN_ROLE` or `PUBLIC_ROLE`).
      *
      * Emits a {RoleGuardianChanged} event
      */
@@ -276,6 +285,7 @@ interface IAccessManager {
      * Requirements:
      *
      * - the caller must be a global admin
+     * - `roleId` must not be the `PUBLIC_ROLE`
      *
      * Emits a {RoleGrantDelayChanged} event.
      */


### PR DESCRIPTION
Align IAccessManager NatSpec with AccessManager implementation and tests by documenting locked-role constraints.
ADMIN_ROLE and PUBLIC_ROLE cannot be targeted by labelRole, setRoleAdmin, or setRoleGuardian, and PUBLIC_ROLE cannot be targeted by setGrantDelay.
Notes clarify that admin/guardian can be set to PUBLIC_ROLE, but the target roleId itself must not be a locked role.
This prevents integrator confusion and ensures interface documentation accurately reflects enforced behavior (see 
AccessManager.sol and AccessManager.test.js).