### PR TITLE
docs(TrieProof): `event` -> `receipt`

### DIFF
--- a/contracts/utils/cryptography/TrieProof.sol
+++ b/contracts/utils/cryptography/TrieProof.sol
@@ -11,7 +11,7 @@ import {RLP} from "../RLP.sol";
  * The {traverse} and {verify} functions can be used to prove the following value:
  *
  * * Transaction against the transactionsRoot of a block.
- * * Event against receiptsRoot of a block.
+ * * Receipt against receiptsRoot of a block.
  * * Account details (RLP encoding of [nonce, balance, storageRoot, codeHash]) against the stateRoot of a block.
  * * Storage slot (RLP encoding of the value) against the storageRoot of a account.
  *

--- a/test/utils/cryptography/TrieProof.test.js
+++ b/test/utils/cryptography/TrieProof.test.js
@@ -66,7 +66,7 @@ describe('TrieProof', function () {
 
   describe('verify', function () {
     it('verify transaction and receipt inclusion in block', async function () {
-      // Multiple transactions/events in a block
+      // Multiple transactions/receipts in a block
       const txs = await batchInBlock(
         [
           () => this.target.mockFunction({ gasLimit: 100000 }),


### PR DESCRIPTION
Corrects the fact that TrieProof.sol can be used to prove a receipt (not an event) against the `receiptsRoot` of a block.