### PR TITLE
docs: document TimelockController CANCELLER_ROLE in governance guide

### DIFF
--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -90,8 +90,8 @@ TimelockController uses an AccessControl setup that we need to understand in ord
 
 - The Proposer role is in charge of queueing operations: this is the role the Governor instance should be granted, and it should likely be the only proposer in the system.
 - The Executor role is in charge of executing already available operations: we can assign this role to the special zero address to allow anyone to execute (if operations can be particularly time sensitive, the Governor should be made Executor instead).
+- The Canceller role can cancel queued operations in the timelock: the Governor should hold this role for proposal cancellations to work after queuing. If the Governor is set as a proposer at deployment, it will automatically receive the Canceller role as well.
 - Lastly, there is the Admin role, which can grant and revoke the two previous roles: this is a very sensitive role that will be granted automatically to the timelock itself, and optionally to a second account, which can be used for ease of setup but should promptly renounce the role.
-- The Canceller role can cancel queued operations in the timelock: the Governor should hold this role for proposal cancellations to work after queuing. If the Governor is set as a proposer at deployment, it will automatically receive the Canceller role as well. If roles are granted after deployment, make sure to explicitly grant `CANCELLER_ROLE` to the Governor.
 
 WARNING: Granting additional proposers or cancellers besides the Governor is risky. They can execute operations as the timelock (bypassing governance) and cancel approved proposals, potentially causing a denial of service against governance.
 


### PR DESCRIPTION
Add explicit mention of CANCELLER_ROLE and its necessity for proposal cancellation with GovernorTimelockControl. Also warn about risks of granting additional proposers/cancellers. This fixes an omission that could lead to misconfigured deployments where cancellations fail or governance can be DoS’d by an extra canceller.