### PR TITLE
docs: fix NatSpec comment format

### DIFF
--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -735,7 +735,7 @@ abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC72
         return currentState;
     }
 
-    /*
+    /**
      * @dev Check if the proposer is authorized to submit a proposal with the given description.
      *
      * If the proposal description ends with `#proposer=0x???`, where `0x???` is an address written as a hex string


### PR DESCRIPTION
Fixed `/*` -> `/**` for _isValidDescriptionForProposer docs so NatSpec tags are properly recognized.