### PR TITLE
docs: fix misleading NatSpec in ERC165Checker

### DIFF
--- a/contracts/utils/introspection/ERC165Checker.sol
+++ b/contracts/utils/introspection/ERC165Checker.sol
@@ -121,7 +121,7 @@ library ERC165Checker {
      * function. It returns:
      *
      * * `success`: true if the call didn't revert, false if it did
-     * * `supported`: true if the call succeeded AND returned data indicating the interface is supported
+     * * `supported`: true if the returned data indicates the interface is supported (independent of `success`)
      */
     function _trySupportsInterface(
         address account,


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

The comment incorrectly stated that the `supported` return value is "true if the call succeeded AND returned data indicating the interface is supported"

This implied that `supported` depends on `success`, which is not how the code actually works.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
