### PR TITLE
Reject trailing bytes in RLP data decoders

### DIFF
--- a/.changeset/olive-rlp-decoders.md
+++ b/.changeset/olive-rlp-decoders.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`RLP`: Reject scalar and data items with trailing bytes when decoding.

--- a/contracts/utils/RLP.sol
+++ b/contracts/utils/RLP.sol
@@ -315,7 +315,7 @@ library RLP {
         require(length <= 33, RLPInvalidEncoding());
 
         (uint256 itemOffset, uint256 itemLength, ItemType itemType) = _decodeLength(item);
-        require(itemType == ItemType.Data, RLPInvalidEncoding());
+        require(itemType == ItemType.Data && length == itemOffset + itemLength, RLPInvalidEncoding());
 
         return itemLength == 0 ? 0 : uint256(item.load(itemOffset)) >> (256 - 8 * itemLength);
     }
@@ -334,8 +334,10 @@ library RLP {
 
     /// @dev Decodes an RLP encoded bytes. See {encode-bytes}
     function readBytes(Memory.Slice item) internal pure returns (bytes memory) {
+        uint256 itemLength = item.length();
+
         (uint256 offset, uint256 length, ItemType itemType) = _decodeLength(item);
-        require(itemType == ItemType.Data, RLPInvalidEncoding());
+        require(itemType == ItemType.Data && itemLength == offset + length, RLPInvalidEncoding());
 
         // Length is checked by {slice}
         return item.slice(offset, length).toBytes();

--- a/test/utils/RLP.test.js
+++ b/test/utils/RLP.test.js
@@ -205,6 +205,18 @@ describe('RLP', function () {
     });
   });
 
+  for (const { name, fn, input } of [
+    { name: 'bool', fn: '$decodeBool', input: '0x0102' },
+    { name: 'uint256', fn: '$decodeUint256', input: '0x0102' },
+    { name: 'bytes32', fn: '$decodeBytes32', input: '0x8204d200' },
+    { name: 'bytes', fn: '$decodeBytes', input: '0x83646f6780' },
+    { name: 'string', fn: '$decodeString', input: '0x83646f6780' },
+  ]) {
+    it(`rejects trailing bytes after ${name}`, async function () {
+      await expect(this.mock[fn](input)).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    });
+  }
+
   it('RLP encoder predict create addresses', async function () {
     for (const [from, nonce] of product(
       [


### PR DESCRIPTION
Fixes #6515

#### Summary

This updates the RLP scalar/data decoders to reject inputs that contain a valid first RLP data item followed by trailing bytes. `readUint256` and `readBytes` now require the decoded item to consume the full slice, which also covers `decodeBool`, `decodeBytes32`, and `decodeString`.

A patch changeset is included.

#### Tests

- `npx hardhat test test/utils/RLP.test.js`
- `npx prettier --log-level warn --ignore-path .gitignore contracts/utils/RLP.sol test/utils/RLP.test.js .changeset/olive-rlp-decoders.md --check`
- `npx eslint test/utils/RLP.test.js`
- `npx solhint --config solhint.config.js --noPoster contracts/utils/RLP.sol`
- `git diff --check`
