### PR TITLE
docs: add setup() to CircularBuffer example to show required initialization

### DIFF
--- a/contracts/utils/structs/CircularBuffer.sol
+++ b/contracts/utils/structs/CircularBuffer.sol
@@ -45,6 +45,8 @@ import {Panic} from "../Panic.sol";
  * }
  * ```
  *
+ * NOTE: Make sure to call {setup} on your buffer during construction/initialization
+ *
  * _Available since v5.1._
  */
 library CircularBuffer {


### PR DESCRIPTION
Update the example in contracts/utils/structs/CircularBuffer.sol to include a setup() call before push().
This clarifies that the buffer must be initialized with a non-zero length before pushing; otherwise push() can panic due to division by zero when the underlying array length is zero.