### PR TITLE
Improve 0.8.35 compatibility

### DIFF
--- a/.changeset/few-baboons-switch.md
+++ b/.changeset/few-baboons-switch.md
@@ -1,0 +1,6 @@
+---
+'openzeppelin-solidity': minor
+---
+
+[Deprecations]
+`Checkpoints`, `DoubleEndedQueue`, `EnumerableMap` and `EnumerableSet`: Deprecate the `at` function for accessing a specific index of the structure. We introduce new `pos` functions to replace them.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -55,7 +55,7 @@ runs:
         FOUNDRY_DEFAULT_VERSION: "stable"
         JAVA_DEFAULT_VERSION: "21"
         PYTHON_DEFAULT_VERSION: "3.13"
-        SOLC_DEFAULT_VERSION: "0.8.31"
+        SOLC_DEFAULT_VERSION: "0.8.35"
     # Node & npm setup
     - name: Install Node (${{ steps.versions.outputs.node }})
       if: inputs.node != 'off'

--- a/contracts/access/extensions/AccessControlEnumerable.sol
+++ b/contracts/access/extensions/AccessControlEnumerable.sol
@@ -34,7 +34,7 @@ abstract contract AccessControlEnumerable is IAccessControlEnumerable, AccessCon
      * for more information.
      */
     function getRoleMember(bytes32 role, uint256 index) public view virtual returns (address) {
-        return _roleMembers[role].at(index);
+        return _roleMembers[role].pos(index);
     }
 
     /**

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -217,9 +217,9 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
      */
     function _checkpoints(
         address account,
-        uint32 pos
+        uint32 index
     ) internal view virtual returns (Checkpoints.Checkpoint208 memory) {
-        return _delegateCheckpoints[account].at(pos);
+        return _delegateCheckpoints[account].pos(index);
     }
 
     function _push(

--- a/contracts/mocks/ConstructorMock.sol
+++ b/contracts/mocks/ConstructorMock.sol
@@ -15,18 +15,18 @@ contract ConstructorMock {
 
     error CustomError();
 
-    constructor(RevertType error) {
+    constructor(RevertType err) {
         // After transpilation to upgradeable contract, the constructor will become an initializer
         // To silence the `... can be restricted to view` warning, we write to state
         foo = true;
 
-        if (error == RevertType.RevertWithoutMessage) {
+        if (err == RevertType.RevertWithoutMessage) {
             revert();
-        } else if (error == RevertType.RevertWithMessage) {
+        } else if (err == RevertType.RevertWithMessage) {
             revert("ConstructorMock: reverting");
-        } else if (error == RevertType.RevertWithCustomError) {
+        } else if (err == RevertType.RevertWithCustomError) {
             revert CustomError();
-        } else if (error == RevertType.Panic) {
+        } else if (err == RevertType.Panic) {
             uint256 a = uint256(0) / uint256(0);
             a;
         }

--- a/contracts/mocks/docs/AccessManagerEnumerable.sol
+++ b/contracts/mocks/docs/AccessManagerEnumerable.sol
@@ -40,7 +40,7 @@ abstract contract AccessManagerEnumerable is AccessManager {
      * for more information.
      */
     function getRoleMember(uint64 roleId, uint256 index) public view virtual returns (address) {
-        return _roleMembers[roleId].at(index);
+        return _roleMembers[roleId].pos(index);
     }
 
     /**
@@ -84,7 +84,7 @@ abstract contract AccessManagerEnumerable is AccessManager {
      * for more information.
      */
     function getRoleTargetFunction(uint64 roleId, address target, uint256 index) public view virtual returns (bytes4) {
-        return _roleTargetFunctions[roleId][target].at(index);
+        return _roleTargetFunctions[roleId][target].pos(index);
     }
 
     /**

--- a/contracts/mocks/token/ERC1155ReceiverMock.sol
+++ b/contracts/mocks/token/ERC1155ReceiverMock.sol
@@ -22,10 +22,10 @@ contract ERC1155ReceiverMock is ERC165, IERC1155Receiver {
     event BatchReceived(address operator, address from, uint256[] ids, uint256[] values, bytes data, uint256 gas);
     error CustomError(bytes4);
 
-    constructor(bytes4 recRetval, bytes4 batRetval, RevertType error) {
+    constructor(bytes4 recRetval, bytes4 batRetval, RevertType err) {
         _recRetval = recRetval;
         _batRetval = batRetval;
-        _error = error;
+        _error = err;
     }
 
     function onERC1155Received(

--- a/contracts/mocks/token/ERC1363ReceiverMock.sol
+++ b/contracts/mocks/token/ERC1363ReceiverMock.sol
@@ -24,9 +24,9 @@ contract ERC1363ReceiverMock is IERC1363Receiver {
         _error = RevertType.None;
     }
 
-    function setUp(bytes4 retval, RevertType error) public {
+    function setUp(bytes4 retval, RevertType err) public {
         _retval = retval;
-        _error = error;
+        _error = err;
     }
 
     function onTransferReceived(

--- a/contracts/mocks/token/ERC1363SpenderMock.sol
+++ b/contracts/mocks/token/ERC1363SpenderMock.sol
@@ -24,9 +24,9 @@ contract ERC1363SpenderMock is IERC1363Spender {
         _error = RevertType.None;
     }
 
-    function setUp(bytes4 retval, RevertType error) public {
+    function setUp(bytes4 retval, RevertType err) public {
         _retval = retval;
-        _error = error;
+        _error = err;
     }
 
     function onApprovalReceived(address owner, uint256 value, bytes calldata data) external override returns (bytes4) {

--- a/contracts/mocks/token/ERC721ReceiverMock.sol
+++ b/contracts/mocks/token/ERC721ReceiverMock.sol
@@ -19,9 +19,9 @@ contract ERC721ReceiverMock is IERC721Receiver {
     event Received(address operator, address from, uint256 tokenId, bytes data, uint256 gas);
     error CustomError(bytes4);
 
-    constructor(bytes4 retval, RevertType error) {
+    constructor(bytes4 retval, RevertType err) {
         _retval = retval;
-        _error = error;
+        _error = err;
     }
 
     function onERC721Received(

--- a/contracts/utils/cryptography/ECDSA.sol
+++ b/contracts/utils/cryptography/ECDSA.sol
@@ -122,8 +122,8 @@ library ECDSA {
      * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.
      */
     function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
-        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);
-        _throwError(error, errorArg);
+        (address recovered, RecoverError err, bytes32 errorArg) = tryRecover(hash, signature);
+        _throwError(err, errorArg);
         return recovered;
     }
 
@@ -131,8 +131,8 @@ library ECDSA {
      * @dev Variant of {recover} that takes a signature in calldata
      */
     function recoverCalldata(bytes32 hash, bytes calldata signature) internal pure returns (address) {
-        (address recovered, RecoverError error, bytes32 errorArg) = tryRecoverCalldata(hash, signature);
-        _throwError(error, errorArg);
+        (address recovered, RecoverError err, bytes32 errorArg) = tryRecoverCalldata(hash, signature);
+        _throwError(err, errorArg);
         return recovered;
     }
 
@@ -158,8 +158,8 @@ library ECDSA {
      * @dev Overload of {ECDSA-recover} that receives the `r` and `vs` short-signature fields separately.
      */
     function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {
-        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);
-        _throwError(error, errorArg);
+        (address recovered, RecoverError err, bytes32 errorArg) = tryRecover(hash, r, vs);
+        _throwError(err, errorArg);
         return recovered;
     }
 
@@ -200,8 +200,8 @@ library ECDSA {
      * `r` and `s` signature fields separately.
      */
     function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
-        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);
-        _throwError(error, errorArg);
+        (address recovered, RecoverError err, bytes32 errorArg) = tryRecover(hash, v, r, s);
+        _throwError(err, errorArg);
         return recovered;
     }
 
@@ -270,14 +270,14 @@ library ECDSA {
     /**
      * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.
      */
-    function _throwError(RecoverError error, bytes32 errorArg) private pure {
-        if (error == RecoverError.NoError) {
+    function _throwError(RecoverError err, bytes32 errorArg) private pure {
+        if (err == RecoverError.NoError) {
             return; // no error: do nothing
-        } else if (error == RecoverError.InvalidSignature) {
+        } else if (err == RecoverError.InvalidSignature) {
             revert ECDSAInvalidSignature();
-        } else if (error == RecoverError.InvalidSignatureLength) {
+        } else if (err == RecoverError.InvalidSignatureLength) {
             revert ECDSAInvalidSignatureLength(uint256(errorArg));
-        } else if (error == RecoverError.InvalidSignatureS) {
+        } else if (err == RecoverError.InvalidSignatureS) {
             revert ECDSAInvalidSignatureS(errorArg);
         }
     }

--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -50,8 +50,8 @@ library Checkpoints {
      */
     function lowerLookup(Trace256 storage self, uint256 key) internal view returns (uint256) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+        uint256 index = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        return index == len ? 0 : _unsafeAccess(self._checkpoints, index)._value;
     }
 
     /**
@@ -60,8 +60,8 @@ library Checkpoints {
      */
     function upperLookup(Trace256 storage self, uint256 key) internal view returns (uint256) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
@@ -86,17 +86,17 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, low, high);
 
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
      * @dev Returns the value in the most recent checkpoint, or zero if there are no checkpoints.
      */
     function latest(Trace256 storage self) internal view returns (uint256) {
-        uint256 pos = self._checkpoints.length;
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 len = self._checkpoints.length;
+        return len == 0 ? 0 : _unsafeAccess(self._checkpoints, len - 1)._value;
     }
 
     /**
@@ -104,11 +104,11 @@ library Checkpoints {
      * in the most recent checkpoint.
      */
     function latestCheckpoint(Trace256 storage self) internal view returns (bool exists, uint256 _key, uint256 _value) {
-        uint256 pos = self._checkpoints.length;
-        if (pos == 0) {
+        uint256 len = self._checkpoints.length;
+        if (len == 0) {
             return (false, 0, 0);
         } else {
-            Checkpoint256 storage ckpt = _unsafeAccess(self._checkpoints, pos - 1);
+            Checkpoint256 storage ckpt = _unsafeAccess(self._checkpoints, len - 1);
             return (true, ckpt._key, ckpt._value);
         }
     }
@@ -122,9 +122,21 @@ library Checkpoints {
 
     /**
      * @dev Returns checkpoint at given position.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
-    function at(Trace256 storage self, uint32 pos) internal view returns (Checkpoint256 memory) {
-        return self._checkpoints[pos];
+    function at(Trace256 storage self, uint32 index) internal view returns (Checkpoint256 memory) {
+        return pos(self, index);
+    }
+
+    /**
+     * @dev Returns checkpoint at given position.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Trace256 storage self, uint32 index) internal view returns (Checkpoint256 memory) {
+        return self._checkpoints[index];
     }
 
     /**
@@ -136,10 +148,10 @@ library Checkpoints {
         uint256 key,
         uint256 value
     ) private returns (uint256 oldValue, uint256 newValue) {
-        uint256 pos = self.length;
+        uint256 len = self.length;
 
-        if (pos > 0) {
-            Checkpoint256 storage last = _unsafeAccess(self, pos - 1);
+        if (len > 0) {
+            Checkpoint256 storage last = _unsafeAccess(self, len - 1);
             uint256 lastKey = last._key;
             uint256 lastValue = last._value;
 
@@ -214,11 +226,11 @@ library Checkpoints {
      */
     function _unsafeAccess(
         Checkpoint256[] storage self,
-        uint256 pos
+        uint256 index
     ) private pure returns (Checkpoint256 storage result) {
         assembly {
             mstore(0x00, self.slot)
-            result.slot := add(keccak256(0x00, 0x20), mul(pos, 2))
+            result.slot := add(keccak256(0x00, 0x20), mul(index, 2))
         }
     }
 
@@ -253,8 +265,8 @@ library Checkpoints {
      */
     function lowerLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+        uint256 index = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        return index == len ? 0 : _unsafeAccess(self._checkpoints, index)._value;
     }
 
     /**
@@ -263,8 +275,8 @@ library Checkpoints {
      */
     function upperLookup(Trace224 storage self, uint32 key) internal view returns (uint224) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
@@ -289,17 +301,17 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, low, high);
 
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
      * @dev Returns the value in the most recent checkpoint, or zero if there are no checkpoints.
      */
     function latest(Trace224 storage self) internal view returns (uint224) {
-        uint256 pos = self._checkpoints.length;
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 len = self._checkpoints.length;
+        return len == 0 ? 0 : _unsafeAccess(self._checkpoints, len - 1)._value;
     }
 
     /**
@@ -307,11 +319,11 @@ library Checkpoints {
      * in the most recent checkpoint.
      */
     function latestCheckpoint(Trace224 storage self) internal view returns (bool exists, uint32 _key, uint224 _value) {
-        uint256 pos = self._checkpoints.length;
-        if (pos == 0) {
+        uint256 len = self._checkpoints.length;
+        if (len == 0) {
             return (false, 0, 0);
         } else {
-            Checkpoint224 storage ckpt = _unsafeAccess(self._checkpoints, pos - 1);
+            Checkpoint224 storage ckpt = _unsafeAccess(self._checkpoints, len - 1);
             return (true, ckpt._key, ckpt._value);
         }
     }
@@ -325,9 +337,21 @@ library Checkpoints {
 
     /**
      * @dev Returns checkpoint at given position.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
-    function at(Trace224 storage self, uint32 pos) internal view returns (Checkpoint224 memory) {
-        return self._checkpoints[pos];
+    function at(Trace224 storage self, uint32 index) internal view returns (Checkpoint224 memory) {
+        return pos(self, index);
+    }
+
+    /**
+     * @dev Returns checkpoint at given position.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Trace224 storage self, uint32 index) internal view returns (Checkpoint224 memory) {
+        return self._checkpoints[index];
     }
 
     /**
@@ -339,10 +363,10 @@ library Checkpoints {
         uint32 key,
         uint224 value
     ) private returns (uint224 oldValue, uint224 newValue) {
-        uint256 pos = self.length;
+        uint256 len = self.length;
 
-        if (pos > 0) {
-            Checkpoint224 storage last = _unsafeAccess(self, pos - 1);
+        if (len > 0) {
+            Checkpoint224 storage last = _unsafeAccess(self, len - 1);
             uint32 lastKey = last._key;
             uint224 lastValue = last._value;
 
@@ -417,11 +441,11 @@ library Checkpoints {
      */
     function _unsafeAccess(
         Checkpoint224[] storage self,
-        uint256 pos
+        uint256 index
     ) private pure returns (Checkpoint224 storage result) {
         assembly {
             mstore(0x00, self.slot)
-            result.slot := add(keccak256(0x00, 0x20), pos)
+            result.slot := add(keccak256(0x00, 0x20), index)
         }
     }
 
@@ -456,8 +480,8 @@ library Checkpoints {
      */
     function lowerLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+        uint256 index = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        return index == len ? 0 : _unsafeAccess(self._checkpoints, index)._value;
     }
 
     /**
@@ -466,8 +490,8 @@ library Checkpoints {
      */
     function upperLookup(Trace208 storage self, uint48 key) internal view returns (uint208) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
@@ -492,17 +516,17 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, low, high);
 
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
      * @dev Returns the value in the most recent checkpoint, or zero if there are no checkpoints.
      */
     function latest(Trace208 storage self) internal view returns (uint208) {
-        uint256 pos = self._checkpoints.length;
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 len = self._checkpoints.length;
+        return len == 0 ? 0 : _unsafeAccess(self._checkpoints, len - 1)._value;
     }
 
     /**
@@ -510,11 +534,11 @@ library Checkpoints {
      * in the most recent checkpoint.
      */
     function latestCheckpoint(Trace208 storage self) internal view returns (bool exists, uint48 _key, uint208 _value) {
-        uint256 pos = self._checkpoints.length;
-        if (pos == 0) {
+        uint256 len = self._checkpoints.length;
+        if (len == 0) {
             return (false, 0, 0);
         } else {
-            Checkpoint208 storage ckpt = _unsafeAccess(self._checkpoints, pos - 1);
+            Checkpoint208 storage ckpt = _unsafeAccess(self._checkpoints, len - 1);
             return (true, ckpt._key, ckpt._value);
         }
     }
@@ -528,9 +552,21 @@ library Checkpoints {
 
     /**
      * @dev Returns checkpoint at given position.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
-    function at(Trace208 storage self, uint32 pos) internal view returns (Checkpoint208 memory) {
-        return self._checkpoints[pos];
+    function at(Trace208 storage self, uint32 index) internal view returns (Checkpoint208 memory) {
+        return pos(self, index);
+    }
+
+    /**
+     * @dev Returns checkpoint at given position.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Trace208 storage self, uint32 index) internal view returns (Checkpoint208 memory) {
+        return self._checkpoints[index];
     }
 
     /**
@@ -542,10 +578,10 @@ library Checkpoints {
         uint48 key,
         uint208 value
     ) private returns (uint208 oldValue, uint208 newValue) {
-        uint256 pos = self.length;
+        uint256 len = self.length;
 
-        if (pos > 0) {
-            Checkpoint208 storage last = _unsafeAccess(self, pos - 1);
+        if (len > 0) {
+            Checkpoint208 storage last = _unsafeAccess(self, len - 1);
             uint48 lastKey = last._key;
             uint208 lastValue = last._value;
 
@@ -620,11 +656,11 @@ library Checkpoints {
      */
     function _unsafeAccess(
         Checkpoint208[] storage self,
-        uint256 pos
+        uint256 index
     ) private pure returns (Checkpoint208 storage result) {
         assembly {
             mstore(0x00, self.slot)
-            result.slot := add(keccak256(0x00, 0x20), pos)
+            result.slot := add(keccak256(0x00, 0x20), index)
         }
     }
 
@@ -659,8 +695,8 @@ library Checkpoints {
      */
     function lowerLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _lowerBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == len ? 0 : _unsafeAccess(self._checkpoints, pos)._value;
+        uint256 index = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        return index == len ? 0 : _unsafeAccess(self._checkpoints, index)._value;
     }
 
     /**
@@ -669,8 +705,8 @@ library Checkpoints {
      */
     function upperLookup(Trace160 storage self, uint96 key) internal view returns (uint160) {
         uint256 len = self._checkpoints.length;
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, 0, len);
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
@@ -695,17 +731,17 @@ library Checkpoints {
             }
         }
 
-        uint256 pos = _upperBinaryLookup(self._checkpoints, key, low, high);
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, low, high);
 
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
      * @dev Returns the value in the most recent checkpoint, or zero if there are no checkpoints.
      */
     function latest(Trace160 storage self) internal view returns (uint160) {
-        uint256 pos = self._checkpoints.length;
-        return pos == 0 ? 0 : _unsafeAccess(self._checkpoints, pos - 1)._value;
+        uint256 len = self._checkpoints.length;
+        return len == 0 ? 0 : _unsafeAccess(self._checkpoints, len - 1)._value;
     }
 
     /**
@@ -713,11 +749,11 @@ library Checkpoints {
      * in the most recent checkpoint.
      */
     function latestCheckpoint(Trace160 storage self) internal view returns (bool exists, uint96 _key, uint160 _value) {
-        uint256 pos = self._checkpoints.length;
-        if (pos == 0) {
+        uint256 len = self._checkpoints.length;
+        if (len == 0) {
             return (false, 0, 0);
         } else {
-            Checkpoint160 storage ckpt = _unsafeAccess(self._checkpoints, pos - 1);
+            Checkpoint160 storage ckpt = _unsafeAccess(self._checkpoints, len - 1);
             return (true, ckpt._key, ckpt._value);
         }
     }
@@ -731,9 +767,21 @@ library Checkpoints {
 
     /**
      * @dev Returns checkpoint at given position.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
-    function at(Trace160 storage self, uint32 pos) internal view returns (Checkpoint160 memory) {
-        return self._checkpoints[pos];
+    function at(Trace160 storage self, uint32 index) internal view returns (Checkpoint160 memory) {
+        return pos(self, index);
+    }
+
+    /**
+     * @dev Returns checkpoint at given position.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Trace160 storage self, uint32 index) internal view returns (Checkpoint160 memory) {
+        return self._checkpoints[index];
     }
 
     /**
@@ -745,10 +793,10 @@ library Checkpoints {
         uint96 key,
         uint160 value
     ) private returns (uint160 oldValue, uint160 newValue) {
-        uint256 pos = self.length;
+        uint256 len = self.length;
 
-        if (pos > 0) {
-            Checkpoint160 storage last = _unsafeAccess(self, pos - 1);
+        if (len > 0) {
+            Checkpoint160 storage last = _unsafeAccess(self, len - 1);
             uint96 lastKey = last._key;
             uint160 lastValue = last._value;
 
@@ -823,11 +871,11 @@ library Checkpoints {
      */
     function _unsafeAccess(
         Checkpoint160[] storage self,
-        uint256 pos
+        uint256 index
     ) private pure returns (Checkpoint160 storage result) {
         assembly {
             mstore(0x00, self.slot)
-            result.slot := add(keccak256(0x00, 0x20), pos)
+            result.slot := add(keccak256(0x00, 0x20), index)
         }
     }
 }

--- a/contracts/utils/structs/Checkpoints.sol
+++ b/contracts/utils/structs/Checkpoints.sol
@@ -123,7 +123,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Trace256 storage self, uint32 index) internal view returns (Checkpoint256 memory) {
@@ -338,7 +338,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Trace224 storage self, uint32 index) internal view returns (Checkpoint224 memory) {
@@ -553,7 +553,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Trace208 storage self, uint32 index) internal view returns (Checkpoint208 memory) {
@@ -768,7 +768,7 @@ library Checkpoints {
     /**
      * @dev Returns checkpoint at given position.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Trace160 storage self, uint32 index) internal view returns (Checkpoint160 memory) {

--- a/contracts/utils/structs/DoubleEndedQueue.sol
+++ b/contracts/utils/structs/DoubleEndedQueue.sol
@@ -188,8 +188,23 @@ library DoubleEndedQueue {
      * `length(deque) - 1`.
      *
      * Reverts with {Panic-ARRAY_OUT_OF_BOUNDS} if the index is out of bounds.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes32Deque storage deque, uint256 index) internal view returns (bytes32) {
+        return pos(deque, index);
+    }
+
+    /**
+     * @dev Return the item at a position in the queue given by `index`, with the first item at 0 and last item at
+     * `length(deque) - 1`.
+     *
+     * Reverts with {Panic-ARRAY_OUT_OF_BOUNDS} if the index is out of bounds.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes32Deque storage deque, uint256 index) internal view returns (bytes32) {
         (bool success, bytes32 value) = tryAt(deque, index);
         if (!success) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
         return value;

--- a/contracts/utils/structs/DoubleEndedQueue.sol
+++ b/contracts/utils/structs/DoubleEndedQueue.sol
@@ -189,7 +189,7 @@ library DoubleEndedQueue {
      *
      * Reverts with {Panic-ARRAY_OUT_OF_BOUNDS} if the index is out of bounds.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes32Deque storage deque, uint256 index) internal view returns (bytes32) {

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -290,7 +290,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(UintToUintMap storage map, uint256 index) internal view returns (uint256 key, uint256 value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (uint256(atKey), uint256(val));
     }
 
@@ -431,7 +431,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(UintToAddressMap storage map, uint256 index) internal view returns (uint256 key, address value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (uint256(atKey), address(uint160(uint256(val))));
     }
 
@@ -572,7 +572,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(UintToBytes32Map storage map, uint256 index) internal view returns (uint256 key, bytes32 value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (uint256(atKey), val);
     }
 
@@ -713,7 +713,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(AddressToUintMap storage map, uint256 index) internal view returns (address key, uint256 value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (address(uint160(uint256(atKey))), uint256(val));
     }
 
@@ -854,7 +854,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(AddressToAddressMap storage map, uint256 index) internal view returns (address key, address value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (address(uint160(uint256(atKey))), address(uint160(uint256(val))));
     }
 
@@ -999,7 +999,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(AddressToBytes32Map storage map, uint256 index) internal view returns (address key, bytes32 value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (address(uint160(uint256(atKey))), val);
     }
 
@@ -1144,7 +1144,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(Bytes32ToUintMap storage map, uint256 index) internal view returns (bytes32 key, uint256 value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (atKey, uint256(val));
     }
 
@@ -1285,7 +1285,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(Bytes32ToAddressMap storage map, uint256 index) internal view returns (bytes32 key, address value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (atKey, address(uint160(uint256(val))));
     }
 
@@ -1430,7 +1430,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(Bytes4ToAddressMap storage map, uint256 index) internal view returns (bytes4 key, address value) {
-        (bytes32 atKey, bytes32 val) = at(map._inner, index);
+        (bytes32 atKey, bytes32 val) = pos(map._inner, index);
         return (bytes4(atKey), address(uint160(uint256(val))));
     }
 

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -102,7 +102,7 @@ library EnumerableMap {
     function clear(Bytes32ToBytes32Map storage map) internal {
         uint256 len = length(map);
         for (uint256 i = 0; i < len; ++i) {
-            delete map._values[map._keys.at(i)];
+            delete map._values[map._keys.pos(i)];
         }
         map._keys.clear();
     }
@@ -151,7 +151,7 @@ library EnumerableMap {
      * Replacement of the deprecated {at} function.
      */
     function pos(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
-        bytes32 atKey = map._keys.at(index);
+        bytes32 atKey = map._keys.pos(index);
         return (atKey, map._values[atKey]);
     }
 
@@ -1534,7 +1534,7 @@ library EnumerableMap {
     function clear(BytesToBytesMap storage map) internal {
         uint256 len = length(map);
         for (uint256 i = 0; i < len; ++i) {
-            delete map._values[map._keys.at(i)];
+            delete map._values[map._keys.pos(i)];
         }
         map._keys.clear();
     }
@@ -1588,7 +1588,7 @@ library EnumerableMap {
         BytesToBytesMap storage map,
         uint256 index
     ) internal view returns (bytes memory key, bytes memory value) {
-        key = map._keys.at(index);
+        key = map._keys.pos(index);
         value = map._values[key];
     }
 

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -130,8 +130,27 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the key-value pair stored at position `index` in the map. O(1).
+     *
+     * Note that there are no guarantees on the ordering of entries inside the
+     * array, and it may change when more entries are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
         bytes32 atKey = map._keys.at(index);
         return (atKey, map._values[atKey]);
     }
@@ -251,8 +270,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(UintToUintMap storage map, uint256 index) internal view returns (uint256 key, uint256 value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(UintToUintMap storage map, uint256 index) internal view returns (uint256 key, uint256 value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (uint256(atKey), uint256(val));
     }
@@ -374,8 +411,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(UintToAddressMap storage map, uint256 index) internal view returns (uint256 key, address value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(UintToAddressMap storage map, uint256 index) internal view returns (uint256 key, address value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (uint256(atKey), address(uint160(uint256(val))));
     }
@@ -497,8 +552,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(UintToBytes32Map storage map, uint256 index) internal view returns (uint256 key, bytes32 value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(UintToBytes32Map storage map, uint256 index) internal view returns (uint256 key, bytes32 value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (uint256(atKey), val);
     }
@@ -620,8 +693,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(AddressToUintMap storage map, uint256 index) internal view returns (address key, uint256 value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(AddressToUintMap storage map, uint256 index) internal view returns (address key, uint256 value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (address(uint160(uint256(atKey))), uint256(val));
     }
@@ -743,8 +834,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(AddressToAddressMap storage map, uint256 index) internal view returns (address key, address value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(AddressToAddressMap storage map, uint256 index) internal view returns (address key, address value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (address(uint160(uint256(atKey))), address(uint160(uint256(val))));
     }
@@ -870,8 +979,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(AddressToBytes32Map storage map, uint256 index) internal view returns (address key, bytes32 value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(AddressToBytes32Map storage map, uint256 index) internal view returns (address key, bytes32 value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (address(uint160(uint256(atKey))), val);
     }
@@ -997,8 +1124,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes32ToUintMap storage map, uint256 index) internal view returns (bytes32 key, uint256 value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes32ToUintMap storage map, uint256 index) internal view returns (bytes32 key, uint256 value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (atKey, uint256(val));
     }
@@ -1120,8 +1265,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes32ToAddressMap storage map, uint256 index) internal view returns (bytes32 key, address value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes32ToAddressMap storage map, uint256 index) internal view returns (bytes32 key, address value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (atKey, address(uint160(uint256(val))));
     }
@@ -1247,8 +1410,26 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes4ToAddressMap storage map, uint256 index) internal view returns (bytes4 key, address value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes4ToAddressMap storage map, uint256 index) internal view returns (bytes4 key, address value) {
         (bytes32 atKey, bytes32 val) = at(map._inner, index);
         return (bytes4(atKey), address(uint160(uint256(val))));
     }
@@ -1381,8 +1562,29 @@ library EnumerableMap {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(
+        BytesToBytesMap storage map,
+        uint256 index
+    ) internal view returns (bytes memory key, bytes memory value) {
+        return pos(map, index);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the map. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(
         BytesToBytesMap storage map,
         uint256 index
     ) internal view returns (bytes memory key, bytes memory value) {

--- a/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/utils/structs/EnumerableMap.sol
@@ -131,7 +131,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
@@ -271,7 +271,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(UintToUintMap storage map, uint256 index) internal view returns (uint256 key, uint256 value) {
@@ -412,7 +412,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(UintToAddressMap storage map, uint256 index) internal view returns (uint256 key, address value) {
@@ -553,7 +553,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(UintToBytes32Map storage map, uint256 index) internal view returns (uint256 key, bytes32 value) {
@@ -694,7 +694,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(AddressToUintMap storage map, uint256 index) internal view returns (address key, uint256 value) {
@@ -835,7 +835,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(AddressToAddressMap storage map, uint256 index) internal view returns (address key, address value) {
@@ -980,7 +980,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(AddressToBytes32Map storage map, uint256 index) internal view returns (address key, bytes32 value) {
@@ -1125,7 +1125,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes32ToUintMap storage map, uint256 index) internal view returns (bytes32 key, uint256 value) {
@@ -1266,7 +1266,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes32ToAddressMap storage map, uint256 index) internal view returns (bytes32 key, address value) {
@@ -1411,7 +1411,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes4ToAddressMap storage map, uint256 index) internal view returns (bytes4 key, address value) {
@@ -1563,7 +1563,7 @@ library EnumerableMap {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -260,8 +260,27 @@ library EnumerableSet {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
+        return pos(set, index);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
         return _at(set._inner, index);
     }
 
@@ -362,8 +381,27 @@ library EnumerableSet {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(Bytes4Set storage set, uint256 index) internal view returns (bytes4) {
+        return pos(set, index);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(Bytes4Set storage set, uint256 index) internal view returns (bytes4) {
         return bytes4(_at(set._inner, index));
     }
 
@@ -464,8 +502,27 @@ library EnumerableSet {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(AddressSet storage set, uint256 index) internal view returns (address) {
+        return pos(set, index);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(AddressSet storage set, uint256 index) internal view returns (address) {
         return address(uint160(uint256(_at(set._inner, index))));
     }
 
@@ -566,8 +623,27 @@ library EnumerableSet {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(UintSet storage set, uint256 index) internal view returns (uint256) {
+        return pos(set, index);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(UintSet storage set, uint256 index) internal view returns (uint256) {
         return uint256(_at(set._inner, index));
     }
 
@@ -712,8 +788,27 @@ library EnumerableSet {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(StringSet storage set, uint256 index) internal view returns (string memory) {
+        return pos(set, index);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(StringSet storage set, uint256 index) internal view returns (string memory) {
         return set._values[index];
     }
 
@@ -854,8 +949,27 @@ library EnumerableSet {
      * Requirements:
      *
      * - `index` must be strictly less than {length}.
+     *
+     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * should use {pos} instead.
      */
     function at(BytesSet storage set, uint256 index) internal view returns (bytes memory) {
+        return pos(set, index);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     *
+     * Replacement of the deprecated {at} function.
+     */
+    function pos(BytesSet storage set, uint256 index) internal view returns (bytes memory) {
         return set._values[index];
     }
 

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -261,7 +261,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
@@ -382,7 +382,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(Bytes4Set storage set, uint256 index) internal view returns (bytes4) {
@@ -503,7 +503,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(AddressSet storage set, uint256 index) internal view returns (address) {
@@ -624,7 +624,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(UintSet storage set, uint256 index) internal view returns (uint256) {
@@ -789,7 +789,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(StringSet storage set, uint256 index) internal view returns (string memory) {
@@ -950,7 +950,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      *
-     * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+     * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
     function at(BytesSet storage set, uint256 index) internal view returns (bytes memory) {

--- a/contracts/utils/structs/EnumerableSet.sol
+++ b/contracts/utils/structs/EnumerableSet.sol
@@ -163,7 +163,7 @@ library EnumerableSet {
      *
      * - `index` must be strictly less than {length}.
      */
-    function _at(Set storage set, uint256 index) private view returns (bytes32) {
+    function _pos(Set storage set, uint256 index) private view returns (bytes32) {
         return set._values[index];
     }
 
@@ -281,7 +281,7 @@ library EnumerableSet {
      * Replacement of the deprecated {at} function.
      */
     function pos(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
-        return _at(set._inner, index);
+        return _pos(set._inner, index);
     }
 
     /**
@@ -402,7 +402,7 @@ library EnumerableSet {
      * Replacement of the deprecated {at} function.
      */
     function pos(Bytes4Set storage set, uint256 index) internal view returns (bytes4) {
-        return bytes4(_at(set._inner, index));
+        return bytes4(_pos(set._inner, index));
     }
 
     /**
@@ -523,7 +523,7 @@ library EnumerableSet {
      * Replacement of the deprecated {at} function.
      */
     function pos(AddressSet storage set, uint256 index) internal view returns (address) {
-        return address(uint160(uint256(_at(set._inner, index))));
+        return address(uint160(uint256(_pos(set._inner, index))));
     }
 
     /**
@@ -644,7 +644,7 @@ library EnumerableSet {
      * Replacement of the deprecated {at} function.
      */
     function pos(UintSet storage set, uint256 index) internal view returns (uint256) {
-        return uint256(_at(set._inner, index));
+        return uint256(_pos(set._inner, index));
     }
 
     /**

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,5 @@
 /// ENVVAR
-// - COMPILER:      compiler version (default: 0.8.31)
+// - COMPILER:      compiler version (default: 0.8.35)
 // - SRC:           contracts folder to compile (default: contracts)
 // - RUNS:          number of optimization runs (default: 200)
 // - IR:            enable IR compilation (default: false)
@@ -18,7 +18,7 @@ const { argv } = require('yargs/yargs')()
     compiler: {
       alias: 'compileVersion',
       type: 'string',
-      default: '0.8.31',
+      default: '0.8.35',
     },
     src: {
       alias: 'source',
@@ -93,6 +93,7 @@ module.exports = {
     '*': {
       'unused-param': !argv.coverage, // coverage causes unused-param warnings
       'transient-storage': false,
+      6335: 'warning', // XXX will be promoted to keyword in the future and will not be allowed as an identifier anymore.
       default: 'error',
     },
   },

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -55,8 +55,8 @@ function push(
  */
 function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
-    uint256 pos = _lowerBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
-    return pos == len ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos).${opts.valueFieldName};
+    uint256 index = _lowerBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
+    return index == len ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, index).${opts.valueFieldName};
 }
 
 /**
@@ -65,8 +65,8 @@ function lowerLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} k
  */
 function upperLookup(${opts.historyTypeName} storage self, ${opts.keyTypeName} key) internal view returns (${opts.valueTypeName}) {
     uint256 len = self.${opts.checkpointFieldName}.length;
-    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
-    return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
+    uint256 index = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, 0, len);
+    return index == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, index - 1).${opts.valueFieldName};
 }
 
 /**
@@ -91,17 +91,17 @@ function upperLookupRecent(${opts.historyTypeName} storage self, ${opts.keyTypeN
         }
     }
 
-    uint256 pos = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
+    uint256 index = _upperBinaryLookup(self.${opts.checkpointFieldName}, key, low, high);
 
-    return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
+    return index == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, index - 1).${opts.valueFieldName};
 }
 
 /**
  * @dev Returns the value in the most recent checkpoint, or zero if there are no checkpoints.
  */
 function latest(${opts.historyTypeName} storage self) internal view returns (${opts.valueTypeName}) {
-    uint256 pos = self.${opts.checkpointFieldName}.length;
-    return pos == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1).${opts.valueFieldName};
+    uint256 len = self.${opts.checkpointFieldName}.length;
+    return len == 0 ? 0 : _unsafeAccess(self.${opts.checkpointFieldName}, len - 1).${opts.valueFieldName};
 }
 
 /**
@@ -109,11 +109,11 @@ function latest(${opts.historyTypeName} storage self) internal view returns (${o
  * in the most recent checkpoint.
  */
 function latestCheckpoint(${opts.historyTypeName} storage self) internal view returns (bool exists, ${opts.keyTypeName} ${opts.keyFieldName}, ${opts.valueTypeName} ${opts.valueFieldName}) {
-    uint256 pos = self.${opts.checkpointFieldName}.length;
-    if (pos == 0) {
+    uint256 len = self.${opts.checkpointFieldName}.length;
+    if (len == 0) {
         return (false, 0, 0);
     } else {
-        ${opts.checkpointTypeName} storage ckpt = _unsafeAccess(self.${opts.checkpointFieldName}, pos - 1);
+        ${opts.checkpointTypeName} storage ckpt = _unsafeAccess(self.${opts.checkpointFieldName}, len - 1);
         return (true, ckpt.${opts.keyFieldName}, ckpt.${opts.valueFieldName});
     }
 }
@@ -127,9 +127,21 @@ function length(${opts.historyTypeName} storage self) internal view returns (uin
 
 /**
  * @dev Returns checkpoint at given position.
+ *
+ * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * should use {pos} instead.
  */
-function at(${opts.historyTypeName} storage self, uint32 pos) internal view returns (${opts.checkpointTypeName} memory) {
-    return self.${opts.checkpointFieldName}[pos];
+function at(${opts.historyTypeName} storage self, uint32 index) internal view returns (${opts.checkpointTypeName} memory) {
+    return pos(self, index);
+}
+
+/**
+ * @dev Returns checkpoint at given position.
+ *
+ * Replacement of the deprecated {at} function.
+ */
+function pos(${opts.historyTypeName} storage self, uint32 index) internal view returns (${opts.checkpointTypeName} memory) {
+    return self.${opts.checkpointFieldName}[index];
 }
 
 /**
@@ -141,10 +153,10 @@ function _insert(
     ${opts.keyTypeName} key,
     ${opts.valueTypeName} value
 ) private returns (${opts.valueTypeName} oldValue, ${opts.valueTypeName} newValue) {
-    uint256 pos = self.length;
+    uint256 len = self.length;
 
-    if (pos > 0) {
-        ${opts.checkpointTypeName} storage last = _unsafeAccess(self, pos - 1);
+    if (len > 0) {
+        ${opts.checkpointTypeName} storage last = _unsafeAccess(self, len - 1);
         ${opts.keyTypeName} lastKey = last.${opts.keyFieldName};
         ${opts.valueTypeName} lastValue = last.${opts.valueFieldName};
 
@@ -219,11 +231,11 @@ function _lowerBinaryLookup(
  */
 function _unsafeAccess(
     ${opts.checkpointTypeName}[] storage self,
-    uint256 pos
+    uint256 index
 ) private pure returns (${opts.checkpointTypeName} storage result) {
     assembly {
         mstore(0x00, self.slot)
-        result.slot := add(keccak256(0x00, 0x20), ${opts.checkpointSize === 1 ? 'pos' : `mul(pos, ${opts.checkpointSize})`})
+        result.slot := add(keccak256(0x00, 0x20), ${opts.checkpointSize === 1 ? 'index' : `mul(index, ${opts.checkpointSize})`})
     }
 }
 `;

--- a/scripts/generate/templates/Checkpoints.js
+++ b/scripts/generate/templates/Checkpoints.js
@@ -128,7 +128,7 @@ function length(${opts.historyTypeName} storage self) internal view returns (uin
 /**
  * @dev Returns checkpoint at given position.
  *
- * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
  * should use {pos} instead.
  */
 function at(${opts.historyTypeName} storage self, uint32 index) internal view returns (${opts.checkpointTypeName} memory) {

--- a/scripts/generate/templates/EnumerableMap.js
+++ b/scripts/generate/templates/EnumerableMap.js
@@ -132,7 +132,7 @@ function length(Bytes32ToBytes32Map storage map) internal view returns (uint256)
  *
  * - \`index\` must be strictly less than {length}.
  *
- * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
  * should use {pos} instead.
  */
 function at(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
@@ -270,7 +270,7 @@ function length(${name} storage map) internal view returns (uint256) {
  *
  * - \`index\` must be strictly less than {length}.
  *
- * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
  * should use {pos} instead.
  */
 function at(${name} storage map, uint256 index) internal view returns (${key.type} key, ${value.type} value) {
@@ -424,7 +424,7 @@ function length(${name} storage map) internal view returns (uint256) {
  *
  * - \`index\` must be strictly less than {length}.
  *
- * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
  * should use {pos} instead.
  */
 function at(

--- a/scripts/generate/templates/EnumerableMap.js
+++ b/scripts/generate/templates/EnumerableMap.js
@@ -131,8 +131,27 @@ function length(Bytes32ToBytes32Map storage map) internal view returns (uint256)
  * Requirements:
  *
  * - \`index\` must be strictly less than {length}.
+ *
+ * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * should use {pos} instead.
  */
 function at(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
+    return pos(map, index);
+}
+
+/**
+ * @dev Returns the key-value pair stored at position \`index\` in the map. O(1).
+ *
+ * Note that there are no guarantees on the ordering of entries inside the
+ * array, and it may change when more entries are added or removed.
+ *
+ * Requirements:
+ *
+ * - \`index\` must be strictly less than {length}.
+ *
+ * Replacement of the deprecated {at} function.
+ */
+function pos(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
     bytes32 atKey = map._keys.at(index);
     return (atKey, map._values[atKey]);
 }
@@ -250,8 +269,26 @@ function length(${name} storage map) internal view returns (uint256) {
  * Requirements:
  *
  * - \`index\` must be strictly less than {length}.
+ *
+ * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * should use {pos} instead.
  */
 function at(${name} storage map, uint256 index) internal view returns (${key.type} key, ${value.type} value) {
+    return pos(map, index);
+}
+
+/**
+ * @dev Returns the element stored at position \`index\` in the map. O(1).
+ * Note that there are no guarantees on the ordering of values inside the
+ * array, and it may change when more values are added or removed.
+ *
+ * Requirements:
+ *
+ * - \`index\` must be strictly less than {length}.
+ *
+ * Replacement of the deprecated {at} function.
+ */
+function pos(${name} storage map, uint256 index) internal view returns (${key.type} key, ${value.type} value) {
     (bytes32 atKey, bytes32 val) = at(map._inner, index);
     return (${fromBytes32(key.type, 'atKey')}, ${fromBytes32(value.type, 'val')});
 }
@@ -386,8 +423,29 @@ function length(${name} storage map) internal view returns (uint256) {
  * Requirements:
  *
  * - \`index\` must be strictly less than {length}.
+ *
+ * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * should use {pos} instead.
  */
 function at(
+    ${name} storage map,
+    uint256 index
+) internal view returns (${key.typeLoc} key, ${value.typeLoc} value) {
+    return pos(map, index);
+}
+
+/**
+ * @dev Returns the element stored at position \`index\` in the map. O(1).
+ * Note that there are no guarantees on the ordering of values inside the
+ * array, and it may change when more values are added or removed.
+ *
+ * Requirements:
+ *
+ * - \`index\` must be strictly less than {length}.
+ *
+ * Replacement of the deprecated {at} function.
+ */
+function pos(
     ${name} storage map,
     uint256 index
 ) internal view returns (${key.typeLoc} key, ${value.typeLoc} value) {

--- a/scripts/generate/templates/EnumerableMap.js
+++ b/scripts/generate/templates/EnumerableMap.js
@@ -103,7 +103,7 @@ function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (
 function clear(Bytes32ToBytes32Map storage map) internal {
     uint256 len = length(map);
     for (uint256 i = 0; i < len; ++i) {
-        delete map._values[map._keys.at(i)];
+        delete map._values[map._keys.pos(i)];
     }
     map._keys.clear();
 }
@@ -152,7 +152,7 @@ function at(Bytes32ToBytes32Map storage map, uint256 index) internal view return
  * Replacement of the deprecated {at} function.
  */
 function pos(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32 key, bytes32 value) {
-    bytes32 atKey = map._keys.at(index);
+    bytes32 atKey = map._keys.pos(index);
     return (atKey, map._values[atKey]);
 }
 
@@ -395,7 +395,7 @@ function remove(${name} storage map, ${key.typeLoc} key) internal returns (bool)
 function clear(${name} storage map) internal {
     uint256 len = length(map);
     for (uint256 i = 0; i < len; ++i) {
-        delete map._values[map._keys.at(i)];
+        delete map._values[map._keys.pos(i)];
     }
     map._keys.clear();
 }
@@ -449,7 +449,7 @@ function pos(
     ${name} storage map,
     uint256 index
 ) internal view returns (${key.typeLoc} key, ${value.typeLoc} value) {
-    key = map._keys.at(index);
+    key = map._keys.pos(index);
     value = map._values[key];
 }
 

--- a/scripts/generate/templates/EnumerableMap.js
+++ b/scripts/generate/templates/EnumerableMap.js
@@ -289,7 +289,7 @@ function at(${name} storage map, uint256 index) internal view returns (${key.typ
  * Replacement of the deprecated {at} function.
  */
 function pos(${name} storage map, uint256 index) internal view returns (${key.type} key, ${value.type} value) {
-    (bytes32 atKey, bytes32 val) = at(map._inner, index);
+    (bytes32 atKey, bytes32 val) = pos(map._inner, index);
     return (${fromBytes32(key.type, 'atKey')}, ${fromBytes32(value.type, 'val')});
 }
 

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -167,7 +167,7 @@ function _length(Set storage set) private view returns (uint256) {
  *
  * - \`index\` must be strictly less than {length}.
  */
-function _at(Set storage set, uint256 index) private view returns (bytes32) {
+function _pos(Set storage set, uint256 index) private view returns (bytes32) {
     return set._values[index];
 }
 
@@ -288,7 +288,7 @@ function at(${name} storage set, uint256 index) internal view returns (${type}) 
  * Replacement of the deprecated {at} function.
  */
 function pos(${name} storage set, uint256 index) internal view returns (${type}) {
-    return ${fromBytes32(type, '_at(set._inner, index)')};
+    return ${fromBytes32(type, '_pos(set._inner, index)')};
 }
 
 /**

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -268,7 +268,7 @@ function length(${name} storage set) internal view returns (uint256) {
  *
  * - \`index\` must be strictly less than {length}.
  *
- * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
  * should use {pos} instead.
  */
 function at(${name} storage set, uint256 index) internal view returns (${type}) {
@@ -435,7 +435,7 @@ function length(${name} storage set) internal view returns (uint256) {
  *
  * - \`index\` must be strictly less than {length}.
  *
- * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
  * should use {pos} instead.
  */
 function at(${name} storage set, uint256 index) internal view returns (${value.type} memory) {

--- a/scripts/generate/templates/EnumerableSet.js
+++ b/scripts/generate/templates/EnumerableSet.js
@@ -267,8 +267,27 @@ function length(${name} storage set) internal view returns (uint256) {
  * Requirements:
  *
  * - \`index\` must be strictly less than {length}.
+ *
+ * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * should use {pos} instead.
  */
 function at(${name} storage set, uint256 index) internal view returns (${type}) {
+    return pos(set, index);
+}
+
+/**
+ * @dev Returns the value stored at position \`index\` in the set. O(1).
+ *
+ * Note that there are no guarantees on the ordering of values inside the
+ * array, and it may change when more values are added or removed.
+ *
+ * Requirements:
+ *
+ * - \`index\` must be strictly less than {length}.
+ *
+ * Replacement of the deprecated {at} function.
+ */
+function pos(${name} storage set, uint256 index) internal view returns (${type}) {
     return ${fromBytes32(type, '_at(set._inner, index)')};
 }
 
@@ -415,8 +434,27 @@ function length(${name} storage set) internal view returns (uint256) {
  * Requirements:
  *
  * - \`index\` must be strictly less than {length}.
+ *
+ * IMPORTANT: Deprecated. This function's name clash with keyword scheduled for inclusion in solidity. Developers
+ * should use {pos} instead.
  */
 function at(${name} storage set, uint256 index) internal view returns (${value.type} memory) {
+    return pos(set, index);
+}
+
+/**
+ * @dev Returns the value stored at position \`index\` in the set. O(1).
+ *
+ * Note that there are no guarantees on the ordering of values inside the
+ * array, and it may change when more values are added or removed.
+ *
+ * Requirements:
+ *
+ * - \`index\` must be strictly less than {length}.
+ *
+ * Replacement of the deprecated {at} function.
+ */
+function pos(${name} storage set, uint256 index) internal view returns (${value.type} memory) {
     return set._values[index];
 }
 


### PR DESCRIPTION
- [x] remove all use of `error` as a variable name
- [x] deprecate all function named `at`
  - [x] add new `pos` function
  - [x] call the `pos` functions wherever `at` was previously called
- [x] use 0.8.35 by default in `hardhat.config.js` 
  - [x] do not escalate warning to errors for the remaining `at` functions.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
