### PR TITLE
Drop redundant await in GovernorNoncesKeyed helper

### DIFF
--- a/test/governance/extensions/GovernorNoncesKeyed.test.js
+++ b/test/governance/extensions/GovernorNoncesKeyed.test.js
@@ -91,11 +91,10 @@ describe('GovernorNoncesKeyed', function () {
 
           const maskedProposalId = BigInt(this.helper.id) & (2n ** 192n - 1n);
 
-          this.getNonce = async address => {
-            return nonceType === 'default'
+          this.getNonce = address =>
+            nonceType === 'default'
               ? this.mock.nonces(address)
               : this.mock['nonces(address,uint192)'](address, maskedProposalId);
-          };
         });
 
         it('votes with an EOA signature', async function () {


### PR DESCRIPTION
Remove the unnecessary return await in GovernorNoncesKeyed.test.js preserve the async helper’s behavior while avoiding the superfluous await pattern