### PR TITLE
fix(checkpoints): change `at()` parameter type from uint32 to uint256

### DIFF
--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -123,7 +123,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      */
-    function at(Trace256 storage self, uint32 pos) internal view returns (Checkpoint256 memory) {
+    function at(Trace256 storage self, uint256 pos) internal view returns (Checkpoint256 memory) {
         return self._checkpoints[pos];
     }
 
@@ -326,7 +326,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      */
-    function at(Trace224 storage self, uint32 pos) internal view returns (Checkpoint224 memory) {
+    function at(Trace224 storage self, uint256 pos) internal view returns (Checkpoint224 memory) {
         return self._checkpoints[pos];
     }
 
@@ -529,7 +529,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      */
-    function at(Trace208 storage self, uint32 pos) internal view returns (Checkpoint208 memory) {
+    function at(Trace208 storage self, uint256 pos) internal view returns (Checkpoint208 memory) {
         return self._checkpoints[pos];
     }
 
@@ -732,7 +732,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      */
-    function at(Trace160 storage self, uint32 pos) internal view returns (Checkpoint160 memory) {
+    function at(Trace160 storage self, uint256 pos) internal view returns (Checkpoint160 memory) {
         return self._checkpoints[pos];
     }
 


### PR DESCRIPTION
The `at()` functions in Checkpoints.sol accept uint32 for the position parameter, but `length()` returns uint256. This inconsistency forces users to cast when using patterns like `at(length() - 1)`. Changed all four `at()` functions (Trace256, Trace224, Trace208, Trace160) to accept uint256 for consistency with the rest of the API.