### PR TITLE
Add IERC6909ContentURI Detection to ERC6909ContentURI

### DIFF
--- a/contracts/token/ERC6909/extensions/ERC6909ContentURI.sol
+++ b/contracts/token/ERC6909/extensions/ERC6909ContentURI.sol
@@ -19,6 +19,13 @@ contract ERC6909ContentURI is ERC6909, IERC6909ContentURI {
     /// @dev See {IERC1155-URI}
     event URI(string value, uint256 indexed id);
 
+    /**
+     * @dev Signals support for the Content URI extension so off-chain clients can safely rely on it.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC6909ContentURI).interfaceId || super.supportsInterface(interfaceId);
+    }
+
     /// @inheritdoc IERC6909ContentURI
     function contractURI() public view virtual override returns (string memory) {
         return _contractURI;


### PR DESCRIPTION


## Description
- declare support for `IERC6909ContentURI` in `ERC6909ContentURI` so clients can detect the extension via `supportsInterface`
- attempted to run `npm run test -- test/token/ERC6909/extensions/ERC6909ContentURI.test.js`, but Hardhat aborted with HH19 (“project is ESM, rename config to .cjs”).
