### PR TITLE
Remove dead abstract contract Impl from DummyImplementation mock

### DIFF
--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -5,10 +5,6 @@ pragma solidity ^0.8.21;
 import {ERC1967Utils} from "../proxy/ERC1967/ERC1967Utils.sol";
 import {StorageSlot} from "../utils/StorageSlot.sol";
 
-abstract contract Impl {
-    function version() public pure virtual returns (string memory);
-}
-
 contract DummyImplementation {
     uint256 public value;
     string public text;


### PR DESCRIPTION
Removedunused abstract contract Impl. Impl is not inherited, imported, or referenced anywhere, and tests interact directly with DummyImplementation and DummyImplementationV2 without an interface layer.