### PR TITLE
docs: fix WebAuthn cross-reference to verify in ERC7913WebAuthnVerifier

### DIFF
--- a/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
@@ -13,7 +13,7 @@ import {IERC7913SignatureVerifier} from "../../../interfaces/IERC7913.sol";
  * The key is expected to be a 64-byte concatenation of the P256 public key coordinates (qx || qy).
  * The signature is expected to be an abi-encoded {WebAuthn-WebAuthnAuth} struct.
  *
- * Uses {WebAuthn-verifyMinimal} for signature verification, which performs the essential
+ * Uses {WebAuthn-verify} for signature verification, which performs the essential
  * WebAuthn checks: type validation, challenge matching, and cryptographic signature verification.
  *
  * NOTE: Wallets that may require default P256 validation may install a P256 verifier separately.


### PR DESCRIPTION
Replace {WebAuthn-verifyMinimal} with {WebAuthn-verify} in ERC7913WebAuthnVerifier.sol.
The WebAuthn library exposes only verify(...) (no verifyMinimal). Our docs generator slugs symbol names with hyphens, so {WebAuthn-verify} is the correct cross-reference and renders properly.