### PR TITLE
Prevent proposals with duplicate actions in GovernorTimelockCompound

### DIFF
--- a/.changeset/governor-timelock-duplicate-actions.md
+++ b/.changeset/governor-timelock-duplicate-actions.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`GovernorTimelockCompound`: Reject proposals containing duplicate actions at submission time with a new `GovernorTimelockCompoundDuplicateProposalAction` error, instead of failing at queue time.

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -19,6 +19,13 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * inaccessible from a proposal, unless executed via {Governor-relay}.
  */
 abstract contract GovernorTimelockCompound is Governor {
+    /**
+     * @dev A proposal contains a duplicate action (same target, value, and calldata). The Compound Timelock identifies
+     * each queued transaction by its `(target, value, calldata, eta)` hash, so duplicate actions within a single
+     * proposal would collide and cannot both be queued.
+     */
+    error GovernorTimelockCompoundDuplicateProposalAction(uint256 index);
+
     ICompoundTimelock private _timelock;
 
     /**
@@ -56,6 +63,38 @@ abstract contract GovernorTimelockCompound is Governor {
     /// @inheritdoc IGovernor
     function proposalNeedsQueuing(uint256) public view virtual override returns (bool) {
         return true;
+    }
+
+    /**
+     * @dev Overridden version of {Governor-_propose} that rejects proposals containing duplicate actions.
+     *
+     * The Compound Timelock identifies each queued transaction by the hash of its `(target, value, calldata, eta)`
+     * parameters. Two identical actions in the same proposal would produce the same hash and collide when queuing,
+     * so such proposals are rejected at submission time.
+     */
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal virtual override returns (uint256) {
+        if (targets.length != values.length || targets.length != calldatas.length) {
+            return super._propose(targets, values, calldatas, description, proposer);
+        }
+
+        for (uint256 i = 0; i < targets.length; ++i) {
+            for (uint256 j = i + 1; j < targets.length; ++j) {
+                if (
+                    targets[i] == targets[j] &&
+                    values[i] == values[j] &&
+                    keccak256(calldatas[i]) == keccak256(calldatas[j])
+                ) {
+                    revert GovernorTimelockCompoundDuplicateProposalAction(i);
+                }
+            }
+        }
+        return super._propose(targets, values, calldatas, description, proposer);
     }
 
     /**

--- a/contracts/mocks/governance/GovernorTimelockCompoundMock.sol
+++ b/contracts/mocks/governance/GovernorTimelockCompoundMock.sol
@@ -66,4 +66,14 @@ abstract contract GovernorTimelockCompoundMock is
     function _executor() internal view override(Governor, GovernorTimelockCompound) returns (address) {
         return super._executor();
     }
+
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal override(Governor, GovernorTimelockCompound) returns (uint256) {
+        return super._propose(targets, values, calldatas, description, proposer);
+    }
 }

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -146,18 +146,26 @@ describe('GovernorTimelockCompound', function () {
               target: this.token.target,
               data: this.token.interface.encodeFunctionData('approve', [this.receiver.target, ethers.MaxUint256]),
             };
-            const { id } = this.helper.setProposal([action, action], '<proposal description>');
+            this.helper.setProposal([action, action], '<proposal description>');
 
-            await this.helper.propose();
-            await this.helper.waitForSnapshot();
-            await this.helper.connect(this.voter1).vote({ support: VoteType.For });
-            await this.helper.waitForDeadline();
-            await expect(this.helper.queue())
-              .to.be.revertedWithCustomError(this.mock, 'GovernorAlreadyQueuedProposal')
-              .withArgs(id);
-            await expect(this.helper.execute())
-              .to.be.revertedWithCustomError(this.mock, 'GovernorUnexpectedProposalState')
-              .withArgs(id, ProposalState.Succeeded, GovernorHelper.proposalStatesToBitMap([ProposalState.Queued]));
+            await expect(this.helper.propose())
+              .to.be.revertedWithCustomError(this.mock, 'GovernorTimelockCompoundDuplicateProposalAction')
+              .withArgs(0n);
+          });
+        });
+
+        describe('on propose', function () {
+          it('if proposal has mismatched array lengths', async function () {
+            await expect(
+              this.mock.propose(
+                [this.receiver.target, this.receiver.target],
+                [0n],
+                [this.receiver.interface.encodeFunctionData('mockFunction')],
+                '<proposal description>',
+              ),
+            )
+              .to.be.revertedWithCustomError(this.mock, 'GovernorInvalidProposalLength')
+              .withArgs(2, 1, 1);
           });
         });
 


### PR DESCRIPTION
The Compound Timelock queues each proposal action as a separate transaction identified by keccak256(target, value, calldata, eta). Two identical actions in the same proposal produce the same hash and the second queue call reverts, leaving the proposal stuck.

Override _propose to detect duplicate (target, value, calldata) tuples and revert with GovernorTimelockCompoundDuplicateProposalAction before the proposal is stored, rather than failing silently at queue time.

Fixes #6431

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
