### PR TITLE
Document ERC165Checker gas forwarding limitation

### DIFF
--- a/.changeset/quiet-lamps-check.md
+++ b/.changeset/quiet-lamps-check.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC165Checker`: Document the gas forwarding limitation when querying `supportsInterface`.

--- a/contracts/utils/introspection/ERC165Checker.sol
+++ b/contracts/utils/introspection/ERC165Checker.sol
@@ -11,6 +11,12 @@ import {IERC165} from "./IERC165.sol";
  * Note that these functions return the actual result of the query: they do not
  * `revert` if an interface is not supported. It is up to the caller to decide
  * what to do in these cases.
+ *
+ * IMPORTANT: The `supportsInterface` function being queried is expected to use
+ * less than 30 000 gas. If the caller does not have enough gas to forward 30 000
+ * gas to the callee, these functions may incorrectly interpret an out-of-gas
+ * error as a lack of support. Make sure the surrounding call has enough gas
+ * before relying on the result.
  */
 library ERC165Checker {
     // As per the ERC-165 spec, no interface should ever match 0xffffffff

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -197,6 +197,10 @@ In Solidity, it's frequently helpful to know whether or not a contract supports 
 * xref:api:utils.adoc#ERC165Checker-_supportsInterface-address-bytes4-[`myAddress._supportsInterface(bytes4)`]
 * xref:api:utils.adoc#ERC165Checker-_supportsAllInterfaces-address-bytes4---[`myAddress._supportsAllInterfaces(bytes4[\])`]
 
+IMPORTANT: ERC-165 requires `supportsInterface` calls to use less than 30 000 gas. If the caller does not have enough
+gas to forward 30 000 gas to the checked contract, `ERC165Checker` may interpret an out-of-gas error as a lack of
+interface support. Make sure the surrounding call has enough gas before relying on these results.
+
 [source,solidity]
 ----
 contract MyContract {


### PR DESCRIPTION
﻿## Summary
- document the ERC165Checker gas-forwarding limitation discussed in #1750
- add the same warning to the utilities guide so callers know to provide enough surrounding gas before relying on interface checks

## Testing
- `npm run compile`
- `npx prettier --log-level warn --ignore-path .gitignore "contracts/utils/introspection/ERC165Checker.sol" --check`
- `npx solhint --config solhint.config.js --noPoster "contracts/utils/introspection/ERC165Checker.sol"`
- `npx hardhat test test/utils/introspection/ERC165Checker.test.js`

Refs #1750
