### PR TITLE
Update AccountERC7579's `accountId`

### DIFF
--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -85,7 +85,7 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
     /// @inheritdoc IERC7579AccountConfig
     function accountId() public view virtual returns (string memory) {
         // vendorname.accountname.semver
-        return "@openzeppelin/community-contracts.AccountERC7579.v0.0.0";
+        return "@openzeppelin/contracts.AccountERC7579.v1.0.0";
     }
 
     /**

--- a/contracts/account/extensions/draft-AccountERC7579Hooked.sol
+++ b/contracts/account/extensions/draft-AccountERC7579Hooked.sol
@@ -42,7 +42,7 @@ abstract contract AccountERC7579Hooked is AccountERC7579 {
     /// @inheritdoc AccountERC7579
     function accountId() public view virtual override returns (string memory) {
         // vendorname.accountname.semver
-        return "@openzeppelin/community-contracts.AccountERC7579Hooked.v0.0.0";
+        return "@openzeppelin/contracts.AccountERC7579Hooked.v1.0.0";
     }
 
     /// @dev Returns the hook module address if installed, or `address(0)` otherwise.

--- a/test/account/extensions/AccountERC7579.behavior.js
+++ b/test/account/extensions/AccountERC7579.behavior.js
@@ -45,8 +45,8 @@ function shouldBehaveLikeAccountERC7579({ withHooks = false } = {}) {
       it('should return the account ID', async function () {
         await expect(this.mock.accountId()).to.eventually.equal(
           withHooks
-            ? '@openzeppelin/community-contracts.AccountERC7579Hooked.v0.0.0'
-            : '@openzeppelin/community-contracts.AccountERC7579.v0.0.0',
+            ? '@openzeppelin/contracts.AccountERC7579Hooked.v1.0.0'
+            : '@openzeppelin/contracts.AccountERC7579.v1.0.0',
         );
       });
     });


### PR DESCRIPTION
Currently, the `accountId` getter in the ERC7579 accounts is returning `community-contracts` as vendor in version `0.0.0`. While we did this for community contracts, I think it's worth using `1.0.0` as version and update the vendor

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
