### PR TITLE
Fix support for very large inputs in InteroperableAddress

### DIFF
--- a/.changeset/red-gifts-appear.md
+++ b/.changeset/red-gifts-appear.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`InteroperableAddress`: Fix invalid parsing of very large (out-of-specs) binary interoperable addresses.

--- a/.changeset/red-gifts-appear.md
+++ b/.changeset/red-gifts-appear.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`InteroperableAddress`: Fix `uint8` overflow in `tryParseV1` and `tryParseV1Calldata` that caused silent incorrect parsing when `chainReference` and `addr` lengths summed to 250 or more, returning an empty address with `success = true` instead of reverting.
+`InteroperableAddress`: Fix overflow in the parsing functions that caused silent misparse of large interoperable addresses.

--- a/.changeset/red-gifts-appear.md
+++ b/.changeset/red-gifts-appear.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`InteroperableAddress`: Fix invalid parsing of very large (out-of-specs) binary interoperable addresses.
+`InteroperableAddress`: Fix `uint8` overflow in `tryParseV1` and `tryParseV1Calldata` that caused silent incorrect parsing when `chainReference` and `addr` lengths summed to 250 or more, returning an empty address with `success = true` instead of reverting.

--- a/contracts/utils/draft-InteroperableAddress.sol
+++ b/contracts/utils/draft-InteroperableAddress.sol
@@ -104,12 +104,12 @@ library InteroperableAddress {
             bytes2 version = _readBytes2(self, 0x00);
             if (version != bytes2(0x0001)) return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
 
-            uint8 chainReferenceLength = uint8(self[0x04]);
+            uint256 chainReferenceLength = uint8(self[0x04]);
             if (self.length < 0x06 + chainReferenceLength)
                 return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
             chainReference = self.slice(0x05, 0x05 + chainReferenceLength);
 
-            uint8 addrLength = uint8(self[0x05 + chainReferenceLength]);
+            uint256 addrLength = uint8(self[0x05 + chainReferenceLength]);
             if (self.length < 0x06 + chainReferenceLength + addrLength)
                 return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
             addr = self.slice(0x06 + chainReferenceLength, 0x06 + chainReferenceLength + addrLength);
@@ -132,12 +132,12 @@ library InteroperableAddress {
             bytes2 version = _readBytes2Calldata(self, 0x00);
             if (version != bytes2(0x0001)) return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
 
-            uint8 chainReferenceLength = uint8(self[0x04]);
+            uint256 chainReferenceLength = uint8(self[0x04]);
             if (self.length < 0x06 + chainReferenceLength)
                 return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
             chainReference = self[0x05:0x05 + chainReferenceLength];
 
-            uint8 addrLength = uint8(self[0x05 + chainReferenceLength]);
+            uint256 addrLength = uint8(self[0x05 + chainReferenceLength]);
             if (self.length < 0x06 + chainReferenceLength + addrLength)
                 return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
             addr = self[0x06 + chainReferenceLength:0x06 + chainReferenceLength + addrLength];

--- a/test/utils/draft-InteroperableAddress.test.js
+++ b/test/utils/draft-InteroperableAddress.test.js
@@ -171,7 +171,7 @@ describe('ERC7390', function () {
     }
   });
 
-  describe.only('handles large references and addresses', function () {
+  describe('handles large references and addresses', function () {
     it('large', async function () {
       const chainType = '0x0000';
       const reference = generators.bytes(142);

--- a/test/utils/draft-InteroperableAddress.test.js
+++ b/test/utils/draft-InteroperableAddress.test.js
@@ -5,6 +5,7 @@ const { addressCoder, nameCoder } = require('interoperable-addresses');
 const { CAIP350, chainTypeCoder } = require('interoperable-addresses/dist/CAIP350');
 
 const { getLocalChain } = require('../helpers/chains');
+const { generators } = require('../helpers/random');
 
 async function fixture() {
   const mock = await ethers.deployContract('$InteroperableAddress');
@@ -168,5 +169,49 @@ describe('ERC7390', function () {
         ]);
       });
     }
+  });
+
+  describe.only('handles large references and addresses', function () {
+    it('large', async function () {
+      const chainType = '0x0000';
+      const reference = generators.bytes(142);
+      const address = generators.bytes(142);
+
+      const binary = addressCoder.encode({ chainType, reference, address });
+
+      // Generic parse
+      await expect(this.mock.$tryParseV1(binary)).to.eventually.deep.equal([true, chainType, reference, address]);
+      await expect(this.mock.$tryParseV1Calldata(binary)).to.eventually.deep.equal([
+        true,
+        chainType,
+        reference,
+        address,
+      ]);
+
+      // EVM parse - too long to be a valid evm format
+      await expect(this.mock.$tryParseEvmV1(binary)).to.eventually.deep.equal([false, 0n, ethers.ZeroAddress]);
+      await expect(this.mock.$tryParseEvmV1Calldata(binary)).to.eventually.deep.equal([false, 0n, ethers.ZeroAddress]);
+    });
+
+    it('very large', async function () {
+      const chainType = '0x0000';
+      const reference = generators.bytes(255);
+      const address = generators.bytes(255);
+
+      const binary = addressCoder.encode({ chainType, reference, address });
+
+      // Generic parse
+      await expect(this.mock.$tryParseV1(binary)).to.eventually.deep.equal([true, chainType, reference, address]);
+      await expect(this.mock.$tryParseV1Calldata(binary)).to.eventually.deep.equal([
+        true,
+        chainType,
+        reference,
+        address,
+      ]);
+
+      // EVM parse - too long to be a valid evm format
+      await expect(this.mock.$tryParseEvmV1(binary)).to.eventually.deep.equal([false, 0n, ethers.ZeroAddress]);
+      await expect(this.mock.$tryParseEvmV1Calldata(binary)).to.eventually.deep.equal([false, 0n, ethers.ZeroAddress]);
+    });
   });
 });


### PR DESCRIPTION
`tryParseV1` and `tryParseV1Calldata` declared the intermediate length variables `chainReferenceLength` and `addrLength` as `uint8`. The addition `chainReferenceLength + addrLength` could silently wrap around when the sum reached 256. For example, a `chainReference` of 32 bytes and an `addr` of 224 bytes would compute a total of 0, causing the bounds check to pass and the subsequent slice to return an empty `addr`: all while returning `success = true`.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
