### PR TITLE
opt(Arrays): convert `_quickSort` tail recursion to iterative loop

### DIFF
--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -114,25 +114,32 @@ library Arrays {
      */
     function _quickSort(uint256 begin, uint256 end, function(uint256, uint256) pure returns (bool) comp) private pure {
         unchecked {
-            if (end - begin < 0x40) return;
+            while (true) {
+                if (end - begin < 0x40) return;
 
-            // Use first element as pivot
-            uint256 pivot = _mload(begin);
-            // Position where the pivot should be at the end of the loop
-            uint256 pos = begin;
+                // Use first element as pivot
+                uint256 pivot = _mload(begin);
+                // Position where the pivot should be at the end of the loop
+                uint256 pos = begin;
 
-            for (uint256 it = begin + 0x20; it < end; it += 0x20) {
-                if (comp(_mload(it), pivot)) {
-                    // If the value stored at the iterator's position comes before the pivot, we increment the
-                    // position of the pivot and move the value there.
-                    pos += 0x20;
-                    _swap(pos, it);
+                for (uint256 it = begin + 0x20; it < end; it += 0x20) {
+                    if (comp(_mload(it), pivot)) {
+                        // If the value stored at the iterator's position comes before the pivot, we increment the
+                        // position of the pivot and move the value there.
+                        pos += 0x20;
+                        _swap(pos, it);
+                    }
+                }
+
+                _swap(begin, pos); // Swap pivot into place
+                if (pos - begin < end - (pos + 0x20)) {
+                    _quickSort(begin, pos, comp); // Sort the left side of the pivot
+                    begin = pos + 0x20; // do another loop without recursion
+                } else {
+                    _quickSort(pos + 0x20, end, comp); // Sort the right side of the pivot
+                    end = pos; // do another loop without recursion
                 }
             }
-
-            _swap(begin, pos); // Swap pivot into place
-            _quickSort(begin, pos, comp); // Sort the left side of the pivot
-            _quickSort(pos + 0x20, end, comp); // Sort the right side of the pivot
         }
     }
 


### PR DESCRIPTION
## Description
Fixes #6289

As detailed by @gpersoon, the `_quickSort()` function is limited in the number of items it can sort due to EVM stack depth limits (~1024), capping recursion depth to ~169 calls. This heavily impacts the worst-case scenario (e.g. an already reverse-sorted array).

Because Solidity does not automatically optimize tail recursion, we can manually do so to mitigate stack depth constraints and save substantial gas.

## Changes
- Wrapped the core partition logic in an iterative `while(true)` loop.
- After partitioning, only the smaller side is sorted recursively. The larger side updates the loop boundaries (`begin` and `end`) and iterates inline without burning a new stack frame.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)