### PR TITLE
Make Votes.sol _validateTimepoint virtual

### DIFF
--- a/.changeset/wicked-dingos-wish.md
+++ b/.changeset/wicked-dingos-wish.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Make Votes.sol \_validateTimepoint virtual

--- a/.changeset/wicked-dingos-wish.md
+++ b/.changeset/wicked-dingos-wish.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-Make Votes.sol \_validateTimepoint virtual
+`Votes`: make `_validateTimepoint` virtual

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -75,7 +75,7 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
     /**
      * @dev Validate that a timepoint is in the past, and return it as a uint48.
      */
-    function _validateTimepoint(uint256 timepoint) internal view returns (uint48) {
+    function _validateTimepoint(uint256 timepoint) internal view virtual returns (uint48) {
         uint48 currentTimepoint = clock();
         if (timepoint >= currentTimepoint) revert ERC5805FutureLookup(timepoint, currentTimepoint);
         return SafeCast.toUint48(timepoint);


### PR DESCRIPTION
Makes `Votes.sol` `_validateTimepoint` virtual, neccesary when combining `ERC20Votes` with other contracts that implement `_validateTimepoint`