### PR TITLE
docs(ERC20Burnable): Fix parameter name typo in burnFrom documentation

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20Burnable.sol
+++ b/contracts/token/ERC20/extensions/ERC20Burnable.sol
@@ -29,7 +29,7 @@ abstract contract ERC20Burnable is Context, ERC20 {
      *
      * Requirements:
      *
-     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * - the caller must have allowance for `account`'s tokens of at least
      * `value`.
      */
     function burnFrom(address account, uint256 value) public virtual {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

Fixes a documentation typo in `ERC20Burnable.burnFrom()` where the parameter name is incorrectly written as ``accounts`` (plural with double backticks) instead of `account` (singular with single backticks).


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
