### PR TITLE
Fix incorrect EIP-2200 refund comment in ReentrancyGuard

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -43,10 +43,10 @@ abstract contract ReentrancyGuard {
     // pointer aliasing, and it cannot be disabled.
 
     // The values being non-zero value makes deployment a bit more expensive,
-    // but in exchange the refund on every call to nonReentrant will be lower in
-    // amount. Since refunds are capped to a percentage of the total
-    // transaction's gas, it is best to keep them low in cases like this one, to
-    // increase the likelihood of the full refund coming into effect.
+    // but in exchange every call to nonReentrant will be cheaper: a non-zero to
+    // non-zero storage write (SSTORE) costs less than writing to a zero slot
+    // (which would also trigger a refund that is capped to a percentage of the
+    // total transaction's gas).
     uint256 private constant NOT_ENTERED = 1;
     uint256 private constant ENTERED = 2;
 
@@ -100,8 +100,9 @@ abstract contract ReentrancyGuard {
     }
 
     function _nonReentrantAfter() private {
-        // By storing the original value once again, a refund is triggered (see
-        // https://eips.ethereum.org/EIPS/eip-2200)
+        // By storing the original value once again, a refund is not triggered
+        // because this is a non-zero to non-zero write (see
+        // https://eips.ethereum.org/EIPS/eip-2200). This keeps gas costs predictable.
         _reentrancyGuardStorageSlot().getUint256Slot().value = NOT_ENTERED;
     }
 


### PR DESCRIPTION
## Description

Fixes incorrect inline documentation about EIP-2200 refund mechanics in `ReentrancyGuard.sol`.

### Problem

The comment in `_nonReentrantAfter()` states:
> By storing the original value once again, a refund is triggered (see EIP-2200)

However, the operation is `ENTERED (2) → NOT_ENTERED (1)`, which is a **non-zero to non-zero** storage write. Per [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200), this does **not** trigger a refund — refunds only occur when writing zero to a non-zero slot.

### Changes

1. Fixed the misleading comment in `_nonReentrantAfter()` to accurately state that no refund is triggered
2. Clarified the earlier comment (lines 45-49) about why non-zero values are used — the benefit is cheaper non-zero to non-zero SSTORE operations, not lower refunds

Fixes #6305