### PR TITLE
chore: add ESLint rule to prevent async in describe blocks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
 import { includeIgnoreFile } from '@eslint/compat';
+import mocha from 'eslint-plugin-mocha';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 import path from 'path';
@@ -10,6 +11,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default [
   js.configs.recommended,
   prettier,
+  {
+    plugins: { mocha },
+    rules: {
+      'mocha/no-async-suite': 'error',
+    },
+  },
   {
     languageOptions: {
       ecmaVersion: 2022,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "chai": "^4.2.0",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
+        "eslint-plugin-mocha": "^11.2.0",
         "ethers": "^6.16.0",
         "glob": "^13.0.0",
         "globals": "^17.0.0",
@@ -4429,6 +4430,33 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.2.0.tgz",
+      "integrity": "sha512-nMdy3tEXZac8AH5Z/9hwUkSfWu8xHf4XqwB5UEQzyTQGKcNlgFeciRAjLjliIKC3dR1Ex/a2/5sqgQzvYRkkkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.1",
+        "globals": "^15.14.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "chai": "^4.2.0",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-mocha": "^11.2.0",
     "ethers": "^6.16.0",
     "glob": "^13.0.0",
     "globals": "^17.0.0",

--- a/test/access/manager/AccessManager.test.js
+++ b/test/access/manager/AccessManager.test.js
@@ -1108,7 +1108,7 @@ describe('AccessManager', function () {
           expect(await this.manager.isTargetClosed(this.target)).to.be.false;
         });
 
-        describe('when the target is the manager', async function () {
+        describe('when the target is the manager', function () {
           it('closes and opens the manager', async function () {
             await expect(this.manager.connect(this.admin).setTargetClosed(this.manager, true))
               .to.emit(this.manager, 'TargetClosed')

--- a/test/crosschain/BridgeERC1155.behavior.js
+++ b/test/crosschain/BridgeERC1155.behavior.js
@@ -27,7 +27,7 @@ function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chainBIsCust
       ]);
     });
 
-    describe('crosschain send (both direction)', async function () {
+    describe('crosschain send (both direction)', function () {
       it('single', async function () {
         const [alice, bruce, chris] = this.accounts;
 

--- a/test/token/ERC6909/ERC6909.behavior.js
+++ b/test/token/ERC6909/ERC6909.behavior.js
@@ -142,7 +142,7 @@ function shouldBehaveLikeERC6909() {
         await expect(this.token.balanceOf(this.recipient, firstTokenId)).to.eventually.equal(amount);
       });
 
-      describe('with approval', async function () {
+      describe('with approval', function () {
         beforeEach(async function () {
           await this.token.connect(this.holder).approve(this.operator, firstTokenId, amount);
         });


### PR DESCRIPTION
## Summary

Fixes #4943

This PR adds [`eslint-plugin-mocha`](https://github.com/lo1tuma/eslint-plugin-mocha) and enables the [`mocha/no-async-suite`](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-async-suite.md) rule at `error` severity.

### Why

Async `describe` callbacks are silently ignored by Mocha — the runner does not await them. This means any `await` used directly in a `describe` body (outside of `it`/`before`/`after` hooks) will be dropped, potentially masking test failures. Adding a lint rule catches this class of mistake automatically.

### Changes

- **`eslint.config.mjs`**: Import `eslint-plugin-mocha` and configure `mocha/no-async-suite: error`
- **`package.json`**: Add `eslint-plugin-mocha` as a dev dependency
- **`test/`**: Remove `async` keyword from `describe` callbacks in 3 files:
  - `test/access/manager/AccessManager.test.js` (line 1111)
  - `test/crosschain/BridgeERC1155.behavior.js` (line 30)
  - `test/token/ERC6909/ERC6909.behavior.js` (line 145)

### PR Checklist
- [x] Linter passes (`npm run lint:js`)
- [ ] Tests pass (`npm test`)

---

> Note: There is an existing open PR (#6438) for this same issue. This contribution was made independently. This fix was contributed with AI assistance by SwarmFix (sulphur-swarm).