### PR TITLE
fix(test): remove redundant nullish coalescing in ERC721 behavior tests

### DIFF
--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -486,9 +486,7 @@ function shouldBehaveLikeERC721() {
 
       const itEmitsApprovalEvent = function () {
         it('emits an approval event', async function () {
-          await expect(this.tx)
-            .to.emit(this.token, 'Approval')
-            .withArgs(this.owner, this.approved, tokenId);
+          await expect(this.tx).to.emit(this.token, 'Approval').withArgs(this.owner, this.approved, tokenId);
         });
       };
 


### PR DESCRIPTION
Found `this.approved ?? this.approved` in ERC721.behavior.js which is a no-op - both operands are identical so the result is always `this.approved` regardless of its value. Looks like a copy-paste leftover. Cleaned it up.