### PR TITLE
Add a Create3 library

### DIFF
--- a/.changeset/swift-trees-build.md
+++ b/.changeset/swift-trees-build.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Create3`: Add a library to deploy contracts using the `CREATE3` mechanism, allowing the deployment address to depend only on the salt and the deployer, independently of the deployed bytecode.

--- a/contracts/mocks/Stateless.sol
+++ b/contracts/mocks/Stateless.sol
@@ -19,6 +19,7 @@ import {Checkpoints} from "../utils/structs/Checkpoints.sol";
 import {CircularBuffer} from "../utils/structs/CircularBuffer.sol";
 import {Clones} from "../proxy/Clones.sol";
 import {Create2} from "../utils/Create2.sol";
+import {Create3} from "../utils/Create3.sol";
 import {DoubleEndedQueue} from "../utils/structs/DoubleEndedQueue.sol";
 import {ECDSA} from "../utils/cryptography/ECDSA.sol";
 import {EIP7702Utils} from "../account/utils/EIP7702Utils.sol";

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -8,7 +8,7 @@ import {LowLevelCall} from "./LowLevelCall.sol";
 
 /**
  * @dev Helper to deploy contracts using the `CREATE3` approach.
- * `CREATE3` compines both `CREATE2` and `CREATE` opcodes to deploy abritrary bytecode at an address that only depends
+ * `CREATE3` compines both `CREATE2` and `CREATE` opcodes to deploy arbitrary bytecode at an address that only depends
  * on the provided salt. At a high level, it depends like a `CREATE2` operation that would not use the bytecodehash to
  * generate the contract address.
  *

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -77,7 +77,7 @@ library Create3 {
      * Requirements:
      *
      * - `bytecode` must not be empty.
-     * - `salt` must have not been used for `bytecode` already.
+     * - `salt` must not have been used already.
      * - the factory must have a balance of at least `amount`.
      * - if `amount` is non-zero, `bytecode` must have a `payable` constructor.
      */

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Create2} from "./Create2.sol";
+import {Errors} from "./Errors.sol";
+import {LowLevelCall} from "./LowLevelCall.sol";
+
+/**
+ * @dev Helper to deploy contracts using the `CREATE3` approach.
+ * `CREATE3` compines both `CREATE2` and `CREATE` opcodes to deploy abritrary bytecode at an address that only depends
+ * on the provided salt. At a high level, it depends like a `CREATE2` operation that would not use the bytecodehash to
+ * generate the contract address.
+ *
+ * CREATE3 can be used to compute in advance the address where a smart contract will be deployed, even if the bytecode
+ * is subject to change.
+ *
+ * See {Create2} for counterfactual deployments that include the bytecodehash in the computation of the address.
+ */
+library Create3 {
+    /**
+     * ===================================[ PROXY CODE ]===================================
+     * Offset | Opcode      | Mnemonic         | Stack           | Memory
+     * -------|-------------|------------------|-----------------|-------------------------
+     * 0x00   | 36          | CALLDATASIZE     | cds             |
+     * 0x01   | 5F          | PUSH0            | 0 cds           |
+     * 0x02   | 5F          | PUSH0            | 0 0 cds         |
+     * 0x03   | 37          | CALLDATACOPY     |                 | [0..cds): calldata
+     * 0x04   | 36          | CALLDATASIZE     | cds             | [0..cds): calldata
+     * 0x05   | 5F          | PUSH0            | 0 cds           | [0..cds): calldata
+     * 0x06   | 34          | CALLVALUE        | value 0 cds     | [0..cds): calldata
+     * 0x07   | f0          | CREATE           | addr            | [0..cds): calldata
+     * 0x08   | 3D          | RETURNDATASIZE   | rds addr        |
+     * 0x09   | 5F          | PUSH0            | 0 rds addr      |
+     * 0x0A   | 5F          | PUSH0            | 0 0 rds addr    |
+     * 0x0B   | 3E          | RETURNDATACOPY   | addr            | [0..rds): returndata
+     * 0x0C   | 5F          | PUSH0            | 0 addr          | [0..rds): returndata
+     * 0x0D   | 3D          | RETURNDATASIZE   | rds 0 addr      | [0..rds): returndata
+     * 0x0E   | 91          | SWAP2            | addr 0 rds      | [0..rds): returndata
+     * 0x0F   | 6013        | PUSH1 0x13       | 0x13 addr 0 rds | [0..rds): returndata
+     * 0x11   | 57          | JUMPI            | 0 rds           | [0..rds): returndata
+     * 0x12   | FD          | REVERT           |                 |
+     * 0x13   | 5b          | JUMPDEST         | 0 rds           | [0..rds): returndata
+     * 0x14   | f3          | RETURN           |                 |
+     *
+     * ==============================[ DEPLOYMENT BYTECODE ]===============================
+     * Offset | Opcode      | Mnemonic         | Stack           | Memory
+     * -------|-------------|------------------|-----------------|-------------------------
+     * 0x00   | 74 bytecode | PUSH21 bytecode  | bytecode        |
+     * 0x16   | 5F          | PUSH0            | 0 bytecode      |
+     * 0x17   | 52          | MSTORE           |                 | [0x0B..0x20): bytecode
+     * 0x18   | 6015        | PUSH1 0x15       | 0x15            | [0x0B..0x20): bytecode
+     * 0x1A   | 600B        | PUSH1 0x0B       | 0x0B 0x15       | [0x0B..0x20): bytecode
+     * 0x1C   | f3          | RETURN           |                 | [0x0B..0x20): bytecode
+     */
+
+    /// @dev The proxy initialization code.
+    bytes29 private constant PROXY_INITCODE = 0x74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3;
+
+    /// @dev Hash of the `PROXY_INITCODE`.
+    /// Equivalent to `keccak256(abi.encodePacked(hex"74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3"))`.
+    bytes32 internal constant PROXY_INITCODE_HASH = 0xd61bbde0460e6c48ddd99fb8b7e1ad36529d2ec79cbac1db0300b3d26ddcdc2a;
+
+    /**
+     * @dev There's no code to deploy.
+     */
+    error Create3EmptyBytecode();
+
+    /**
+     * @dev Deploys a contract using the `CREATE3` mechanism. The address where the contract
+     * will be deployed can be known in advance via {computeAddress}, and only depends on the salt.
+     * The bytecode that is deployed DOES NOT affect the location at which it is deployed.
+     *
+     * The bytecode for a contract can be obtained from Solidity with
+     * `type(contractName).creationCode`.
+     *
+     * Requirements:
+     *
+     * - `bytecode` must not be empty.
+     * - `salt` must have not been used for `bytecode` already.
+     * - the factory must have a balance of at least `amount`.
+     * - if `amount` is non-zero, `bytecode` must have a `payable` constructor.
+     */
+    function deploy(uint256 amount, bytes32 salt, bytes memory bytecode) internal returns (address) {
+        if (address(this).balance < amount) {
+            revert Errors.InsufficientBalance(address(this).balance, amount);
+        }
+        if (bytecode.length == 0) {
+            revert Create3EmptyBytecode();
+        }
+        // This fails if the salt was already used. Will never return address(0).
+        address proxy = Create2.deploy(0, salt, abi.encodePacked(PROXY_INITCODE));
+        // Perform the actual deployment (create on the proxy with nonce 1).
+        bool success = LowLevelCall.callNoReturn(proxy, amount, bytecode);
+        if (!success) {
+            if (LowLevelCall.returnDataSize() == 0) {
+                revert Errors.FailedDeployment();
+            } else {
+                LowLevelCall.bubbleRevert();
+            }
+        }
+
+        // TODO: check that instance has code? Can create successed without any code placed?
+        return _computeCreateAddress(proxy);
+    }
+
+    /**
+     * @dev Returns the address where a contract will be stored if deployed via {deploy}. Any change in the
+     * `salt` will result in a new destination address.
+     */
+    function computeAddress(bytes32 salt) internal view returns (address) {
+        return computeAddress(salt, address(this));
+    }
+
+    /**
+     * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
+     * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
+     */
+    function computeAddress(bytes32 salt, address deployer) internal pure returns (address) {
+        return _computeCreateAddress(Create2.computeAddress(salt, PROXY_INITCODE_HASH, deployer));
+    }
+
+    /// @dev Compute the address of the first contract that `createor` would deployed using CREATE (nonce 1).
+    function _computeCreateAddress(address creator) private pure returns (address addr) {
+        assembly ("memory-safe") {
+            mstore(0x15, 0x01)
+            mstore(0x14, creator)
+            mstore(0x00, 0xd694)
+            addr := and(keccak256(0x1e, 0x17), 0xffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -120,7 +120,7 @@ library Create3 {
         return _computeCreateAddress(Create2.computeAddress(salt, PROXY_INITCODE_HASH, deployer));
     }
 
-    /// @dev Compute the address of the first contract that `createor` would deployed using CREATE (nonce 1).
+    /// @dev Compute the address of the first contract that `creator` would deployed using CREATE (nonce 1).
     function _computeCreateAddress(address creator) private pure returns (address addr) {
         assembly ("memory-safe") {
             mstore(0x15, 0x01)

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -43,7 +43,7 @@ library Create3 {
      * 0x13   | 5b          | JUMPDEST         | 0 rds           | [0..rds): returndata
      * 0x14   | f3          | RETURN           |                 |
      *
-     * ==============================[ DEPLOYMENT BYTECODE ]===============================
+     * ================================[ DEPLOYMENT CODE ]=================================
      * Offset | Opcode      | Mnemonic         | Stack           | Memory
      * -------|-------------|------------------|-----------------|-------------------------
      * 0x00   | 74 bytecode | PUSH21 bytecode  | bytecode        |

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -8,7 +8,7 @@ import {LowLevelCall} from "./LowLevelCall.sol";
 
 /**
  * @dev Helper to deploy contracts using the `CREATE3` approach.
- * `CREATE3` compines both `CREATE2` and `CREATE` opcodes to deploy arbitrary bytecode at an address that only depends
+ * `CREATE3` combines both `CREATE2` and `CREATE` opcodes to deploy arbitrary bytecode at an address that only depends
  * on the provided salt. At a high level, it depends like a `CREATE2` operation that would not use the bytecodehash to
  * generate the contract address.
  *

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -100,7 +100,7 @@ library Create3 {
             }
         }
 
-        // TODO: check that instance has code? Can create successed without any code placed?
+        // TODO: check that instance has code? Can create succeed without any code placed?
         return _computeCreateAddress(proxy);
     }
 

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -9,7 +9,7 @@ import {LowLevelCall} from "./LowLevelCall.sol";
 /**
  * @dev Helper to deploy contracts using the `CREATE3` approach.
  * `CREATE3` combines both `CREATE2` and `CREATE` opcodes to deploy arbitrary bytecode at an address that only depends
- * on the provided salt. At a high level, it depends like a `CREATE2` operation that would not use the bytecodehash to
+ * on the provided salt. At a high level, it behaves like a `CREATE2` operation that would not use the bytecodehash to
  * generate the contract address.
  *
  * CREATE3 can be used to compute in advance the address where a smart contract will be deployed, even if the bytecode
@@ -100,7 +100,6 @@ library Create3 {
             }
         }
 
-        // TODO: check that instance has code? Can create succeed without any code placed?
         return _computeCreateAddress(proxy);
     }
 

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -61,7 +61,7 @@ library Create3 {
     bytes29 private constant PROXY_INITCODE = 0x74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3;
 
     /// @dev Hash of the `PROXY_INITCODE`.
-    /// Equivalent to `keccak256(abi.encodePacked(hex"74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3"))`.
+    /// Equivalent to `keccak256(hex"74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3")`.
     bytes32 internal constant PROXY_INITCODE_HASH = 0xd61bbde0460e6c48ddd99fb8b7e1ad36529d2ec79cbac1db0300b3d26ddcdc2a;
 
     /**

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -15,8 +15,8 @@ import {LowLevelCall} from "./LowLevelCall.sol";
  * CREATE3 can be used to compute in advance the address where a smart contract will be deployed, even if the bytecode
  * is subject to change.
  *
- * NOTE: To get the same deployment address on multiple chains, the linking contract must live at the same address on each
- * chain.
+ * NOTE: To get the same deployment address on multiple chains, the deployer contract must live at the same address on
+ * each chain.
  *
  * See {Create2} for counterfactual deployments that include the bytecodehash in the computation of the address.
  */
@@ -117,9 +117,6 @@ library Create3 {
     /**
      * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
      * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
-     *
-     * NOTE: To predict the same address across chains, `deployer` must be a contract that lives at the same address
-     * on each chain.
      */
     function computeAddress(bytes32 salt, address deployer) internal pure returns (address) {
         return _computeCreateAddress(Create2.computeAddress(salt, PROXY_INITCODE_HASH, deployer));

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -9,11 +9,14 @@ import {LowLevelCall} from "./LowLevelCall.sol";
 /**
  * @dev Helper to deploy contracts using the `CREATE3` approach.
  * `CREATE3` combines both `CREATE2` and `CREATE` opcodes to deploy arbitrary bytecode at an address that only depends
- * on the provided salt. At a high level, it behaves like a `CREATE2` operation that would not use the bytecodehash to
- * generate the contract address.
+ * on the provided salt and the address of the contract using this library. At a high level, it behaves like a `CREATE2`
+ * operation that would not use the bytecodehash to generate the contract address.
  *
  * CREATE3 can be used to compute in advance the address where a smart contract will be deployed, even if the bytecode
  * is subject to change.
+ *
+ * NOTE: To get the same deployment address on multiple chains, the linking contract must live at the same address on each
+ * chain.
  *
  * See {Create2} for counterfactual deployments that include the bytecodehash in the computation of the address.
  */
@@ -114,6 +117,9 @@ library Create3 {
     /**
      * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
      * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
+     *
+     * NOTE: To predict the same address across chains, `deployer` must be a contract that lives at the same address
+     * on each chain.
      */
     function computeAddress(bytes32 salt, address deployer) internal pure returns (address) {
         return _computeCreateAddress(Create2.computeAddress(salt, PROXY_INITCODE_HASH, deployer));

--- a/contracts/utils/README.adoc
+++ b/contracts/utils/README.adoc
@@ -33,6 +33,7 @@ Miscellaneous contracts and libraries containing utility functions you can use t
  * {Comparators}: A library that contains comparator functions to use with the {Heap} library.
  * {Context}: A utility for abstracting the sender and calldata in the current execution context.
  * {Create2}: Wrapper around the https://blog.openzeppelin.com/getting-the-most-out-of-create2/[`CREATE2` EVM opcode] for safe use without having to deal with low-level assembly.
+ * {Create3}: Library implementing the Create3 mechanism for counterfactually deploying contract at addresses that are only affected by the salt (and not by the bytecodehash like Create2).
  * {InteroperableAddress}: Library for formatting and parsing ERC-7930 interoperable addresses.
  * {LowLevelCall}: Collection of functions to perform calls with low-level assembly.
  * {Memory}: A utility library to manipulate memory.
@@ -131,6 +132,8 @@ Ethereum contracts have no native concept of an interface, so applications must 
 {{Context}}
 
 {{Create2}}
+
+{{Create3}}
 
 {{InteroperableAddress}}
 

--- a/test/utils/Create3.t.sol
+++ b/test/utils/Create3.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Create3} from "@openzeppelin/contracts/utils/Create3.sol";
+
+contract Create3Test is Test {
+    function testSymbolicComputeAddressSpillage(bytes32 salt, address deployer) public pure {
+        address predicted = Create3.computeAddress(salt, deployer);
+        bytes32 spillage;
+        assembly ("memory-safe") {
+            spillage := and(predicted, 0xffffffffffffffffffffffff0000000000000000000000000000000000000000)
+        }
+        assertEq(spillage, bytes32(0));
+    }
+}

--- a/test/utils/Create3.t.sol
+++ b/test/utils/Create3.t.sol
@@ -14,4 +14,12 @@ contract Create3Test is Test {
         }
         assertEq(spillage, bytes32(0));
     }
+
+    function testSymbolicDeployMatchesComputeAddress(bytes32 salt) public {
+        // Minimal init code that deploys a contract with empty runtime code (PUSH1 0, PUSH1 0, RETURN).
+        bytes memory bytecode = hex"60006000f3";
+        address predicted = Create3.computeAddress(salt);
+        address deployed = Create3.deploy(0, salt, bytecode);
+        assertEq(deployed, predicted);
+    }
 }

--- a/test/utils/Create3.test.js
+++ b/test/utils/Create3.test.js
@@ -1,0 +1,171 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
+
+const { RevertType } = require('../helpers/enums');
+
+// const PROXY_INITCODE_HASH = '0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f';
+const PROXY_INITCODE_HASH = '0xd61bbde0460e6c48ddd99fb8b7e1ad36529d2ec79cbac1db0300b3d26ddcdc2a';
+const getCreate3Address = (deployer, salt) =>
+  ethers.getCreateAddress({ from: ethers.getCreate2Address(deployer, salt, PROXY_INITCODE_HASH), nonce: 1 });
+
+async function fixture() {
+  const [deployer, other] = await ethers.getSigners();
+
+  const factory = await ethers.deployContract('$Create3');
+
+  // Bytecode for deploying a contract that includes a constructor.
+  // We use a vesting wallet, with 3 constructor arguments.
+  const constructorByteCode = await ethers
+    .getContractFactory('VestingWallet')
+    .then(factory => ethers.concat([factory.bytecode, factory.interface.encodeDeploy([other.address, 0n, 0n])]));
+
+  // Bytecode for deploying a contract that has no constructor log.
+  // Here we use the Create2 helper factory.
+  const constructorLessBytecode = await ethers
+    .getContractFactory('$Create2')
+    .then(factory => ethers.concat([factory.bytecode, factory.interface.encodeDeploy([])]));
+
+  const mockFactory = await ethers.getContractFactory('ConstructorMock');
+
+  return { deployer, other, factory, constructorByteCode, constructorLessBytecode, mockFactory };
+}
+
+describe('Create2', function () {
+  const salt = 'salt message';
+  const saltHex = ethers.id(salt);
+
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  describe('computeAddress', function () {
+    it('computes the correct contract address', async function () {
+      await expect(this.factory.$computeAddress(saltHex)).to.eventually.equal(
+        getCreate3Address(this.factory.target, saltHex),
+      );
+    });
+
+    it('computes the correct contract address with deployer', async function () {
+      await expect(this.factory.$computeAddress(saltHex, ethers.Typed.address(this.deployer))).to.eventually.equal(
+        getCreate3Address(this.deployer.address, saltHex),
+      );
+    });
+  });
+
+  describe('deploy', function () {
+    it('deploys a contract without constructor', async function () {
+      const offChainComputed = getCreate3Address(this.factory.target, saltHex);
+
+      await expect(this.factory.$deploy(0n, saltHex, this.constructorLessBytecode))
+        .to.emit(this.factory, 'return$deploy')
+        .withArgs(offChainComputed);
+
+      expect(this.constructorLessBytecode).to.include((await ethers.provider.getCode(offChainComputed)).slice(2));
+    });
+
+    it('deploys a contract with constructor arguments', async function () {
+      const offChainComputed = getCreate3Address(this.factory.target, saltHex);
+
+      await expect(this.factory.$deploy(0n, saltHex, this.constructorByteCode))
+        .to.emit(this.factory, 'return$deploy')
+        .withArgs(offChainComputed);
+
+      const instance = await ethers.getContractAt('VestingWallet', offChainComputed);
+
+      expect(await instance.owner()).to.equal(this.other);
+    });
+
+    it('deploys a contract with funds deposited in the factory', async function () {
+      const value = 10n;
+
+      await this.deployer.sendTransaction({ to: this.factory, value });
+
+      const offChainComputed = getCreate3Address(this.factory.target, saltHex);
+
+      expect(await ethers.provider.getBalance(this.factory)).to.equal(value);
+      expect(await ethers.provider.getBalance(offChainComputed)).to.equal(0n);
+
+      await expect(this.factory.$deploy(value, saltHex, this.constructorByteCode))
+        .to.emit(this.factory, 'return$deploy')
+        .withArgs(offChainComputed);
+
+      expect(await ethers.provider.getBalance(this.factory)).to.equal(0n);
+      expect(await ethers.provider.getBalance(offChainComputed)).to.equal(value);
+    });
+
+    it('fails deploying a contract in an existent address', async function () {
+      await expect(this.factory.$deploy(0n, saltHex, this.constructorByteCode)).to.emit(this.factory, 'return$deploy');
+
+      await expect(this.factory.$deploy(0n, saltHex, this.constructorByteCode)).to.be.revertedWithCustomError(
+        this.factory,
+        'FailedDeployment',
+      );
+    });
+
+    it('fails deploying a contract if the bytecode length is zero', async function () {
+      await expect(this.factory.$deploy(0n, saltHex, '0x')).to.be.revertedWithCustomError(
+        this.factory,
+        'Create3EmptyBytecode',
+      );
+    });
+
+    it('fails deploying a contract if factory contract does not have sufficient balance', async function () {
+      await expect(this.factory.$deploy(1n, saltHex, this.constructorByteCode))
+        .to.be.revertedWithCustomError(this.factory, 'InsufficientBalance')
+        .withArgs(0n, 1n);
+    });
+
+    describe('reverts error thrown during contract creation', function () {
+      it('bubbles up without message', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([
+              this.mockFactory.bytecode,
+              this.mockFactory.interface.encodeDeploy([RevertType.RevertWithoutMessage]),
+            ]),
+          ),
+        ).to.be.revertedWithCustomError(this.factory, 'FailedDeployment');
+      });
+
+      it('bubbles up message', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([
+              this.mockFactory.bytecode,
+              this.mockFactory.interface.encodeDeploy([RevertType.RevertWithMessage]),
+            ]),
+          ),
+        ).to.be.revertedWith('ConstructorMock: reverting');
+      });
+
+      it('bubbles up custom error', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([
+              this.mockFactory.bytecode,
+              this.mockFactory.interface.encodeDeploy([RevertType.RevertWithCustomError]),
+            ]),
+          ),
+        ).to.be.revertedWithCustomError({ interface: this.mockFactory.interface }, 'CustomError');
+      });
+
+      it('bubbles up panic', async function () {
+        await expect(
+          this.factory.$deploy(
+            0n,
+            saltHex,
+            ethers.concat([this.mockFactory.bytecode, this.mockFactory.interface.encodeDeploy([RevertType.Panic])]),
+          ),
+        ).to.be.revertedWithPanic(PANIC_CODES.DIVISION_BY_ZERO);
+      });
+    });
+  });
+});

--- a/test/utils/Create3.test.js
+++ b/test/utils/Create3.test.js
@@ -32,7 +32,7 @@ async function fixture() {
   return { deployer, other, factory, constructorByteCode, constructorLessBytecode, mockFactory };
 }
 
-describe('Create2', function () {
+describe('Create3', function () {
   const salt = 'salt message';
   const saltHex = ethers.id(salt);
 

--- a/test/utils/Create3.test.js
+++ b/test/utils/Create3.test.js
@@ -5,7 +5,6 @@ const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const { RevertType } = require('../helpers/enums');
 
-// const PROXY_INITCODE_HASH = '0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f';
 const PROXY_INITCODE_HASH = '0xd61bbde0460e6c48ddd99fb8b7e1ad36529d2ec79cbac1db0300b3d26ddcdc2a';
 const getCreate3Address = (deployer, salt) =>
   ethers.getCreateAddress({ from: ethers.getCreate2Address(deployer, salt, PROXY_INITCODE_HASH), nonce: 1 });
@@ -21,7 +20,7 @@ async function fixture() {
     .getContractFactory('VestingWallet')
     .then(factory => ethers.concat([factory.bytecode, factory.interface.encodeDeploy([other.address, 0n, 0n])]));
 
-  // Bytecode for deploying a contract that has no constructor log.
+  // Bytecode for deploying a contract that has no constructor logic.
   // Here we use the Create2 helper factory.
   const constructorLessBytecode = await ethers
     .getContractFactory('$Create2')

--- a/test/utils/Create3.test.js
+++ b/test/utils/Create3.test.js
@@ -1,6 +1,6 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { loadFixture, takeSnapshot } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const { RevertType } = require('../helpers/enums');
@@ -73,7 +73,7 @@ describe('Create3', function () {
 
       const instance = await ethers.getContractAt('VestingWallet', offChainComputed);
 
-      expect(await instance.owner()).to.equal(this.other);
+      await expect(instance.owner()).to.eventually.equal(this.other);
     });
 
     it('deploys a contract with funds deposited in the factory', async function () {
@@ -83,15 +83,30 @@ describe('Create3', function () {
 
       const offChainComputed = getCreate3Address(this.factory.target, saltHex);
 
-      expect(await ethers.provider.getBalance(this.factory)).to.equal(value);
-      expect(await ethers.provider.getBalance(offChainComputed)).to.equal(0n);
+      await expect(ethers.provider.getBalance(this.factory)).to.eventually.equal(value);
+      await expect(ethers.provider.getBalance(offChainComputed)).to.eventually.equal(0n);
 
       await expect(this.factory.$deploy(value, saltHex, this.constructorByteCode))
         .to.emit(this.factory, 'return$deploy')
         .withArgs(offChainComputed);
 
-      expect(await ethers.provider.getBalance(this.factory)).to.equal(0n);
-      expect(await ethers.provider.getBalance(offChainComputed)).to.equal(value);
+      await expect(ethers.provider.getBalance(this.factory)).to.eventually.equal(0n);
+      await expect(ethers.provider.getBalance(offChainComputed)).to.eventually.equal(value);
+    });
+
+    it('produces the same address regardless of the deployed bytecode', async function () {
+      const offChainComputed = getCreate3Address(this.factory.target, saltHex);
+      const snapshot = await takeSnapshot();
+
+      await expect(this.factory.$deploy(0n, saltHex, this.constructorLessBytecode))
+        .to.emit(this.factory, 'return$deploy')
+        .withArgs(offChainComputed);
+
+      await snapshot.restore();
+
+      await expect(this.factory.$deploy(0n, saltHex, this.constructorByteCode))
+        .to.emit(this.factory, 'return$deploy')
+        .withArgs(offChainComputed);
     });
 
     it('fails deploying a contract in an existent address', async function () {
@@ -114,6 +129,20 @@ describe('Create3', function () {
       await expect(this.factory.$deploy(1n, saltHex, this.constructorByteCode))
         .to.be.revertedWithCustomError(this.factory, 'InsufficientBalance')
         .withArgs(0n, 1n);
+    });
+
+    it('fails deploying a contract when sending value to a non-payable constructor', async function () {
+      const value = 10n;
+      await this.deployer.sendTransaction({ to: this.factory, value });
+
+      // ConstructorMock has a non-payable constructor: Solidity inserts a callvalue check that reverts with no data.
+      await expect(
+        this.factory.$deploy(
+          value,
+          saltHex,
+          ethers.concat([this.mockFactory.bytecode, this.mockFactory.interface.encodeDeploy([RevertType.None])]),
+        ),
+      ).to.be.revertedWithCustomError(this.factory, 'FailedDeployment');
     });
 
     describe('reverts error thrown during contract creation', function () {

--- a/test/utils/Create3.test.js
+++ b/test/utils/Create3.test.js
@@ -131,20 +131,6 @@ describe('Create3', function () {
         .withArgs(0n, 1n);
     });
 
-    it('fails deploying a contract when sending value to a non-payable constructor', async function () {
-      const value = 10n;
-      await this.deployer.sendTransaction({ to: this.factory, value });
-
-      // ConstructorMock has a non-payable constructor: Solidity inserts a callvalue check that reverts with no data.
-      await expect(
-        this.factory.$deploy(
-          value,
-          saltHex,
-          ethers.concat([this.mockFactory.bytecode, this.mockFactory.interface.encodeDeploy([RevertType.None])]),
-        ),
-      ).to.be.revertedWithCustomError(this.factory, 'FailedDeployment');
-    });
-
     describe('reverts error thrown during contract creation', function () {
       it('bubbles up without message', async function () {
         await expect(


### PR DESCRIPTION
This is a variant of Solady's [create3 library](https://github.com/Vectorized/solady/blob/main/src/utils/CREATE3.sol).

The main difference is that the proxy used in this version will bubble any revert that happens during the CREATE phase.
Test are mostly a copy of the exisitng Create2 tests.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
