### PR TITLE
docs: document P256 ERC-7913 key format

### DIFF
--- a/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol
@@ -9,6 +9,11 @@ import {IERC7913SignatureVerifier} from "../../../interfaces/IERC7913.sol";
 /**
  * @dev ERC-7913 signature verifier that support P256 (secp256r1) keys.
  *
+ * Key format:
+ * - The `key` MUST be a 64-byte concatenation of the P256 public key coordinates `qx || qy`.
+ * - Each coordinate is a 32-byte big-endian value (`bytes32`).
+ * - SEC1 prefixes are not accepted and compressed keys are not supported.
+ *
  * @custom:stateless
  */
 contract ERC7913P256Verifier is IERC7913SignatureVerifier {


### PR DESCRIPTION
Add NatSpec in ERC7913P256Verifier.sol to explicitly state the required key format for P256 ERC‑7913 verifiers: 64‑byte concatenation qx || qy, each 32‑byte big‑endian. Clarifies that SEC1 prefixes are not accepted and compressed keys are not supported.
Purpose: eliminate ambiguity for integrators; align with code behavior (key.length == 0x40 and bytes32 slicing) and sibling ERC7913WebAuthnVerifier documentation; prevent misuse with SEC1/uncompressed/compressed encodings.