### PR TITLE
fix: incorrect comment in Arrays.sol upperBound function

### DIFF
--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -286,7 +286,7 @@ library Arrays {
     /**
      * @dev Searches an `array` sorted in ascending order and returns the first
      * index that contains a value strictly greater than `element`. If no such index
-     * exists (i.e. all values in the array are strictly less than `element`), the array
+     * exists (i.e. all values in the array are less than or equal to `element`), the array
      * length is returned. Time complexity O(log n).
      *
      * See C++'s https://en.cppreference.com/w/cpp/algorithm/upper_bound[upper_bound].

--- a/scripts/generate/templates/Arrays.js
+++ b/scripts/generate/templates/Arrays.js
@@ -224,7 +224,7 @@ function lowerBound(uint256[] storage array, uint256 element) internal view retu
 /**
  * @dev Searches an \`array\` sorted in ascending order and returns the first
  * index that contains a value strictly greater than \`element\`. If no such index
- * exists (i.e. all values in the array are strictly less than \`element\`), the array
+ * exists (i.e. all values in the array are less than or equal to \`element\`), the array
  * length is returned. Time complexity O(log n).
  *
  * See C++'s https://en.cppreference.com/w/cpp/algorithm/upper_bound[upper_bound].


### PR DESCRIPTION
upperBound returns first index with value > element. Comment incorrectly stated "strictly less than" for the no-match case — should be "less than or equal to".