### PR TITLE
test: cover ERC1155Burnable authorization overrides

### DIFF
--- a/contracts/mocks/token/ERC1155BurnableOverrideMock.sol
+++ b/contracts/mocks/token/ERC1155BurnableOverrideMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC1155} from "../../token/ERC1155/ERC1155.sol";
+import {ERC1155Burnable} from "../../token/ERC1155/extensions/ERC1155Burnable.sol";
+
+contract ERC1155BurnableOverrideMock is ERC1155Burnable {
+    address private immutable _forcedOperator;
+
+    constructor(string memory uri_, address forcedOperator) ERC1155(uri_) {
+        _forcedOperator = forcedOperator;
+    }
+
+    function mint(address account, uint256 id, uint256 value, bytes memory data) external {
+        _mint(account, id, value, data);
+    }
+
+    function _checkAuthorized(address operator, address owner) internal view virtual override {
+        if (operator != _forcedOperator) {
+            revert ERC1155MissingApprovalForAll(operator, owner);
+        }
+    }
+}

--- a/test/token/ERC1155/extensions/ERC1155Burnable.test.js
+++ b/test/token/ERC1155/extensions/ERC1155Burnable.test.js
@@ -15,6 +15,19 @@ async function fixture() {
   return { token, holder, operator, other };
 }
 
+async function overrideFixture() {
+  const [holder, operator, other] = await ethers.getSigners();
+
+  const token = await ethers.deployContract('ERC1155BurnableOverrideMock', [
+    'https://token-cdn-domain/{id}.json',
+    operator,
+  ]);
+  await token.mint(holder, ids[0], values[0], '0x');
+  await token.mint(holder, ids[1], values[1], '0x');
+
+  return { token, holder, operator, other };
+}
+
 describe('ERC1155Burnable', function () {
   beforeEach(async function () {
     Object.assign(this, await loadFixture(fixture));
@@ -62,5 +75,31 @@ describe('ERC1155Burnable', function () {
         .to.be.revertedWithCustomError(this.token, 'ERC1155MissingApprovalForAll')
         .withArgs(this.other, this.holder);
     });
+  });
+});
+
+
+describe('ERC1155Burnable with overridden authorization', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(overrideFixture));
+  });
+
+  it('burn respects overridden _checkAuthorized semantics', async function () {
+    await expect(this.token.connect(this.holder).burn(this.holder, ids[0], values[0] - 1n))
+      .to.be.revertedWithCustomError(this.token, 'ERC1155MissingApprovalForAll')
+      .withArgs(this.holder, this.holder);
+
+    await this.token.connect(this.operator).burn(this.holder, ids[0], values[0] - 1n);
+    expect(await this.token.balanceOf(this.holder, ids[0])).to.equal(1n);
+  });
+
+  it('burnBatch respects overridden _checkAuthorized semantics', async function () {
+    await expect(this.token.connect(this.holder).burnBatch(this.holder, ids, [values[0] - 1n, values[1] - 2n]))
+      .to.be.revertedWithCustomError(this.token, 'ERC1155MissingApprovalForAll')
+      .withArgs(this.holder, this.holder);
+
+    await this.token.connect(this.operator).burnBatch(this.holder, ids, [values[0] - 1n, values[1] - 2n]);
+    expect(await this.token.balanceOf(this.holder, ids[0])).to.equal(1n);
+    expect(await this.token.balanceOf(this.holder, ids[1])).to.equal(2n);
   });
 });


### PR DESCRIPTION
Adds regression coverage to ensure ERC1155Burnable uses the overridable _checkAuthorized hook for both burn and burnBatch.

This adds a small mock that overrides _checkAuthorized with custom authorization semantics, then verifies:

- burn rejects the token holder when the override does not authorize them
- burn succeeds for the override-authorized operator
- burnBatch follows the same override semantics

Local validation:

- ./node_modules/.bin/hardhat test test/token/ERC1155/extensions/ERC1155Burnable.test.js