### PR TITLE
fix(docs): add EIP712 to multisig example contracts’ inheritance

### DIFF
--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -52,7 +52,7 @@ Most smart accounts are deployed by a factory, the best practice is to create xr
 ----
 import {Account} from "@openzeppelin/community-contracts/account/Account.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {SignerECDSA} from "@openzeppelin/community-contracts/utils/cryptography/SignerECDSA.sol";
+import {SignerECDSA} from "@openzeppelin/community/utils/cryptography/signers/SignerECDSA.sol";
 
 contract MyAccount is Initializable, Account, SignerECDSA, ... {
     // ...
@@ -96,7 +96,7 @@ Here's an example of how to use batched execution using EIP-7702:
 ----
 import {Account} from "@openzeppelin/community-contracts/account/Account.sol";
 import {ERC7821} from "@openzeppelin/community-contracts/account/extensions/draft-ERC7821.sol";
-import {SignerEIP7702} from "@openzeppelin/community-contracts/utils/cryptography/SignerEIP7702.sol";
+import {SignerEIP7702} from "@openzeppelin/contracts/utils/cryptography/signers/SignerEIP7702.sol";
 
 contract MyAccount is Account, SignerEIP7702, ERC7821 {
     // Override to allow the entrypoint to execute batches

--- a/docs/modules/ROOT/pages/multisig.adoc
+++ b/docs/modules/ROOT/pages/multisig.adoc
@@ -34,14 +34,14 @@ The xref:api:utils.adoc#SignerERC7913[`SignerERC7913`] contract allows a single 
 
 pragma solidity ^0.8.24;
 
-import {Account} from "@openzeppelin/community-contracts/account/Account.sol";
+import {Account} from "@openzeppelin/contracts/account/Account.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
-import {ERC7739} from "@openzeppelin/community-contracts/utils/cryptography/signers/ERC7739.sol";
-import {ERC7821} from "@openzeppelin/community-contracts/account/extensions/ERC7821.sol";
+import {ERC7739} from "@openzeppelin/contracts/utils/cryptography/signers/draft-ERC7739.sol";
+import {ERC7821} from "@openzeppelin/contracts/account/extensions/draft-ERC7821.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {SignerERC7913} from "@openzeppelin/community-contracts/utils/cryptography/signers/SignerERC7913.sol";
+import {SignerERC7913} from "@openzeppelin/contracts/utils/cryptography/signers/SignerERC7913.sol";
 
 contract MyAccountERC7913 is Account, EIP712, SignerERC7913, ERC7739, ERC7821, ERC721Holder, ERC1155Holder, Initializable {
     constructor() EIP712("MyAccount7913", "1") {}
@@ -78,14 +78,14 @@ The xref:api:utils/cryptography.adoc#MultiSignerERC7913[`MultiSignerERC7913`] co
 
 pragma solidity ^0.8.27;
 
-import {Account} from "@openzeppelin/community-contracts/account/Account.sol";
+import {Account} from "@openzeppelin/contracts/account/Account.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
-import {ERC7739} from "@openzeppelin/community-contracts/utils/cryptography/signers/ERC7739.sol";
-import {ERC7821} from "@openzeppelin/community-contracts/account/extensions/ERC7821.sol";
+import {ERC7739} from "@openzeppelin/contracts/utils/cryptography/signers/draft-ERC7739.sol";
+import {ERC7821} from "@openzeppelin/contracts/account/extensions/draft-ERC7821.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {MultiSignerERC7913} from "@openzeppelin/community-contracts/utils/cryptography/signers/MultiSignerERC7913.sol";
+import {MultiSignerERC7913} from "@openzeppelin/contracts/utils/cryptography/signers/MultiSignerERC7913.sol";
 
 contract MyAccountMultiSigner is
     Account,
@@ -146,14 +146,14 @@ For more sophisticated governance structures, the xref:api:utils/cryptography.ad
 
 pragma solidity ^0.8.27;
 
-import {Account} from "@openzeppelin/community-contracts/account/Account.sol";
+import {Account} from "@openzeppelin/contracts/account/Account.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
-import {ERC7739} from "@openzeppelin/community-contracts/utils/cryptography/signers/ERC7739.sol";
-import {ERC7821} from "@openzeppelin/community-contracts/account/extensions/ERC7821.sol";
+import {ERC7739} from "@openzeppelin/contracts/utils/cryptography/signers/draft-ERC7739.sol";
+import {ERC7821} from "@openzeppelin/contracts/account/extensions/draft-ERC7821.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {MultiSignerERC7913Weighted} from "@openzeppelin/community-contracts/utils/cryptography/signers/MultiSignerERC7913Weighted.sol";
+import {MultiSignerERC7913Weighted} from "@openzeppelin/contracts/utils/cryptography/signers/MultiSignerERC7913Weighted.sol";
 
 contract MyAccountMultiSignerWeighted is
     Account,


### PR DESCRIPTION
The multisig examples in docs/modules/ROOT/pages/multisig.adoc called the EIP712 base constructor without inheriting EIP712, which causes a compile-time error in Solidity because base constructors can only be invoked for direct or indirect bases. The examples also mix in ERC7739, whose nested EIP-712 hashing pattern requires an EIP-712 domain. Aligning with OpenZeppelin patterns (e.g., Governor), I added EIP712 to the inheritance lists of MyAccountERC7913, MyAccountMultiSigner, and MyAccountMultiSignerWeighted so that the existing EIP712("…","1") constructor calls are correct and the examples compile as intended