### PR TITLE
Skip files for coverage

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -77,6 +77,9 @@ export default defineConfig({
       },
     },
   },
+  coverage: {
+    skipFiles: ['contracts/mocks/**', 'contracts-exposed/**', 'lib/**'],
+  },
   warnings: {
     'npm/**/*': 'off',
     'test/**/*': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "globals": "^17.0.0",
         "graphlib": "^2.1.8",
         "handlebars": "^4.7.9",
-        "hardhat": "^3.5.0",
+        "hardhat": "^3.9.0",
         "hardhat-ignore-warnings": "^0.3.0",
         "hardhat-predeploy": "^1.0.1",
         "husky": "^9.1.7",
@@ -1603,28 +1603,28 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.33.tgz",
-      "integrity": "sha512-+jwZcGgUKVUykqP+hbVEXClpqZbIdo/MztP/6Xp8DDmB8c+WxJvwCDmPrnfkV+s3NNj2lSDCyOZoPw9/UNcmXw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0.tgz",
+      "integrity": "sha512-dVfrB70L//W05s+s+/c6n52Fct+kVKoXYT+/CKL9ZsNdq/yLr5LaPNsvpVkQHP1JdAiOrubUzA/MwZIk4gRxAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.33",
-        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.33",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.33",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.33",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.33",
-        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.33",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.33"
+        "@nomicfoundation/edr-darwin-arm64": "0.12.0",
+        "@nomicfoundation/edr-darwin-x64": "0.12.0",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0",
+        "@nomicfoundation/edr-linux-x64-musl": "0.12.0",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.33.tgz",
-      "integrity": "sha512-CEaDltNmTRLyJPMwSVHNtYuXthJ3vm44SkRAQLiDYuhLbbzxAWmkCdnvKyo5QPmaRKxBGFwtahCJz2biBM43Ig==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0.tgz",
+      "integrity": "sha512-z/8jU2dgZjhY2iLtJ1DGi3t/N2xbmjgok9K3R0f7+UZxSSJ5LbXCFn5So33fVh47RzGzOqEB+Yk4SdyUq2odqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1632,9 +1632,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.33.tgz",
-      "integrity": "sha512-3V5XgzKLXFO+Cw0sWoO3ug2hHYL3VThskA1Iu98EPO44P4w0S6tW3bdsIH2OJPD+zi5RIHjg8H6HDZ+xeipXAA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0.tgz",
+      "integrity": "sha512-F9RrA60mEtxfKFiGB7QsydoUwzz4ckoustVMFegcIKmjRxRVb1qrRYiAc9oQiKMdJWIZKDYsOpHABJ9Um4U/+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.33.tgz",
-      "integrity": "sha512-5+1wkqlUEem9yhKX2AwSINlaiNk6NYfm4WbvaeEAmDZivLEDhW56BNe5+fuue1B4Fa50OONaimw9wEe3d1xYNA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0.tgz",
+      "integrity": "sha512-EtGRZbh1d4BF/1SIG5rVrKQ9R0nuNvPgCYiU5fCmY3bojAFOUf4m7I2ezIhim1vb1QBlXmFaoFNPZFIdMltBGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.33.tgz",
-      "integrity": "sha512-/Zr+9HxJfOSjtSTr3PkErSrGkP40j5op2koY1vVwsC1CqRiNnxKfXpwa6WH8zEUzIkEAGLq5ZwjD251irrf1uA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0.tgz",
+      "integrity": "sha512-5gWtmKuVfftcO1OUbF/3KTPVSR6klC7RI9Z96G5lDO325jQhYqOG+hkvDPKtM+nbYf+A0veOndghqbUgAX+E4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.33.tgz",
-      "integrity": "sha512-KrK/eUlVJo6FdHOBx9kXnzq8g+j8A2218ZVoVI/TJYgZFRXkhUI0tBeDmmdmfcRtk8J4Hw5QGRJVIXA2TAWUZQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0.tgz",
+      "integrity": "sha512-0Ty0fov3/NFL0dIshNTGCi06sjVzsgB7k+n9LAoj+57OsqP9X4e3P5XwjlTSNuyYshv8JdYMHqY+1ZIZ8SHsyQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1672,9 +1672,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.33.tgz",
-      "integrity": "sha512-o6Kmj4YKdRNZ6U4wn2hd0wyh3r2Pu0/RjBBiqs+zeeRopI/san7H4n6kIxe+8PbqlAcC48MI+oWLSNwnkqONwg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0.tgz",
+      "integrity": "sha512-e5du3t17vdB3tAY0kl3Ip1cu8CcwiaeJeUC4mMPmL91HDM//AQehqpyIP8upam4AeIl1H6FA3xIUIDA6VOZSxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.12.0-next.33",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.33.tgz",
-      "integrity": "sha512-PPiOTOIShzhK7+i+QMDz6/0m2JcEHBMqCthLj8dru2RFhXT1Jory35u12awaVS2fU91flBg7zz7Qju4v8hrnLw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0.tgz",
+      "integrity": "sha512-wD8YxhFdlY2IXb7uVrSF7VHartFKXEYeiE6ISJOV10Y7YOUE1IzfwB0QOdKtLUepwB+HXis+KRy4h22dWEbT0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1692,13 +1692,13 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-errors": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.13.tgz",
-      "integrity": "sha512-h0nWNzKbmP6XhINMgSUfGixevzksT8BQPK08KNnsr/8kQORAeYzsv6bf0CLUD8mZfmBEP45m4QMlNP6xcoc0Ow==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.15.tgz",
+      "integrity": "sha512-h3r32RzpmWEcB2bz6aqZKlKOP8tzyvHLkPFleFFqwVvjO5AUfSoMUxm8OjaTuNgPF35mXPYRISh+kNCwmsKVOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-utils": "^4.1.2"
+        "@nomicfoundation/hardhat-utils": "^4.1.3"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.1.2.tgz",
-      "integrity": "sha512-jUQfbyIoTLHmSua+BMhIqUIk7uDwL2bhTtJgfwRoVooM3TTvm5rIdRK+eNkvZcZR/wAL/SBQOq/r9yOekj4Unw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.1.3.tgz",
+      "integrity": "sha512-SYDKX6SCdzs/5mC/S1D+AjNSQJrhxevHTI24TIouIjO0Xs0dB0+S4cYCqHWOgvnHLshrcrJ7XGUjS7+apWa1Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4481,15 +4481,15 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.5.0.tgz",
-      "integrity": "sha512-JT5YMXluyCD6RePp1ySezgZD9zZelS0v/wtarkQHb44pGqWqvVz1E68aEKSsbdMDRjHSHvW7/ILNJ3N1wt/MqQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.9.0.tgz",
+      "integrity": "sha512-MjLHYgxCbqhpLfu6FBkHkhTu9igJmtwgILJwdw7XUZ3xjnXLdGeXtwhykPA16hjeRrmWZH4yv5Tv4maw0dJASw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr": "0.12.0-next.33",
-        "@nomicfoundation/hardhat-errors": "^3.0.13",
-        "@nomicfoundation/hardhat-utils": "^4.1.2",
+        "@nomicfoundation/edr": "0.12.0",
+        "@nomicfoundation/hardhat-errors": "^3.0.15",
+        "@nomicfoundation/hardhat-utils": "^4.1.3",
         "@nomicfoundation/hardhat-vendored": "^3.0.4",
         "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "globals": "^17.0.0",
     "graphlib": "^2.1.8",
     "handlebars": "^4.7.9",
-    "hardhat": "^3.5.0",
+    "hardhat": "^3.9.0",
     "hardhat-ignore-warnings": "^0.3.0",
     "hardhat-predeploy": "^1.0.1",
     "husky": "^9.1.7",

--- a/scripts/checks/inheritance-ordering.js
+++ b/scripts/checks/inheritance-ordering.js
@@ -24,18 +24,24 @@ for (const artifact of artifacts) {
   const names = {};
   const linearized = [];
 
-  for (const source in solcOutput?.contracts ?? []) {
-    if (match.isMatch(source.replace(/^project/, ''), patterns)) {
-      for (const contractDef of findAll('ContractDefinition', solcOutput.sources[source].ast)) {
-        names[contractDef.id] = contractDef.name;
-        linearized.push(contractDef.linearizedBaseContracts);
+  // Rebuild solcOutput?.sources by removing the "project" prefix from the keys, so that we can match them against the patterns in package.json
+  const sources = Object.fromEntries(
+    Object.entries(solcOutput?.sources ?? {}).map(([key, value]) => [key.replace(/^project/, ''), value]),
+  );
 
-        contractDef.linearizedBaseContracts.forEach((c1, i, contracts) =>
-          contracts.slice(i + 1).forEach(c2 => {
-            graph.setEdge(c1, c2);
-          }),
-        );
-      }
+  // For each source file that matches the patterns ...
+  for (const file of match(Object.keys(sources), patterns)) {
+    // ... find all ContractDefinition in this file ...
+    for (const contractDef of findAll('ContractDefinition', sources[file].ast)) {
+      // ... record the details for that contracts ...
+      names[contractDef.id] = contractDef.name;
+      linearized.push(contractDef.linearizedBaseContracts);
+      // ... and add edges to the graph for each pair of contracts in the linearized base contracts.
+      contractDef.linearizedBaseContracts.forEach((c1, i, contracts) =>
+        contracts.slice(i + 1).forEach(c2 => {
+          graph.setEdge(c1, c2);
+        }),
+      );
     }
   }
 


### PR DESCRIPTION
Hardhat 3.9.0 adds support for `skipFiles` in coverage reports: https://github.com/NomicFoundation/hardhat/releases/tag/hardhat%403.9.0 

This PR updates to the latest version of Hardhat, then mimics the `.solcover.js` setting of `skipfiles` so that mocks are excluded.

It also excludes the `./contracts-exposed` and `./lib` folders, so that only the coverage of core contracts is reported.