### PR TITLE
fix(Arrays): optimize _quickSort to prevent stack overflow

### DIFF
--- a/.changeset/wet-books-report.md
+++ b/.changeset/wet-books-report.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Optimize `_quickSort` to use iterative approach, preventing stack overflow for arrays larger than ~169 elements

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -114,25 +114,34 @@ library Arrays {
      */
     function _quickSort(uint256 begin, uint256 end, function(uint256, uint256) pure returns (bool) comp) private pure {
         unchecked {
-            if (end - begin < 0x40) return;
-
-            // Use first element as pivot
-            uint256 pivot = _mload(begin);
-            // Position where the pivot should be at the end of the loop
-            uint256 pos = begin;
-
-            for (uint256 it = begin + 0x20; it < end; it += 0x20) {
-                if (comp(_mload(it), pivot)) {
-                    // If the value stored at the iterator's position comes before the pivot, we increment the
-                    // position of the pivot and move the value there.
-                    pos += 0x20;
-                    _swap(pos, it);
+            uint256 size = (end - begin) / 0x20;
+            if (size < 2) return;
+            uint256[] memory stack = new uint256[](2 * size);
+            uint256 top = 0;
+            stack[top++] = begin;
+            stack[top++] = end;
+            while (top > 0) {
+                end = stack[--top];
+                begin = stack[--top];
+                if (end - begin < 0x40) continue;
+                uint256 pivot = _mload(begin);
+                uint256 pos = begin;
+                for (uint256 it = begin + 0x20; it < end; it += 0x20) {
+                    if (comp(_mload(it), pivot)) {
+                        pos += 0x20;
+                        _swap(pos, it);
+                    }
+                }
+                _swap(begin, pos);
+                if (pos > begin + 0x20) {
+                    stack[top++] = begin;
+                    stack[top++] = pos;
+                }
+                if (pos + 0x40 < end) {
+                    stack[top++] = pos + 0x20;
+                    stack[top++] = end;
                 }
             }
-
-            _swap(begin, pos); // Swap pivot into place
-            _quickSort(begin, pos, comp); // Sort the left side of the pivot
-            _quickSort(pos + 0x20, end, comp); // Sort the right side of the pivot
         }
     }
 

--- a/scripts/generate/templates/Arrays.js
+++ b/scripts/generate/templates/Arrays.js
@@ -62,25 +62,34 @@ const quickSort = `\
  */
 function _quickSort(uint256 begin, uint256 end, function(uint256, uint256) pure returns (bool) comp) private pure {
     unchecked {
-        if (end - begin < 0x40) return;
-
-        // Use first element as pivot
-        uint256 pivot = _mload(begin);
-        // Position where the pivot should be at the end of the loop
-        uint256 pos = begin;
-
-        for (uint256 it = begin + 0x20; it < end; it += 0x20) {
-            if (comp(_mload(it), pivot)) {
-                // If the value stored at the iterator's position comes before the pivot, we increment the
-                // position of the pivot and move the value there.
-                pos += 0x20;
-                _swap(pos, it);
+        uint256 size = (end - begin) / 0x20;
+        if (size < 2) return;
+        uint256[] memory stack = new uint256[](2 * size);
+        uint256 top = 0;
+        stack[top++] = begin;
+        stack[top++] = end;
+        while (top > 0) {
+            end = stack[--top];
+            begin = stack[--top];
+            if (end - begin < 0x40) continue;
+            uint256 pivot = _mload(begin);
+            uint256 pos = begin;
+            for (uint256 it = begin + 0x20; it < end; it += 0x20) {
+                if (comp(_mload(it), pivot)) {
+                    pos += 0x20;
+                    _swap(pos, it);
+                }
+            }
+            _swap(begin, pos);
+            if (pos > begin + 0x20) {
+                stack[top++] = begin;
+                stack[top++] = pos;
+            }
+            if (pos + 0x40 < end) {
+                stack[top++] = pos + 0x20;
+                stack[top++] = end;
             }
         }
-
-        _swap(begin, pos); // Swap pivot into place
-        _quickSort(begin, pos, comp); // Sort the left side of the pivot
-        _quickSort(pos + 0x20, end, comp); // Sort the right side of the pivot
     }
 }
 

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -133,7 +133,7 @@ describe('Arrays', function () {
 
       if (isValueType) {
         describe('sort', function () {
-          for (const length of [0, 1, 2, 8, 32, 128]) {
+          for (const length of [0, 1, 2, 8, 32, 128, 200]) {
             describe(`${name}[] of length ${length}`, function () {
               beforeEach(async function () {
                 this.array = Array.from({ length }, generators[name]);


### PR DESCRIPTION
Replace recursive _quickSort with iterative stack-based implementation. The recursive version was limited to ~169 elements before hitting EVM stack overflow (depth 1024, 5 slots per call).

The iterative version uses an explicit memory stack, eliminating recursion depth limits entirely.

Fixes #6289

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
