### PR TITLE
fix: reject proposals with duplicate actions in GovernorTimelockCompound

### DIFF
--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -34,6 +34,38 @@ abstract contract GovernorTimelockCompound is Governor {
     }
 
     /**
+     * @dev Reject proposals that contain duplicate actions. Duplicate (target, value, calldata)
+     * actions would generate identical timelock transaction hashes, causing queueing to fail
+     * silently in {_queueOperations}. Detecting duplicates at proposal creation time provides
+     * a clear error instead.
+     */
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal virtual override returns (uint256) {
+        for (uint256 i = 0; i < targets.length; ++i) {
+            for (uint256 j = i + 1; j < targets.length; ++j) {
+                if (
+                    targets[i] == targets[j] &&
+                    values[i] == values[j] &&
+                    keccak256(calldatas[i]) == keccak256(calldatas[j])
+                ) {
+                    revert GovernorDuplicateAction(targets[i], values[i], calldatas[i]);
+                }
+            }
+        }
+        return super._propose(targets, values, calldatas, description, proposer);
+    }
+
+    /**
+     * @dev Emitted when a proposal contains duplicate actions.
+     */
+    error GovernorDuplicateAction(address target, uint256 value, bytes calldata);
+
+    /**
      * @dev Overridden version of the {Governor-state} function with added support for the `Expired` state.
      */
     function state(uint256 proposalId) public view virtual override returns (ProposalState) {


### PR DESCRIPTION
## Problem

Proposals containing 2+ actions with identical `(target, value, calldata)` will fail during queueing in `_queueOperations`. The Compound timelock generates transaction hashes from `keccak256(abi.encode(targets[i], values[i], "", calldatas[i], etaSeconds))`, so duplicate actions produce identical hashes. The first action queues successfully, but the second triggers `GovernorAlreadyQueuedProposal` because the hash is already marked as queued.

This can be circumvented by appending extra bytes to calldata, but users may not realize their proposal is unexecutable until after voting ends.

## Solution

Override `_propose` in `GovernorTimelockCompound` to detect duplicate actions at proposal creation time, providing a clear error before any gas is wasted on voting.

```solidity
function _propose(
    address[] memory targets,
    uint256[] memory values,
    bytes[] memory calldatas,
    string memory description,
    address proposer
) internal virtual override returns (uint256) {
    for (uint256 i = 0; i < targets.length; ++i) {
        for (uint256 j = i + 1; j < targets.length; ++j) {
            if (
                targets[i] == targets[j] &&
                values[i] == values[j] &&
                keccak256(calldatas[i]) == keccak256(calldatas[j])
            ) {
                revert GovernorDuplicateAction(targets[i], values[i], calldatas[i]);
            }
        }
    }
    return super._propose(targets, values, calldatas, description, proposer);
}
```

## Complexity

O(n²) pairwise comparison where n = number of actions. For typical proposals (n < 20), this is negligible gas cost.

## Tests

TODO: Add test cases for:
- Proposal with no duplicates → succeeds
- Proposal with duplicate actions → reverts with `GovernorDuplicateAction`
- Proposal with same target/value but different calldata → succeeds

Fixes #6431
