### PR TITLE
docs: add missing contract references to README files

### DIFF
--- a/contracts/finance/README.adoc
+++ b/contracts/finance/README.adoc
@@ -8,7 +8,10 @@ This directory includes primitives for financial systems:
 - {VestingWallet} handles the vesting of Ether and ERC-20 tokens for a given beneficiary. Custody of multiple tokens can
   be given to this contract, which will release the token to the beneficiary following a given, customizable, vesting
   schedule.
+- {VestingWalletCliff} is an extension of {VestingWallet} that adds a cliff to the vesting schedule.
 
 == Contracts
 
 {{VestingWallet}}
+
+{{VestingWalletCliff}}

--- a/contracts/governance/README.adoc
+++ b/contracts/governance/README.adoc
@@ -56,6 +56,8 @@ Other extensions can customize the behavior or interface in multiple ways.
 
 * {GovernorNoncesKeyed}: An extension of {Governor} with support for keyed nonces in addition to traditional nonces when voting by signature.
 
+* {GovernorSequentialProposalId}: An extension of {Governor} that changes the numbering of proposal ids from the default hash-based approach to sequential ids.
+
 In addition to modules and extensions, the core contract requires a few virtual functions to be implemented to your particular specifications:
 
 * <<Governor-votingDelay-,`votingDelay()`>>: Delay (in ERC-6372 clock) since the proposal is submitted until voting power is fixed and voting starts. This can be used to enforce a delay after a proposal is published for users to buy tokens, or delegate their votes.
@@ -104,7 +106,11 @@ NOTE: Functions of the `Governor` contract do not include access control. If you
 
 {{GovernorNoncesKeyed}}
 
+{{GovernorSequentialProposalId}}
+
 == Utils
+
+{{IVotes}}
 
 {{Votes}}
 

--- a/contracts/utils/cryptography/README.adoc
+++ b/contracts/utils/cryptography/README.adoc
@@ -58,6 +58,8 @@ A collection of contracts and libraries that implement various signature validat
 
 {{SignerEIP7702}}
 
+{{SignerWebAuthn}}
+
 {{SignerERC7913}}
 
 {{MultiSignerERC7913}}


### PR DESCRIPTION

While going through the codebase I spotted a few contracts that somehow slipped through the docs:

- VestingWalletCliff (added in v5.1)
- GovernorSequentialProposalId (added in v5.4)  
- SignerWebAuthn (added in v5.5)
- IVotes interface
