### PR TITLE
L-52: `ERC1155Burnable`: use `_checkAuthorized` to correctly apply authorization overrides

### DIFF
--- a/.changeset/heavy-pots-reply.md
+++ b/.changeset/heavy-pots-reply.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC1155Burnable`: use `_checkAuthorized` to correctly apply authorization overrides

--- a/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
@@ -11,18 +11,12 @@ import {ERC1155} from "../ERC1155.sol";
  */
 abstract contract ERC1155Burnable is ERC1155 {
     function burn(address account, uint256 id, uint256 value) public virtual {
-        if (account != _msgSender() && !isApprovedForAll(account, _msgSender())) {
-            revert ERC1155MissingApprovalForAll(_msgSender(), account);
-        }
-
+        _checkAuthorized(_msgSender(), account);
         _burn(account, id, value);
     }
 
     function burnBatch(address account, uint256[] memory ids, uint256[] memory values) public virtual {
-        if (account != _msgSender() && !isApprovedForAll(account, _msgSender())) {
-            revert ERC1155MissingApprovalForAll(_msgSender(), account);
-        }
-
+        _checkAuthorized(_msgSender(), account);
         _burnBatch(account, ids, values);
     }
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
