### PR TITLE
Add test for RLP when encoding a payload with length >= 2**64

### DIFF
--- a/test/utils/RLP.test.js
+++ b/test/utils/RLP.test.js
@@ -205,6 +205,16 @@ describe('RLP', function () {
     });
   });
 
+  it('reverts out of gas when encoding payload with length >= 2**64', async function () {
+    const data = ethers.concat([
+      this.mock.interface.getFunction('$encode(bytes)').selector,
+      ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], ['0x20']), // offset to bytes
+      ethers.toBeHex(MAX_UINT64, 32), // forged length
+      ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [56]), // long-form path (length > 55)
+    ]);
+    await expect(this.mock.runner.sendTransaction({ to: this.mock.target, data })).to.be.revertedWithoutReason();
+  });
+
   it('RLP encoder predict create addresses', async function () {
     for (const [from, nonce] of product(
       [


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
