### PR TITLE
docs(governor): correct Natspec to reference ICompoundTimelock

### DIFF
--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -14,15 +14,15 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * the admin of the timelock for any operation to be performed. A public, unrestricted,
  * {GovernorTimelockCompound-__acceptAdmin} is available to accept ownership of the timelock.
  *
- * Using this model means the proposal will be operated by the {TimelockController} and not by the {Governor}. Thus,
- * the assets and permissions must be attached to the {TimelockController}. Any asset sent to the {Governor} will be
+ * Using this model means the proposal will be operated by the {ICompoundTimelock} and not by the {Governor}. Thus,
+ * the assets and permissions must be attached to the {ICompoundTimelock}. Any asset sent to the {Governor} will be
  * inaccessible from a proposal, unless executed via {Governor-relay}.
  */
 abstract contract GovernorTimelockCompound is Governor {
     ICompoundTimelock private _timelock;
 
     /**
-     * @dev Emitted when the timelock controller used for proposal execution is modified.
+     * @dev Emitted when the timelock used for proposal execution is modified.
      */
     event TimelockChange(address oldTimelock, address newTimelock);
 


### PR DESCRIPTION
- Replace incorrect {TimelockController} mentions with {ICompoundTimelock} in GovernorTimelockCompound.sol Natspec.
- Clarify the TimelockChange event description to avoid confusion with TimelockController.

Rationale: This module integrates with Compound’s Timelock via ICompoundTimelock; prior wording was a copy-paste error that could mislead integrators and reviewers. No logic changes.