### PR TITLE
Use strict equality in Arrays test helpers

### DIFF
--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -9,13 +9,13 @@ const { TYPES } = require('../../scripts/generate/templates/Arrays.opts');
 // See https://en.cppreference.com/w/cpp/algorithm/lower_bound
 const lowerBound = (array, value) => {
   const i = array.findIndex(element => value <= element);
-  return i == -1 ? array.length : i;
+  return i === -1 ? array.length : i;
 };
 
 // See https://en.cppreference.com/w/cpp/algorithm/upper_bound
 const upperBound = (array, value) => {
   const i = array.findIndex(element => value < element);
-  return i == -1 ? array.length : i;
+  return i === -1 ? array.length : i;
 };
 
 const bigintSign = x => (x > 0n ? 1 : x < 0n ? -1 : 0);


### PR DESCRIPTION


Replace loose equality (`==`) with strict equality (`===`) in `lowerBound` and `upperBound` test helper functions to improve code consistency and avoid potential type coercion issues.
