### PR TITLE
⚡Optimize ERC1967Clones Lib

### DIFF
--- a/.changeset/bold-rice-move.md
+++ b/.changeset/bold-rice-move.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+Optimize ERC1967Clones

--- a/.changeset/bold-rice-move.md
+++ b/.changeset/bold-rice-move.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-Optimize ERC1967Clones

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -45,41 +45,41 @@ library ERC1967Clones {
      * 0x2D   | 5f          | PUSH0            | 0 rds success              |
      * 0x2E   | 5f          | PUSH0            | 0 0 rds success            |
      * 0x2F   | 3e          | RETURNDATACOPY   | success                    | [0...rds): returndata
-     * 0x30   | 5f          | PUSH0            | 0 success                  | [0...rds): returndata
-     * 0x31   | 3d          | RETURNDATASIZE   | rds 0 success              | [0...rds): returndata
-     * 0x32   | 91          | SWAP2            | success 0 rds              | [0...rds): returndata
-     * 0x33   | 6037        | PUSH1 0x37       | 0x37 success 0 rds         | [0...rds): returndata
-     * 0x35   | 57          | JUMPI            | 0 rds                      | [0...rds): returndata
-     * 0x36   | fd          | REVERT           |                            |
-     * 0x37   | 5b          | JUMPDEST         | 0 rds                      | [0...rds): returndata
-     * 0x38   | f3          | RETURN           |                            |
+     * 0x30   | 6036        | PUSH1 0x36       | 0x36 success               | [0...rds): returndata
+     * 0x32   | 57          | JUMPI            |                            | [0...rds): returndata
+     * 0x33   | 5f          | PUSH0            | 0                          | [0...rds): returndata
+     * 0x34   | 3d          | RETURNDATASIZE   | rds 0                      | [0...rds): returndata
+     * 0x35   | fd          | REVERT           |                            |
+     * 0x36   | 5b          | JUMPDEST         |                            | [0...rds): returndata
+     * 0x37   | 3d          | RETURNDATASIZE   | rds                        | [0...rds): returndata
+     * 0x38   | 5f          | PUSH0            | 0 rds                      | [0...rds): returndata
+     * 0x39   | f3          | RETURN           |                            |
      *
      * =====================================[ DEPLOYMENT CODE  ]=====================================
      * Offset | Opcode      | Mnemonic         | Stack                      | Memory
      * -------|-------------|------------------|----------------------------|------------------------
-     * 0x00   | 6039        | PUSH1 0x39       | 0x39                       |
-     * 0x02   | 5f          | PUSH0            | 0 0x39                     |
-     * 0x03   | 81          | DUP2             | 0x39 0 0x39                |
-     * 0x04   | 6047        | PUSH1 0x47       | 0x47 0x39 0 0x39           |
-     * 0x06   | 5f          | PUSH0            | 0 0x47 0x39 0 0x39         |
-     * 0x07   | 39          | CODECOPY         | 0 0x39                     | [0...0x39): proxycode
-     * 0x08   | 73<impl>    | PUSH20 impl      | impl 0 0x39                | [0...0x39): proxycode
-     * 0x1d   | 80          | DUP1             | impl impl 0 0x39           | [0...0x39): proxycode
-     * 0x1e   | 7f<topic>   | PUSH32 topic     | topic impl impl 0 0x39     | [0...0x39): proxycode
-     * 0x3f   | 5f          | PUSH0            | 0 topic impl impl 0 0x39   | [0...0x39): proxycode
-     * 0x40   | 5f          | PUSH0            | 0 0 topic impl impl 0 0x39 | [0...0x39): proxycode
-     * 0x41   | a2          | LOG2             | impl 0 0x39                | [0...0x39): proxycode
-     * 0x42   | 6009        | PUSH1 0x09       | 0x09 impl 0 0x39           | [0...0x39): proxycode
-     * 0x44   | 51          | MLOAD            | slot impl 0 0x39           | [0...0x39): proxycode
-     * 0x45   | 55          | SSTORE           | 0 0x39                     | [0...0x39): proxycode
+     * 0x00   | 603a        | PUSH1 0x3a       | 0x3a                       |
+     * 0x02   | 5f          | PUSH0            | 0 0x3a                     |
+     * 0x03   | 81          | DUP2             | 0x3a 0 0x3a                |
+     * 0x04   | 6047        | PUSH1 0x47       | 0x47 0x3a 0 0x3a           |
+     * 0x06   | 5f          | PUSH0            | 0 0x47 0x3a 0 0x3a         |
+     * 0x07   | 39          | CODECOPY         | 0 0x3a                     | [0...0x3a): proxycode
+     * 0x08   | 73<impl>    | PUSH20 impl      | impl 0 0x3a                | [0...0x3a): proxycode
+     * 0x1d   | 80          | DUP1             | impl impl 0 0x3a           | [0...0x3a): proxycode
+     * 0x1e   | 7f<topic>   | PUSH32 topic     | topic impl impl 0 0x3a     | [0...0x3a): proxycode
+     * 0x3f   | 5f          | PUSH0            | 0 topic impl impl 0 0x3a   | [0...0x3a): proxycode
+     * 0x40   | 5f          | PUSH0            | 0 0 topic impl impl 0 0x3a | [0...0x3a): proxycode
+     * 0x41   | a2          | LOG2             | impl 0 0x3a                | [0...0x3a): proxycode
+     * 0x42   | 6009        | PUSH1 0x09       | 0x09 impl 0 0x3a           | [0...0x3a): proxycode
+     * 0x44   | 51          | MLOAD            | slot impl 0 0x3a           | [0...0x3a): proxycode
+     * 0x45   | 55          | SSTORE           | 0 0x3a                     | [0...0x3a): proxycode
      * 0x46   | f3          | RETURN           |                            |
      *
      * NOTE:
-     * - 0x39: length of the proxy code
+     * - 0x3a: length of the proxy code
      * - 0x47: length of the deployment code, since the proxy code is just after the deployment code, that is also the offset of the proxy code
      * - 0x09: position of the ERC1967 implementation slot in the proxy code.
      */
-
     /**
      * @dev Deploys and returns the address of a minimal ERC-1967 proxy that delegates to `implementation`.
      *
@@ -108,21 +108,18 @@ library ERC1967Clones {
      */
     function clone(address implementation, uint256 value) internal returns (address instance) {
         require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
-        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
-        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x77), 0x545af43d5f5f3e5f3d91603757fd5bf3)
-            mstore(add(ptr, 0x67), implementationSlot)
-            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
-            mstore(add(ptr, 0x36), topic1)
-            mstore(add(ptr, 0x16), 0x807f)
+            mstore(add(ptr, 0x78), 0x3e2076cc3735a920a3ca505d382bbc545af43d5f5f3e6036575f3dfd5b3d5ff3)
+            mstore(add(ptr, 0x58), 0xa260095155f3365f5f375f5f365f7f360894a13ba1a3210667c828492db98dca)
+            mstore(add(ptr, 0x38), 0xd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f5f)
+            mstore(add(ptr, 0x18), 0x807fbc7c)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x60395f8160475f3973)
+            mstore(ptr, 0x603a5f8160475f3973)
 
             // Call create
-            instance := create(value, add(ptr, 0x17), 0x80)
+            instance := create(value, add(ptr, 0x17), 0x81)
         }
 
         // deployment code doesn't have a revert, so no need to handle returndata
@@ -163,21 +160,18 @@ library ERC1967Clones {
         uint256 value
     ) internal returns (address instance) {
         require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
-        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
-        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x77), 0x545af43d5f5f3e5f3d91603757fd5bf3)
-            mstore(add(ptr, 0x67), implementationSlot)
-            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
-            mstore(add(ptr, 0x36), topic1)
-            mstore(add(ptr, 0x16), 0x807f)
+            mstore(add(ptr, 0x78), 0x3e2076cc3735a920a3ca505d382bbc545af43d5f5f3e6036575f3dfd5b3d5ff3)
+            mstore(add(ptr, 0x58), 0xa260095155f3365f5f375f5f365f7f360894a13ba1a3210667c828492db98dca)
+            mstore(add(ptr, 0x38), 0xd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f5f)
+            mstore(add(ptr, 0x18), 0x807fbc7c)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x60395f8160475f3973)
+            mstore(ptr, 0x603a5f8160475f3973)
 
             // Call create2
-            instance := create2(value, add(ptr, 0x17), 0x80, salt)
+            instance := create2(value, add(ptr, 0x17), 0x81, salt)
         }
         require(instance != address(0), Errors.FailedDeployment());
     }
@@ -202,16 +196,16 @@ library ERC1967Clones {
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x77), 0x545af43d5f5f3e5f3d91603757fd5bf3)
+            mstore(add(ptr, 0x78), 0x545af43d5f5f3e6036575f3dfd5b3d5ff3)
             mstore(add(ptr, 0x67), implementationSlot)
             mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
             mstore(add(ptr, 0x36), topic1)
             mstore(add(ptr, 0x16), 0x807f)
             mstore(add(ptr, 0x14), implementation)
-            mstore(ptr, 0x60395f8160475f3973)
+            mstore(ptr, 0x603a5f8160475f3973)
 
             // Compute hash
-            bytecodeHash := keccak256(add(ptr, 0x17), 0x80)
+            bytecodeHash := keccak256(add(ptr, 0x17), 0x81)
         }
     }
 }

--- a/contracts/proxy/ERC1967/ERC1967Clones.sol
+++ b/contracts/proxy/ERC1967/ERC1967Clones.sol
@@ -47,8 +47,8 @@ library ERC1967Clones {
      * 0x2F   | 3e          | RETURNDATACOPY   | success                    | [0...rds): returndata
      * 0x30   | 6036        | PUSH1 0x36       | 0x36 success               | [0...rds): returndata
      * 0x32   | 57          | JUMPI            |                            | [0...rds): returndata
-     * 0x33   | 5f          | PUSH0            | 0                          | [0...rds): returndata
-     * 0x34   | 3d          | RETURNDATASIZE   | rds 0                      | [0...rds): returndata
+     * 0x33   | 3d          | RETURNDATASIZE   | rds                        | [0...rds): returndata
+     * 0x34   | 5f          | PUSH0            | 0 rds                      | [0...rds): returndata
      * 0x35   | fd          | REVERT           |                            |
      * 0x36   | 5b          | JUMPDEST         |                            | [0...rds): returndata
      * 0x37   | 3d          | RETURNDATASIZE   | rds                        | [0...rds): returndata
@@ -80,6 +80,7 @@ library ERC1967Clones {
      * - 0x47: length of the deployment code, since the proxy code is just after the deployment code, that is also the offset of the proxy code
      * - 0x09: position of the ERC1967 implementation slot in the proxy code.
      */
+
     /**
      * @dev Deploys and returns the address of a minimal ERC-1967 proxy that delegates to `implementation`.
      *
@@ -108,13 +109,16 @@ library ERC1967Clones {
      */
     function clone(address implementation, uint256 value) internal returns (address instance) {
         require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
+        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x78), 0x3e2076cc3735a920a3ca505d382bbc545af43d5f5f3e6036575f3dfd5b3d5ff3)
-            mstore(add(ptr, 0x58), 0xa260095155f3365f5f375f5f365f7f360894a13ba1a3210667c828492db98dca)
-            mstore(add(ptr, 0x38), 0xd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f5f)
-            mstore(add(ptr, 0x18), 0x807fbc7c)
+            mstore(add(ptr, 0x78), 0x545af43d5f5f3e6036573d5ffd5b3d5ff3)
+            mstore(add(ptr, 0x67), implementationSlot)
+            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x36), topic1)
+            mstore(add(ptr, 0x16), 0x807f)
             mstore(add(ptr, 0x14), implementation)
             mstore(ptr, 0x603a5f8160475f3973)
 
@@ -160,13 +164,16 @@ library ERC1967Clones {
         uint256 value
     ) internal returns (address instance) {
         require(address(this).balance >= value, Errors.InsufficientBalance(address(this).balance, value));
+        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        bytes32 topic1 = IERC1967.Upgraded.selector;
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x78), 0x3e2076cc3735a920a3ca505d382bbc545af43d5f5f3e6036575f3dfd5b3d5ff3)
-            mstore(add(ptr, 0x58), 0xa260095155f3365f5f375f5f365f7f360894a13ba1a3210667c828492db98dca)
-            mstore(add(ptr, 0x38), 0xd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f5f)
-            mstore(add(ptr, 0x18), 0x807fbc7c)
+            mstore(add(ptr, 0x78), 0x545af43d5f5f3e6036573d5ffd5b3d5ff3)
+            mstore(add(ptr, 0x67), implementationSlot)
+            mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
+            mstore(add(ptr, 0x36), topic1)
+            mstore(add(ptr, 0x16), 0x807f)
             mstore(add(ptr, 0x14), implementation)
             mstore(ptr, 0x603a5f8160475f3973)
 
@@ -196,7 +203,7 @@ library ERC1967Clones {
         assembly ("memory-safe") {
             // Set code in memory
             let ptr := mload(0x40)
-            mstore(add(ptr, 0x78), 0x545af43d5f5f3e6036575f3dfd5b3d5ff3)
+            mstore(add(ptr, 0x78), 0x545af43d5f5f3e6036573d5ffd5b3d5ff3)
             mstore(add(ptr, 0x67), implementationSlot)
             mstore(add(ptr, 0x47), 0x5f5fa260095155f3365f5f375f5f365f7f)
             mstore(add(ptr, 0x36), topic1)

--- a/test/proxy/Proxy.behaviour.js
+++ b/test/proxy/Proxy.behaviour.js
@@ -192,8 +192,10 @@ module.exports = function shouldBehaveLikeProxy({ allowUninitialized = false, al
         this.initializeData = this.implementation.interface.encodeFunctionData('reverts');
       });
 
-      it('reverts', async function () {
-        await expect(this.createProxy(this.implementation, this.initializeData)).to.be.reverted;
+      it('bubbles up the revert reason from the implementation', async function () {
+        await expect(this.createProxy(this.implementation, this.initializeData)).to.be.revertedWith(
+          'DummyImplementation reverted',
+        );
       });
     });
   });


### PR DESCRIPTION
Increase bytecode size by `1 byte` to save `3 gas` on all runtime calls (both success and revert paths). 

By avoiding the stack setup (`PUSH0`, `RETURNDATASIZE`, `SWAP2`) before the conditional branch (`JUMPI`), we save `3 gas` per call. The values for returning or reverting (`0` and `rds`) are now pushed separately on their respective execution branches, resulting in a cleaner and cheaper execution path at runtime at the cost of `1 `extra byte of code.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
