### PR TITLE
feat: add eslint-plugin-mocha no-async-describe rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
 import { includeIgnoreFile } from '@eslint/compat';
+import mocha from 'eslint-plugin-mocha';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 import path from 'path';
@@ -10,6 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default [
   js.configs.recommended,
   prettier,
+  mocha.configs.flat.recommended,
   {
     languageOptions: {
       ecmaVersion: 2022,
@@ -23,6 +25,9 @@ export default [
         extendEnvironment: 'readonly',
         expect: 'readonly',
       },
+    },
+    rules: {
+      'mocha/no-async-describe': 'error',
     },
   },
   includeIgnoreFile(path.resolve(__dirname, '.gitignore')),


### PR DESCRIPTION
## Summary

Adds the `no-async-describe` ESLint rule from `eslint-plugin-mocha` to catch async functions in describe blocks.

## Motivation

Async describe blocks are a common source of test bugs — they silently pass even when assertions fail. This rule prevents that class of errors.

As suggested by @fvictorio in #4942.

Closes #4943