### PR TITLE
docs: replace Ethereum-specific terminology with EVM-compatible in tokens.adoc

### DIFF
--- a/docs/modules/ROOT/pages/tokens.adoc
+++ b/docs/modules/ROOT/pages/tokens.adoc
@@ -9,7 +9,7 @@ A token is a _representation of something in the blockchain_. This something can
 
 Much of the confusion surrounding tokens comes from two concepts getting mixed up: _token contracts_ and the actual _tokens_.
 
-A _token contract_ is simply an Ethereum smart contract. "Sending tokens" actually means "calling a method on a smart contract that someone wrote and deployed". At the end of the day, a token contract is not much more than a mapping of addresses to balances, plus some methods to add and subtract from those balances.
+A _token contract_ is simply an EVM-compatible smart contract. "Sending tokens" actually means "calling a method on a smart contract that someone wrote and deployed". At the end of the day, a token contract is not much more than a mapping of addresses to balances, plus some methods to add and subtract from those balances.
 
 It is these balances that represent the _tokens_ themselves. Someone "has tokens" when their balance in the token contract is non-zero. That's it! These balances could be considered money, experience points in a game, deeds of ownership, or voting rights, and each of these tokens would be stored in different token contracts.
 
@@ -22,7 +22,7 @@ In a nutshell, when dealing with non-fungibles (like your house) you care about 
 
 == Standards
 
-Even though the concept of a token is simple, they have a variety of complexities in the implementation. Because everything in Ethereum is just a smart contract, and there are no rules about what smart contracts have to do, the community has developed a variety of *standards* (called EIPs or ERCs) for documenting how a contract can interoperate with other contracts.
+Even though the concept of a token is simple, they have a variety of complexities in the implementation. Because everything in EVM-compatible blockchains is just a smart contract, and there are no rules about what smart contracts have to do, the community has developed a variety of *standards* (called EIPs or ERCs) for documenting how a contract can interoperate with other contracts.
 
 You've probably heard of the ERC-20 or ERC-721 token standards, and that's why you're here. Head to our specialized guides to learn more about these:
 


### PR DESCRIPTION
Fixed a couple of places in tokens.adoc where we were saying "Ethereum" when we should have been saying "EVM-compatible". 

The docs were making it sound like this library only works on Ethereum, but it actually works on all EVM chains - Polygon, Arbitrum, Base, you name it. I noticed this while working on something else and figured it was worth fixing since it could confuse devs building on other chains.

Changed:
- "Ethereum smart contract" → "EVM-compatible smart contract"
- "everything in Ethereum" → "everything in EVM-compatible blockchains"

This keeps things consistent with the rest of the docs where we already use "EVM" for stuff that applies to all chains.