### PR TITLE
docs: clarify AccessControl initialization behavior in upgradeable contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,7 @@ OpenZeppelin Contracts is released under the [MIT License](LICENSE).
 
 ## Legal
 
-Your use of this Project is governed by the terms found at www.openzeppelin.com/tos (the "Terms").
+Your use of this Project is governed by the terms found at www.openzeppelin.com/tos (the "Terms").> Note: When using AccessControl with upgradeable contracts, role admin
+> relationships must be reinitialized after proxy deployment. Failing to do so
+> may leave roles without a valid admin.
+


### PR DESCRIPTION
This PR adds a short clarification to the AccessControl documentation
explaining that role admin relationships must be reinitialized when using
upgradeable (proxy) deployments.

Without this step, some roles may not have a valid admin, which can lead
to unexpected authorization behavior.

Documentation-only change, no functional code modifications.
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
