### PR TITLE
fix: correct renounceRole RoleRevoked comment

### DIFF
--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -143,7 +143,7 @@ abstract contract AccessControl is Context, IAccessControl, ERC165 {
      * purpose is to provide a mechanism for accounts to lose their privileges
      * if they are compromised (such as when a trusted device is misplaced).
      *
-     * If the calling account had been revoked `role`, emits a {RoleRevoked}
+     * If the calling account had been granted `role`, emits a {RoleRevoked}
      * event.
      *
      * Requirements:


### PR DESCRIPTION
Adjusted the renounceRole comment so it now says the RoleRevoked event fires only when the caller actually held the role before renouncing, matching the guard in _revokeRole.

- [x] Documentation

