### PR TITLE
Revert for nonexistent proposals in proposalExecutionPlan

### DIFF
--- a/contracts/governance/extensions/GovernorTimelockAccess.sol
+++ b/contracts/governance/extensions/GovernorTimelockAccess.sol
@@ -158,6 +158,10 @@ abstract contract GovernorTimelockAccess is Governor {
     function proposalExecutionPlan(
         uint256 proposalId
     ) public view returns (uint32 delay, bool[] memory indirect, bool[] memory withDelay) {
+        if (proposalSnapshot(proposalId) == 0) {
+            revert GovernorNonexistentProposal(proposalId);
+        }
+
         ExecutionPlan storage plan = _executionPlan[proposalId];
 
         uint32 length = plan.length;

--- a/test/governance/extensions/GovernorTimelockAccess.test.js
+++ b/test/governance/extensions/GovernorTimelockAccess.test.js
@@ -350,6 +350,13 @@ describe('GovernorTimelockAccess', function () {
             ]);
           }
         });
+
+        it('reverts for non-existing proposal', async function () {
+          const nonExistentProposalId = 999n;
+          await expect(this.mock.proposalExecutionPlan(nonExistentProposalId))
+            .to.be.revertedWithCustomError(this.mock, 'GovernorNonexistentProposal')
+            .withArgs(nonExistentProposalId);
+        });
       });
 
       describe('base delay only', function () {


### PR DESCRIPTION
Add existence check to `GovernorTimelockAccess.proposalExecutionPlan()`, matching the error behavior of `GovernorStorage` view functions.