### PR TITLE
Fix NatSpec inconsistency in GovernorVotesSuperQuorumFraction

### DIFF
--- a/contracts/governance/extensions/GovernorVotesSuperQuorumFraction.sol
+++ b/contracts/governance/extensions/GovernorVotesSuperQuorumFraction.sol
@@ -28,7 +28,7 @@ abstract contract GovernorVotesSuperQuorumFraction is GovernorVotesQuorumFractio
     error GovernorInvalidSuperQuorumFraction(uint256 superQuorumNumerator, uint256 denominator);
 
     /**
-     * @dev The super quorum set is not valid as it is smaller or equal to the quorum.
+     * @dev The super quorum set is not valid as it is smaller than the quorum.
      */
     error GovernorInvalidSuperQuorumTooSmall(uint256 superQuorumNumerator, uint256 quorumNumerator);
 
@@ -41,7 +41,7 @@ abstract contract GovernorVotesSuperQuorumFraction is GovernorVotesQuorumFractio
      * @dev Initialize super quorum as a fraction of the token's total supply.
      *
      * The super quorum is specified as a fraction of the token's total supply and has to
-     * be greater than the quorum.
+     * be greater than or equal to the quorum.
      */
     constructor(uint256 superQuorumNumeratorValue) {
         _updateSuperQuorumNumerator(superQuorumNumeratorValue);


### PR DESCRIPTION
## Summary

- The constructor docstring and `GovernorInvalidSuperQuorumTooSmall` error description claim a strict inequality between super quorum and quorum, but the validation logic (in both `_updateSuperQuorumNumerator` and `_updateQuorumNumerator`) accepts equal values, matching the requirements lists on the public/internal updaters.
- Update the constructor docstring (`greater than` → `greater than or equal to`) and the error description (`smaller or equal to` → `smaller than`) so the NatSpec consistently reflects actual behavior.
- Docs-only; no behavior or ABI change.

## Test plan

- [x] No code change — existing tests still pass.
- [x] `prettier` and `solhint` run via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)