### PR TITLE
chore: fix typos

### DIFF
--- a/contracts/token/ERC1155/extensions/ERC1155Supply.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Supply.sol
@@ -26,7 +26,7 @@ abstract contract ERC1155Supply is ERC1155 {
     uint256 private _totalSupplyAll;
 
     /**
-     * @dev Total value of tokens in with a given id.
+     * @dev Total value of tokens with a given id.
      */
     function totalSupply(uint256 id) public view virtual returns (uint256) {
         return _totalSupply[id];


### PR DESCRIPTION
corresponding is an NFT -> corresponding token is an NFT
tokens in with -> tokens with

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
