### PR TITLE
⚡Optimize Create3 Lib

### DIFF
--- a/.changeset/whole-trains-sin.md
+++ b/.changeset/whole-trains-sin.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Optimize create3 lib

--- a/.changeset/whole-trains-sin.md
+++ b/.changeset/whole-trains-sin.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-Optimize create3 lib

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -42,18 +42,18 @@ library Create3 {
      * 0x0F   | 3D          | RETURNDATASIZE   | rds             | [0..rds): returndata
      * 0x10   | 5F          | PUSH0            | 0 rds           | [0..rds): returndata
      * 0x11   | FD          | REVERT           |                 |
-     * 0x12   | 5b          | JUMPDEST         | 0 rds           |
+     * 0x12   | 5b          | JUMPDEST         |                 |
      * 0x13   | 00          | STOP             |                 |
      *
      * ================================[ DEPLOYMENT CODE ]=================================
      * Offset | Opcode      | Mnemonic         | Stack           | Memory
      * -------|-------------|------------------|-----------------|-------------------------
      * 0x00   | 73 bytecode | PUSH20 bytecode  | bytecode        |
-     * 0x16   | 5F          | PUSH0            | 0 bytecode      |
-     * 0x17   | 52          | MSTORE           |                 | [0x0C..0x20): bytecode
-     * 0x18   | 6014        | PUSH1 0x14       | 0x14            | [0x0C..0x20): bytecode
-     * 0x1A   | 600C        | PUSH1 0x0C       | 0x0C 0x14       | [0x0C..0x20): bytecode
-     * 0x1C   | f3          | RETURN           |                 | [0x0C..0x20): bytecode
+     * 0x15   | 5F          | PUSH0            | 0 bytecode      |
+     * 0x16   | 52          | MSTORE           |                 | [0x0C..0x20): bytecode
+     * 0x17   | 6014        | PUSH1 0x14       | 0x14            | [0x0C..0x20): bytecode
+     * 0x19   | 600C        | PUSH1 0x0C       | 0x0C 0x14       | [0x0C..0x20): bytecode
+     * 0x1B   | f3          | RETURN           |                 | [0x0C..0x20): bytecode
      */
     /// @dev The proxy initialization code.
     bytes28 private constant PROXY_INITCODE = 0x73365f5f37365f34f06012573d5f5f3e3d5ffd5b005f526014600cf3;

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -33,36 +33,34 @@ library Create3 {
      * 0x05   | 5F          | PUSH0            | 0 cds           | [0..cds): calldata
      * 0x06   | 34          | CALLVALUE        | value 0 cds     | [0..cds): calldata
      * 0x07   | f0          | CREATE           | addr            | [0..cds): calldata
-     * 0x08   | 3D          | RETURNDATASIZE   | rds addr        |
-     * 0x09   | 5F          | PUSH0            | 0 rds addr      |
-     * 0x0A   | 5F          | PUSH0            | 0 0 rds addr    |
-     * 0x0B   | 3E          | RETURNDATACOPY   | addr            | [0..rds): returndata
-     * 0x0C   | 5F          | PUSH0            | 0 addr          | [0..rds): returndata
-     * 0x0D   | 3D          | RETURNDATASIZE   | rds 0 addr      | [0..rds): returndata
-     * 0x0E   | 91          | SWAP2            | addr 0 rds      | [0..rds): returndata
-     * 0x0F   | 6013        | PUSH1 0x13       | 0x13 addr 0 rds | [0..rds): returndata
-     * 0x11   | 57          | JUMPI            | 0 rds           | [0..rds): returndata
-     * 0x12   | FD          | REVERT           |                 |
-     * 0x13   | 5b          | JUMPDEST         | 0 rds           | [0..rds): returndata
-     * 0x14   | f3          | RETURN           |                 |
+     * 0x08   | 6012        | PUSH1 0x12       | 0x12 addr       |
+     * 0x0A   | 56          | JUMPI            |                 |
+     * 0x0B   | 3D          | RETURNDATASIZE   | rds             |
+     * 0x0C   | 5F          | PUSH0            | 0 rds           |
+     * 0x0D   | 5F          | PUSH0            | 0 0 rds         |
+     * 0x0E   | 3E          | RETURNDATACOPY   |                 | [0..rds): returndata
+     * 0x0F   | 3D          | RETURNDATASIZE   | rds             |
+     * 0x10   | 5F          | PUSH0            | 0 rds           | [0..rds): returndata
+     * 0x11   | FD          | REVERT           |                 |
+     * 0x12   | 5b          | JUMPDEST         | 0 rds           | [0..rds): returndata
+     * 0x13   | 00          | STOP             |                 |
      *
      * ================================[ DEPLOYMENT CODE ]=================================
      * Offset | Opcode      | Mnemonic         | Stack           | Memory
      * -------|-------------|------------------|-----------------|-------------------------
-     * 0x00   | 74 bytecode | PUSH21 bytecode  | bytecode        |
+     * 0x00   | 73 bytecode | PUSH20 bytecode  | bytecode        |
      * 0x16   | 5F          | PUSH0            | 0 bytecode      |
-     * 0x17   | 52          | MSTORE           |                 | [0x0B..0x20): bytecode
-     * 0x18   | 6015        | PUSH1 0x15       | 0x15            | [0x0B..0x20): bytecode
-     * 0x1A   | 600B        | PUSH1 0x0B       | 0x0B 0x15       | [0x0B..0x20): bytecode
-     * 0x1C   | f3          | RETURN           |                 | [0x0B..0x20): bytecode
+     * 0x17   | 52          | MSTORE           |                 | [0x0C..0x20): bytecode
+     * 0x18   | 6014        | PUSH1 0x14       | 0x14            | [0x0C..0x20): bytecode
+     * 0x1A   | 600C        | PUSH1 0x0C       | 0x0C 0x14       | [0x0C..0x20): bytecode
+     * 0x1C   | f3          | RETURN           |                 | [0x0C..0x20): bytecode
      */
-
     /// @dev The proxy initialization code.
-    bytes29 private constant PROXY_INITCODE = 0x74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3;
+    bytes28 private constant PROXY_INITCODE = 0x73365f5f37365f34f06012573d5f5f3e3d5ffd5b005f526014600cf3;
 
     /// @dev Hash of the `PROXY_INITCODE`.
-    /// Equivalent to `keccak256(hex"74365F5F37365F34f03D5F5F3E5F3D91601357FD5bf35F526015600Bf3")`.
-    bytes32 internal constant PROXY_INITCODE_HASH = 0xd61bbde0460e6c48ddd99fb8b7e1ad36529d2ec79cbac1db0300b3d26ddcdc2a;
+    /// Equivalent to `keccak256(hex"73365f5f37365f34f06012573d5f5f3e3d5ffd5b005f526014600cf3")`.
+    bytes32 internal constant PROXY_INITCODE_HASH = 0x57a34f6e879358dd76825d6700df87013ad6a3fb43c0d0c602f70a8772c153bd;
 
     /**
      * @dev There's no code to deploy.

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -39,10 +39,10 @@ library Create3 {
      * 0x0C   | 5F          | PUSH0            | 0 rds           |
      * 0x0D   | 5F          | PUSH0            | 0 0 rds         |
      * 0x0E   | 3E          | RETURNDATACOPY   |                 | [0..rds): returndata
-     * 0x0F   | 3D          | RETURNDATASIZE   | rds             |
+     * 0x0F   | 3D          | RETURNDATASIZE   | rds             | [0..rds): returndata
      * 0x10   | 5F          | PUSH0            | 0 rds           | [0..rds): returndata
      * 0x11   | FD          | REVERT           |                 |
-     * 0x12   | 5b          | JUMPDEST         | 0 rds           | [0..rds): returndata
+     * 0x12   | 5b          | JUMPDEST         | 0 rds           |
      * 0x13   | 00          | STOP             |                 |
      *
      * ================================[ DEPLOYMENT CODE ]=================================

--- a/contracts/utils/Create3.sol
+++ b/contracts/utils/Create3.sol
@@ -34,7 +34,7 @@ library Create3 {
      * 0x06   | 34          | CALLVALUE        | value 0 cds     | [0..cds): calldata
      * 0x07   | f0          | CREATE           | addr            | [0..cds): calldata
      * 0x08   | 6012        | PUSH1 0x12       | 0x12 addr       |
-     * 0x0A   | 56          | JUMPI            |                 |
+     * 0x0A   | 57          | JUMPI            |                 |
      * 0x0B   | 3D          | RETURNDATASIZE   | rds             |
      * 0x0C   | 5F          | PUSH0            | 0 rds           |
      * 0x0D   | 5F          | PUSH0            | 0 0 rds         |

--- a/test/utils/Create3.test.js
+++ b/test/utils/Create3.test.js
@@ -5,7 +5,7 @@ const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const { RevertType } = require('../helpers/enums');
 
-const PROXY_INITCODE_HASH = '0xd61bbde0460e6c48ddd99fb8b7e1ad36529d2ec79cbac1db0300b3d26ddcdc2a';
+const PROXY_INITCODE_HASH = '0x57a34f6e879358dd76825d6700df87013ad6a3fb43c0d0c602f70a8772c153bd';
 const getCreate3Address = (deployer, salt) =>
   ethers.getCreateAddress({ from: ethers.getCreate2Address(deployer, salt, PROXY_INITCODE_HASH), nonce: 1 });
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Reduce bytecode size by 1 byte by removing the `RETURN` opcode from the successful deployment path.

If `CREATE` succeeds, the initcode has already returned the runtime bytecode, which the EVM copies into the newly created contract's code storage. Nothing is returned to the caller's returndata buffer, so an additional `RETURN` is unnecessary.

Cheaper 16 gas for successful deployment and 3 gas for revert path.


<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
