### PR TITLE
[codex] fix RLP trailing-byte validation

### DIFF
--- a/.changeset/quick-lions-ask.md
+++ b/.changeset/quick-lions-ask.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`RLP`: reject trailing bytes after valid scalar and bytes decoders.

--- a/contracts/utils/RLP.sol
+++ b/contracts/utils/RLP.sol
@@ -316,6 +316,7 @@ library RLP {
 
         (uint256 itemOffset, uint256 itemLength, ItemType itemType) = _decodeLength(item);
         require(itemType == ItemType.Data, RLPInvalidEncoding());
+        require(length == itemOffset + itemLength, RLPInvalidEncoding());
 
         return itemLength == 0 ? 0 : uint256(item.load(itemOffset)) >> (256 - 8 * itemLength);
     }
@@ -336,6 +337,7 @@ library RLP {
     function readBytes(Memory.Slice item) internal pure returns (bytes memory) {
         (uint256 offset, uint256 length, ItemType itemType) = _decodeLength(item);
         require(itemType == ItemType.Data, RLPInvalidEncoding());
+        require(item.length() == offset + length, RLPInvalidEncoding());
 
         // Length is checked by {slice}
         return item.slice(offset, length).toBytes();

--- a/test/utils/RLP.test.js
+++ b/test/utils/RLP.test.js
@@ -93,9 +93,15 @@ describe('RLP', function () {
   it('rejects trailing bytes after valid RLP data items', async function () {
     await expect(this.mock.$decodeBool('0x0102')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
     await expect(this.mock.$decodeUint256('0x0102')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
-    await expect(this.mock.$decodeBytes32('0x83646f6780')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    await expect(this.mock.$decodeBytes32('0x83646f6780')).to.be.revertedWithCustomError(
+      this.mock,
+      'RLPInvalidEncoding',
+    );
     await expect(this.mock.$decodeBytes('0x83646f6780')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
-    await expect(this.mock.$decodeString('0x83646f6780')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    await expect(this.mock.$decodeString('0x83646f6780')).to.be.revertedWithCustomError(
+      this.mock,
+      'RLPInvalidEncoding',
+    );
   });
 
   it('encode/decode bytes32', async function () {

--- a/test/utils/RLP.test.js
+++ b/test/utils/RLP.test.js
@@ -90,6 +90,14 @@ describe('RLP', function () {
     }
   });
 
+  it('rejects trailing bytes after valid RLP data items', async function () {
+    await expect(this.mock.$decodeBool('0x0102')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    await expect(this.mock.$decodeUint256('0x0102')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    await expect(this.mock.$decodeBytes32('0x83646f6780')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    await expect(this.mock.$decodeBytes('0x83646f6780')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+    await expect(this.mock.$decodeString('0x83646f6780')).to.be.revertedWithCustomError(this.mock, 'RLPInvalidEncoding');
+  });
+
   it('encode/decode bytes32', async function () {
     for (const input of [
       '0x0000000000000000000000000000000000000000000000000000000000000000',


### PR DESCRIPTION
## Summary

Reject RLP scalar/data inputs that contain trailing bytes after a valid item.

This addresses #6515 by tightening the top-level `readUint256` and `readBytes` paths so they require the input slice to be fully consumed.

## Details

- Adds an exact-length check to `readUint256`
- Adds an exact-length check to `readBytes`
- Adds regression coverage for trailing bytes on `decodeBool`, `decodeUint256`, `decodeBytes32`, `decodeBytes`, and `decodeString`

## Verification

```bash
npx hardhat test test/utils/RLP.test.js
```

Result: `18 passing`
