### PR TITLE
docs: fix 404 link

### DIFF
--- a/contracts/crosschain/README.adoc
+++ b/contracts/crosschain/README.adoc
@@ -1,7 +1,7 @@
 = Cross chain interoperability
 
 [.readme-notice]
-NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/api/crosschain
+NOTE: This document is better viewed at https://docs.openzeppelin.com/community-contracts/api/crosschain
 
 This directory contains contracts for sending and receiving cross chain messages that follows the ERC-7786 standard.
 


### PR DESCRIPTION
Previous one was broken - https://docs.openzeppelin.com/contracts/api/crosschain
The one that I changed to is - https://docs.openzeppelin.com/community-contracts/api/crosschain