### PR TITLE
docs(interfaces): correct IPaymaster.postOp param description for actualUserOpFeePerGas

### DIFF
--- a/contracts/interfaces/draft-IERC4337.sol
+++ b/contracts/interfaces/draft-IERC4337.sol
@@ -242,7 +242,8 @@ interface IPaymaster {
     /**
      * @dev Verifies the sender is the entrypoint.
      * @param actualGasCost the actual amount paid (by account or paymaster) for this UserOperation
-     * @param actualUserOpFeePerGas total gas used by this UserOperation (including preVerification, creation, validation and execution)
+     * @param actualUserOpFeePerGas the effective gas price (wei per gas) paid by this UserOperation, equal to
+     * min(maxFeePerGas, maxPriorityFeePerGas + basefee)
      */
     function postOp(
         PostOpMode mode,


### PR DESCRIPTION
This change corrects the documentation for the IPaymaster.postOp parameter actualUserOpFeePerGas in interfaces/draft-IERC4337.sol to describe it as the effective gas price (wei per gas) rather than “total gas used”. The updated description aligns with the canonical EntryPoint implementation in eth-infinitism, where postOp is invoked with actualGasCost and the computed gasPrice equal to min(maxFeePerGas, maxPriorityFeePerGas + basefee), and with the ERC-4337 specification’s function signature. 