### PR TITLE
Dealocate unused memory when queuing transactions

### DIFF
--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -78,7 +78,7 @@ abstract contract GovernorTimelockCompound is Governor {
             ) {
                 revert GovernorAlreadyQueuedProposal(proposalId);
             }
-            Memory.setFreeMemoryPointer(ptr); // dealocate the memory that was reserved by "abi.encode".
+            Memory.setFreeMemoryPointer(ptr); // deallocate the memory that was reserved by "abi.encode".
             _timelock.queueTransaction(targets[i], values[i], "", calldatas[i], etaSeconds);
         }
 


### PR DESCRIPTION
Added memory management for transaction queuing in GovernorTimelockCompound.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
