### PR TITLE
Return empty bytes (instead of the revert data) for calls that fails in the EXEC_TYPE_TRY mode.

### DIFF
--- a/contracts/account/utils/draft-ERC7579Utils.sol
+++ b/contracts/account/utils/draft-ERC7579Utils.sol
@@ -243,13 +243,17 @@ library ERC7579Utils {
         bytes memory returndata
     ) private returns (bytes memory) {
         if (execType == ERC7579Utils.EXECTYPE_DEFAULT) {
-            Address.verifyCallResult(success, returndata);
+            return Address.verifyCallResult(success, returndata);
         } else if (execType == ERC7579Utils.EXECTYPE_TRY) {
-            if (!success) emit ERC7579TryExecuteFail(index, returndata);
+            if (success) {
+                return returndata;
+            } else {
+                emit ERC7579TryExecuteFail(index, returndata);
+                return new bytes(0);
+            }
         } else {
             revert ERC7579UnsupportedExecType(execType);
         }
-        return returndata;
     }
 }
 

--- a/test/account/utils/draft-ERC7579Utils.test.js
+++ b/test/account/utils/draft-ERC7579Utils.test.js
@@ -102,7 +102,9 @@ describe('ERC7579Utils', function () {
             ['bytes4', 'bytes'],
             [selector('Error(string)'), coder.encode(['string'], ['CallReceiverMock: reverting'])],
           ),
-        );
+        )
+        .to.emit(this.utils, 'return$execSingle')
+        .withArgs(['0x']); // Check that the return data is empty for the failing call
     });
 
     it('reverts with an invalid exec type', async function () {
@@ -190,7 +192,12 @@ describe('ERC7579Utils', function () {
             ['bytes4', 'bytes'],
             [selector('Error(string)'), coder.encode(['string'], ['CallReceiverMock: reverting'])],
           ),
-        );
+        )
+        .to.emit(this.utils, 'return$execBatch')
+        .withArgs([
+          this.target.interface.encodeFunctionResult('mockFunction', ['0x1234']),
+          '0x', // Check that the return data is empty for the failing call
+        ]);
 
       // Check balances
       await expect(ethers.provider.getBalance(this.target)).to.eventually.equal(value1);
@@ -253,7 +260,9 @@ describe('ERC7579Utils', function () {
             ['bytes4', 'bytes'],
             [selector('Error(string)'), coder.encode(['string'], ['CallReceiverMock: reverting'])],
           ),
-        );
+        )
+        .to.emit(this.utils, 'return$execDelegateCall')
+        .withArgs(['0x']); // Check that the return data is empty for the failing call
     });
 
     it('reverts with an invalid exec type', async function () {


### PR DESCRIPTION
Fixes L-38

Check alternative #6420

> ERC-7579 execution results are surfaced to executor modules through [executeFromExecutor](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fd1781b1454fd1ef8e722282f86f9293cacf256/contracts/interfaces/draft-IERC7579.sol#L137-L140), which returns bytes[] memory returnData. AccountERC7579 forwards execution to ERC7579Utils through its internal [_execute](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fd1781b1454fd1ef8e722282f86f9293cacf256/contracts/account/extensions/draft-AccountERC7579.sol#L228-L237), which performs the low-level call in [_call](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fd1781b1454fd1ef8e722282f86f9293cacf256/contracts/account/utils/draft-ERC7579Utils.sol#L213-L225) and validates the mode in [_validateExecutionMode](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fd1781b1454fd1ef8e722282f86f9293cacf256/contracts/account/utils/draft-ERC7579Utils.sol#L238-L253).
> 
> In TRY mode, _validateExecutionMode emits [ERC7579TryExecuteFail](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fd1781b1454fd1ef8e722282f86f9293cacf256/contracts/account/utils/draft-ERC7579Utils.sol#L41-L46) when success == false but always returns the raw returndata (line [252](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fd1781b1454fd1ef8e722282f86f9293cacf256/contracts/account/utils/draft-ERC7579Utils.sol#L252)). Since contracts cannot read events during execution, on-chain executor modules cannot reliably distinguish successful return values from revert payloads. Revert data is controlled by the callee and can be crafted to decode into plausible values under an expected return schema, creating logic confusion when modules branch on TRY-mode returnData.
> 
> Consider returning an explicit per-call success signal (for example, a parallel bool[], or encoding each element as abi.encode(success, returndata)), or clearly documenting that TRY-mode returnData must not be used for on-chain branching and is only suitable for off-chain inspection.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
