### PR TITLE
Fix incorrect reference in _withdraw documentation

### DIFF
--- a/contracts/mocks/docs/ERC4626Fees.sol
+++ b/contracts/mocks/docs/ERC4626Fees.sol
@@ -57,7 +57,7 @@ abstract contract ERC4626Fees is ERC4626 {
         }
     }
 
-    /// @dev Send exit fee to {_exitFeeRecipient}. See {IERC4626-_deposit}.
+    /// @dev Send exit fee to {_exitFeeRecipient}. See {IERC4626-_withdraw}.
     function _withdraw(
         address caller,
         address receiver,


### PR DESCRIPTION
The comment for _withdraw function incorrectly referenced {IERC4626-_deposit} instead of {IERC4626-_withdraw}. 
This was a copy-paste error from the _deposit function above it.