### PR TITLE
fix(docs): correct mathematical equivalence in ERC4626 inflation attack formula

### DIFF
--- a/docs/modules/ROOT/pages/erc4626.adoc
+++ b/docs/modules/ROOT/pages/erc4626.adoc
@@ -172,7 +172,7 @@ For the attacker to dilute that deposit to 0 shares, causing the user to lose al
 
 [stem]
 ++++
-\iff 10^\delta \times u \le \mathit{loss}
+\iff 10^\delta \times u < 1 + \mathit{loss}
 ++++
 
 - If the offset is 0, the attacker's loss is at least equal to the user's deposit.


### PR DESCRIPTION
Fixes incorrect mathematical equivalence in the virtual offset defense section.

The formula now correctly shows that 10^δ × u < 1 + loss is equivalent to the previous transformations, rather than the incorrect 10^δ × u ≤ loss.