### PR TITLE
Fix grammar and wording in NatSpec comments and tests

### DIFF
--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -45,7 +45,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with a key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace256 storage self, uint256 key) internal view returns (uint256) {
@@ -55,7 +55,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace256 storage self, uint256 key) internal view returns (uint256) {
@@ -65,7 +65,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -162,7 +162,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key strictly greater than the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -186,7 +186,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -248,7 +248,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with a key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
@@ -258,7 +258,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
@@ -268,7 +268,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -365,7 +365,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key strictly greater than the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -389,7 +389,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -451,7 +451,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with a key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
@@ -461,7 +461,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
@@ -471,7 +471,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -568,7 +568,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key strictly greater than the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -592,7 +592,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -654,7 +654,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with a key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
@@ -664,7 +664,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
@@ -674,7 +674,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -771,7 +771,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key strictly greater than the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -795,7 +795,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with a key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *

--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -45,7 +45,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater or equal than the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace256 storage self, uint256 key) internal view returns (uint256) {
@@ -55,7 +55,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace256 storage self, uint256 key) internal view returns (uint256) {
@@ -65,7 +65,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -186,7 +186,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -248,7 +248,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater or equal than the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
@@ -258,7 +258,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
@@ -268,7 +268,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -389,7 +389,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -451,7 +451,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater or equal than the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
@@ -461,7 +461,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
@@ -471,7 +471,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -592,7 +592,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *
@@ -654,7 +654,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the first (oldest) checkpoint with key greater or equal than the search key, or zero if
+     * @dev Returns the value in the first (oldest) checkpoint with key greater than or equal to the search key, or zero if
      * there is none.
      */
     function lowerLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
@@ -664,7 +664,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      */
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
@@ -674,7 +674,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+     * @dev Returns the value in the last (most recent) checkpoint with key lower than or equal to the search key, or zero
      * if there is none.
      *
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -795,7 +795,7 @@ library Checkpoints {
     }
 
     /**
-     * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or `high`
+     * @dev Return the index of the first (oldest) checkpoint with key greater than or equal to the search key, or `high`
      * if there is none. `low` and `high` define a section where to do the search, with inclusive `low` and exclusive
      * `high`.
      *

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -50,7 +50,7 @@ function push(
 }
 
 /**
- * @dev Returns the value in the first (oldest) checkpoint with key greater or equal than the search key, or zero if
+ * @dev Returns the value in the first (oldest) checkpoint with a key greater than or equal to the search key, or zero if
  * there is none.
  */
 function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
@@ -60,7 +60,7 @@ function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
 }
 
 /**
- * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+ * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
  * if there is none.
  */
 function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
@@ -70,7 +70,7 @@ function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
 }
 
 /**
- * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
+ * @dev Returns the value in the last (most recent) checkpoint with a key lower than or equal to the search key, or zero
  * if there is none.
  *
  * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
@@ -167,7 +167,7 @@ function _insert(
 }
 
 /**
- * @dev Return the index of the first (oldest) checkpoint with key strictly bigger than the search key, or \`high\`
+ * @dev Return the index of the first (oldest) checkpoint with a key strictly greater than the search key, or \`high\`
  * if there is none. \`low\` and \`high\` define a section where to do the search, with inclusive \`low\` and exclusive
  * \`high\`.
  *
@@ -191,7 +191,7 @@ function _upperBinaryLookup(
 }
 
 /**
- * @dev Return the index of the first (oldest) checkpoint with key greater or equal than the search key, or \`high\`
+ * @dev Return the index of the first (oldest) checkpoint with a key greater than or equal to the search key, or \`high\`
  * if there is none. \`low\` and \`high\` define a section where to do the search, with inclusive \`low\` and exclusive
  * \`high\`.
  *

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -1076,7 +1076,7 @@ describe('AccessManager', function () {
           expect(await this.newManagedTarget.authority()).to.equal(this.manager);
 
           await expect(this.manager.connect(this.admin).updateAuthority(this.newManagedTarget, this.newAuthority))
-            .to.emit(this.newManagedTarget, 'AuthorityUpdated') // Managed contract is responsible of notifying the change through an event
+            .to.emit(this.newManagedTarget, 'AuthorityUpdated') // Managed contract is responsible for notifying the change through an event
             .withArgs(this.newAuthority);
 
           expect(await this.newManagedTarget.authority()).to.equal(this.newAuthority);


### PR DESCRIPTION
Improve comparisons phrasing**: replace “greater/lower or equal than” with “greater/lower than or equal to” 