### PR TITLE
fix: _useNonce documentation in NoncesKeyed

### DIFF
--- a/contracts/utils/NoncesKeyed.sol
+++ b/contracts/utils/NoncesKeyed.sol
@@ -24,7 +24,7 @@ abstract contract NoncesKeyed is Nonces {
     /**
      * @dev Consumes the next unused nonce for an address and key.
      *
-     * Returns the current value without the key prefix. Consumed nonce is increased, so calling this function twice
+     * Returns the current value with the key prefix (i.e. the packed keyNonce). Consumed nonce is increased, so calling this function twice
      * with the same arguments will return different (sequential) results.
      */
     function _useNonce(address owner, uint192 key) internal virtual returns (uint256) {


### PR DESCRIPTION
Update the _useNonce(address,uint192) comment in NoncesKeyed to correctly state that it returns the value with the key prefix (packed keyNonce), aligning the documentation with the actual implementation behavior.