### PR TITLE
Optimize gas cost of `Heap.pop()` when size==1

### DIFF
--- a/contracts/utils/structs/Heap.sol
+++ b/contracts/utils/structs/Heap.sol
@@ -88,9 +88,12 @@ library Heap {
             if (size == 1) {
                 self.tree.pop();
             } else {
-                // swap last leaf with root, shrink tree and re-heapify
-                uint256 lastValue = self.tree.unsafeAccess(0).value = self.tree.unsafeAccess(size - 1).value;
+                // swap last leaf with root ...
+                uint256 lastValue = self.tree.unsafeAccess(size - 1).value;
+                self.tree.unsafeAccess(0).value = lastValue;
+                // ... shrink tree ...
                 self.tree.pop();
+                // ... re-heapify
                 _siftDown(self, size - 1, 0, lastValue, comp);
             }
             return rootValue;


### PR DESCRIPTION
Introduce an early return in Heap.pop() when the heap size is one to avoid a redundant same-value SSTORE to index 0 after shrinking the array length to zero and to skip an unnecessary _siftDown call; this preserves behavior and invariants while reducing gas in the single element case because the previous implementation re-wrote index 0 with the same value even though the array length had become zero and then invoked _siftDown with size minus one equal to zero which is a no-op, whereas the new fast-path reads the root, pops the array, and returns immediately, aligning with the library’s existing approach of caching to minimize storage reads and doing no extra work beyond what is required.