### PR TITLE
fix: correct log2() lookup table comment to MSB-first half

### DIFF
--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -646,7 +646,7 @@ library Math {
         // |    1110    |   14    |        table[14] = 3        |
         // |    1111    |   15    |        table[15] = 3        |
         //
-        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.
+        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the first 16 bytes (most significant half).
         assembly ("memory-safe") {
             r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))
         }


### PR DESCRIPTION
The comment in Math.log2(uint256) incorrectly stated that the nibble MSB lookup table lived in the last 16 bytes of the 32-byte constant. In Yul, byte(i, w) indexes from the most significant byte, and the constant places the table in the first 16 bytes (indices 0–15). Updated the comment to reflect the actual layout.