### PR TITLE
Document that `ReentrancyGuardTransient` and `ReentrancyGuard` are not interoperable

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -20,7 +20,7 @@ import {StorageSlot} from "./StorageSlot.sol";
  * TIP: If EIP-1153 (transient storage) is available on the chain you're deploying at,
  * consider using {ReentrancyGuardTransient} instead.
  *
- * NOTE: `ReentrancyGuard` and {ReentrancyGuardTransient} are not interoperable. Since
+ * NOTE: {ReentrancyGuard} and {ReentrancyGuardTransient} are not interoperable. Since
  * each tracks reentrancy state independently, a `nonReentrant` function from one will not
  * prevent reentrant calls to a `nonReentrant` function from the other.
  *

--- a/contracts/utils/ReentrancyGuardTransient.sol
+++ b/contracts/utils/ReentrancyGuardTransient.sol
@@ -10,7 +10,7 @@ import {TransientSlot} from "./TransientSlot.sol";
  *
  * NOTE: This variant only works on networks where EIP-1153 is available.
  *
- * NOTE: `ReentrancyGuardTransient` and {ReentrancyGuard} are not interoperable. Since
+ * NOTE: {ReentrancyGuardTransient} and {ReentrancyGuard} are not interoperable. Since
  * each tracks reentrancy state independently, a `nonReentrant` function from one will not
  * prevent reentrant calls to a `nonReentrant` function from the other.
  *


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Document that `ReentrancyGuard` and `ReentrancyGuardTransient` are not interoperable.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
