### PR TITLE
fix(ReentrancyGuard): correct misleading EIP-2200 refund comment

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -100,8 +100,9 @@ abstract contract ReentrancyGuard {
     }
 
     function _nonReentrantAfter() private {
-        // By storing the original value once again, a refund is triggered (see
-        // https://eips.ethereum.org/EIPS/eip-2200)
+        // Restore the original value to allow future calls.
+        // Note: Using 1/2 instead of 0/1 avoids the overhead of writing to uninitialized
+        // storage and keeps gas costs predictable (no EIP-2200 refund behavior).
         _reentrancyGuardStorageSlot().getUint256Slot().value = NOT_ENTERED;
     }
 


### PR DESCRIPTION
## 🧐 Motivation

Fixes #6305

The comment in `_nonReentrantAfter()` incorrectly states that a refund is triggered when restoring the original value:

```solidity
// By storing the original value once again, a refund is triggered (see
// https://eips.ethereum.org/EIPS/eip-2200)
```

However, the implementation uses values `NOT_ENTERED = 1` and `ENTERED = 2`. The operation `2 → 1` is a **non-zero to non-zero** storage change, which does **not** trigger a refund according to EIP-2200.

## 📝 Changes

Updated the comment to:
1. Accurately describe the purpose (restoring value for future calls)
2. Explain *why* 1/2 is used instead of 0/1 (avoids uninitialized storage overhead)
3. Clarify there is no EIP-2200 refund behavior

## ✅ Checklist

- [x] Documentation-only change (comment fix)
- [x] No functional changes to contract behavior
- [x] Addresses the issue raised in #6305