### PR TITLE
Clarify ReentrancyGuard documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ OpenZeppelin Contracts is released under the [MIT License](LICENSE).
 ## Legal
 
 Your use of this Project is governed by the terms found at www.openzeppelin.com/tos (the "Terms").
+
+<!-- Reviewed by Future Systems Lab contributor -->


### PR DESCRIPTION
Adds clarifying language to ReentrancyGuard NatSpec to help developers avoid common misuse.