### PR TITLE
Use IERC20 as input type in tryGetDecimals

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -42,7 +42,7 @@ abstract contract ERC20Wrapper is ERC20 {
      * storage, it should also override this function and use a conditional ternary instead.
      */
     function decimals() public view virtual override returns (uint8) {
-        (bool success, uint8 decimals_) = SafeERC20.tryGetDecimals(address(_underlying));
+        (bool success, uint8 decimals_) = SafeERC20.tryGetDecimals(_underlying);
         return uint8(Math.ternary(success, decimals_, super.decimals())); // Safe cast. Both are uint8.
     }
 

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -97,7 +97,7 @@ abstract contract ERC4626 is ERC20, IERC4626 {
      * @dev Set the underlying asset contract. This must be an ERC20-compatible contract (ERC-20 or ERC-777).
      */
     constructor(IERC20 asset_) {
-        (bool success, uint8 assetDecimals) = SafeERC20.tryGetDecimals(address(asset_));
+        (bool success, uint8 assetDecimals) = SafeERC20.tryGetDecimals(asset_);
         _underlyingDecimals = success ? assetDecimals : 18;
         _asset = asset_;
     }

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -166,7 +166,7 @@ library SafeERC20 {
     }
 
     /// @dev Attempts to fetch the token decimals. A return value of false indicates that the attempt failed in some way.
-    function tryGetDecimals(address token) internal view returns (bool success, uint8 decimals) {
+    function tryGetDecimals(IERC20 token) internal view returns (bool success, uint8 decimals) {
         bytes4 selector = IERC20Metadata.decimals.selector;
         assembly ("memory-safe") {
             mstore(0x00, selector)


### PR DESCRIPTION
All other functions SafeERC20 takes their input as IERC20 or IERC1363. I believe tryGetDecimals should also take a contract type. Could be IERC20 or IERC20Metadata.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
