### PR TITLE
fix: correct grammar in draft-InteroperableAddress NatSpec (a ERC → a…

### DIFF
--- a/contracts/utils/draft-InteroperableAddress.sol
+++ b/contracts/utils/draft-InteroperableAddress.sol
@@ -66,7 +66,7 @@ library InteroperableAddress {
     }
 
     /**
-     * @dev Parse a ERC-7930 interoperable address (version 1) into its different components. Reverts if the input is
+     * @dev Parse an ERC-7930 interoperable address (version 1) into its different components. Reverts if the input is
      * not following a version 1 of ERC-7930.
      *
      * NOTE: Trailing bytes after a valid v1 encoding are ignored. The same decoded address may therefore correspond
@@ -149,7 +149,7 @@ library InteroperableAddress {
     }
 
     /**
-     * @dev Parse a ERC-7930 interoperable address (version 1) corresponding to an EIP-155 chain. The `chainId` and
+     * @dev Parse an ERC-7930 interoperable address (version 1) corresponding to an EIP-155 chain. The `chainId` and
      * `addr` return values will be zero if the input doesn't include a chainReference or an address, respectively.
      *
      * NOTE: Trailing bytes after a valid v1 encoding are ignored. The same decoded (chainId, addr) may therefore


### PR DESCRIPTION
Line 69 of `contracts/utils/draft-InteroperableAddress.sol` used 
"a ERC-7930" which is grammatically incorrect. "ERC" starts with 
a vowel sound, so it should be "an ERC-7930".