### PR TITLE
Defer `signer()` reads until after `tryDecodeAuth` success in SignerWebAuthn

### DIFF
--- a/contracts/utils/cryptography/signers/SignerWebAuthn.sol
+++ b/contracts/utils/cryptography/signers/SignerWebAuthn.sol
@@ -40,12 +40,12 @@ abstract contract SignerWebAuthn is SignerP256 {
         bytes32 hash,
         bytes calldata signature
     ) internal view virtual override returns (bool) {
-        (bytes32 qx, bytes32 qy) = signer();
         (bool decodeSuccess, WebAuthn.WebAuthnAuth calldata auth) = WebAuthn.tryDecodeAuth(signature);
-
-        return
-            decodeSuccess
-                ? WebAuthn.verify(abi.encodePacked(hash), auth, qx, qy)
-                : super._rawSignatureValidation(hash, signature);
+        if (decodeSuccess) {
+            (bytes32 qx, bytes32 qy) = signer();
+            return WebAuthn.verify(abi.encodePacked(hash), auth, qx, qy);
+        } else {
+            return super._rawSignatureValidation(hash, signature);
+        }
     }
 }


### PR DESCRIPTION
- Avoid premature SLOADs by decoding WebAuthn first and only reading the P256 public key if decoding succeeds.
- Eliminates two unnecessary storage reads on the fallback path to raw P256 validation
- Aligns with existing patterns in SignerECDSA and ERC7913WebAuthnVerifier where decoding/recovery precedes storage access.