### PR TITLE
    Add an internal function in ERC7913WebAuthnVerifier to allow disabling the UV check

### DIFF
--- a/.changeset/slimy-pugs-shop.md
+++ b/.changeset/slimy-pugs-shop.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC7913WebAuthnVerifier`: Add an internal `_requireUV` function that can be overriden to disable the UV check
+`ERC7913WebAuthnVerifier`: Add an internal `_requireUV` function that can be overridden to disable the UV check

--- a/.changeset/slimy-pugs-shop.md
+++ b/.changeset/slimy-pugs-shop.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC7913WebAuthnVerifier`: Add an internal `_requireUV` function that can be overriden to disable the UV check

--- a/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
@@ -39,7 +39,7 @@ contract ERC7913WebAuthnVerifier is IERC7913SignatureVerifier {
                 : bytes4(0xFFFFFFFF);
     }
 
-    function _requireUV() internal pure returns (bool) {
+    function _requireUV() internal pure virtual returns (bool) {
         return true;
     }
 }

--- a/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
@@ -28,8 +28,18 @@ contract ERC7913WebAuthnVerifier is IERC7913SignatureVerifier {
         return
             decodeSuccess &&
                 key.length == 0x40 &&
-                WebAuthn.verify(abi.encodePacked(hash), auth, bytes32(key[0x00:0x20]), bytes32(key[0x20:0x40]))
+                WebAuthn.verify(
+                    abi.encodePacked(hash),
+                    auth,
+                    bytes32(key[0x00:0x20]),
+                    bytes32(key[0x20:0x40]),
+                    _requireUV()
+                )
                 ? IERC7913SignatureVerifier.verify.selector
                 : bytes4(0xFFFFFFFF);
+    }
+
+    function _requireUV() internal pure returns (bool) {
+        return true;
     }
 }


### PR DESCRIPTION
Today, people that want an ERC-7913 verifier that supports webauthn without the UV check have to write it from scratch. This change gives them the opportunity to inherit `ERC7913WebAuthnVerifier` and disable the check by overriding `_requireUV()`

An alternative option would be to have a `bool immutable internal _requireUV;` and a constructor, but it would be breaking (adding a constructor to a contract that doesn't have one.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`)
