### PR TITLE
WebAuthn: Simplify challenge comparison

### DIFF
--- a/contracts/utils/cryptography/WebAuthn.sol
+++ b/contracts/utils/cryptography/WebAuthn.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.24;
 import {P256} from "./P256.sol";
 import {Base64} from "../Base64.sol";
 import {Bytes} from "../Bytes.sol";
-import {Strings} from "../Strings.sol";
 
 /**
  * @dev Library for verifying WebAuthn Authentication Assertions.
@@ -155,11 +154,13 @@ library WebAuthn {
     ) private pure returns (bool) {
         // solhint-disable-next-line quotes
         string memory expectedChallenge = string.concat('"challenge":"', Base64.encodeURL(challenge), '"');
-        string memory actualChallenge = string(
-            Bytes.slice(bytes(clientDataJSON), challengeIndex, challengeIndex + bytes(expectedChallenge).length)
+        bytes memory actualChallenge = Bytes.slice(
+            bytes(clientDataJSON),
+            challengeIndex,
+            challengeIndex + bytes(expectedChallenge).length
         );
 
-        return Strings.equal(actualChallenge, expectedChallenge);
+        return Bytes.equal(actualChallenge, bytes(expectedChallenge));
     }
 
     /**


### PR DESCRIPTION
This PR removes a redundant `Strings` dependency in `WebAuthn._validateChallenge` by comparing the extracted challenge bytes directly via `Bytes.equal`.
`Strings.equal(a, b)` is a thin wrapper over `Bytes.equal(bytes(a), bytes(b))`, so routing the check through `Strings` added an extra import and an unnecessary string cast without changing semantics.


