### PR TITLE
fix(test): use this.value instead of undefined this.amount

### DIFF
--- a/test/metatx/ERC2771Forwarder.test.js
+++ b/test/metatx/ERC2771Forwarder.test.js
@@ -268,7 +268,7 @@ describe('ERC2771Forwarder', function () {
             this.accounts[1],
           );
 
-          await expect(this.forwarder.executeBatch(this.requests, this.refundReceiver, { value: this.amount }))
+          await expect(this.forwarder.executeBatch(this.requests, this.refundReceiver, { value: this.value }))
             .to.be.revertedWithCustomError(this.forwarder, 'ERC2771ForwarderExpiredRequest')
             .withArgs(this.requests[idx].deadline);
         });


### PR DESCRIPTION
Replace the undefined variable this.amount with this.value in test/metatx/ERC2771Forwarder.test.js at the expired deadline path for the zero refund receiver scenario to align with the suite’s established pattern where this.value holds the sum of request values computed in the beforeEach, ensuring executeBatch receives the correct msg.value as required by the contract which reverts on ERC2771ForwarderMismatchedValue when totals do not match; this change also mirrors nearby tests that already pass { value: this.value } and prevents a test reference error from masking the intended ERC2771ForwarderExpiredRequest assertion.