### PR TITLE
docs(IERC1363): Remove outdated "unless throwing" phrase from return documentation

### DIFF
--- a/contracts/interfaces/IERC1363.sol
+++ b/contracts/interfaces/IERC1363.sol
@@ -30,7 +30,7 @@ interface IERC1363 is IERC20, IERC165 {
      * and then calls {IERC1363Receiver-onTransferReceived} on `to`.
      * @param to The address which you want to transfer to.
      * @param value The amount of tokens to be transferred.
-     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     * @return true
      */
     function transferAndCall(address to, uint256 value) external returns (bool);
 
@@ -40,7 +40,7 @@ interface IERC1363 is IERC20, IERC165 {
      * @param to The address which you want to transfer to.
      * @param value The amount of tokens to be transferred.
      * @param data Additional data with no specified format, sent in call to `to`.
-     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     * @return true
      */
     function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);
 
@@ -50,7 +50,7 @@ interface IERC1363 is IERC20, IERC165 {
      * @param from The address which you want to send tokens from.
      * @param to The address which you want to transfer to.
      * @param value The amount of tokens to be transferred.
-     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     * @return true
      */
     function transferFromAndCall(address from, address to, uint256 value) external returns (bool);
 
@@ -61,7 +61,7 @@ interface IERC1363 is IERC20, IERC165 {
      * @param to The address which you want to transfer to.
      * @param value The amount of tokens to be transferred.
      * @param data Additional data with no specified format, sent in call to `to`.
-     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     * @return true
      */
     function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);
 
@@ -70,7 +70,7 @@ interface IERC1363 is IERC20, IERC165 {
      * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.
      * @param spender The address which will spend the funds.
      * @param value The amount of tokens to be spent.
-     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     * @return true
      */
     function approveAndCall(address spender, uint256 value) external returns (bool);
 
@@ -80,7 +80,7 @@ interface IERC1363 is IERC20, IERC165 {
      * @param spender The address which will spend the funds.
      * @param value The amount of tokens to be spent.
      * @param data Additional data with no specified format, sent in call to `spender`.
-     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     * @return true
      */
     function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->
Updates the `@return` documentation for all 6 functions in `IERC1363` interface to remove the outdated phrase "unless throwing" which is a remnant from Solidity 0.4.x semantics.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
