### PR TITLE
docs: correct EIP-2200 refund comment in ReentrancyGuard

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -42,11 +42,11 @@ abstract contract ReentrancyGuard {
     // back. This is the compiler's defense against contract upgrades and
     // pointer aliasing, and it cannot be disabled.
 
-    // The values being non-zero value makes deployment a bit more expensive,
-    // but in exchange the refund on every call to nonReentrant will be lower in
-    // amount. Since refunds are capped to a percentage of the total
-    // transaction's gas, it is best to keep them low in cases like this one, to
-    // increase the likelihood of the full refund coming into effect.
+    // The values being non-zero makes deployment a bit more expensive,
+    // but in exchange makes gas costs more predictable. Using 1 and 2 instead of 0 and 1
+    // avoids EIP-2200 refunds (non-zero to non-zero changes do not trigger refunds),
+    // which ensures consistent gas costs across different execution contexts and
+    // simplifies gas estimation for users.
     uint256 private constant NOT_ENTERED = 1;
     uint256 private constant ENTERED = 2;
 
@@ -100,8 +100,8 @@ abstract contract ReentrancyGuard {
     }
 
     function _nonReentrantAfter() private {
-        // By storing the original value once again, a refund is triggered (see
-        // https://eips.ethereum.org/EIPS/eip-2200)
+        // Restore the original value to allow future calls.
+        // Note: Using 1/2 instead of 0/1 avoids EIP-2200 refunds and makes gas costs predictable.
         _reentrancyGuardStorageSlot().getUint256Slot().value = NOT_ENTERED;
     }
 


### PR DESCRIPTION
Fixes #6305 

## 🐛 Issue

The current comment in `_nonReentrantAfter()` incorrectly claims that restoring the storage value triggers a gas refund according to EIP-2200. This is **technically incorrect** given the implementation.

### Current (Incorrect) Comment

```solidity
// By storing the original value once again, a refund is triggered (see
// https://eips.ethereum.org/EIPS/eip-2200)
```

### Why This Is Wrong

The implementation uses:
- `NOT_ENTERED = 1`
- `ENTERED = 2`

The state transition in `_nonReentrantAfter()` is: **2 → 1**

According to [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200):
- **Non-zero to non-zero**: 5,000 gas cost, **NO refund**
- Non-zero to zero: 15,000 gas refund
- Zero to non-zero: 20,000 gas cost

Since both values are non-zero, **no refund is triggered**.

## ✅ Fix

### Updated Comment in `_nonReentrantAfter()`

```solidity
// Restore the original value to allow future calls.
// Note: Using 1/2 instead of 0/1 avoids EIP-2200 refunds and makes gas costs predictable.
```

### Enhanced Constant Declaration Comment

Also updated the comment at lines 45-49 to accurately reflect the gas behavior:

**Before:**
> "but in exchange the refund on every call to nonReentrant will be lower in amount"

**After:**
> "but in exchange makes gas costs more predictable. Using 1 and 2 instead of 0 and 1 avoids EIP-2200 refunds..."

## 🎯 Rationale for 1/2 Pattern

The design choice to use 1 and 2 (instead of 0 and 1) is **intentional**:

1. **Avoids Cold Storage Access**: First write to slot is cheaper (1 → 2 costs 5,000 gas vs 0 → 1 costs 20,000 gas)
2. **Predictable Gas Costs**: No refund complexity to consider
3. **Simpler Gas Estimation**: Consistent costs across contexts
4. **No Refund Cap Issues**: Refunds are capped; avoiding them is cleaner

## 📊 Gas Comparison

| Operation | Cost | Refund | Net Cost |
|-----------|------|--------|----------|
| 0 → 1 (set) | 20,000 | 0 | 20,000 |
| 1 → 0 (reset) | 5,000 | 15,000 | -10,000 (refund) |
| 1 → 2 (set) | 5,000 | 0 | 5,000 ✅ |
| 2 → 1 (reset) | 5,000 | 0 | 5,000 ✅ |

**Using 1/2 saves gas and is more predictable!**

## 🔒 Security Impact

**ReentrancyGuard is a critical security primitive** used in thousands of contracts. Accurate documentation is essential for:
- Security auditors reviewing implementations
- Developers understanding gas behavior
- Proper integration in gas-sensitive contexts
- Educational purposes

## ✅ Changes Made

### File: `contracts/utils/ReentrancyGuard.sol`

**Line 45-49:** Updated constant declaration comment
- ✅ Removed incorrect refund discussion
- ✅ Added accurate gas behavior explanation
- ✅ Clarified design rationale

**Line 102-106:** Updated `_nonReentrantAfter()` comment
- ✅ Removed misleading EIP-2200 refund claim
- ✅ Added accurate note about predictable gas costs
- ✅ Clarified 1/2 pattern rationale

## 📝 Documentation Quality

**Before:**
- Misleading gas refund claims
- Confusing for developers
- Incorrect EIP-2200 interpretation

**After:**
- Accurate gas behavior description
- Clear design rationale
- Correct EIP-2200 understanding
- Educational and helpful

## 🧪 Testing

- ✅ No code logic changes (documentation only)
- ✅ All existing tests pass unchanged
- ✅ Gas behavior remains identical
- ✅ Security properties unchanged
- ✅ Backward compatible

## 📚 References

- [EIP-2200: Structured Definitions for Net Gas Metering](https://eips.ethereum.org/EIPS/eip-2200)
- [OpenZeppelin Blog: Reentrancy After Istanbul](https://blog.openzeppelin.com/reentrancy-after-istanbul/)
- Related discussion: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2829/files#r1893062063

## ✅ Checklist

- [x] Fixed incorrect EIP-2200 refund comment
- [x] Updated related comments for consistency
- [x] Preserved code logic (documentation only)
- [x] Clarified design rationale
- [x] Improved developer understanding

---

**Impact:** Critical security documentation correction in widely-used smart contract library.

Resolves #6305

Made with [Cursor](https://cursor.com)