### PR TITLE
docs(ERC20): fix incorrect immutable claim in constructor comment

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -39,7 +39,10 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     /**
      * @dev Sets the values for {name} and {symbol}.
      *
-     * Both values are immutable: they can only be set once during construction.
+     * Both of these values are set during construction and cannot be changed
+     * afterwards because there are no public setter functions. However, they are not
+     * declared as immutable storage variables, allowing derived contracts to customize
+     * their behavior if needed.
      */
     constructor(string memory name_, string memory symbol_) {
         _name = name_;


### PR DESCRIPTION
The constructor comment claimed that name and symbol are "immutable", but they're actually just regular private storage variables. There's no `immutable` keyword on them at all (see lines 36-37).

Sure, there are no public setters, but saying they're immutable is technically wrong and confusing since "immutable" has a specific meaning in Solidity. Plus, both name() and symbol() are virtual functions, so derived contracts can override them anyway.

Changed the comment to describe what's actually happening in the code.