### PR TITLE
Move multiproof hashes allocation under condition to avoid zero-length alloc

### DIFF
--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -217,9 +217,9 @@ library MerkleProof {
             revert MerkleProofInvalidMultiproof();
         }
 
-        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
-        // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
         if (proofFlagsLen > 0) {
+            // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+            // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
             bytes32[] memory hashes = new bytes32[](proofFlagsLen);
             uint256 leafPos = 0;
             uint256 hashPos = 0;
@@ -304,9 +304,9 @@ library MerkleProof {
             revert MerkleProofInvalidMultiproof();
         }
 
-        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
-        // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
         if (proofFlagsLen > 0) {
+            // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+            // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
             bytes32[] memory hashes = new bytes32[](proofFlagsLen);
             uint256 leafPos = 0;
             uint256 hashPos = 0;
@@ -389,9 +389,9 @@ library MerkleProof {
             revert MerkleProofInvalidMultiproof();
         }
 
-        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
-        // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
         if (proofFlagsLen > 0) {
+            // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+            // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
             bytes32[] memory hashes = new bytes32[](proofFlagsLen);
             uint256 leafPos = 0;
             uint256 hashPos = 0;
@@ -476,9 +476,9 @@ library MerkleProof {
             revert MerkleProofInvalidMultiproof();
         }
 
-        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
-        // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
         if (proofFlagsLen > 0) {
+            // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+            // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
             bytes32[] memory hashes = new bytes32[](proofFlagsLen);
             uint256 leafPos = 0;
             uint256 hashPos = 0;

--- a/scripts/generate/templates/MerkleProof.js
+++ b/scripts/generate/templates/MerkleProof.js
@@ -138,26 +138,25 @@ function processMultiProof${suffix}(${formatArgsMultiline(
         revert MerkleProofInvalidMultiproof();
     }
 
-    // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
-    // \`xxx[xxxPos++]\`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
-    bytes32[] memory hashes = new bytes32[](proofFlagsLen);
-    uint256 leafPos = 0;
-    uint256 hashPos = 0;
-    uint256 proofPos = 0;
-    // At each step, we compute the next hash using two values:
-    // - a value from the "main queue". If not all leaves have been consumed, we get the next leaf, otherwise we
-    //   get the next hash.
-    // - depending on the flag, either another value from the "main queue" (merging branches) or an element from the
-    //   \`proof\` array.
-    for (uint256 i = 0; i < proofFlagsLen; i++) {
-        bytes32 a = leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++];
-        bytes32 b = proofFlags[i]
-            ? (leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++])
-            : proof[proofPos++];
-        hashes[i] = ${hash ?? DEFAULT_HASH}(a, b);
-    }
-
     if (proofFlagsLen > 0) {
+        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+        // \`xxx[xxxPos++]\`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
+        bytes32[] memory hashes = new bytes32[](proofFlagsLen);
+        uint256 leafPos = 0;
+        uint256 hashPos = 0;
+        uint256 proofPos = 0;
+        // At each step, we compute the next hash using two values:
+        // - a value from the "main queue". If not all leaves have been consumed, we get the next leaf, otherwise we
+        //   get the next hash.
+        // - depending on the flag, either another value from the "main queue" (merging branches) or an element from the
+        //   \`proof\` array.
+        for (uint256 i = 0; i < proofFlagsLen; i++) {
+            bytes32 a = leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++];
+            bytes32 b = proofFlags[i]
+                ? (leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++])
+                : proof[proofPos++];
+            hashes[i] = ${hash ?? DEFAULT_HASH}(a, b);
+        }
         if (proofPos != proof.length) {
             revert MerkleProofInvalidMultiproof();
         }


### PR DESCRIPTION
This change relocates the allocation of the temporary hashes array and related counters inside the if (proofFlagsLen > 0) branch across all four multiproof functions in MerkleProof.sol. When proofFlagsLen == 0, the function returns early and hashes is never used; previously this still incurred an unnecessary zero-length memory allocation and variable initialization. The refactor avoids that overhead without changing semantics, consistent with existing docs and tests.