### PR TITLE
ERC20 Approval Cap and Expiration Configurables

### DIFF
--- a/.changeset/chubby-heads-film.md
+++ b/.changeset/chubby-heads-film.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Added ERC20 extension for configurable approval caps and expiry

--- a/README.md
+++ b/README.md
@@ -1,122 +1,155 @@
-# <img src="logo.svg" alt="OpenZeppelin" height="40px">
+# ERC20SafeApproval — OpenZeppelin Extension
 
-[![Github Release](https://img.shields.io/github/v/tag/OpenZeppelin/openzeppelin-contracts.svg?filter=v*&sort=semver&label=github)](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/latest)
-[![NPM Package](https://img.shields.io/npm/v/@openzeppelin/contracts.svg)](https://www.npmjs.org/package/@openzeppelin/contracts)
-[![Coverage Status](https://codecov.io/gh/OpenZeppelin/openzeppelin-contracts/graph/badge.svg)](https://codecov.io/gh/OpenZeppelin/openzeppelin-contracts)
-[![GitPOAPs](https://public-api.gitpoap.io/v1/repo/OpenZeppelin/openzeppelin-contracts/badge)](https://www.gitpoap.io/gh/OpenZeppelin/openzeppelin-contracts)
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-yellow)](https://docs.openzeppelin.com/contracts)
-[![Forum](https://img.shields.io/badge/forum-%F0%9F%92%AC-yellow)](https://forum.openzeppelin.com/)
+> A contribution-quality extension of OpenZeppelin's ERC20 contract that adds
+> configurable approval caps and per-approval expiration timestamps.
 
-**A library for secure smart contract development.** Build on a solid foundation of community-vetted code.
+**Team:** Kenny Bartel & Brianna Patten
+**Course:** CS5833
+**Upstream Repo:** [OpenZeppelin/openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)
+**Related Issue:** [openzeppelin-contracts#6500](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/6500)
 
- * Implementations of standards like [ERC20](https://docs.openzeppelin.com/contracts/erc20) and [ERC721](https://docs.openzeppelin.com/contracts/erc721).
- * Flexible [role-based permissioning](https://docs.openzeppelin.com/contracts/access-control) scheme.
- * Reusable [Solidity components](https://docs.openzeppelin.com/contracts/utilities) to build custom contracts and complex decentralized systems.
-
-:mage: **Not sure how to get started?** Check out [Contracts Wizard](https://wizard.openzeppelin.com/) — an interactive smart contract generator.
-
-> [!IMPORTANT]
-> OpenZeppelin Contracts uses semantic versioning to communicate backwards compatibility of its API and storage layout. For upgradeable contracts, the storage layout of different major versions should be assumed incompatible, for example, it is unsafe to upgrade from 4.9.3 to 5.0.0. Learn more at [Backwards Compatibility](https://docs.openzeppelin.com/contracts/backwards-compatibility).
+---
 
 ## Overview
 
-### Release tags
+The standard ERC-20 approval mechanism allows unlimited, non-expiring approvals.
+This has been a known vector for token drains in DeFi, where users who previously
+signed unlimited approvals to contracts that later turned malicious had their tokens
+drained. While OpenZeppelin's `ERC20Permit` (ERC-2612) addresses expiry via
+off-chain signatures, it requires EIP-712 infrastructure not available in simpler
+applications and does not address approval caps.
 
-We use NPM tags to clearly distinguish between audited and non-audited versions of our package:
+`ERC20SafeApproval` is an abstract Solidity extension that enforces both on-chain
+through simple inheritance, requiring no off-chain signing infrastructure.
 
-| Tag        | Purpose                  | Description                                                                                                                                                                   |
-| :--------- | :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **latest** | ✅ Audited releases      | Stable, audited versions of the package. This is the **default** version installed when users run `npm install @openzeppelin/contracts`.                                      |
-| **dev**    | 🧪 Final but not audited | Versions that are finalized and feature-complete but have **not yet been audited**. This version is fully tested, can be used in production and is covered by the bug bounty. |
-| **next**   | 🚧 Release candidates    | Pre-release versions that are **not final**. Used for testing and validation before the version becomes a final `dev` or `latest` release.                                    |
+---
+
+## Features
+
+- **Approval Cap** — a configurable maximum approval ceiling; no spender can ever
+  be approved above this limit regardless of what the user signs
+- **Approval Expiry** — per-approval expiration timestamps; expired approvals
+  automatically revert in `transferFrom()`
+
+---
+
+## Project Structure
+contracts/
+└── token/
+└── ERC20/
+└── extensions/
+└── ERC20SafeApproval.sol   # main extension
+test/
+└── token/
+└── ERC20/
+└── ERC20SafeApproval.t.sol     # Foundry test suite
+script/
+└── DeployERC20SafeApproval.s.sol       # Sepolia deployment script
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- Git
 
 ### Installation
 
-#### Hardhat (npm)
-
-```
-$ npm install @openzeppelin/contracts
-```
-→ Installs the latest audited release (`latest`).
-
-```
-$ npm install @openzeppelin/contracts@dev
-```
-→ Installs the latest unaudited release (`dev`).
-
-#### Foundry (git)
-
-> [!WARNING]
-> When installing via git, it is a common error to use the `master` branch. This is a development branch that should be avoided in favor of tagged releases. The release process involves security measures that the `master` branch does not guarantee.
-
-> [!WARNING]
-> Foundry installs the latest version initially, but subsequent `forge update` commands will use the `master` branch.
-
-```
-$ forge install OpenZeppelin/openzeppelin-contracts
+```bash
+git clone https://github.com/kennyb66/CS5833-FinalProject
+cd contracts
+forge install
 ```
 
-Add `@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/` in `remappings.txt`.
+### Build
 
-### Usage
+```bash
+forge build
+```
 
-Once installed, you can use the contracts in the library by importing them:
+### Run Tests
+
+```bash
+forge test --match-path test/token/ERC20/ERC20SafeApproval.t.sol -v
+```
+
+### Run Gas Benchmarks
+
+```bash
+forge test --match-path test/token/ERC20/ERC20SafeApproval.t.sol --gas-report
+```
+
+### Deploy to Sepolia
+
+```bash
+forge script script/DeployERC20SafeApproval.s.sol \
+  --rpc-url $SEPOLIA_RPC_URL \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+---
+
+## Testnet Deployment
+
+| Contract | Network | Address |
+|----------|---------|---------|
+| ERC20SafeApproval | Sepolia | `0x...` |
+
+Verified on [Sepolia Etherscan](https://sepolia.etherscan.io/address/0x...)
+
+---
+
+## Gas Benchmarks
+
+| Function | Base ERC20 | ERC20SafeApproval | Delta |
+|----------|-----------|-------------------|-------|
+| `approve()` | - | - | - |
+| `transferFrom()` | - | - | - |
+
+*To be filled in during Week 3*
+
+---
+
+## Usage Example
 
 ```solidity
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./extensions/ERC20SafeApproval.sol";
 
-contract MyCollectible is ERC721 {
-    constructor() ERC721("MyCollectible", "MCO") {
+contract MyToken is ERC20SafeApproval {
+    constructor() ERC20("MyToken", "MTK") {
+        // set approval cap to 1000 tokens
+        // set default expiry to 30 days
     }
 }
 ```
 
-_If you're new to smart contract development, head to [Developing Smart Contracts](https://docs.openzeppelin.com/learn/developing-smart-contracts) to learn about creating a new project and compiling your contracts._
+---
 
-To keep your system secure, you should **always** use the installed code as-is, and neither copy-paste it from online sources nor modify it yourself. The library is designed so that only the contracts and functions you use are deployed, so you don't need to worry about it needlessly increasing gas costs.
+## Team Contributions
 
-## Learn More
+| Member | Contributions |
+|--------|--------------|
+| Kenny Bartel | |
+| Brianna Patten | |
 
-The guides in the [documentation site](https://docs.openzeppelin.com/contracts) will teach about different concepts, and how to use the related contracts that OpenZeppelin Contracts provides:
+*To be filled in as work progresses*
 
-* [Access Control](https://docs.openzeppelin.com/contracts/access-control): decide who can perform each of the actions on your system.
-* [Tokens](https://docs.openzeppelin.com/contracts/tokens): create tradeable assets or collectibles for popular ERC standards like ERC-20, ERC-721, ERC-1155, and ERC-6909.
-* [Utilities](https://docs.openzeppelin.com/contracts/utilities): generic useful tools including non-overflowing math, signature verification, and trustless paying systems.
+---
 
-The [full API](https://docs.openzeppelin.com/contracts/api/token/ERC20) is also thoroughly documented, and serves as a great reference when developing your smart contract application. You can also ask for help or follow Contracts' development in the [community forum](https://forum.openzeppelin.com).
+## Demo Video
 
-Finally, you may want to take a look at the [guides on our blog](https://blog.openzeppelin.com/), which cover several common use cases and good practices. The following articles provide great background reading, though please note that some of the referenced tools have changed, as the tooling in the ecosystem continues to rapidly evolve.
+*Link to be added in Week 3*
 
-* [The Hitchhiker’s Guide to Smart Contracts in Ethereum](https://blog.openzeppelin.com/the-hitchhikers-guide-to-smart-contracts-in-ethereum-848f08001f05) will help you get an overview of the various tools available for smart contract development, and help you set up your environment.
-* [A Gentle Introduction to Ethereum Programming, Part 1](https://blog.openzeppelin.com/a-gentle-introduction-to-ethereum-programming-part-1-783cc7796094) provides very useful information on an introductory level, including many basic concepts from the Ethereum platform.
-* For a more in-depth dive, you may read the guide [Designing the Architecture for Your Ethereum Application](https://blog.openzeppelin.com/designing-the-architecture-for-your-ethereum-application-9cec086f8317), which discusses how to better structure your application and its relationship to the real world.
+---
 
-## Security
+## References
 
-This project is maintained by [OpenZeppelin](https://openzeppelin.com) with the goal of providing a secure and reliable library of smart contract components for the ecosystem. We address security through risk management in various areas such as engineering and open source best practices, scoping and API design, multi-layered review processes, and incident response preparedness.
-
-The [OpenZeppelin Contracts Security Center](https://contracts.openzeppelin.com/security) contains more details about the secure development process.
-
-The security policy is detailed in [`SECURITY.md`](./SECURITY.md) as well, and specifies how you can report security vulnerabilities, which versions will receive security patches, and how to stay informed about them. We run a [bug bounty program on Immunefi](https://immunefi.com/bounty/openzeppelin) to reward the responsible disclosure of vulnerabilities.
-
-The engineering guidelines we follow to promote project quality can be found in [`GUIDELINES.md`](./GUIDELINES.md).
-
-Past audits can be found in [`audits/`](./audits).
-
-Smart contracts are a nascent technology and carry a high level of technical risk and uncertainty. Although OpenZeppelin is well known for its security audits, using OpenZeppelin Contracts is not a substitute for a security audit.
-
-OpenZeppelin Contracts is made available under the MIT License, which disclaims all warranties in relation to the project and which limits the liability of those that contribute and maintain the project, including OpenZeppelin. As set out further in the Terms, you acknowledge that you are solely responsible for any use of OpenZeppelin Contracts and you assume all risks associated with any such use.
-
-## Contribute
-
-OpenZeppelin Contracts exists thanks to its contributors. There are many ways you can participate and help build high quality software. Check out the [contribution guide](CONTRIBUTING.md)!
-
-## License
-
-OpenZeppelin Contracts is released under the [MIT License](LICENSE).
-
-## Legal
-
-Your use of this Project is governed by the terms found at www.openzeppelin.com/tos (the "Terms").
+- [OpenZeppelin ERC20 source](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/token/ERC20)
+- [ERC-2612 / ERC20Permit](https://eips.ethereum.org/EIPS/eip-2612)
+- [OpenZeppelin contribution guidelines](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -34,17 +34,13 @@ through simple inheritance, requiring no off-chain signing infrastructure.
 ---
 
 ## Project Structure
-contracts/
-└── token/
-└── ERC20/
-└── extensions/
-└── ERC20SafeApproval.sol   # main extension
-test/
-└── token/
-└── ERC20/
-└── ERC20SafeApproval.t.sol     # Foundry test suite
-script/
-└── DeployERC20SafeApproval.s.sol       # Sepolia deployment script
+
+New files added to the OpenZeppelin repository structure:
+
+- `contracts/token/ERC20/extensions/ERC20SafeApproval.sol` — main extension contract
+- `contracts/mocks/token/ERC20SafeApprovalMock.sol` — mock contract used for testing
+- `test/token/ERC20/extensions/ERC20SafeApproval.test.js` — Hardhat test suite
+- `scripts/deployERC20SafeApproval.js` — Sepolia deployment script
 
 ---
 
@@ -52,42 +48,42 @@ script/
 
 ### Prerequisites
 
-- [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- Node.js
 - Git
 
 ### Installation
 
 ```bash
 git clone https://github.com/kennyb66/CS5833-FinalProject
-cd contracts
-forge install
+cd CS5833-FinalProject
+npm install
 ```
 
 ### Build
 
 ```bash
-forge build
+npm run compile
 ```
 
 ### Run Tests
 
 ```bash
-forge test --match-path test/token/ERC20/ERC20SafeApproval.t.sol -v
-```
-
-### Run Gas Benchmarks
-
-```bash
-forge test --match-path test/token/ERC20/ERC20SafeApproval.t.sol --gas-report
+npm run test test/token/ERC20/extensions/ERC20SafeApproval.test.js
 ```
 
 ### Deploy to Sepolia
 
+Create a `.env` file in the root of the repo:
+
+```
+SEPOLIA_RPC_URL=your_rpc_url_here
+PRIVATE_KEY=your_private_key_here
+```
+
+Then run:
+
 ```bash
-forge script script/DeployERC20SafeApproval.s.sol \
-  --rpc-url $SEPOLIA_RPC_URL \
-  --private-key $PRIVATE_KEY \
-  --broadcast
+./node_modules/.bin/hardhat run scripts/deployERC20SafeApproval.js --network sepolia
 ```
 
 ---
@@ -96,20 +92,29 @@ forge script script/DeployERC20SafeApproval.s.sol \
 
 | Contract | Network | Address |
 |----------|---------|---------|
-| ERC20SafeApproval | Sepolia | `0x...` |
+| ERC20SafeApprovalMock | Sepolia | `0xdD1bf110349890E6183537eec6200775d425Dd0f` |
 
-Verified on [Sepolia Etherscan](https://sepolia.etherscan.io/address/0x...)
+Verified on [Sepolia Etherscan](https://sepolia.etherscan.io/address/0xdD1bf110349890E6183537eec6200775d425Dd0f)
+
+**Transactions:**
+
+| Transaction | Hash |
+|-------------|------|
+| Mint | [0x6ff8385d...](https://sepolia.etherscan.io/tx/0x6ff8385d0ab3ea04af89dfaee6333c8ea6e821985d1917ff667ed4df0675e559) |
+| Approve | [0x0a48fc2c...](https://sepolia.etherscan.io/tx/0x0a48fc2cf04500729582d4507a322826af6398dd8a1eb430b602c59a885dd864) |
+| ApproveWithExpiration | [0xfc6893b8...](https://sepolia.etherscan.io/tx/0xfc6893b80e466afe456fea38eacb2aea2d9d8a8ed00ac2881e5a254776ee9a6f) |
 
 ---
 
 ## Gas Benchmarks
 
-| Function | Base ERC20 | ERC20SafeApproval | Delta |
-|----------|-----------|-------------------|-------|
-| `approve()` | - | - | - |
-| `transferFrom()` | - | - | - |
+| Function | Standard ERC-20 | ERC20SafeApproval | Overhead |
+|----------|----------------|-------------------|----------|
+| `approve()` | 46,000 | 48,296 | +2,296 (+5%) |
+| `approveWithExpiration()` | N/A | 73,112 | N/A |
+| `transferFrom()` | 34,000 | 59,910 | +25,910 (+76%) |
 
-*To be filled in during Week 3*
+*Measured using hardhat-gas-reporter. The `transferFrom()` overhead reflects the additional expiry check performed before each transfer.*
 
 ---
 
@@ -122,9 +127,8 @@ pragma solidity ^0.8.20;
 import "./extensions/ERC20SafeApproval.sol";
 
 contract MyToken is ERC20SafeApproval {
-    constructor() ERC20("MyToken", "MTK") {
-        // set approval cap to 1000 tokens
-        // set default expiry to 30 days
+    constructor() ERC20("MyToken", "MTK") ERC20SafeApproval(1000) {
+        // approval cap set to 1000 tokens at deploy time
     }
 }
 ```
@@ -135,16 +139,14 @@ contract MyToken is ERC20SafeApproval {
 
 | Member | Contributions |
 |--------|--------------|
-| Kenny Bartel | |
-| Brianna Patten | |
-
-*To be filled in as work progresses*
+| Kenny Bartel | Project proposal, repository setup, test suite implementation, deployment script, GitHub contribution artifacts |
+| Brianna Patten | Project report, ERC20SafeApproval extension contract, ERC20SafeApprovalToken contract, ERC20SafeApprovalMock contract |
 
 ---
 
 ## Demo Video
 
-*Link to be added in Week 3*
+[Demo Link](https://drive.google.com/file/d/1E0e3O1lz2cZ3P9AZo5LPKV2ekhCwC3fD/view?usp=sharing)
 
 ---
 
@@ -153,3 +155,4 @@ contract MyToken is ERC20SafeApproval {
 - [OpenZeppelin ERC20 source](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/token/ERC20)
 - [ERC-2612 / ERC20Permit](https://eips.ethereum.org/EIPS/eip-2612)
 - [OpenZeppelin contribution guidelines](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md)
+- [Upstream Issue #6500](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/6500)

--- a/contracts/mocks/token/ERC20SafeApprovalMock.sol
+++ b/contracts/mocks/token/ERC20SafeApprovalMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.20;
+
+import {ERC20SafeApproval} from "../../token/ERC20/extensions/ERC20SafeApproval.sol";
+import {ERC20} from "../../token/ERC20/ERC20.sol";
+
+contract ERC20SafeApprovalMock is ERC20SafeApproval {
+    constructor(string memory name, string memory symbol, uint256 cap)
+        ERC20(name, symbol)
+        ERC20SafeApproval(cap)
+    {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+
+    function setApprovalCap(uint256 newCap) external {
+        _setApprovalCap(newCap);
+    }
+}

--- a/contracts/token/ERC20/extensions/ERC20SafeApproval.sol
+++ b/contracts/token/ERC20/extensions/ERC20SafeApproval.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "../ERC20.sol";
+
+/**
+ * @dev Extension of ERC20 that adds a configurable approval cap
+ * and per-approval expiration timestamps.
+ */
+abstract contract ERC20SafeApproval is ERC20 {
+    // TODO: approval cap storage
+    // TODO: expiry storage
+    // TODO: override approve()
+    // TODO: override transferFrom()
+}

--- a/contracts/token/ERC20/extensions/ERC20SafeApproval.sol
+++ b/contracts/token/ERC20/extensions/ERC20SafeApproval.sol
@@ -8,8 +8,85 @@ import {ERC20} from "../ERC20.sol";
  * and per-approval expiration timestamps.
  */
 abstract contract ERC20SafeApproval is ERC20 {
+
+    /**
+     * @dev The approval amount exceeds the configured cap
+     */
+    error ERC20ApprovalCapExceeded(uint256 attempted, uint256 cap);
+
+    /**
+     * @dev A transferFrom was attempted with an expired approval
+     */
+    error ERC20ApprovalExpired(address owner, address spender, uint256 expiryTime);
+
+    /**
+     * @dev An approval was attempted with an expiration time in the past
+     */
+    error ERC20InvalidExpiration(uint256 expiryTime);
+
     // TODO: approval cap storage
+    uint256 private _approvalCap;
     // TODO: expiry storage
-    // TODO: override approve()
+    
     // TODO: override transferFrom()
+    mapping(address owner => mapping(address spender => uint256 expiry)) private _approvalExpiry;
+
+    event ApprovalCapUpdated(uint256 oldCap, uint256 newCap);
+    event ApprovalWithExpiration(address indexed owner, address indexed spender, uint256 value, uint256 expiryTime);
+
+    constructor(uint256 cap) {
+        _setApprovalCap(cap);
+    }
+
+    function getApprovalCap() public view virtual returns (uint256) {
+        return _approvalCap;
+    }
+
+    function getApprovalExpiry(address owner, address spender) public view virtual returns (uint256) {
+        return _approvalExpiry[owner][spender];
+    }
+
+    function isApprovalExpired(address owner, address spender) public view virtual returns (bool) {
+        uint256 expiry = _approvalExpiry[owner][spender];
+        return expiry != 0 && block.timestamp > expiry;
+    }
+
+    // TODO: override approve()
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _checkCap(amount);
+        delete _approvalExpiry[msg.sender][spender];
+        return super.approve(spender, amount);
+    }
+
+    function approveWithExpiration(address spender, uint256 amount, uint256 expiryTime) public virtual returns (bool) {
+        if (expiryTime <= block.timestamp) {
+            revert ERC20InvalidExpiration(expiryTime);
+        }
+        _checkCap(amount);
+        _approvalExpiry[msg.sender][spender] = expiryTime;
+        emit ApprovalWithExpiration(msg.sender, spender, amount, expiryTime);
+        return super.approve(spender, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
+        uint256 expiry = _approvalExpiry[from][msg.sender];
+        if (expiry != 0 && block.timestamp > expiry) {
+            revert ERC20ApprovalExpired(from, msg.sender, expiry);
+        }
+        return super.transferFrom(from, to, amount);
+    }
+
+    function _checkCap(uint256 value) internal view virtual {
+        uint256 cap = _approvalCap;
+        if (cap != type(uint256).max && value > cap) {
+            revert ERC20ApprovalCapExceeded(value, cap);
+        }
+    }
+
+    function _setApprovalCap(uint256 newCap) internal virtual {
+        uint256 oldCap = _approvalCap;
+        _approvalCap = newCap;
+        emit ApprovalCapUpdated(oldCap, newCap);
+    }
+    
 }

--- a/contracts/token/ERC20/extensions/ERC20SafeApprovalToken.sol
+++ b/contracts/token/ERC20/extensions/ERC20SafeApprovalToken.sol
@@ -2,12 +2,19 @@
 pragma solidity ^0.8.20;
 
 import {ERC20SafeApproval} from "./ERC20SafeApproval.sol";
+import {ERC20} from "../ERC20.sol";
 
 /**
  * @dev Concrete ERC20 token using ERC20SafeApproval extension.
  * Used for testing and demonstration purposes.
  */
 contract ERC20SafeApprovalToken is ERC20SafeApproval {
+    constructor(string memory name, string memory symbol, uint256 cap, uint256 initialSupply)
+        ERC20(name, symbol)
+        ERC20SafeApproval(cap)
+    {
+        _mint(msg.sender, initialSupply);
+    }
 
     // TODO: add owner storage and onlyOwner modifier
 

--- a/contracts/token/ERC20/extensions/ERC20SafeApprovalToken.sol
+++ b/contracts/token/ERC20/extensions/ERC20SafeApprovalToken.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20SafeApproval} from "./ERC20SafeApproval.sol";
+
+/**
+ * @dev Concrete ERC20 token using ERC20SafeApproval extension.
+ * Used for testing and demonstration purposes.
+ */
+contract ERC20SafeApprovalToken is ERC20SafeApproval {
+
+    // TODO: add owner storage and onlyOwner modifier
+
+    // TODO: add constructor
+
+    // TODO: expose setApprovalCap for owner
+}

--- a/test/token/ERC20/ERC20SafeApproval.t.sol
+++ b/test/token/ERC20/ERC20SafeApproval.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20SafeApprovalToken} from
+    "../../../contracts/token/ERC20/extensions/ERC20SafeApprovalToken.sol";
+
+contract ERC20SafeApprovalTest is Test {
+
+    ERC20SafeApprovalToken token;
+
+    address owner     = address(0x1);
+    address spender   = address(0x2);
+    address recipient = address(0x3);
+
+    function setUp() public {
+        // TODO: deploy token with initial cap and supply
+    }
+
+    // TODO: test normal approval within cap
+
+    // TODO: test approval above cap reverts
+
+    // TODO: test approveWithExpiry sets expiry correctly
+
+    // TODO: test transferFrom before expiry succeeds
+
+    // TODO: test transferFrom after expiry reverts
+
+    // TODO: test combined cap + expiry case
+}

--- a/test/token/ERC20/ERC20SafeApproval.t.sol
+++ b/test/token/ERC20/ERC20SafeApproval.t.sol
@@ -1,3 +1,4 @@
+/*
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -28,4 +29,4 @@ contract ERC20SafeApprovalTest is Test {
     // TODO: test transferFrom after expiry reverts
 
     // TODO: test combined cap + expiry case
-}
+}*/

--- a/test/token/ERC20/extensions/ERC20SafeApproval.test.js
+++ b/test/token/ERC20/extensions/ERC20SafeApproval.test.js
@@ -1,7 +1,6 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const time = require('../../../helpers/time');
+const { loadFixture, time } = require('@nomicfoundation/hardhat-network-helpers');
 
 const cap = 500n;
 
@@ -17,4 +16,158 @@ describe('ERC20SafeApproval', function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
+  // -------------------------
+  // Approval Cap Tests
+  // -------------------------
+
+  describe('approval cap', function () {
+    it('returns the correct approval cap', async function () {
+      expect(await this.token.getApprovalCap()).to.equal(cap);
+    });
+
+    it('allows approval at exactly the cap', async function () {
+      await expect(this.token.connect(this.holder).approve(this.spender, cap))
+        .to.not.be.reverted;
+      expect(await this.token.allowance(this.holder, this.spender)).to.equal(cap);
+    });
+
+    it('allows approval below the cap', async function () {
+      await expect(this.token.connect(this.holder).approve(this.spender, 100n))
+        .to.not.be.reverted;
+      expect(await this.token.allowance(this.holder, this.spender)).to.equal(100n);
+    });
+
+    it('reverts when approval exceeds the cap', async function () {
+      await expect(this.token.connect(this.holder).approve(this.spender, cap + 1n))
+        .to.be.revertedWithCustomError(this.token, 'ERC20ApprovalCapExceeded')
+        .withArgs(cap + 1n, cap);
+    });
+
+    it('allows any approval amount when cap is set to max uint256', async function () {
+      await this.token.setApprovalCap(ethers.MaxUint256);
+      await expect(this.token.connect(this.holder).approve(this.spender, ethers.MaxUint256))
+        .to.not.be.reverted;
+    });
+
+    it('emits ApprovalCapUpdated when cap is changed', async function () {
+      await expect(this.token.setApprovalCap(1000n))
+        .to.emit(this.token, 'ApprovalCapUpdated')
+        .withArgs(cap, 1000n);
+      expect(await this.token.getApprovalCap()).to.equal(1000n);
+    });
+
+    it('enforces updated cap on new approvals', async function () {
+      await this.token.setApprovalCap(200n);
+      await expect(this.token.connect(this.holder).approve(this.spender, 201n))
+        .to.be.revertedWithCustomError(this.token, 'ERC20ApprovalCapExceeded')
+        .withArgs(201n, 200n);
+    });
+
+    it('allows transferFrom within cap and allowance', async function () {
+      await this.token.connect(this.holder).approve(this.spender, 100n);
+      await expect(this.token.connect(this.spender).transferFrom(this.holder, this.other, 50n))
+        .to.not.be.reverted;
+      expect(await this.token.balanceOf(this.other)).to.equal(50n);
+    });
+  });
+
+  // -------------------------
+  // Approval Expiry Tests
+  // -------------------------
+
+  describe('approval expiration', function () {
+    it('sets expiry correctly with approveWithExpiration', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry);
+      expect(await this.token.getApprovalExpiry(this.holder, this.spender)).to.equal(expiry);
+      expect(await this.token.allowance(this.holder, this.spender)).to.equal(100n);
+    });
+
+    it('emits ApprovalWithExpiration event', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await expect(this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry))
+        .to.emit(this.token, 'ApprovalWithExpiration')
+        .withArgs(this.holder.address, this.spender.address, 100n, expiry);
+    });
+
+    it('reverts when expiry is in the past', async function () {
+      const pastExpiry = BigInt(await time.latest()) - 1n;
+      await expect(this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, pastExpiry))
+        .to.be.revertedWithCustomError(this.token, 'ERC20InvalidExpiration')
+        .withArgs(pastExpiry);
+    });
+
+    it('reverts when expiry is current timestamp', async function () {
+      const now = BigInt(await time.latest());
+      await expect(this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, now))
+        .to.be.revertedWithCustomError(this.token, 'ERC20InvalidExpiration')
+        .withArgs(now);
+    });
+
+    it('allows transferFrom before expiry', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry);
+      await expect(this.token.connect(this.spender).transferFrom(this.holder, this.other, 50n))
+        .to.not.be.reverted;
+      expect(await this.token.balanceOf(this.other)).to.equal(50n);
+    });
+
+    it('reverts transferFrom after expiry', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry);
+
+      await time.increaseTo(expiry + 1n);
+
+      await expect(this.token.connect(this.spender).transferFrom(this.holder, this.other, 50n))
+        .to.be.revertedWithCustomError(this.token, 'ERC20ApprovalExpired')
+        .withArgs(this.holder.address, this.spender.address, expiry);
+    });
+
+    it('isApprovalExpired returns false before expiry', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry);
+      expect(await this.token.isApprovalExpired(this.holder, this.spender)).to.equal(false);
+    });
+
+    it('isApprovalExpired returns true after expiry', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry);
+      await time.increaseTo(expiry + 1n);
+      expect(await this.token.isApprovalExpired(this.holder, this.spender)).to.equal(true);
+    });
+
+    it('normal approve clears any existing expiry', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await this.token.connect(this.holder).approveWithExpiration(this.spender, 100n, expiry);
+
+      // Re-approve without expiry
+      await this.token.connect(this.holder).approve(this.spender, 100n);
+      expect(await this.token.getApprovalExpiry(this.holder, this.spender)).to.equal(0n);
+
+      // transferFrom should work even after original expiry passes
+      await time.increaseTo(expiry + 1n);
+      await expect(this.token.connect(this.spender).transferFrom(this.holder, this.other, 50n))
+        .to.not.be.reverted;
+    });
+  });
+
+  // -------------------------
+  // Combined Tests
+  // -------------------------
+
+  describe('cap and expiry combined', function () {
+    it('reverts approveWithExpiration above cap', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await expect(this.token.connect(this.holder).approveWithExpiration(this.spender, cap + 1n, expiry))
+        .to.be.revertedWithCustomError(this.token, 'ERC20ApprovalCapExceeded')
+        .withArgs(cap + 1n, cap);
+    });
+
+    it('allows approveWithExpiration at exactly the cap', async function () {
+      const expiry = BigInt(await time.latest()) + 86400n;
+      await expect(this.token.connect(this.holder).approveWithExpiration(this.spender, cap, expiry))
+        .to.not.be.reverted;
+      expect(await this.token.allowance(this.holder, this.spender)).to.equal(cap);
+    });
+  });
 });

--- a/test/token/ERC20/extensions/ERC20SafeApproval.test.js
+++ b/test/token/ERC20/extensions/ERC20SafeApproval.test.js
@@ -1,0 +1,20 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const time = require('../../../helpers/time');
+
+const cap = 500n;
+
+async function fixture() {
+  const [holder, spender, other] = await ethers.getSigners();
+  const token = await ethers.deployContract('ERC20SafeApprovalMock', ['My Token', 'MTKN', cap]);
+  await token.mint(holder, 1000n);
+  return { holder, spender, other, token };
+}
+
+describe('ERC20SafeApproval', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+});


### PR DESCRIPTION
Fixes #6500 

Added an ERC20 extension that adds two optional and configurable constraints (an approval cap and an approval expiration time).

ERC20SafeApproval extends OpenZeppelin’s ERC20 implementation and introduces a configurable approval cap that restricts the maximum allowance that can be granted. Any approval exceeding the cap is reverted using a custom error (ERC20ApprovalCapExceeded). The cap can be updated by an internal setter and enforced consistently across approve and approveWithExpiration.

The approveWithExpiration function allows setting a timestamp after which the allowance becomes invalid. The transferFrom function is extended to check whether the approval has expired and reverts with ERC20ApprovalExpired if so. Expiration state is stored per (owner, spender) pair.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
