### PR TITLE
docs: add migration guide for AccessControlDefaultAdminRules

### DIFF
--- a/docs/modules/ROOT/pages/access-control.adoc
+++ b/docs/modules/ROOT/pages/access-control.adoc
@@ -87,6 +87,24 @@ Note that, unlike the previous examples, no accounts are granted the 'minter' or
 
 Dynamic role allocation is often a desirable property, for example in systems where trust in a participant may vary over time. It can also be used to support use cases such as https://en.wikipedia.org/wiki/Know_your_customer[KYC], where the list of role-bearers may not be known up-front, or may be prohibitively expensive to include in a single transaction.
 
+[[migrating-to-access-control-default-admin-rules]]
+=== Migrating to `AccessControlDefaultAdminRules`
+
+If you are starting a new project or modifying un-deployed contracts, deploying with `AccessControlDefaultAdminRules` instead of `AccessControl` is highly recommended. It mitigates the risk of a single point of failure by adding built-in protections such as a two-step transfer process and delays for the `DEFAULT_ADMIN_ROLE`.
+
+To migrate, replace `AccessControl` with `AccessControlDefaultAdminRules` and update your constructor to set the initial delay and initial default admin:
+
+[source,solidity]
+----
+import {AccessControlDefaultAdminRules} from "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
+
+contract SecureAccess is AccessControlDefaultAdminRules {
+    constructor() AccessControlDefaultAdminRules(3 days, msg.sender) {}
+}
+----
+
+NOTE: Because `AccessControlDefaultAdminRules` relies on inheritance and a custom constructor, it cannot be added retroactively to an already-deployed, non-upgradeable contract. If you need to secure the `DEFAULT_ADMIN_ROLE` of an existing contract, consider transferring the role to a secure governance contract such as a xref:api:governance.adoc#TimelockController[`TimelockController`], a multisig, or migrating to xref:api:access.adoc#AccessManager[`AccessManager`].
+
 [[querying-privileged-accounts]]
 === Querying Privileged Accounts
 


### PR DESCRIPTION
Resolves an audit finding suggesting more prominent documentation and migration guides for existing contracts regarding the use of AccessControlDefaultAdminRules to secure DEFAULT_ADMIN_ROLE.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #6413 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
### Changes Introduced
- Added a `Migrating to AccessControlDefaultAdminRules` section to `docs/modules/ROOT/pages/access-control.adoc`.
- Clarified that `AccessControlDefaultAdminRules` requires inheritance and provided an example on how to migrate for new or un-deployed contracts.
- Added a warning explicitly advising already-deployed contracts against attempting retroactive additions, and pointing them instead to `AccessManager` or `TimelockController`.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
