### PR TITLE
Document `verifyBlockHeader(fields, headerHash)` binding precondition

### DIFF
--- a/contracts/utils/BlockHeader.sol
+++ b/contracts/utils/BlockHeader.sol
@@ -51,7 +51,15 @@ library BlockHeader {
         return Blockhash.blockHash(getNumber(headerRLP)) == keccak256(headerRLP);
     }
 
-    /// @dev Variant of {verifyBlockHeader} that takes a pre-parsed list of fields and the header hash.
+    /**
+     * @dev Variant of {verifyBlockHeader} that takes a pre-parsed list of fields and a pre-computed
+     * header hash.
+     *
+     * NOTE: The caller must supply `headerHash == keccak256(rlp)`, where `rlp` is the RLP
+     * buffer that `fields` was parsed from; this overload only checks that `headerHash` is the
+     * canonical hash for the block number in `fields`. Use this when the hash was already computed
+     * to avoid a second `keccak256`.
+     */
     function verifyBlockHeader(Memory.Slice[] memory fields, bytes32 headerHash) internal view returns (bool) {
         return Blockhash.blockHash(getNumber(fields)) == headerHash;
     }


### PR DESCRIPTION
## Summary

- Extends the NatSpec on the pre-parsed `verifyBlockHeader(Memory.Slice[], bytes32)` overload to spell out that the caller must supply `headerHash == keccak256(rlp)` — i.e. the hash computed from the same RLP buffer `fields` was parsed from.
- Clarifies that this overload only checks the `(number, hash)` pair against the canonical chain and skips the RLP re-hashing done by the `bytes` overload, so it's the right choice when the hash was already computed.

## Test plan

- [ ] NatSpec-only change — no behavior change, no changeset needed.
- [ ] `npm run lint` clean.