### PR TITLE
fix: align EnumerableMap FV comments with invariants

### DIFF
--- a/fv/specs/EnumerableMap.spec
+++ b/fv/specs/EnumerableMap.spec
@@ -53,7 +53,7 @@ invariant indexedContained(uint256 index)
 
 /*
 ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Invariant: A value can only be stored at a single location                                                          │
+│ Invariant: A key can only be stored at a single location                                                            │
 └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 */
 invariant atUniqueness(uint256 index1, uint256 index2)
@@ -72,9 +72,9 @@ invariant atUniqueness(uint256 index1, uint256 index2)
 
 /*
 ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Invariant: index <> value relationship is consistent                                                                │
+│ Invariant: index <> key relationship is consistent                                                                  │
 │                                                                                                                     │
-│ Note that the two consistencyXxx invariants, put together, prove that at_ and _positionOf are inverse of one        │
+│ Note that the two consistencyXxx invariants, put together, prove that key_at and _positionOf are inverse of one     │
 │ another. This proves that we have a bijection between indices (the enumerability part) and keys (the entries that   │
 │ are set and removed from the EnumerableMap).                                                                        │
 └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
Update the FV comments for EnumerableMap to describe the actual invariants over keys instead of values. The atUniqueness invariant now explicitly states that a key can only be stored at a single location, and the index–key consistency block is documented as an index–key relationship.

The note explaining the bijection between indices and keys now refers to key_at and positionOf as inverses, matching the methods used in the spec. These changes make the comments consistent with the formal invariants and the underlying EnumerableMap/EnumerableSet implementation, avoiding confusion for readers of the proofs.