### PR TITLE
Optimize _quickSort with median-of-three pivot selection

### DIFF
--- a/.changeset/quicksort-median-pivot.md
+++ b/.changeset/quicksort-median-pivot.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`Arrays`: Optimize `_quickSort` with median-of-three pivot selection to avoid worst-case O(n²) behavior on already-sorted inputs.

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -116,7 +116,18 @@ library Arrays {
         unchecked {
             if (end - begin < 0x40) return;
 
-            // Use first element as pivot
+            // Median-of-three pivot selection: pick the first, middle, and last elements, sort them,
+            // then use the middle value as pivot. This avoids worst-case O(n²) behavior on sorted inputs.
+            uint256 mid = begin + (((end - begin) >> 1) & ~uint256(0x1f));
+            if (comp(_mload(mid), _mload(begin))) _swap(begin, mid);
+            if (end - begin > 0x40) {
+                uint256 last = end - 0x20;
+                if (comp(_mload(last), _mload(begin))) _swap(begin, last);
+                if (comp(_mload(last), _mload(mid))) _swap(mid, last);
+                _swap(begin, mid); // Put median at begin to use as pivot
+            }
+
+            // Use first element (now the median of first/middle/last) as pivot
             uint256 pivot = _mload(begin);
             // Position where the pivot should be at the end of the loop
             uint256 pos = begin;

--- a/scripts/generate/templates/Arrays.js
+++ b/scripts/generate/templates/Arrays.js
@@ -64,7 +64,18 @@ function _quickSort(uint256 begin, uint256 end, function(uint256, uint256) pure 
     unchecked {
         if (end - begin < 0x40) return;
 
-        // Use first element as pivot
+        // Median-of-three pivot selection: pick the first, middle, and last elements, sort them,
+        // then use the middle value as pivot. This avoids worst-case O(n²) behavior on sorted inputs.
+        uint256 mid = begin + (((end - begin) >> 1) & ~uint256(0x1f));
+        if (comp(_mload(mid), _mload(begin))) _swap(begin, mid);
+        if (end - begin > 0x40) {
+            uint256 last = end - 0x20;
+            if (comp(_mload(last), _mload(begin))) _swap(begin, last);
+            if (comp(_mload(last), _mload(mid))) _swap(mid, last);
+            _swap(begin, mid); // Put median at begin to use as pivot
+        }
+
+        // Use first element (now the median of first/middle/last) as pivot
         uint256 pivot = _mload(begin);
         // Position where the pivot should be at the end of the loop
         uint256 pos = begin;


### PR DESCRIPTION
Using the first element as pivot degrades to O(n²) on already-sorted inputs, which is the most common real-world case. Switch to median-of- three selection (first, middle, last) to guarantee a balanced split on sorted inputs and avoid worst-case behavior.

For arrays of exactly 2 elements the middle and last pointers coincide, so the full three-way selection is skipped and a single comparison sorts them directly.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
Using the first element as pivot degrades to O(n²) on already-sorted inputs, which is the most common real-world case. Switch to median-of-three selection (first, middle, last) to guarantee a balanced split on sorted inputs and avoid worst-case behavior.

For arrays of exactly 2 elements the middle and last pointers coincide, so the full three-way selection is skipped and a single comparison sorts them directly.

Fixes #6289

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ x] Tests
- [ ] Documentation
- [ x] Changeset entry (run `npx changeset add`)
