### PR TITLE
perf: short-circuit TrieProof.verify on traversal error

### DIFF
--- a/contracts/utils/cryptography/TrieProof.sol
+++ b/contracts/utils/cryptography/TrieProof.sol
@@ -73,7 +73,7 @@ library TrieProof {
         bytes[] memory proof
     ) internal pure returns (bool) {
         (bytes memory processedValue, ProofError err) = tryTraverse(root, key, proof);
-        return processedValue.equal(value) && err == ProofError.NO_ERROR;
+        return err == ProofError.NO_ERROR && processedValue.equal(value);
     }
 
     /**


### PR DESCRIPTION
#### PR Checklist

Reordered the condition in TrieProof.verify so that it first checks whether tryTraverse finished with NO_ERROR before calling Bytes.equal on the returned value. This preserves the existing behavior while avoiding unnecessary keccak256 computations for invalid proofs, making verification slightly cheaper in the common failure path.
- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
