### PR TITLE
docs(tokens): add cross-links to ERC-6909 and ERC-4626

### DIFF
--- a/docs/modules/ROOT/pages/tokens.adoc
+++ b/docs/modules/ROOT/pages/tokens.adoc
@@ -29,3 +29,5 @@ You've probably heard of the ERC-20 or ERC-721 token standards, and that's why y
  * xref:erc20.adoc[ERC-20]: the most widespread token standard for fungible assets, albeit somewhat limited by its simplicity.
  * xref:erc721.adoc[ERC-721]: the de-facto solution for non-fungible tokens, often used for collectibles and games.
  * xref:erc1155.adoc[ERC-1155]: a novel standard for multi-tokens, allowing for a single contract to represent multiple fungible and non-fungible tokens, along with batched operations for increased gas efficiency.
+* xref:erc6909.adoc[ERC-6909]: minimal multi-token standard with account-based balances.
+* xref:erc4626.adoc[ERC-4626]: tokenized vault standard for yield-bearing assets.


### PR DESCRIPTION
Updated the tokens overview to include cross-links for ERC-6909 and ERC-4626, which are already present in the codebase and documentation. Adding these references improves discoverability and completeness of the standards overview: ERC-6909 provides a minimal multi-token model aligned with account-based balances in this repo under contracts/token/ERC6909/, and ERC-4626 formalizes tokenized vaults which are commonly used with ERC-20 for yield-bearing strategies and is documented alongside existing token topics. These links keep the overview consistent with current library coverage and help readers navigate to modern token standards beyond ERC-20/721/1155.