### PR TITLE
Fix(RLP): reject trailing bytes in scalar/data decoders

### DIFF
--- a/.changeset/common-frogs-pick.md
+++ b/.changeset/common-frogs-pick.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Fix RLP scalar decoders to reject inputs with trailing bytes after valid data item

--- a/contracts/utils/RLP.sol
+++ b/contracts/utils/RLP.sol
@@ -315,7 +315,7 @@ library RLP {
         require(length <= 33, RLPInvalidEncoding());
 
         (uint256 itemOffset, uint256 itemLength, ItemType itemType) = _decodeLength(item);
-        require(itemType == ItemType.Data, RLPInvalidEncoding());
+        require(itemType == ItemType.Data && itemOffset + itemLength == item.length(), RLPInvalidEncoding());
 
         return itemLength == 0 ? 0 : uint256(item.load(itemOffset)) >> (256 - 8 * itemLength);
     }
@@ -335,7 +335,7 @@ library RLP {
     /// @dev Decodes an RLP encoded bytes. See {encode-bytes}
     function readBytes(Memory.Slice item) internal pure returns (bytes memory) {
         (uint256 offset, uint256 length, ItemType itemType) = _decodeLength(item);
-        require(itemType == ItemType.Data, RLPInvalidEncoding());
+        require(itemType == ItemType.Data && offset + length == item.length(), RLPInvalidEncoding());
 
         // Length is checked by {slice}
         return item.slice(offset, length).toBytes();

--- a/test/utils/RLP.test.js
+++ b/test/utils/RLP.test.js
@@ -197,6 +197,9 @@ describe('RLP', function () {
     { name: 'list with invalid length', input: '0xc100' },
     { name: 'truncated long string', input: '0xb838' },
     { name: 'invalid single byte encoding (non-minimal)', input: '0x8100' },
+    { name: 'uint256 with trailing bytes', input: '0x0102' },
+    { name: 'bytes with trailing bytes', input: '0x83646f6780' },
+    { name: 'string with trailing bytes', input: '0x83646f6780' },
   ];
 
   invalidTests.forEach(({ name, input }) => {


### PR DESCRIPTION
<## Motivation
Fixes #6515

RLP scalar decoders (`decodeUint256`, `decodeBytes`, `decodeBytes32`, 
`decodeBool`, `decodeAddress`, `decodeString`) silently ignored trailing 
bytes after a valid RLP data item.

For example:
- `decodeUint256(0x0102)` returned `1` instead of reverting
- `decodeBytes(0x83646f6780)` returned `dog` instead of reverting

`decodeList` already correctly rejected trailing bytes — this fix 
brings scalar decoders in line with the same behavior.

## Changes
Added trailing bytes check to `readUint256` and `readBytes`:
- `readUint256`: require `itemOffset + itemLength == item.length()`
- `readBytes`: require `offset + length == item.length()`

`readBytes32`, `decodeBool`, `decodeAddress`, `decodeString` all 
delegate to these two functions so are fixed automatically.

## Testing
Added 3 regression tests. All 20 tests pass.
