### PR TITLE
docs: update miner terminology to block proposer for PoS compatibility

### DIFF
--- a/docs/modules/ROOT/pages/erc20-supply.adoc
+++ b/docs/modules/ROOT/pages/erc20-supply.adoc
@@ -34,7 +34,7 @@ contract ERC20FixedSupply is ERC20 {
 
 Encapsulating state like this makes it safer to extend contracts. For instance, in the first example we had to manually keep the `totalSupply` in sync with the modified balances, which is easy to forget. In fact, we omitted something else that is also easily forgotten: the `Transfer` event that is required by the standard, and which is relied on by some clients. The second example does not have this bug, because the internal `_mint` function takes care of it.
 
-[[rewarding-miners]]
+[[rewarding-block-proposers]]
 == Rewarding Block Proposers
 
 The internal xref:api:token/ERC20.adoc#ERC20-_mint-address-uint256-[`_mint`] function is the key building block that allows us to write ERC-20 extensions that implement a supply mechanism.


### PR DESCRIPTION
Update documentation to reflect that block.coinbase refers to fee recipient in Proof of Stake networks, not miners. 

This aligns the docs with Ethereum's current consensus mechanism after The Merge.