### PR TITLE
fix: make Bytes.toNibbles allocation memory-safe

### DIFF
--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -210,8 +210,10 @@ library Bytes {
     function toNibbles(bytes memory input) internal pure returns (bytes memory output) {
         assembly ("memory-safe") {
             let length := mload(input)
+            let chunks := shr(4, add(length, 0x0f))
+            let dataBytes := shl(5, chunks)
             output := mload(0x40)
-            mstore(0x40, add(add(output, 0x20), mul(length, 2)))
+            mstore(0x40, add(add(output, 0x20), dataBytes))
             mstore(output, mul(length, 2))
             for {
                 let i := 0


### PR DESCRIPTION
`Bytes.toNibbles` was updating the free memory pointer assuming a logical payload size of `2 * input.length`, but the loop was actually writing `32 * ceil(length / 16)` bytes. For non‑multiple-of-16 inputs this meant some `mstore `writes occurred above the new free memory pointer, which violates the assumptions of the `memory-safe` assembly dialect even though the visible `bytes` contents and length remained correct.

This change keeps the logical length of the returned buffer at `2 * input.length`, but adjusts the allocation and free memory pointer to reserve `32 * ceil(length / 16)` bytes for the internal 32‑byte chunk writes. This aligns the actual writes with the declared allocation, restoring compliance with memory-safe assembly and Yul IR expectations without changing the external behaviour of `toNibbles`.