### PR TITLE
perf: use calldata and external to avoid memory copy

### DIFF
--- a/contracts/mocks/AuthorityMock.sol
+++ b/contracts/mocks/AuthorityMock.sol
@@ -63,7 +63,7 @@ contract AuthorityObserveIsConsuming {
         return (false, 1);
     }
 
-    function consumeScheduledOp(address caller, bytes memory data) public {
+    function consumeScheduledOp(address caller, bytes calldata data) external {
         emit ConsumeScheduledOpCalled(caller, data, IAccessManaged(msg.sender).isConsumingScheduledOp());
     }
 }


### PR DESCRIPTION
Switch consumeScheduledOp in AuthorityObserveIsConsuming to external and bytes calldata.
Avoids unnecessary memory allocation/copy since the function only emits the provided data.
Aligns with IAccessManager.consumeScheduledOp(address, bytes calldata) and AccessManaged forwarding of calldata.