### PR TITLE
Prevent duplicate actions in GovernorTimelockCompound proposals

### DIFF
--- a/.changeset/eighty-parts-fix.md
+++ b/.changeset/eighty-parts-fix.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Prevent duplicate actions in GovernorTimelockCompound proposals

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -22,6 +22,11 @@ abstract contract GovernorTimelockCompound is Governor {
     ICompoundTimelock private _timelock;
 
     /**
+     * @dev Thrown when a proposal contains duplicate actions.
+     */
+    error GovernorDuplicateProposalAction(uint256 index1, uint256 index2);
+
+    /**
      * @dev Emitted when the timelock controller used for proposal execution is modified.
      */
     event TimelockChange(address oldTimelock, address newTimelock);
@@ -56,6 +61,31 @@ abstract contract GovernorTimelockCompound is Governor {
     /// @inheritdoc IGovernor
     function proposalNeedsQueuing(uint256) public view virtual override returns (bool) {
         return true;
+    }
+
+    /**
+     * @dev Overridden version of the {Governor-_propose} function to check for duplicate actions.
+     */
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal virtual override returns (uint256) {
+        for (uint256 i = 0; i < targets.length; ++i) {
+            for (uint256 j = 0; j < i; ++j) {
+                if (
+                    targets[i] == targets[j] &&
+                    values[i] == values[j] &&
+                    keccak256(calldatas[i]) == keccak256(calldatas[j])
+                ) {
+                    revert GovernorDuplicateProposalAction(i, j);
+                }
+            }
+        }
+
+        return super._propose(targets, values, calldatas, description, proposer);
     }
 
     /**

--- a/contracts/mocks/governance/GovernorTimelockCompoundMock.sol
+++ b/contracts/mocks/governance/GovernorTimelockCompoundMock.sol
@@ -66,4 +66,14 @@ abstract contract GovernorTimelockCompoundMock is
     function _executor() internal view override(Governor, GovernorTimelockCompound) returns (address) {
         return super._executor();
     }
+
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal override(Governor, GovernorTimelockCompound) returns (uint256) {
+        return super._propose(targets, values, calldatas, description, proposer);
+    }
 }

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -124,6 +124,115 @@ describe('GovernorTimelockCompound', function () {
           .to.emit(this.receiver, 'MockFunctionCalled');
       });
 
+      describe('duplicate action validation', function () {
+        it('should allow a proposal with a single action', async function () {
+          await expect(
+            this.mock.propose(
+              [this.receiver.target],
+              [0],
+              [this.receiver.interface.encodeFunctionData('mockFunction')],
+              'description',
+            ),
+          ).to.emit(this.mock, 'ProposalCreated');
+        });
+
+        it('should allow a proposal with multiple distinct actions', async function () {
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target],
+              [0, 0],
+              [
+                this.receiver.interface.encodeFunctionData('mockFunction'),
+                this.receiver.interface.encodeFunctionData('mockFunctionNonPayable'),
+              ],
+              'description',
+            ),
+          ).to.emit(this.mock, 'ProposalCreated');
+        });
+
+        it('should revert when two consecutive actions are identical', async function () {
+          const calldata = this.receiver.interface.encodeFunctionData('mockFunction');
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target],
+              [0, 0],
+              [calldata, calldata],
+              'description',
+            ),
+          )
+            .to.be.revertedWithCustomError(this.mock, 'GovernorDuplicateProposalAction')
+            .withArgs(1, 0);
+        });
+
+        it('should revert when non-consecutive duplicates exist', async function () {
+          const calldataA = this.receiver.interface.encodeFunctionData('mockFunction');
+          const calldataB = this.receiver.interface.encodeFunctionData('mockFunctionNonPayable');
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target, this.receiver.target],
+              [0, 0, 0],
+              [calldataA, calldataB, calldataA],
+              'description',
+            ),
+          )
+            .to.be.revertedWithCustomError(this.mock, 'GovernorDuplicateProposalAction')
+            .withArgs(2, 0);
+        });
+
+        it('should revert when multiple pairs of duplicates exist', async function () {
+          const calldataA = this.receiver.interface.encodeFunctionData('mockFunction');
+          const calldataB = this.receiver.interface.encodeFunctionData('mockFunctionNonPayable');
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target, this.receiver.target, this.receiver.target],
+              [0, 0, 0, 0],
+              [calldataA, calldataB, calldataA, calldataB],
+              'description',
+            ),
+          )
+            .to.be.revertedWithCustomError(this.mock, 'GovernorDuplicateProposalAction')
+            .withArgs(2, 0);
+        });
+
+        it('should allow proposals with the same target and calldata but different value', async function () {
+          const calldata = this.receiver.interface.encodeFunctionData('mockFunction');
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target],
+              [0, 1],
+              [calldata, calldata],
+              'description',
+            ),
+          ).to.emit(this.mock, 'ProposalCreated');
+        });
+
+        it('should allow proposals with the same target and value but different calldata', async function () {
+          const calldataA = this.receiver.interface.encodeFunctionData('mockFunction');
+          const calldataB = this.receiver.interface.encodeFunctionData('mockFunctionNonPayable');
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target],
+              [0, 0],
+              [calldataA, calldataB],
+              'description',
+            ),
+          ).to.emit(this.mock, 'ProposalCreated');
+        });
+
+        it('should revert when duplicate empty calldata actions exist', async function () {
+          await expect(
+            this.mock.propose(
+              [this.receiver.target, this.receiver.target],
+              [1, 1],
+              ['0x', '0x'],
+              'description',
+            ),
+          )
+            .to.be.revertedWithCustomError(this.mock, 'GovernorDuplicateProposalAction')
+            .withArgs(1, 0);
+        });
+      });
+
       describe('should revert', function () {
         describe('on queue', function () {
           it('if already queued', async function () {
@@ -141,24 +250,7 @@ describe('GovernorTimelockCompound', function () {
               );
           });
 
-          it('if proposal contains duplicate calls', async function () {
-            const action = {
-              target: this.token.target,
-              data: this.token.interface.encodeFunctionData('approve', [this.receiver.target, ethers.MaxUint256]),
-            };
-            const { id } = this.helper.setProposal([action, action], '<proposal description>');
 
-            await this.helper.propose();
-            await this.helper.waitForSnapshot();
-            await this.helper.connect(this.voter1).vote({ support: VoteType.For });
-            await this.helper.waitForDeadline();
-            await expect(this.helper.queue())
-              .to.be.revertedWithCustomError(this.mock, 'GovernorAlreadyQueuedProposal')
-              .withArgs(id);
-            await expect(this.helper.execute())
-              .to.be.revertedWithCustomError(this.mock, 'GovernorUnexpectedProposalState')
-              .withArgs(id, ProposalState.Succeeded, GovernorHelper.proposalStatesToBitMap([ProposalState.Queued]));
-          });
         });
 
         describe('on execute', function () {

--- a/test/governance/extensions/GovernorTimelockCompound.test.js
+++ b/test/governance/extensions/GovernorTimelockCompound.test.js
@@ -221,12 +221,7 @@ describe('GovernorTimelockCompound', function () {
 
         it('should revert when duplicate empty calldata actions exist', async function () {
           await expect(
-            this.mock.propose(
-              [this.receiver.target, this.receiver.target],
-              [1, 1],
-              ['0x', '0x'],
-              'description',
-            ),
+            this.mock.propose([this.receiver.target, this.receiver.target], [1, 1], ['0x', '0x'], 'description'),
           )
             .to.be.revertedWithCustomError(this.mock, 'GovernorDuplicateProposalAction')
             .withArgs(1, 0);
@@ -249,8 +244,6 @@ describe('GovernorTimelockCompound', function () {
                 GovernorHelper.proposalStatesToBitMap([ProposalState.Succeeded]),
               );
           });
-
-
         });
 
         describe('on execute', function () {


### PR DESCRIPTION
Fixes #6431

#### Summary
Prevent proposals with duplicate actions from being created in `GovernorTimelockCompound`.

#### Problem
Proposals containing duplicate actions (same `target`, `value`, and `calldata`) are accepted during `propose()`, but fail during `queue()` due to identical transaction hashes.

#### Solution
Add validation in `_propose()` to detect duplicates early and revert.

#### Tests
- Added duplicate action tests
- Updated existing tests
- All tests passing

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry