### PR TITLE
fix: typos in ERC1155 extension

### DIFF
--- a/contracts/token/ERC1155/extensions/ERC1155Supply.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Supply.sol
@@ -11,8 +11,8 @@ import {Arrays} from "../../../utils/Arrays.sol";
  *
  * Useful for scenarios where Fungible and Non-fungible tokens have to be
  * clearly identified. Note: While a totalSupply of 1 might mean the
- * corresponding is an NFT, there is no guarantees that no other token with the
- * same id are not going to be minted.
+ * corresponding token is an NFT, there are no guarantees that no other token
+ * with the same id are not going to be minted.
  *
  * NOTE: This contract implies a global limit of 2**256 - 1 to the number of tokens
  * that can be minted.
@@ -40,7 +40,7 @@ abstract contract ERC1155Supply is ERC1155 {
     }
 
     /**
-     * @dev Indicates whether any token exist with a given id, or not.
+     * @dev Indicates whether any token exists with a given id, or not.
      */
     function exists(uint256 id) public view virtual returns (bool) {
         return totalSupply(id) > 0;


### PR DESCRIPTION
there is no guarantees -> there are no guarantees
corresponding is an NFT -> corresponding token is an NFT
any token exist -> any token exists