### PR TITLE
docs(erc4626): replace “developer” with “attacker” in inflation defense text

### DIFF
--- a/docs/modules/ROOT/pages/erc4626.adoc
+++ b/docs/modules/ROOT/pages/erc4626.adoc
@@ -107,7 +107,7 @@ The defense we propose is based on the approach used in link:https://github.com/
 - Use an offset between the "precision" of the representation of shares and assets. Said otherwise, we use more decimal places to represent the shares than the underlying token does to represent the assets.
 - Include virtual shares and virtual assets in the exchange rate computation. These virtual assets enforce the conversion rate when the vault is empty.
 
-These two parts work together in enforcing the security of the vault. First, the increased precision corresponds to a high rate, which we saw is safer as it reduces the rounding error when computing the amount of shares. Second, the virtual assets and shares (in addition to simplifying a lot of the computations) capture part of the donation, making it unprofitable for a developer to perform an attack.
+These two parts work together in enforcing the security of the vault. First, the increased precision corresponds to a high rate, which we saw is safer as it reduces the rounding error when computing the amount of shares. Second, the virtual assets and shares (in addition to simplifying a lot of the computations) capture part of the donation, making it unprofitable for an attacker to perform an attack.
 
 Following the previous math definitions, we have:
 


### PR DESCRIPTION
Align terminology with surrounding context and security semantics. The section discusses an inflation attack; “attacker” is the correct subject. No other occurrences required changes.