### PR TITLE
docs: replace broken learn:: xrefs with direct documentation link

### DIFF
--- a/docs/modules/ROOT/pages/wizard.adoc
+++ b/docs/modules/ROOT/pages/wizard.adoc
@@ -4,7 +4,7 @@
 Not sure where to start? Use the interactive generator below to bootstrap your
 contract and learn about the components offered in OpenZeppelin Contracts.
 
-TIP: Place the resulting contract in your `contracts` or `src` directory in order to compile it with a tool like Hardhat or Foundry. Consider reading our guide on xref:learn::developing-smart-contracts.adoc[Developing Smart Contracts] for more guidance!
+TIP: Place the resulting contract in your `contracts` or `src` directory in order to compile it with a tool like Hardhat or Foundry. Consider reading our guide on https://docs.openzeppelin.com/contracts[Contracts] for more guidance!
 
 ++++
 <script async src="https://wizard.openzeppelin.com/build/embed.js"></script>


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

Replaced `xref:learn::developing-smart-contracts.adoc` with direct link to the contracts documentation


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
