### PR TITLE
chore: fix crashes when heading data is missing

### DIFF
--- a/scripts/release/workflow/github-release.js
+++ b/scripts/release/workflow/github-release.js
@@ -32,11 +32,9 @@ function extractSection(document, wantedHeading) {
   let start, end;
 
   for (const m of document.matchAll(heading)) {
-    if (!start) {
-      if (m.groups.text.search(wantedHeadingRe) === 0) {
-        start = m;
-      }
-    } else if (m.groups.lead.length <= start.groups.lead.length) {
+    if (!start && m.groups.text?.search(wantedHeadingRe) === 0) {
+      start = m;
+    } else if (start && m.groups.lead.length <= start.groups.lead.length) {
       end = m;
       break;
     }


### PR DESCRIPTION
found a couple of small spots that could throw errors if the heading match didn’t have all the expected groups.

* added `?.` so it won’t blow up when `m.groups.text` is missing.
* added a `start &&` check before touching `start.groups`.

this pr makes the heading check a bit safer and avoids random crashes on empty headings.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
