### PR TITLE
Align authority delay mock return type and clarify no-response mock

### DIFF
--- a/contracts/mocks/AuthorityMock.sol
+++ b/contracts/mocks/AuthorityMock.sol
@@ -29,13 +29,13 @@ contract AuthorityNoDelayMock is IAuthority {
 
 contract AuthorityDelayMock {
     bool private _immediate;
-    uint256 private _delay;
+    uint32 private _delay;
 
     function canCall(
         address /* caller */,
         address /* target */,
         bytes4 /* selector */
-    ) external view returns (bool immediate, uint256 delay) {
+    ) external view returns (bool immediate, uint32 delay) {
         return (_immediate, _delay);
     }
 
@@ -43,12 +43,15 @@ contract AuthorityDelayMock {
         _immediate = immediate;
     }
 
-    function _setDelay(uint256 delay) external {
+    function _setDelay(uint32 delay) external {
         _delay = delay;
     }
 }
 
 contract AuthorityNoResponse {
+    // This mock intentionally returns no data from canCall.
+    // It is used to test robustness when an authority does not
+    // respond with the expected return values.
     function canCall(address /* caller */, address /* target */, bytes4 /* selector */) external view {}
 }
 

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,14 @@
+{
+  "lib/erc4626-tests": {
+    "rev": "232ff9ba8194e406967f52ecc5cb52ed764209e9"
+  },
+  "lib/forge-std": {
+    "branch": {
+      "name": "v1",
+      "rev": "3b20d60d14b343ee4f908cb8079495c07f5e8981"
+    }
+  },
+  "lib/halmos-cheatcodes": {
+    "rev": "7328abe100445fc53885c21d0e713b95293cf14c"
+  }
+}


### PR DESCRIPTION
Fixes #6267 
This PR addresses an inconsistency in the authority mock return types and improves clarity around the no-response authority behavior.

Changes included:
- Align the delayed authority mock return type with how delay values are consumed in AccessManager-style interfaces
- Add a clarifying comment explaining the intentional no-response authority mock

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
