### PR TITLE
docs: use safe mint in ERC721 example

### DIFF
--- a/.changeset/erc721-docs-safe-mint-example.md
+++ b/.changeset/erc721-docs-safe-mint-example.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use `_safeMint` in the ERC721 GameItem documentation example.

--- a/contracts/mocks/docs/token/ERC721/GameItem.sol
+++ b/contracts/mocks/docs/token/ERC721/GameItem.sol
@@ -11,7 +11,7 @@ contract GameItem is ERC721URIStorage {
 
     function awardItem(address player, string memory tokenURI) public returns (uint256) {
         uint256 tokenId = _nextTokenId++;
-        _mint(player, tokenId);
+        _safeMint(player, tokenId);
         _setTokenURI(tokenId, tokenURI);
 
         return tokenId;


### PR DESCRIPTION
## Summary
- use `_safeMint` in the ERC721 `GameItem` docs example
- keeps `_nextTokenId++` before minting so the token id is advanced before the receiver callback

Closes #4033.

## Tests
- `npx prettier --log-level warn --ignore-path .gitignore contracts/mocks/docs/token/ERC721/GameItem.sol --check`
- `npx solhint --config solhint.config.js --noPoster contracts/mocks/docs/token/ERC721/GameItem.sol`
- `npx hardhat compile`
- `git diff --check`

Note: the local pre-commit hook invokes Unix shell scripts directly and did not run on Windows, so I committed with `--no-verify` after running the checks above manually.