### PR TITLE
docs(Heap): clarify priority via comparator and default min-heap behavior

### DIFF
--- a/contracts/utils/structs/Heap.sol
+++ b/contracts/utils/structs/Heap.sol
@@ -18,9 +18,10 @@ import {StorageSlot} from "../StorageSlot.sol";
  * index i is the child of the node at index (i-1)/2 and the parent of nodes at index 2*i+1 and 2*i+2. Each node
  * stores an element of the heap.
  *
- * The structure is ordered so that each node is bigger than its parent. An immediate consequence is that the
- * highest priority value is the one at the root. This value can be looked up in constant time (O(1)) at
- * `heap.tree[0]`
+ * The structure is ordered so that, per the comparator, each node has lower priority than its parent; as a
+ * consequence, the highest-priority value is at the root. This value can be looked up in constant time (O(1)) at
+ * `heap.tree[0]`. By default, the comparator is `Comparators.lt`, which treats smaller values as higher priority
+ * (min-heap). Using `Comparators.gt` yields a max-heap.
  *
  * The structure is designed to perform the following operations with the corresponding complexities:
  *


### PR DESCRIPTION
Fix top-level documentation in contracts/utils/structs/Heap.sol to define priority in terms of the comparator.
Explicitly state that the default comparator is Comparators.lt (min-heap: smaller value = higher priority) and that Comparators.gt produces a max-heap.
Reason: Previous wording incorrectly claimed “each node is bigger than its parent,” conflicting with the default lt comparator and tests showing min-heap semantics. This change aligns docs with actual behavior and broader utilities documentation.