### PR TITLE
Remove unecessary natspec comments from the upgradeable patch

### DIFF
--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -173,7 +173,7 @@ index c156fa1cc..895e39342 100644
       * @dev Prevents a contract from calling itself, directly or indirectly.
       * Calling a `nonReentrant` function from another `nonReentrant`
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index 2bc45a4b2..826a7059a 100644
+index 2bc45a4b2..a5aa41d21 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -194,7 +194,7 @@ index 2bc45a4b2..826a7059a 100644
 - *
 - * @custom:oz-upgrades-unsafe-allow state-variable-immutable
 + * NOTE: The upgradeable version of this contract does not use an immutable cache and recomputes the domain separator
-+ * each time {_domainSeparatorV4} is called. That is cheaper than accessing a cached version in cold storage.
++ * each time {_domainSeparatorV4} is called. This is cheaper than accessing a cached version in cold storage.
   */
  abstract contract EIP712 is IERC5267 {
 -    using ShortStrings for *;


### PR DESCRIPTION
In the transition from 4.8 to 4.9, we had to add a lot of logic to support the storage transition from `_hashedName` to `_name` (and `_hashedVersion` to `version`). This logic was necessary to support cases where the old values had to be taken into consideration because the new one were not set during re-initialization.

Since 5.0, the `_hashedName` and `_hashedVersion` were kept in storage (oversight), and we still check their value. We shouldn't! Since no version (since the transition to namespace storage) ever wrote to these slot, we know for a fact that they are empty.

This PR simplifies the logic by removing the (now superfluous) hangling of these values.