### PR TITLE
fix: add missing space in NatSpec comment

### DIFF
--- a/contracts/utils/cryptography/MerkleProof.sol
+++ b/contracts/utils/cryptography/MerkleProof.sol
@@ -30,7 +30,7 @@ import {Hashes} from "./Hashes.sol";
  */
 library MerkleProof {
     /**
-     *@dev The multiproof provided is not valid.
+     * @dev The multiproof provided is not valid.
      */
     error MerkleProofInvalidMultiproof();
 


### PR DESCRIPTION
Fixed a formatting typo in MerkleProof.sol where `*@dev` was missinga space before the tag. All other NatSpec comments in the codebase use `* @dev` format, this was the only inconsistency.