### PR TITLE
Fix `InvalidBase64Char` arguments encoding when invalid char is at some positions 

### DIFF
--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -208,7 +208,7 @@ library Base64 {
                 // slither-disable-next-line incorrect-shift
                 if iszero(and(shl(d, 1), 0xffffffd0ffffffc47ff5)) {
                     mstore(0, errorSelector)
-                    mstore(4, add(d, 43))
+                    mstore(4, shl(248, add(d, 43)))
                     revert(0, 0x24)
                 }
 


### PR DESCRIPTION
In Base64 decode validation, bytes 'a', 'b', and 'c' properly shift the error parameter with shl(248, ...) before storing, but byte 'd' was missing this operation. This caused incorrect ABI encoding when the 4th byte in a chunk was invalid.

Changed line 211 from:
    mstore(4, add(d, 43))
to:
    mstore(4, shl(248, add(d, 43)))

