### PR TITLE
Fix docs Defender Transaction Proposals xref in governance.adoc

### DIFF
--- a/contracts/utils/RateLimiter.sol
+++ b/contracts/utils/RateLimiter.sol
@@ -20,7 +20,7 @@ import {Time} from "./types/Time.sol";
  *   interval. Suitable when a strict cap on usage within a rolling window is required. Each successful consumption
  *   appends a checkpoint, making it a more expensive option with a larger storage footprint.
  *
- * === Limiter vs. entries ===
+ * === Limiter vs. entries
  *
  * Each storage struct is a _limiter_: it pairs a single, shared configuration (the `window`, together with the
  * `capacity` of a {RefillingBucket} or the `limit` of a {SlidingWindow}) with a mapping of independent _entries_

--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -32,7 +32,7 @@ When using a timelock with your Governor contract, you can use either OpenZeppel
 
 https://www.tally.xyz[Tally] is a full-fledged application for user owned on-chain governance. It comprises a voting dashboard, proposal creation wizard, real time research and analysis, and educational content.
 
-For all of these options, the Governor will be compatible with Tally: users will be able to create proposals, see voting periods and delays following xref:api:interfaces.adoc#IERC6372[IERC6372], visualize voting power and advocates, navigate proposals, and cast votes. For proposal creation in particular, projects can also use xref:defender::module/actions.adoc#transaction-proposals-reference[Defender Transaction Proposals] as an alternative interface.
+For all of these options, the Governor will be compatible with Tally: users will be able to create proposals, see voting periods and delays following xref:api:interfaces.adoc#IERC6372[IERC6372], visualize voting power and advocates, navigate proposals, and cast votes. For proposal creation in particular, projects can also use xref:defender::module/transaction-proposals.adoc[Defender Transaction Proposals] as an alternative interface.
 
 In the rest of this guide, we will focus on a fresh deploy of the vanilla OpenZeppelin Governor features without concern for compatibility with GovernorAlpha or Bravo.
 
@@ -105,7 +105,7 @@ A proposal is a sequence of actions that the Governor contract will perform if i
 
 Let’s say we want to create a proposal to give a team a grant, in the form of ERC-20 tokens from the governance treasury. This proposal will consist of a single action where the target is the ERC-20 token, calldata is the encoded function call `transfer(<team wallet>, <grant amount>)`, and with 0 ETH attached.
 
-Generally a proposal will be created with the help of an interface such as Tally or xref:defender::module/actions.adoc#transaction-proposals-reference[Defender Proposals]. Here we will show how to create the proposal using Ethers.js.
+Generally a proposal will be created with the help of an interface such as Tally or xref:defender::module/transaction-proposals.adoc[Defender Proposals]. Here we will show how to create the proposal using Ethers.js.
 
 First we get all the parameters necessary for the proposal action.
 


### PR DESCRIPTION
## Summary
- Both xrefs in `docs/modules/ROOT/pages/governance.adoc` pointed at `defender::module/actions.adoc#transaction-proposals-reference` — the anchor doesn't exist on that page. The correct target is `defender::module/transaction-proposals.adoc`.
- Surfaced while reviewing [OpenZeppelin/docs#206](https://github.com/OpenZeppelin/docs/pull/206) (the auto-generated v5.7.0-rc.0 docs update). The docs transformation rewrites absolute `docs.openzeppelin.com` URLs to internal paths, which exposes the broken anchor as an in-site link that navigates nowhere.

## Test plan
- [ ] Regenerate `content/contracts/5.x/governance.mdx` from this branch and verify both links render as `/defender/module/transaction-proposals` (no fragment).
- [ ] Verify `/defender/module/transaction-proposals` renders as the target page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)