### PR TITLE
chore: remove unused ERC1155 holder mock

### DIFF
--- a/contracts/mocks/docs/token/ERC1155/MyERC115HolderContract.sol
+++ b/contracts/mocks/docs/token/ERC1155/MyERC115HolderContract.sol
@@ -1,7 +1,0 @@
-// contracts/MyERC115HolderContract.sol
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
-
-import {ERC1155Holder} from "../../../../token/ERC1155/utils/ERC1155Holder.sol";
-
-contract MyERC115HolderContract is ERC1155Holder {}


### PR DESCRIPTION
Removes an unused ERC1155 holder mock contract