### PR TITLE
Drop unused IERC165 import from timelock controller

### DIFF
--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -7,7 +7,6 @@ import {AccessControl} from "../access/AccessControl.sol";
 import {ERC721Holder} from "../token/ERC721/utils/ERC721Holder.sol";
 import {ERC1155Holder} from "../token/ERC1155/utils/ERC1155Holder.sol";
 import {Address} from "../utils/Address.sol";
-import {IERC165} from "../utils/introspection/ERC165.sol";
 
 /**
  * @dev Contract module which acts as a timelocked controller. When set as the
@@ -155,7 +154,7 @@ contract TimelockController is AccessControl, ERC721Holder, ERC1155Holder {
      */
     receive() external payable virtual {}
 
-    /// @inheritdoc IERC165
+    /// @inheritdoc AccessControl
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(AccessControl, ERC1155Holder) returns (bool) {


### PR DESCRIPTION
 Remove the dead IERC165 import from `TimelockController` point the `supportsInterface` docblock to the actual parent `AccessControl` for accurate inheritance docs
