### PR TITLE
chore: annual license year update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2025 Zeppelin Group Ltd
+Copyright (c) 2016-2026 Zeppelin Group Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
New Year Update!

This PR updates the copyright year from 2025 to 2026 in the license files.

Happy coding in 2026!