### PR TITLE
Add Foundry fuzz tests for Strings.escapeJSON

### DIFF
--- a/.changeset/quiet-moons-teach.md
+++ b/.changeset/quiet-moons-teach.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Add Foundry fuzz tests for `Strings.escapeJSON`.

--- a/test/utils/Strings.t.sol
+++ b/test/utils/Strings.t.sol
@@ -47,4 +47,45 @@ contract StringsTest is Test {
         (bool success, ) = input.tryParseAddress(begin, begin + 40);
         assertFalse(success);
     }
+
+    function testEscapeJSONLength(string memory input) external pure {
+        assertGe(bytes(input.escapeJSON()).length, bytes(input).length);
+    }
+
+    // Validates the output of escapeJSON is well-formed JSON string content:
+    // - no unescaped control characters (U+0000 to U+001F)
+    // - no unescaped double quotes
+    // - every backslash begins a valid escape sequence (\b \t \n \f \r \\ \" or \u00XX)
+    function testEscapeJSON(string memory input) external pure {
+        bytes memory escaped = bytes(input.escapeJSON());
+
+        for (uint256 i = 0; i < escaped.length; i++) {
+            uint8 c = uint8(escaped[i]);
+            assertGe(c, 0x20);
+
+            if (c == 0x5c) {
+                assertLt(i + 1, escaped.length);
+                uint8 next = uint8(escaped[++i]);
+                if (next == 0x75) {
+                    // \u00XX
+                    assertLt(i + 4, escaped.length);
+                    assertEq(uint8(escaped[i + 1]), 0x30);
+                    assertEq(uint8(escaped[i + 2]), 0x30);
+                    i += 4;
+                } else {
+                    assertTrue(
+                        next == 0x62 || // \b
+                        next == 0x74 || // \t
+                        next == 0x6e || // \n
+                        next == 0x66 || // \f
+                        next == 0x72 || // \r
+                        next == 0x5c || // \\
+                        next == 0x22    // \"
+                    );
+                }
+            } else {
+                assertTrue(c != 0x22);
+            }
+        }
+    }
 }

--- a/test/utils/Strings.t.sol
+++ b/test/utils/Strings.t.sol
@@ -73,22 +73,18 @@ contract StringsTest is Test {
                     assertEq(uint8(escaped[i + 2]), 0x30);
                     uint8 hi = uint8(escaped[i + 3]);
                     uint8 lo = uint8(escaped[i + 4]);
-                    assertTrue(
-                        (hi >= 0x30 && hi <= 0x39) || (hi >= 0x41 && hi <= 0x46) || (hi >= 0x61 && hi <= 0x66)
-                    );
-                    assertTrue(
-                        (lo >= 0x30 && lo <= 0x39) || (lo >= 0x41 && lo <= 0x46) || (lo >= 0x61 && lo <= 0x66)
-                    );
+                    assertTrue((hi >= 0x30 && hi <= 0x39) || (hi >= 0x41 && hi <= 0x46) || (hi >= 0x61 && hi <= 0x66));
+                    assertTrue((lo >= 0x30 && lo <= 0x39) || (lo >= 0x41 && lo <= 0x46) || (lo >= 0x61 && lo <= 0x66));
                     i += 4;
                 } else {
                     assertTrue(
                         next == 0x62 || // \b
-                        next == 0x74 || // \t
-                        next == 0x6e || // \n
-                        next == 0x66 || // \f
-                        next == 0x72 || // \r
-                        next == 0x5c || // \\
-                        next == 0x22    // \"
+                            next == 0x74 || // \t
+                            next == 0x6e || // \n
+                            next == 0x66 || // \f
+                            next == 0x72 || // \r
+                            next == 0x5c || // \\
+                            next == 0x22 // \"
                     );
                 }
             } else {

--- a/test/utils/Strings.t.sol
+++ b/test/utils/Strings.t.sol
@@ -71,6 +71,14 @@ contract StringsTest is Test {
                     assertLt(i + 4, escaped.length);
                     assertEq(uint8(escaped[i + 1]), 0x30);
                     assertEq(uint8(escaped[i + 2]), 0x30);
+                    uint8 hi = uint8(escaped[i + 3]);
+                    uint8 lo = uint8(escaped[i + 4]);
+                    assertTrue(
+                        (hi >= 0x30 && hi <= 0x39) || (hi >= 0x41 && hi <= 0x46) || (hi >= 0x61 && hi <= 0x66)
+                    );
+                    assertTrue(
+                        (lo >= 0x30 && lo <= 0x39) || (lo >= 0x41 && lo <= 0x46) || (lo >= 0x61 && lo <= 0x66)
+                    );
                     i += 4;
                 } else {
                     assertTrue(


### PR DESCRIPTION
The Foundry test file for Strings has fuzz tests for the parse/toString functions but nothing for escapeJSON. Given that escapeJSON was recently changed (#6344) and does nontrivial bit manipulation with raw memory writes, it seems like a good candidate for property-based testing.

I added two fuzz tests. The first one just checks that escaping never shrinks the string. The second one is the interesting one, it walks the output and checks that it's actually valid JSON string content: no raw control chars leaked through, no bare double quotes, and every backslash is the start of a real escape sequence (\b \t \n \f \r \\ \" or \u00XX). Both pass with 5k runs.