### PR TITLE
refactor(test): remove redundant await in governance helper return statements

### DIFF
--- a/test/helpers/governance.js
+++ b/test/helpers/governance.js
@@ -130,7 +130,7 @@ class GovernorHelper {
       args.push(vote.reason);
     }
 
-    return await this.governor[method](...args);
+    return this.governor[method](...args);
   }
 
   async overrideVote(vote = {}) {
@@ -145,7 +145,7 @@ class GovernorHelper {
       args.push(vote.voter, vote.reason ?? '', sign);
     }
 
-    return await this.governor[method](...args);
+    return this.governor[method](...args);
   }
 
   /// Clock helpers


### PR DESCRIPTION
Removes unnecessary `await` keyword from `return` statements in `GovernorHelper` class methods where no `try/catch` block is present.