### PR TITLE
docs: fix super quorum fraction NatSpec

### DIFF
--- a/contracts/governance/extensions/GovernorVotesSuperQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesSuperQuorumFraction.sol
@@ -28,7 +28,7 @@ abstract contract GovernorVotesSuperQuorumFraction is GovernorVotesQuorumFractio
     error GovernorInvalidSuperQuorumFraction(uint256 superQuorumNumerator, uint256 denominator);
 
     /**
-     * @dev The super quorum set is not valid as it is smaller or equal to the quorum.
+     * @dev The super quorum set is not valid as it is smaller than the quorum.
      */
     error GovernorInvalidSuperQuorumTooSmall(uint256 superQuorumNumerator, uint256 quorumNumerator);
 
@@ -41,7 +41,7 @@ abstract contract GovernorVotesSuperQuorumFraction is GovernorVotesQuorumFractio
      * @dev Initialize super quorum as a fraction of the token's total supply.
      *
      * The super quorum is specified as a fraction of the token's total supply and has to
-     * be greater than the quorum.
+     * be greater than or equal to the quorum.
      */
     constructor(uint256 superQuorumNumeratorValue) {
         _updateSuperQuorumNumerator(superQuorumNumeratorValue);


### PR DESCRIPTION
Update NatSpec comments in GovernorVotesSuperQuorumFraction so they accurately describe the super quorum invariant. The previous wording implied that the super quorum must be strictly greater than the quorum, while the implementation allows it to be equal (>=).