### PR TITLE
Fix SlotDerivation documentation example

### DIFF
--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -417,7 +417,7 @@ Users can leverage this standard using the xref:api:utils.adoc#SlotDerivation[`S
 [source,solidity]
 ----
 using SlotDerivation for bytes32;
-string private constant _NAMESPACE = "<namespace>" // eg. example.main
+string private constant _NAMESPACE = "<namespace>"; // e.g. example.main
 
 function erc7201Pointer() internal view returns (bytes32) {
     return _NAMESPACE.erc7201Slot();


### PR DESCRIPTION
Fixes a small Solidity snippet issue in the SlotDerivation documentation.

The `_NAMESPACE` constant declaration in `utilities.adoc` was missing a semicolon, so copying the snippet as Solidity would fail to compile. This also normalizes the adjacent example comment from `eg.` to `e.g.`.

## Validation

- `git diff --check`
- confirmed the snippet now reads `string private constant _NAMESPACE = "<namespace>"; // e.g. example.main`

Docs-only change; no changeset added because this does not affect contracts, package output, or public API.