### PR TITLE
docs: fix misleading in ERC721Enumerable._increaseBalance

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/extensions/ERC721Enumerable.sol
@@ -153,7 +153,8 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     }
 
     /**
-     * See {ERC721-_increaseBalance}. We need that to account tokens that were minted in batch
+     * See {ERC721-_increaseBalance}. We need to forbid batch minting because the enumeration
+     * extension does not support it.
      */
     function _increaseBalance(address account, uint128 amount) internal virtual override {
         if (amount > 0) {


### PR DESCRIPTION
The comment for _increaseBalance in ERC721Enumerable was saying the opposite of what the code actually does.

It said `We need that to account tokens that were minted in batch` which sounds like we're supporting batch minting. But the code literally reverts if you try to batch mint (amount > 0).

Fixed it to say `We need to forbid batch minting because the enumeration extension does not support it` which matches what the code actually does and aligns with the error name ERC721EnumerableForbiddenBatchMint.