### PR TITLE
Remove unreachable return value checks in ERC1363

### DIFF
--- a/contracts/token/ERC20/extensions/ERC1363.sol
+++ b/contracts/token/ERC20/extensions/ERC1363.sol
@@ -65,9 +65,7 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
      * no specified format.
      */
     function transferAndCall(address to, uint256 value, bytes memory data) public virtual returns (bool) {
-        if (!transfer(to, value)) {
-            revert ERC1363TransferFailed(to, value);
-        }
+        transfer(to, value);
         ERC1363Utils.checkOnERC1363TransferReceived(_msgSender(), _msgSender(), to, value, data);
         return true;
     }
@@ -98,9 +96,7 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
         uint256 value,
         bytes memory data
     ) public virtual returns (bool) {
-        if (!transferFrom(from, to, value)) {
-            revert ERC1363TransferFromFailed(from, to, value);
-        }
+        transferFrom(from, to, value);
         ERC1363Utils.checkOnERC1363TransferReceived(_msgSender(), from, to, value, data);
         return true;
     }
@@ -126,9 +122,7 @@ abstract contract ERC1363 is ERC20, ERC165, IERC1363 {
      * no specified format.
      */
     function approveAndCall(address spender, uint256 value, bytes memory data) public virtual returns (bool) {
-        if (!approve(spender, value)) {
-            revert ERC1363ApproveFailed(spender, value);
-        }
+        approve(spender, value);
         ERC1363Utils.checkOnERC1363ApprovalReceived(_msgSender(), spender, value, data);
         return true;
     }


### PR DESCRIPTION

Remove unreachable return value checks in `transferAndCall`, `transferFromAndCall`, and `approveAndCall` functions.

The base `ERC20` contract's `transfer`, `transferFrom`, and `approve` functions always revert on failure and never return `false`. Therefore, the conditional checks `if (!transfer(...)) revert` are unreachable dead code that only increases bytecode size and gas costs without providing any functional benefit.
