### PR TITLE
Remove unused IERC165 imports from AccessControl extensions

### DIFF
--- a/contracts/access/extensions/AccessControlDefaultAdminRules.sol
+++ b/contracts/access/extensions/AccessControlDefaultAdminRules.sol
@@ -8,7 +8,6 @@ import {AccessControl, IAccessControl} from "../AccessControl.sol";
 import {SafeCast} from "../../utils/math/SafeCast.sol";
 import {Math} from "../../utils/math/Math.sol";
 import {IERC5313} from "../../interfaces/IERC5313.sol";
-import {IERC165} from "../../utils/introspection/IERC165.sol";
 
 /**
  * @dev Extension of {AccessControl} that allows specifying special rules to manage
@@ -61,7 +60,7 @@ abstract contract AccessControlDefaultAdminRules is IAccessControlDefaultAdminRu
         _grantRole(DEFAULT_ADMIN_ROLE, initialDefaultAdmin);
     }
 
-    /// @inheritdoc IERC165
+    /// @inheritdoc AccessControl
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IAccessControlDefaultAdminRules).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/contracts/access/extensions/AccessControlEnumerable.sol
+++ b/contracts/access/extensions/AccessControlEnumerable.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.24;
 import {IAccessControlEnumerable} from "./IAccessControlEnumerable.sol";
 import {AccessControl} from "../AccessControl.sol";
 import {EnumerableSet} from "../../utils/structs/EnumerableSet.sol";
-import {IERC165} from "../../utils/introspection/ERC165.sol";
 
 /**
  * @dev Extension of {AccessControl} that allows enumerating the members of each role.
@@ -16,7 +15,7 @@ abstract contract AccessControlEnumerable is IAccessControlEnumerable, AccessCon
 
     mapping(bytes32 role => EnumerableSet.AddressSet) private _roleMembers;
 
-    /// @inheritdoc IERC165
+    /// @inheritdoc AccessControl
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IAccessControlEnumerable).interfaceId || super.supportsInterface(interfaceId);
     }


### PR DESCRIPTION
Removes unused IERC165 imports from AccessControlEnumerable and AccessControlDefaultAdminRules, updates comments to reference AccessControl instead.