### PR TITLE
Document VestingWallet allocation bound

### DIFF
--- a/.changeset/calm-wallets-warn.md
+++ b/.changeset/calm-wallets-warn.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`VestingWallet`: Document the historical allocation bound used by vesting calculations.

--- a/contracts/finance/VestingWallet.sol
+++ b/contracts/finance/VestingWallet.sol
@@ -17,6 +17,10 @@ import {Ownable} from "../access/Ownable.sol";
  * Consequently, if the vesting has already started, any amount of tokens sent to this contract will (at least partly)
  * be immediately releasable.
  *
+ * NOTE: The vesting schedule is computed from an asset's historical allocation, defined as the current balance plus
+ * the amount already released. Make sure this sum never exceeds `type(uint256).max`, or the relevant view and release
+ * functions will revert.
+ *
  * By setting the duration to 0, one can configure this contract to behave like an asset timelock that holds tokens for
  * a beneficiary until a specified time.
  *


### PR DESCRIPTION
﻿## Summary
- document the `VestingWallet` historical-allocation bound used by `vestedAmount`
- call out that current balance plus released amount must stay within `uint256` for views and releases to work

## Testing
- `npm ci`
- `npm run compile`
- `npx prettier --log-level warn --ignore-path .gitignore "contracts/finance/VestingWallet.sol" --check`
- `npx solhint --config solhint.config.js --noPoster "contracts/finance/VestingWallet.sol"`
- `npx hardhat test test/finance/VestingWallet.test.js`

Refs #5793
