### PR TITLE
fix: add input length validation to ERC7579Utils decode functions

### DIFF
--- a/contracts/account/utils/draft-ERC7579Utils.sol
+++ b/contracts/account/utils/draft-ERC7579Utils.sol
@@ -165,6 +165,8 @@ library ERC7579Utils {
     function decodeDelegate(
         bytes calldata executionCalldata
     ) internal pure returns (address target, bytes calldata callData) {
+        // executionCalldata = <target (20 bytes)> | <callData (N bytes)>
+        if (executionCalldata.length < 0x14) revert ERC7579DecodingError();
         target = address(bytes20(executionCalldata[0:0x14]));
         callData = executionCalldata[0x14:];
     }


### PR DESCRIPTION
Adds explicit length validation to `decodeSingle` and `decodeDelegate` functions in `ERC7579Utils` to prevent out-of-bounds access panics and ensure consistent error handling across all decode functions.