### PR TITLE
perf(Math): early return in ceilDiv when a == 0

### DIFF
--- a/contracts/utils/math/Math.sol
+++ b/contracts/utils/math/Math.sol
@@ -191,8 +191,11 @@ library Math {
         // The largest possible result occurs when (a - 1) / b is type(uint256).max,
         // but the largest value we can obtain is type(uint256).max - 1, which happens
         // when a = type(uint256).max and b = 1.
+        if (a == 0) {
+            return 0;
+        }
         unchecked {
-            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);
+            return (a - 1) / b + 1;
         }
     }
 


### PR DESCRIPTION
Replace the branchless SafeCast.toUint(a > 0) * ((a - 1) / b + 1) with an early return 0 when a == 0, keeping the b == 0 division-by-zero check intact and then computing (a - 1) / b + 1 in the non-zero path. This removes unnecessary division/addition for the zero-input case without changing behavior. Minor gas/bytecode improvement in that path; test expectations remain unchanged;