### PR TITLE
Add a ERC1967Clones library

### DIFF
--- a/.changeset/quiet-otters-jump.md
+++ b/.changeset/quiet-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC1967Clones`: Add a library to deploy minimal ERC-1967 proxies via `CREATE` or `CREATE2`.

--- a/contracts/mocks/Stateless.sol
+++ b/contracts/mocks/Stateless.sol
@@ -28,6 +28,7 @@ import {ERC165} from "../utils/introspection/ERC165.sol";
 import {ERC165Checker} from "../utils/introspection/ERC165Checker.sol";
 import {ERC721Holder} from "../token/ERC721/utils/ERC721Holder.sol";
 import {ERC1155Holder} from "../token/ERC1155/utils/ERC1155Holder.sol";
+import {ERC1967Clones} from "../proxy/ERC1967/ERC1967Clones.sol";
 import {ERC1967Utils} from "../proxy/ERC1967/ERC1967Utils.sol";
 import {ERC4337Utils} from "../account/utils/draft-ERC4337Utils.sol";
 import {ERC7579Utils} from "../account/utils/draft-ERC7579Utils.sol";

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -7,73 +7,84 @@ import {Errors} from "../../utils/Errors.sol";
 import {ERC1967Utils} from "./ERC1967Utils.sol";
 
 library ERC1967Clones {
+    /// @dev Topic1 for the IERC1967.Upgraded event. Equal to keccak256("Upgraded(address)").
+    // solhint-disable-next-line private-vars-leading-underscore
+    bytes32 internal constant UPGRADE_TOPIC1 = 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b;
+
     /**
-     * =====================================[ PROXY CODE ]=====================================
-     * Offset | Opcode      | Mnemonic         | Stack                | Memory
-     * -------|-------------|------------------|----------------------|------------------------
-     * 0x00   | 36          | CALLDATASIZE     | cds                  |
-     * 0x01   | 5F          | PUSH0            | 0 cds                |
-     * 0x02   | 5F          | PUSH0            | 0 0 cds              |
-     * 0x03   | 37          | CALLDATACOPY     |                      | [0..cds): calldata
-     * 0x04   | 5F          | PUSH0            | 0                    | [0..cds): calldata
-     * 0x05   | 5F          | PUSH0            | 0 0                  | [0..cds): calldata
-     * 0x06   | 36          | CALLDATASIZE     | cds 0 0              | [0..cds): calldata
-     * 0x07   | 5F          | PUSH0            | 0 cds 0 0            | [0..cds): calldata
-     * 0x08   | 7f<slot>    | PUSH32 slot      | slot 0 cds 0 0       | [0..cds): calldata
-     * 0x29   | 54          | SLOAD            | addr 0 cds 0 0       | [0..cds): calldata
-     * 0x2A   | 5A          | GAS              | gas addr 0 cds 0 0   | [0..cds): calldata
-     * 0x2B   | F4          | DELEGATECALL     | success              |
-     * 0x2C   | 3D          | RETURNDATASIZE   | rds success          |
-     * 0x2D   | 5F          | PUSH0            | 0 rds success        |
-     * 0x2E   | 5F          | PUSH0            | 0 0 rds success      |
-     * 0x2F   | 3E          | RETURNDATACOPY   | success              | [0...rds): returndata
-     * 0x30   | 5F          | PUSH0            | 0 success            | [0...rds): returndata
-     * 0x31   | 3D          | RETURNDATASIZE   | rds 0 success        | [0...rds): returndata
-     * 0x32   | 91          | SWAP2            | success 0 rds        | [0...rds): returndata
-     * 0x33   | 6037        | PUSH1 0x37       | 0x37 success 0 rds   | [0...rds): returndata
-     * 0x35   | 57          | JUMPI            | 0 rds                | [0...rds): returndata
-     * 0x36   | FD          | REVERT           |                      |
-     * 0x37   | 5B          | JUMPDEST         | 0 rds                | [0...rds): returndata
-     * 0x38   | F3          | RETURN           |                      |
+     * ========================================[ PROXY CODE ]========================================
+     * Offset | Opcode      | Mnemonic         | Stack                      | Memory
+     * -------|-------------|------------------|----------------------------|------------------------
+     * 0x00   | 36          | CALLDATASIZE     | cds                        |
+     * 0x01   | 5f          | PUSH0            | 0 cds                      |
+     * 0x02   | 5f          | PUSH0            | 0 0 cds                    |
+     * 0x03   | 37          | CALLDATACOPY     |                            | [0..cds): calldata
+     * 0x04   | 5f          | PUSH0            | 0                          | [0..cds): calldata
+     * 0x05   | 5f          | PUSH0            | 0 0                        | [0..cds): calldata
+     * 0x06   | 36          | CALLDATASIZE     | cds 0 0                    | [0..cds): calldata
+     * 0x07   | 5f          | PUSH0            | 0 cds 0 0                  | [0..cds): calldata
+     * 0x08   | 7f<slot>    | PUSH32 slot      | slot 0 cds 0 0             | [0..cds): calldata
+     * 0x29   | 54          | SLOAD            | addr 0 cds 0 0             | [0..cds): calldata
+     * 0x2A   | 5a          | GAS              | gas addr 0 cds 0 0         | [0..cds): calldata
+     * 0x2B   | f4          | DELEGATECALL     | success                    |
+     * 0x2C   | 3d          | RETURNDATASIZE   | rds success                |
+     * 0x2D   | 5f          | PUSH0            | 0 rds success              |
+     * 0x2E   | 5f          | PUSH0            | 0 0 rds success            |
+     * 0x2F   | 3e          | RETURNDATACOPY   | success                    | [0...rds): returndata
+     * 0x30   | 5f          | PUSH0            | 0 success                  | [0...rds): returndata
+     * 0x31   | 3d          | RETURNDATASIZE   | rds 0 success              | [0...rds): returndata
+     * 0x32   | 91          | SWAP2            | success 0 rds              | [0...rds): returndata
+     * 0x33   | 6037        | PUSH1 0x37       | 0x37 success 0 rds         | [0...rds): returndata
+     * 0x35   | 57          | JUMPI            | 0 rds                      | [0...rds): returndata
+     * 0x36   | fd          | REVERT           |                            |
+     * 0x37   | 5b          | JUMPDEST         | 0 rds                      | [0...rds): returndata
+     * 0x38   | f3          | RETURN           |                            |
      *
-     * ==================================[ DEPLOYMENT CODE  ]==================================
-     * Offset | Opcode      | Mnemonic         | Stack                | Memory
-     * -------|-------------|------------------|----------------------|------------------------
-     * 0x00   | 6039        | PUSH1 0x39       | 0x39                 |
-     * 0x03   | 5f          | PUSH0            | 0 0x39               |
-     * 0x04   | 81          | DUP2             | 0x39 0 0x39          |
-     * 0x05   | 6022        | PUSH1 0x22       | 0x22 0x39 0 0x39     |
-     * 0x07   | 5f          | PUSH0            | 0 0x22 0x39 0 0x39   |
-     * 0x08   | 39          | CODECOPY         | 0 0x39               | [0...0x39): proxycode
-     * 0x09   | 73<impl>    | PUSH20 impl      | impl 0 0x39          | [0...0x39): proxycode
-     * 0x1d   | 6009        | PUSH1 0x09       | 0x09 impl 0 0x39     | [0...0x39): proxycode
-     * 0x1f   | 51          | MLOAD            | slot impl 0 0x39     | [0...0x39): proxycode
-     * 0x20   | 55          | SSTORE           | 0 0x39               | [0...0x39): proxycode
-     * 0x21   | f3          | RETURN           |                      |
+     * =====================================[ DEPLOYMENT CODE  ]=====================================
+     * Offset | Opcode      | Mnemonic         | Stack                      | Memory
+     * -------|-------------|------------------|----------------------------|------------------------
+     * 0x00   | 6039        | PUSH1 0x39       | 0x39                       |
+     * 0x02   | 5f          | PUSH0            | 0 0x39                     |
+     * 0x03   | 81          | DUP2             | 0x39 0 0x39                |
+     * 0x04   | 6047        | PUSH1 0x47       | 0x47 0x39 0 0x39           |
+     * 0x06   | 5f          | PUSH0            | 0 0x47 0x39 0 0x39         |
+     * 0x07   | 39          | CODECOPY         | 0 0x39                     | [0...0x39): proxycode
+     * 0x08   | 73<impl>    | PUSH20 impl      | impl 0 0x39                | [0...0x39): proxycode
+     * 0x1d   | 80          | DUP1             | impl impl 0 0x39           | [0...0x39): proxycode
+     * 0x1e   | 7f<topic>   | PUSH32 topic     | topic impl impl 0 0x39     | [0...0x39): proxycode
+     * 0x3f   | 5f          | PUSH0            | 0 topic impl impl 0 0x39   | [0...0x39): proxycode
+     * 0x40   | 5f          | PUSH0            | 0 0 topic impl impl 0 0x39 | [0...0x39): proxycode
+     * 0x41   | a2          | LOG2             | impl 0 0x39                | [0...0x39): proxycode
+     * 0x42   | 6009        | PUSH1 0x09       | 0x09 impl 0 0x39           | [0...0x39): proxycode
+     * 0x44   | 51          | MLOAD            | slot impl 0 0x39           | [0...0x39): proxycode
+     * 0x45   | 55          | SSTORE           | 0 0x39                     | [0...0x39): proxycode
+     * 0x46   | f3          | RETURN           |                            |
      *
      * Note:
      * - 0x39: length of the proxy code
-     * - 0x22: length of the deployment code, since the proxy code is just after the deployment code, that is also to offset of the proxy code
+     * - 0x47: length of the deployment code, since the proxy code is just after the deployment code, that is also to offset of the proxy code
      * - 0x09: position of the ERC1967Implementation slot in the proxy code.
      */
-
     function deploy(address implementation) internal returns (address addr) {
         return deploy(implementation, uint256(0));
     }
 
     function deploy(address implementation, uint256 amount) internal returns (address addr) {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        bytes32 topic1 = UPGRADE_TOPIC1;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x52), 0x545af43d5f5f3e5f3d91603757fd5bf3)
-            mstore(add(ptr, 0x42), implementationSlot)
-            mstore(add(ptr, 0x22), 0x60095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x77), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x67), implementationSlot)
+            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x36), topic1)
+            mstore(add(ptr, 0x16), 0x807f)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x60395f8160225f3973)
+            mstore(ptr, 0x60395f8160475f3973)
 
             // Call create
-            addr := create(amount, add(ptr, 0x17), 0x5b)
+            addr := create(amount, add(ptr, 0x17), 0x80)
         }
 
         // deployment code doesn't have a revert, so no need to handle returndata
@@ -86,17 +97,20 @@ library ERC1967Clones {
 
     function deploy(address implementation, uint256 amount, bytes32 salt) internal returns (address addr) {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        bytes32 topic1 = UPGRADE_TOPIC1;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x52), 0x545af43d5f5f3e5f3d91603757fd5bf3)
-            mstore(add(ptr, 0x42), implementationSlot)
-            mstore(add(ptr, 0x22), 0x60095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x77), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x67), implementationSlot)
+            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x36), topic1)
+            mstore(add(ptr, 0x16), 0x807f)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x60395f8160225f3973)
+            mstore(ptr, 0x60395f8160475f3973)
 
             // Call create2
-            addr := create2(amount, add(ptr, 0x17), 0x5b, salt)
+            addr := create2(amount, add(ptr, 0x17), 0x80, salt)
         }
 
         // deployment code doesn't have a revert, so no need to handle returndata
@@ -113,17 +127,20 @@ library ERC1967Clones {
 
     function _getCloneHash(address implementation) private pure returns (bytes32 bytecodeHash) {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        bytes32 topic1 = UPGRADE_TOPIC1;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x52), 0x545af43d5f5f3e5f3d91603757fd5bf3)
-            mstore(add(ptr, 0x42), implementationSlot)
-            mstore(add(ptr, 0x22), 0x60095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x77), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x67), implementationSlot)
+            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x36), topic1)
+            mstore(add(ptr, 0x16), 0x807f)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x60395f8160225f3973)
+            mstore(ptr, 0x60395f8160475f3973)
 
             // Compute hash
-            bytecodeHash := keccak256(add(ptr, 0x17), 0x5b)
+            bytecodeHash := keccak256(add(ptr, 0x17), 0x80)
         }
     }
 }

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -56,6 +56,11 @@ library ERC1967Clones {
      * - 0x22: length of the deployment code, since the proxy code is just after the deployment code, that is also to offset of the proxy code
      * - 0x09: position of the ERC1967Implementation slot in the proxy code.
      */
+
+    function deploy(address implementation) internal returns (address addr) {
+        return deploy(implementation, uint256(0));
+    }
+
     function deploy(address implementation, uint256 amount) internal returns (address addr) {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
         assembly ("memory-safe") {
@@ -75,7 +80,11 @@ library ERC1967Clones {
         require(addr != address(0), Errors.FailedDeployment());
     }
 
-    function deployDeterministic(address implementation, uint256 amount, bytes32 salt) internal returns (address addr) {
+    function deploy(address implementation, bytes32 salt) internal returns (address addr) {
+        return deploy(implementation, uint256(0), salt);
+    }
+
+    function deploy(address implementation, uint256 amount, bytes32 salt) internal returns (address addr) {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
         assembly ("memory-safe") {
             // Set code in memory

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.26;
+
+import {Create2} from "../../utils/Create2.sol";
+import {Errors} from "../../utils/Errors.sol";
+import {ERC1967Utils} from "./ERC1967Utils.sol";
+
+library ERC1967Clones {
+    /**
+     * =====================================[ PROXY CODE ]=====================================
+     * Offset | Opcode      | Mnemonic         | Stack                | Memory
+     * -------|-------------|------------------|----------------------|------------------------
+     * 0x00   | 36          | CALLDATASIZE     | cds                  |
+     * 0x01   | 5F          | PUSH0            | 0 cds                |
+     * 0x02   | 5F          | PUSH0            | 0 0 cds              |
+     * 0x03   | 37          | CALLDATACOPY     |                      | [0..cds): calldata
+     * 0x04   | 5F          | PUSH0            | 0                    | [0..cds): calldata
+     * 0x05   | 5F          | PUSH0            | 0 0                  | [0..cds): calldata
+     * 0x06   | 36          | CALLDATASIZE     | cds 0 0              | [0..cds): calldata
+     * 0x07   | 5F          | PUSH0            | 0 cds 0 0            | [0..cds): calldata
+     * 0x08   | 7f<slot>    | PUSH32 slot      | slot 0 cds 0 0       | [0..cds): calldata
+     * 0x29   | 54          | SLOAD            | addr 0 cds 0 0       | [0..cds): calldata
+     * 0x2A   | 5A          | GAS              | gas addr 0 cds 0 0   | [0..cds): calldata
+     * 0x2B   | F4          | DELEGATECALL     | success              |
+     * 0x2C   | 3D          | RETURNDATASIZE   | rds success          |
+     * 0x2D   | 5F          | PUSH0            | 0 rds success        |
+     * 0x2E   | 5F          | PUSH0            | 0 0 rds success      |
+     * 0x2F   | 3E          | RETURNDATACOPY   | success              | [0...rds): returndata
+     * 0x30   | 5F          | PUSH0            | 0 success            | [0...rds): returndata
+     * 0x31   | 3D          | RETURNDATASIZE   | rds 0 success        | [0...rds): returndata
+     * 0x32   | 91          | SWAP2            | success 0 rds        | [0...rds): returndata
+     * 0x33   | 6037        | PUSH1 0x37       | 0x37 success 0 rds   | [0...rds): returndata
+     * 0x35   | 57          | JUMPI            | 0 rds                | [0...rds): returndata
+     * 0x36   | FD          | REVERT           |                      |
+     * 0x37   | 5B          | JUMPDEST         | 0 rds                | [0...rds): returndata
+     * 0x38   | F3          | RETURN           |                      |
+     *
+     * ==================================[ DEPLOYMENT CODE  ]==================================
+     * Offset | Opcode      | Mnemonic         | Stack                | Memory
+     * -------|-------------|------------------|----------------------|------------------------
+     * 0x00   | 6039        | PUSH1 0x39       | 0x39                 |
+     * 0x03   | 5f          | PUSH0            | 0 0x39               |
+     * 0x04   | 81          | DUP2             | 0x39 0 0x39          |
+     * 0x05   | 6022        | PUSH1 0x22       | 0x22 0x39 0 0x39     |
+     * 0x07   | 5f          | PUSH0            | 0 0x22 0x39 0 0x39   |
+     * 0x08   | 39          | CODECOPY         | 0 0x39               | [0...0x39): proxycode
+     * 0x09   | 73<impl>    | PUSH20 impl      | impl 0 0x39          | [0...0x39): proxycode
+     * 0x1d   | 6009        | PUSH1 0x09       | 0x09 impl 0 0x39     | [0...0x39): proxycode
+     * 0x1f   | 51          | MLOAD            | slot impl 0 0x39     | [0...0x39): proxycode
+     * 0x20   | 55          | SSTORE           | 0 0x39               | [0...0x39): proxycode
+     * 0x21   | f3          | RETURN           |                      |
+     *
+     * Note:
+     * - 0x39: length of the proxy code
+     * - 0x22: length of the deployment code, since the proxy code is just after the deployment code, that is also to offset of the proxy code
+     * - 0x09: position of the ERC1967Implementation slot in the proxy code.
+     */
+    function deploy(address implementation, uint256 amount) internal returns (address addr) {
+        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        assembly ("memory-safe") {
+            // Set code in memory
+            let ptr := mload(0x40)
+            mstore(add(ptr, 0x52), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x42), implementationSlot)
+            mstore(add(ptr, 0x22), 0x60095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x14), implementation)
+            mstore(ptr, 0x60395f8160225f3973)
+
+            // Call create
+            addr := create(amount, add(ptr, 0x17), 0x5b)
+        }
+
+        // deployment code doesn't have a revert, so no need to handle returndata
+        require(addr != address(0), Errors.FailedDeployment());
+    }
+
+    function deployDeterministic(address implementation, uint256 amount, bytes32 salt) internal returns (address addr) {
+        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        assembly ("memory-safe") {
+            // Set code in memory
+            let ptr := mload(0x40)
+            mstore(add(ptr, 0x52), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x42), implementationSlot)
+            mstore(add(ptr, 0x22), 0x60095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x14), implementation)
+            mstore(ptr, 0x60395f8160225f3973)
+
+            // Call create2
+            addr := create2(amount, add(ptr, 0x17), 0x5b, salt)
+        }
+
+        // deployment code doesn't have a revert, so no need to handle returndata
+        require(addr != address(0), Errors.FailedDeployment());
+    }
+
+    function computeAddress(address implementation, bytes32 salt) internal view returns (address) {
+        return computeAddress(implementation, salt, address(this));
+    }
+
+    function computeAddress(address implementation, bytes32 salt, address deployer) internal pure returns (address) {
+        return Create2.computeAddress(salt, _getCloneHash(implementation), deployer);
+    }
+
+    function _getCloneHash(address implementation) private pure returns (bytes32 bytecodeHash) {
+        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        assembly ("memory-safe") {
+            // Set code in memory
+            let ptr := mload(0x40)
+            mstore(add(ptr, 0x52), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x42), implementationSlot)
+            mstore(add(ptr, 0x22), 0x60095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x14), implementation)
+            mstore(ptr, 0x60395f8160225f3973)
+
+            // Compute hash
+            bytecodeHash := keccak256(add(ptr, 0x17), 0x5b)
+        }
+    }
+}

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.26;
 import {Create2} from "../../utils/Create2.sol";
 import {Errors} from "../../utils/Errors.sol";
 import {ERC1967Utils} from "./ERC1967Utils.sol";
+import {IERC1967} from "../../interfaces/IERC1967.sol";
 
 /**
  * @dev https://eips.ethereum.org/EIPS/eip-1967[ERC-1967] is the standard for upgradeable proxies that
@@ -24,10 +25,6 @@ import {ERC1967Utils} from "./ERC1967Utils.sol";
  * returned address in the same transaction as the deployment.
  */
 library ERC1967Clones {
-    /// @dev Topic1 for the {IERC1967-Upgraded} event. Equal to `keccak256("Upgraded(address)")`.
-    // solhint-disable-next-line private-vars-leading-underscore
-    bytes32 internal constant UPGRADE_TOPIC1 = 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b;
-
     /**
      * ========================================[ PROXY CODE ]========================================
      * Offset | Opcode      | Mnemonic         | Stack                      | Memory
@@ -112,7 +109,7 @@ library ERC1967Clones {
     function clone(address implementation, uint256 value) internal returns (address instance) {
         require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
-        bytes32 topic1 = UPGRADE_TOPIC1;
+        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
@@ -167,7 +164,7 @@ library ERC1967Clones {
     ) internal returns (address instance) {
         require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
-        bytes32 topic1 = UPGRADE_TOPIC1;
+        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
@@ -201,7 +198,7 @@ library ERC1967Clones {
 
     function _getCloneHash(address implementation) private pure returns (bytes32 bytecodeHash) {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
-        bytes32 topic1 = UPGRADE_TOPIC1;
+        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -6,8 +6,25 @@ import {Create2} from "../../utils/Create2.sol";
 import {Errors} from "../../utils/Errors.sol";
 import {ERC1967Utils} from "./ERC1967Utils.sol";
 
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-1967[ERC-1967] is the standard for upgradeable proxies that
+ * store the implementation address in a fixed storage slot. This library deploys minimal proxies that
+ * mimic the behavior of {ERC1967Proxy} with a bytecode optimized for cheap deployment and usage. The
+ * deployment emits {IERC1967-Upgraded} from the proxy address, so on-chain tooling and indexers can
+ * track the new instance from the block it was created in.
+ *
+ * The library includes functions to deploy a proxy using either `create` (traditional deployment) or
+ * `create2` (salted deterministic deployment). It also includes a function to predict the addresses of
+ * proxies deployed using the deterministic method.
+ *
+ * IMPORTANT: Unlike {ERC1967Proxy}, this proxy does not run an initialization call at construction and
+ * does not check that `implementation` has code. Calls forwarded to a non-contract `implementation`
+ * succeed silently and return empty data, which an uninitialized clone cannot distinguish from a
+ * legitimate response. Factories using this library are expected to invoke the initializer on the
+ * returned address in the same transaction as the deployment.
+ */
 library ERC1967Clones {
-    /// @dev Topic1 for the IERC1967.Upgraded event. Equal to keccak256("Upgraded(address)").
+    /// @dev Topic1 for the {IERC1967-Upgraded} event. Equal to `keccak256("Upgraded(address)")`.
     // solhint-disable-next-line private-vars-leading-underscore
     bytes32 internal constant UPGRADE_TOPIC1 = 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b;
 
@@ -60,16 +77,40 @@ library ERC1967Clones {
      * 0x45   | 55          | SSTORE           | 0 0x39                     | [0...0x39): proxycode
      * 0x46   | f3          | RETURN           |                            |
      *
-     * Note:
+     * NOTE:
      * - 0x39: length of the proxy code
-     * - 0x47: length of the deployment code, since the proxy code is just after the deployment code, that is also to offset of the proxy code
-     * - 0x09: position of the ERC1967Implementation slot in the proxy code.
+     * - 0x47: length of the deployment code, since the proxy code is just after the deployment code, that is also the offset of the proxy code
+     * - 0x09: position of the ERC1967 implementation slot in the proxy code.
      */
-    function deploy(address implementation) internal returns (address addr) {
-        return deploy(implementation, uint256(0));
+
+    /**
+     * @dev Deploys and returns the address of a minimal ERC-1967 proxy that delegates to `implementation`.
+     *
+     * This function uses the create opcode, which should never revert.
+     *
+     * Emits an {IERC1967-Upgraded} event from the deployed proxy.
+     *
+     * WARNING: This function does not check if `implementation` has code, and the deployed proxy does not run
+     * any initialization call at construction.
+     */
+    function clone(address implementation) internal returns (address) {
+        return clone(implementation, 0);
     }
 
-    function deploy(address implementation, uint256 amount) internal returns (address addr) {
+    /**
+     * @dev Same as {xref-ERC1967Clones-clone-address-}[clone], but with a `value` parameter to send native
+     * currency to the new contract.
+     *
+     * Emits an {IERC1967-Upgraded} event from the deployed proxy.
+     *
+     * WARNING: This function does not check if `implementation` has code, and the deployed proxy does not run
+     * any initialization call at construction.
+     *
+     * NOTE: Using a non-zero value at creation will require the contract using this function (e.g. a factory)
+     * to always have enough balance for new deployments. Consider exposing this function under a payable method.
+     */
+    function clone(address implementation, uint256 value) internal returns (address instance) {
+        require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
         bytes32 topic1 = UPGRADE_TOPIC1;
         assembly ("memory-safe") {
@@ -84,18 +125,47 @@ library ERC1967Clones {
             mstore(ptr, 0x60395f8160475f3973)
 
             // Call create
-            addr := create(amount, add(ptr, 0x17), 0x80)
+            instance := create(value, add(ptr, 0x17), 0x80)
         }
 
         // deployment code doesn't have a revert, so no need to handle returndata
-        require(addr != address(0), Errors.FailedDeployment());
+        require(instance != address(0), Errors.FailedDeployment());
     }
 
-    function deploy(address implementation, bytes32 salt) internal returns (address addr) {
-        return deploy(implementation, uint256(0), salt);
+    /**
+     * @dev Deploys and returns the address of a minimal ERC-1967 proxy that delegates to `implementation`.
+     *
+     * This function uses the create2 opcode and a `salt` to deterministically deploy the clone. Using the
+     * same `implementation` and `salt` multiple times will revert, since the clones cannot be deployed twice
+     * at the same address.
+     *
+     * Emits an {IERC1967-Upgraded} event from the deployed proxy.
+     *
+     * WARNING: This function does not check if `implementation` has code, and the deployed proxy does not run
+     * any initialization call at construction.
+     */
+    function cloneDeterministic(address implementation, bytes32 salt) internal returns (address) {
+        return cloneDeterministic(implementation, salt, 0);
     }
 
-    function deploy(address implementation, uint256 amount, bytes32 salt) internal returns (address addr) {
+    /**
+     * @dev Same as {xref-ERC1967Clones-cloneDeterministic-address-bytes32-}[cloneDeterministic], but with a
+     * `value` parameter to send native currency to the new contract.
+     *
+     * Emits an {IERC1967-Upgraded} event from the deployed proxy.
+     *
+     * WARNING: This function does not check if `implementation` has code, and the deployed proxy does not run
+     * any initialization call at construction.
+     *
+     * NOTE: Using a non-zero value at creation will require the contract using this function (e.g. a factory)
+     * to always have enough balance for new deployments. Consider exposing this function under a payable method.
+     */
+    function cloneDeterministic(
+        address implementation,
+        bytes32 salt,
+        uint256 value
+    ) internal returns (address instance) {
+        require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
         bytes32 topic1 = UPGRADE_TOPIC1;
         assembly ("memory-safe") {
@@ -110,18 +180,22 @@ library ERC1967Clones {
             mstore(ptr, 0x60395f8160475f3973)
 
             // Call create2
-            addr := create2(amount, add(ptr, 0x17), 0x80, salt)
+            instance := create2(value, add(ptr, 0x17), 0x80, salt)
         }
-
-        // deployment code doesn't have a revert, so no need to handle returndata
-        require(addr != address(0), Errors.FailedDeployment());
+        require(instance != address(0), Errors.FailedDeployment());
     }
 
-    function computeAddress(address implementation, bytes32 salt) internal view returns (address) {
-        return computeAddress(implementation, salt, address(this));
+    /// @dev Computes the address of a clone deployed using {ERC1967Clones-cloneDeterministic}.
+    function predictDeterministicAddress(address implementation, bytes32 salt) internal view returns (address) {
+        return predictDeterministicAddress(implementation, salt, address(this));
     }
 
-    function computeAddress(address implementation, bytes32 salt, address deployer) internal pure returns (address) {
+    /// @dev Computes the address of a clone deployed using {ERC1967Clones-cloneDeterministic}.
+    function predictDeterministicAddress(
+        address implementation,
+        bytes32 salt,
+        address deployer
+    ) internal pure returns (address) {
         return Create2.computeAddress(salt, _getCloneHash(implementation), deployer);
     }
 

--- a/contracts/proxy/README.adoc
+++ b/contracts/proxy/README.adoc
@@ -13,7 +13,7 @@ In order to avoid clashes with the storage variables of the implementation contr
 
 - {ERC1967Utils}: Internal functions to get and set the storage slots defined in ERC-1967.
 - {ERC1967Proxy}: A proxy using ERC-1967 storage slots. Not upgradeable by default.
-- {ERC1967Clones}: A library that can deploy minimal ERC-1967 proxies that replicate the behavior of {ERC1967Proxy} with a bytecode optimized for cheap deployment and usage. Usable by factories only.
+- {ERC1967Clones}: A library that can deploy minimal ERC-1967 proxies that replicate the behavior of {ERC1967Proxy} with a bytecode optimized for cheap deployment and usage. Unlike {ERC1967Proxy}, the clones do not accept initialization data at construction, so the deployer is expected to initialize the proxy in the same transaction as the deployment.
 
 There are two alternative ways to add upgradeability to an ERC-1967 proxy. Their differences are explained below in <<transparent-vs-uups>>.
 

--- a/contracts/proxy/README.adoc
+++ b/contracts/proxy/README.adoc
@@ -13,6 +13,7 @@ In order to avoid clashes with the storage variables of the implementation contr
 
 - {ERC1967Utils}: Internal functions to get and set the storage slots defined in ERC-1967.
 - {ERC1967Proxy}: A proxy using ERC-1967 storage slots. Not upgradeable by default.
+- {ERC1967Clones}: A library that can deploy minimal ERC-1967 proxies that replicate the behavior of {ERC1967Proxy} with a bytecode optimized for cheap deployment and usage. Usable by factories only.
 
 There are two alternative ways to add upgradeability to an ERC-1967 proxy. Their differences are explained below in <<transparent-vs-uups>>.
 
@@ -59,6 +60,8 @@ The current implementation of this security mechanism uses https://eips.ethereum
 {{IERC1967}}
 
 {{ERC1967Proxy}}
+
+{{ERC1967Clones}}
 
 {{ERC1967Utils}}
 

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -1,0 +1,56 @@
+const { ethers } = require('hardhat');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
+const { generators } = require('../../helpers/random');
+const shouldBehaveLikeProxy = require('../Proxy.behaviour');
+
+const fixture = async () => {
+  const [admin, nonContractAddress] = await ethers.getSigners();
+
+  const factory = await ethers.deployContract('$ERC1967Clones');
+  const implementation = await ethers.deployContract('DummyImplementation');
+
+  return { admin, nonContractAddress, factory, implementation };
+};
+
+describe('ERC1967Clones', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  describe('non-deterministic deployment (create)', function () {
+    before(function () {
+      this.createProxy = async (implementation, initData, opts = {}) => {
+        const tx = await this.factory.$deploy(implementation, 0n);
+        const instance = await tx
+          .wait()
+          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deploy').args[0])
+          .then(addr => new ethers.Contract(addr, [], this.admin, tx));
+        if (initData !== '0x' || opts.value > 0n) {
+          await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
+        }
+        return instance;
+      };
+    });
+
+    shouldBehaveLikeProxy({ allowUninitialized: true, allowNonContractAddress: true });
+  });
+
+  describe('deterministic deployment (create)', function () {
+    before(function () {
+      this.createProxy = async (implementation, initData, opts = {}) => {
+        const tx = await this.factory.$deployDeterministic(implementation, 0n, opts.salt ?? generators.bytes32());
+        const instance = await tx
+          .wait()
+          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deployDeterministic').args[0])
+          .then(addr => new ethers.Contract(addr, [], this.admin, tx));
+        if (initData !== '0x' || opts.value > 0n) {
+          await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
+        }
+        return instance;
+      };
+    });
+
+    shouldBehaveLikeProxy({ allowUninitialized: true, allowNonContractAddress: true });
+  });
+});

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -1,4 +1,5 @@
 const { ethers } = require('hardhat');
+const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const { generators } = require('../../helpers/random');
@@ -21,14 +22,18 @@ describe('ERC1967Clones', function () {
   describe('non-deterministic deployment (create)', function () {
     before(function () {
       this.createProxy = async (implementation, initData, opts = {}) => {
-        const tx = await this.factory.$deploy(implementation);
-        const instance = await tx
-          .wait()
-          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deploy_address').args[0])
-          .then(addr => new ethers.Contract(addr, [], this.admin, tx));
+        const predictedAddress = await ethers.provider
+          .getTransactionCount(this.factory)
+          .then(nonce => ethers.getCreateAddress({ from: this.factory.target, nonce }));
+        const deploymentTx = await this.factory.$deploy(implementation);
+
+        await expect(deploymentTx).to.emit(this.factory, 'return$deploy_address').withArgs(predictedAddress);
+
+        const instance = new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
         if (initData !== '0x' || opts.value > 0n) {
           await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
         }
+
         return instance;
       };
     });
@@ -39,14 +44,17 @@ describe('ERC1967Clones', function () {
   describe('deterministic deployment (create2)', function () {
     before(function () {
       this.createProxy = async (implementation, initData, opts = {}) => {
-        const tx = await this.factory.$deploy(implementation, ethers.Typed.bytes32(opts.salt ?? generators.bytes32()));
-        const instance = await tx
-          .wait()
-          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deploy_address_bytes32').args[0])
-          .then(addr => new ethers.Contract(addr, [], this.admin, tx));
+        const salt = ethers.Typed.bytes32(opts.salt ?? generators.bytes32());
+        const predictedAddress = await this.factory.$computeAddress(implementation, salt);
+        const deploymentTx = await this.factory.$deploy(implementation, salt);
+
+        await expect(deploymentTx).to.emit(this.factory, 'return$deploy_address_bytes32').withArgs(predictedAddress);
+
+        const instance = new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
         if (initData !== '0x' || opts.value > 0n) {
           await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
         }
+
         return instance;
       };
     });

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -21,10 +21,10 @@ describe('ERC1967Clones', function () {
   describe('non-deterministic deployment (create)', function () {
     before(function () {
       this.createProxy = async (implementation, initData, opts = {}) => {
-        const tx = await this.factory.$deploy(implementation, 0n);
+        const tx = await this.factory.$deploy(implementation);
         const instance = await tx
           .wait()
-          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deploy').args[0])
+          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deploy_address').args[0])
           .then(addr => new ethers.Contract(addr, [], this.admin, tx));
         if (initData !== '0x' || opts.value > 0n) {
           await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
@@ -36,13 +36,13 @@ describe('ERC1967Clones', function () {
     shouldBehaveLikeProxy({ allowUninitialized: true, allowNonContractAddress: true });
   });
 
-  describe('deterministic deployment (create)', function () {
+  describe('deterministic deployment (create2)', function () {
     before(function () {
       this.createProxy = async (implementation, initData, opts = {}) => {
-        const tx = await this.factory.$deployDeterministic(implementation, 0n, opts.salt ?? generators.bytes32());
+        const tx = await this.factory.$deploy(implementation, ethers.Typed.bytes32(opts.salt ?? generators.bytes32()));
         const instance = await tx
           .wait()
-          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deployDeterministic').args[0])
+          .then(receipt => receipt.logs.find(ev => ev.fragment.name === 'return$deploy_address_bytes32').args[0])
           .then(addr => new ethers.Contract(addr, [], this.admin, tx));
         if (initData !== '0x' || opts.value > 0n) {
           await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -10,8 +10,9 @@ const fixture = async () => {
 
   const factory = await ethers.deployContract('$ERC1967Clones');
   const implementation = await ethers.deployContract('DummyImplementation');
+  const erc1967 = await ethers.getContractFactory('$ERC1967Utils');
 
-  return { admin, nonContractAddress, factory, implementation };
+  return { admin, nonContractAddress, factory, erc1967, implementation };
 };
 
 describe('ERC1967Clones', function () {
@@ -27,7 +28,11 @@ describe('ERC1967Clones', function () {
           .then(nonce => ethers.getCreateAddress({ from: this.factory.target, nonce }));
         const deploymentTx = await this.factory.$deploy(implementation);
 
-        await expect(deploymentTx).to.emit(this.factory, 'return$deploy_address').withArgs(predictedAddress);
+        await expect(deploymentTx)
+          .to.emit(this.factory, 'return$deploy_address')
+          .withArgs(predictedAddress)
+          .to.emit(this.erc1967.attach(predictedAddress), 'Upgraded')
+          .withArgs(implementation);
 
         const instance = new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
         if (initData !== '0x' || opts.value > 0n) {
@@ -48,7 +53,11 @@ describe('ERC1967Clones', function () {
         const predictedAddress = await this.factory.$computeAddress(implementation, salt);
         const deploymentTx = await this.factory.$deploy(implementation, salt);
 
-        await expect(deploymentTx).to.emit(this.factory, 'return$deploy_address_bytes32').withArgs(predictedAddress);
+        await expect(deploymentTx)
+          .to.emit(this.factory, 'return$deploy_address_bytes32')
+          .withArgs(predictedAddress)
+          .to.emit(this.erc1967.attach(predictedAddress), 'Upgraded')
+          .withArgs(implementation);
 
         const instance = new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
         if (initData !== '0x' || opts.value > 0n) {

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -109,18 +109,18 @@ describe('ERC1967Clones', function () {
       );
 
       // address predicted for a deployer that is not the factory doesn't match the one predicted for the factory
-      expect(predicted).to.not.equal(
-        await this.factory.$predictDeterministicAddress(this.implementation, ethers.Typed.bytes32(salt)),
-      );
+      await expect(
+        this.factory.$predictDeterministicAddress(this.implementation, ethers.Typed.bytes32(salt)),
+      ).to.eventually.not.equal(predicted);
 
       // address predicted for a deployer that is not the factory can be predicted onchain by explicitly providing the deployer
-      expect(predicted).to.equal(
-        await this.factory.$predictDeterministicAddress(
+      await expect(
+        this.factory.$predictDeterministicAddress(
           this.implementation,
           ethers.Typed.bytes32(salt),
           ethers.Typed.address(deployer),
         ),
-      );
+      ).to.eventually.equal(predicted);
     });
 
     it('forwards value to the new clone', async function () {

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -26,10 +26,10 @@ describe('ERC1967Clones', function () {
         const predictedAddress = await ethers.provider
           .getTransactionCount(this.factory)
           .then(nonce => ethers.getCreateAddress({ from: this.factory.target, nonce }));
-        const deploymentTx = await this.factory.$deploy(implementation);
+        const deploymentTx = await this.factory.$clone(implementation);
 
         await expect(deploymentTx)
-          .to.emit(this.factory, 'return$deploy_address')
+          .to.emit(this.factory, 'return$clone_address')
           .withArgs(predictedAddress)
           .to.emit(this.erc1967.attach(predictedAddress), 'Upgraded')
           .withArgs(implementation);
@@ -44,17 +44,38 @@ describe('ERC1967Clones', function () {
     });
 
     shouldBehaveLikeProxy({ allowUninitialized: true, allowNonContractAddress: true });
+
+    it('forwards value to the new clone', async function () {
+      const value = ethers.parseEther('1');
+      await this.admin.sendTransaction({ to: this.factory, value });
+
+      const predictedAddress = await ethers.provider
+        .getTransactionCount(this.factory)
+        .then(nonce => ethers.getCreateAddress({ from: this.factory.target, nonce }));
+
+      await expect(this.factory.$clone(this.implementation, ethers.Typed.uint256(value))).to.changeEtherBalances(
+        [this.factory, predictedAddress],
+        [-value, value],
+      );
+    });
+
+    it('reverts when factory balance is below value', async function () {
+      const value = ethers.parseEther('1');
+      await expect(this.factory.$clone(this.implementation, ethers.Typed.uint256(value)))
+        .to.be.revertedWithCustomError(this.factory, 'InsufficientBalance')
+        .withArgs(0n, value);
+    });
   });
 
   describe('deterministic deployment (create2)', function () {
     before(function () {
       this.createProxy = async (implementation, initData, opts = {}) => {
         const salt = ethers.Typed.bytes32(opts.salt ?? generators.bytes32());
-        const predictedAddress = await this.factory.$computeAddress(implementation, salt);
-        const deploymentTx = await this.factory.$deploy(implementation, salt);
+        const predictedAddress = await this.factory.$predictDeterministicAddress(implementation, salt);
+        const deploymentTx = await this.factory.$cloneDeterministic(implementation, salt);
 
         await expect(deploymentTx)
-          .to.emit(this.factory, 'return$deploy_address_bytes32')
+          .to.emit(this.factory, 'return$cloneDeterministic_address_bytes32')
           .withArgs(predictedAddress)
           .to.emit(this.erc1967.attach(predictedAddress), 'Upgraded')
           .withArgs(implementation);
@@ -69,5 +90,59 @@ describe('ERC1967Clones', function () {
     });
 
     shouldBehaveLikeProxy({ allowUninitialized: true, allowNonContractAddress: true });
+
+    it('reverts when the same implementation and salt are reused', async function () {
+      const salt = generators.bytes32();
+      await expect(this.factory.$cloneDeterministic(this.implementation, salt)).to.not.be.reverted;
+      await expect(this.factory.$cloneDeterministic(this.implementation, salt)).to.be.revertedWithCustomError(
+        this.factory,
+        'FailedDeployment',
+      );
+    });
+
+    it('predicts addresses for an arbitrary deployer', async function () {
+      const salt = generators.bytes32();
+      const deployer = ethers.Wallet.createRandom().address;
+      const predicted = await this.factory.$predictDeterministicAddress(
+        this.implementation,
+        ethers.Typed.bytes32(salt),
+        ethers.Typed.address(deployer),
+      );
+
+      const expected = await this.factory.$predictDeterministicAddress(this.implementation, ethers.Typed.bytes32(salt));
+      expect(predicted).to.not.equal(expected);
+      expect(predicted).to.equal(
+        await this.factory.$predictDeterministicAddress(
+          this.implementation,
+          ethers.Typed.bytes32(salt),
+          ethers.Typed.address(deployer),
+        ),
+      );
+    });
+
+    it('forwards value to the new clone', async function () {
+      const value = ethers.parseEther('1');
+      await this.admin.sendTransaction({ to: this.factory, value });
+
+      const salt = generators.bytes32();
+      const predictedAddress = await this.factory.$predictDeterministicAddress(
+        this.implementation,
+        ethers.Typed.bytes32(salt),
+      );
+
+      await expect(
+        this.factory.$cloneDeterministic(this.implementation, ethers.Typed.bytes32(salt), ethers.Typed.uint256(value)),
+      ).to.changeEtherBalances([this.factory, predictedAddress], [-value, value]);
+    });
+
+    it('reverts when factory balance is below value', async function () {
+      const value = ethers.parseEther('1');
+      const salt = generators.bytes32();
+      await expect(
+        this.factory.$cloneDeterministic(this.implementation, ethers.Typed.bytes32(salt), ethers.Typed.uint256(value)),
+      )
+        .to.be.revertedWithCustomError(this.factory, 'InsufficientBalance')
+        .withArgs(0n, value);
+    });
   });
 });

--- a/test/proxy/ERC1967/ERC1967Clones.test.js
+++ b/test/proxy/ERC1967/ERC1967Clones.test.js
@@ -34,12 +34,11 @@ describe('ERC1967Clones', function () {
           .to.emit(this.erc1967.attach(predictedAddress), 'Upgraded')
           .withArgs(implementation);
 
-        const instance = new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
         if (initData !== '0x' || opts.value > 0n) {
-          await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
+          await this.admin.sendTransaction({ to: predictedAddress, data: initData, ...opts });
         }
 
-        return instance;
+        return new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
       };
     });
 
@@ -80,12 +79,11 @@ describe('ERC1967Clones', function () {
           .to.emit(this.erc1967.attach(predictedAddress), 'Upgraded')
           .withArgs(implementation);
 
-        const instance = new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
         if (initData !== '0x' || opts.value > 0n) {
-          await this.admin.sendTransaction({ to: instance.target, data: initData, ...opts });
+          await this.admin.sendTransaction({ to: predictedAddress, data: initData, ...opts });
         }
 
-        return instance;
+        return new ethers.Contract(predictedAddress, [], this.admin, deploymentTx);
       };
     });
 
@@ -102,15 +100,20 @@ describe('ERC1967Clones', function () {
 
     it('predicts addresses for an arbitrary deployer', async function () {
       const salt = generators.bytes32();
-      const deployer = ethers.Wallet.createRandom().address;
+      const deployer = generators.address();
+
       const predicted = await this.factory.$predictDeterministicAddress(
         this.implementation,
         ethers.Typed.bytes32(salt),
         ethers.Typed.address(deployer),
       );
 
-      const expected = await this.factory.$predictDeterministicAddress(this.implementation, ethers.Typed.bytes32(salt));
-      expect(predicted).to.not.equal(expected);
+      // address predicted for a deployer that is not the factory doesn't match the one predicted for the factory
+      expect(predicted).to.not.equal(
+        await this.factory.$predictDeterministicAddress(this.implementation, ethers.Typed.bytes32(salt)),
+      );
+
+      // address predicted for a deployer that is not the factory can be predicted onchain by explicitly providing the deployer
       expect(predicted).to.equal(
         await this.factory.$predictDeterministicAddress(
           this.implementation,

--- a/test/proxy/ERC1967/ERC1967Proxy.test.js
+++ b/test/proxy/ERC1967/ERC1967Proxy.test.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const shouldBehaveLikeProxy = require('../Proxy.behaviour');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const fixture = async () => {
   const [nonContractAddress] = await ethers.getSigners();
@@ -22,7 +22,7 @@ describe('ERC1967Proxy', function () {
         ethers.deployContract('ERC1967Proxy', [implementation, initData], opts);
     });
 
-    shouldBehaveLikeProxy(false);
+    shouldBehaveLikeProxy({ allowUninitialized: false });
   });
 
   describe('(unsafe) allowUninitialized is true', function () {
@@ -31,6 +31,6 @@ describe('ERC1967Proxy', function () {
         ethers.deployContract('ERC1967ProxyUnsafe', [implementation, initData], opts);
     });
 
-    shouldBehaveLikeProxy(true);
+    shouldBehaveLikeProxy({ allowUninitialized: true });
   });
 });

--- a/test/proxy/Proxy.behaviour.js
+++ b/test/proxy/Proxy.behaviour.js
@@ -3,15 +3,17 @@ const { expect } = require('chai');
 
 const { getAddressInSlot, ImplementationSlot } = require('../helpers/storage');
 
-module.exports = function shouldBehaveLikeProxy(allowUninitialized = false) {
-  it('cannot be initialized with a non-contract address', async function () {
-    const initializeData = '0x00'; // non empty data to avoid uninitialized error
-    const contractFactory = await ethers.getContractFactory('ERC1967Proxy');
+module.exports = function shouldBehaveLikeProxy({ allowUninitialized = false, allowNonContractAddress = false }) {
+  if (!allowNonContractAddress) {
+    it('cannot be initialized with a non-contract address', async function () {
+      const initializeData = '0x00'; // non empty data to avoid uninitialized error
+      const contractFactory = await ethers.getContractFactory('ERC1967Proxy');
 
-    await expect(this.createProxy(this.nonContractAddress, initializeData))
-      .to.be.revertedWithCustomError(contractFactory, 'ERC1967InvalidImplementation')
-      .withArgs(this.nonContractAddress);
-  });
+      await expect(this.createProxy(this.nonContractAddress, initializeData))
+        .to.be.revertedWithCustomError(contractFactory, 'ERC1967InvalidImplementation')
+        .withArgs(this.nonContractAddress);
+    });
+  }
 
   const assertProxyInitialization = function ({ value, balance }) {
     it('sets the implementation address', async function () {

--- a/test/proxy/Proxy.behaviour.js
+++ b/test/proxy/Proxy.behaviour.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 
 const { getAddressInSlot, ImplementationSlot } = require('../helpers/storage');
 
-module.exports = function shouldBehaveLikeProxy({ allowUninitialized = false, allowNonContractAddress = false }) {
+module.exports = function shouldBehaveLikeProxy({ allowUninitialized = false, allowNonContractAddress = false } = {}) {
   if (!allowNonContractAddress) {
     it('cannot be initialized with a non-contract address', async function () {
       const initializeData = '0x00'; // non empty data to avoid uninitialized error


### PR DESCRIPTION
These minimal proxy differ from the "normal" ERC1967Proxy:
- no initdata is provided at construction. Factory that uses the ERC1967Clones library must initialize manually.
- construction doesn't revert if implementation has no code.
- ~~Upgrade(address) event is not emitted at construction~~ (fixed)

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
