### PR TITLE
fix: ClashingImplementation comment to reference upgradeToAndCall

### DIFF
--- a/contracts/mocks/proxy/ClashingImplementation.sol
+++ b/contracts/mocks/proxy/ClashingImplementation.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.20;
 
 /**
- * @dev Implementation contract with a payable changeAdmin(address) function made to clash with
- * TransparentUpgradeableProxy's to test correct functioning of the Transparent Proxy feature.
+ * @dev Implementation contract with a payable upgradeToAndCall(address,bytes) function made to clash with
+ * TransparentUpgradeableProxy's interface to test correct functioning of the Transparent Proxy pattern.
  */
 contract ClashingImplementation {
     event ClashingImplementationCall();


### PR DESCRIPTION
ClashingImplementation is used to test selector clash behavior of TransparentUpgradeableProxy. The proxy’s external interface exposes upgradeToAndCall(address,bytes) (see ITransparentUpgradeableProxy and _fallback()), not changeAdmin(address). The previous comment referenced changeAdmin(address), which is only an internal utility in ERC1967Utils and not part of the proxy’s external interface.