### PR TITLE
docs: list IVotes in governance utils

### DIFF
--- a/contracts/governance/README.adoc
+++ b/contracts/governance/README.adoc
@@ -106,6 +106,8 @@ NOTE: Functions of the `Governor` contract do not include access control. If you
 
 == Utils
 
+{{IVotes}}
+
 {{Votes}}
 
 {{VotesExtended}}


### PR DESCRIPTION
The governance utils README mentioned Votes and VotesExtended but omitted IVotes, even though the interface exists in the codebase and is referenced elsewhere in the document. This change adds IVotes to the Utils section so that all relevant governance vote utilities are consistently documented and easier to discover.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
