### PR TITLE
docs: link ERC-1155 metadata schema to canonical EIP page

### DIFF
--- a/docs/modules/ROOT/pages/erc1155.adoc
+++ b/docs/modules/ROOT/pages/erc1155.adoc
@@ -90,7 +90,7 @@ The JSON document for token ID 2 might look something like:
 }
 ----
 
-For more information about the metadata JSON Schema, check out the https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1155.md#erc-1155-metadata-uri-json-schema[ERC-1155 Metadata URI JSON Schema].
+For more information about the metadata JSON Schema, check out the https://eips.ethereum.org/EIPS/eip-1155[ERC-1155 Metadata URI JSON Schema].
 
 NOTE: You'll notice that the item's information is included in the metadata, but that information isn't on-chain! So a game developer could change the underlying metadata, changing the rules of the game!
 


### PR DESCRIPTION
This updates the ERC-1155 metadata schema reference to the canonical EIP page instead of the GitHub master blob URL.

No code behavior changes.