### PR TITLE
Paymaster gas optimization

### DIFF
--- a/.changeset/paymaster-gas-council.md
+++ b/.changeset/paymaster-gas-council.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`PaymasterSigner`, `PaymasterERC20`, `PaymasterERC721Owner`: Reduce gas usage on the validation and postOp hot paths.

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -205,8 +205,11 @@ abstract contract PaymasterERC20 is Paymaster {
         bytes calldata /* prefundContext */
     ) internal virtual returns (bool success, uint256 actualAmount) {
         // Under ERC-4337 EntryPoint, `actualGasCost <= maxCost` and `actualUserOpFeePerGas <= maxFeePerGas`,
-        // so `actualAmount_ <= prefundAmount` holds.
-        return (token.trySafeTransfer(prefunder, prefundAmount - actualAmount_), actualAmount_);
+        // so `actualAmount_ <= prefundAmount` holds and the subtraction cannot underflow. If a caller breaks
+        // that requirement, the wrapped amount makes `trySafeTransfer` fail and {_postOp} revert.
+        unchecked {
+            return (token.trySafeTransfer(prefunder, prefundAmount - actualAmount_), actualAmount_);
+        }
     }
 
     /**

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -289,9 +289,12 @@ abstract contract PaymasterERC20 is Paymaster {
      */
     function _erc20Cost(uint256 nativeCost, uint256 tokenPerNative) internal view virtual returns (uint256) {
         uint256 denominator = _tokenPerNativeDenominator();
-        (uint256 high, ) = nativeCost.mul512(tokenPerNative);
+        (uint256 high, uint256 low) = nativeCost.mul512(tokenPerNative);
+        if (high >= denominator) return type(uint256).max;
+        // When the product fits in one word, a plain ceiling division avoids repeating
+        // the 512-bit product inside `mulDiv`.
         return
-            high < denominator ? nativeCost.mulDiv(tokenPerNative, denominator, Math.Rounding.Ceil) : type(uint256).max;
+            high == 0 ? low.ceilDiv(denominator) : nativeCost.mulDiv(tokenPerNative, denominator, Math.Rounding.Ceil);
     }
 
     /// @dev Internal function that allows the withdrawer to extract ERC-20 tokens resulting from gas payments.

--- a/contracts/account/paymaster/extensions/PaymasterERC721Owner.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC721Owner.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 
 import {IERC721} from "../../../interfaces/IERC721.sol";
 import {ERC4337Utils, PackedUserOperation} from "../../utils/ERC4337Utils.sol";
+import {SafeCast} from "../../../utils/math/SafeCast.sol";
 import {Paymaster} from "../Paymaster.sol";
 
 /**
@@ -44,10 +45,9 @@ abstract contract PaymasterERC721Owner is Paymaster {
         return (
             bytes(""),
             // balanceOf reverts if the `userOp.sender` is the address(0), so this becomes unreachable with address(0)
-            // assuming a compliant entrypoint (`_validatePaymasterUserOp` is called after `validateUserOp`),
-            token().balanceOf(userOp.sender) == 0
-                ? ERC4337Utils.SIG_VALIDATION_FAILED
-                : ERC4337Utils.SIG_VALIDATION_SUCCESS
+            // assuming a compliant entrypoint (`_validatePaymasterUserOp` is called after `validateUserOp`).
+            // `SIG_VALIDATION_FAILED == 1` and `SIG_VALIDATION_SUCCESS == 0`, so the cast is branchless.
+            SafeCast.toUint(token().balanceOf(userOp.sender) == 0)
         );
     }
 }

--- a/contracts/account/paymaster/extensions/PaymasterSigner.sol
+++ b/contracts/account/paymaster/extensions/PaymasterSigner.sol
@@ -94,9 +94,11 @@ abstract contract PaymasterSigner is AbstractSigner, EIP712, Paymaster {
         PackedUserOperation calldata userOp
     ) internal pure virtual returns (uint48 validAfter, uint48 validUntil, bytes calldata signature) {
         bytes calldata paymasterData = userOp.paymasterData();
-        return
-            paymasterData.length < 12
-                ? (uint48(0), uint48(0), Calldata.emptyBytes())
-                : (uint48(bytes6(paymasterData[0:6])), uint48(bytes6(paymasterData[6:12])), paymasterData[12:]);
+        if (paymasterData.length < 12) return (uint48(0), uint48(0), Calldata.emptyBytes());
+
+        // Both timestamps share the 12-byte window at [0:12]: a single load replaces
+        // the two bounds-checked slices.
+        bytes12 validity = bytes12(paymasterData[:12]);
+        return (uint48(bytes6(validity)), uint48(bytes6(validity << 48)), paymasterData[12:]);
     }
 }

--- a/contracts/account/paymaster/extensions/PaymasterSigner.sol
+++ b/contracts/account/paymaster/extensions/PaymasterSigner.sol
@@ -37,6 +37,11 @@ abstract contract PaymasterSigner is AbstractSigner, EIP712, Paymaster {
         uint48 validAfter,
         uint48 validUntil
     ) internal view virtual returns (bytes32) {
+        // Both paymaster gas limits share the word at [20:52]: a single load replaces
+        // the two `ERC4337Utils` accessors, which each length-check and load it.
+        uint256 paymasterGasLimits = userOp.paymasterAndData.length < 52
+            ? 0
+            : uint256(bytes32(userOp.paymasterAndData[20:52]));
         return
             _hashTypedDataV4(
                 keccak256(
@@ -49,8 +54,8 @@ abstract contract PaymasterSigner is AbstractSigner, EIP712, Paymaster {
                         userOp.accountGasLimits,
                         userOp.preVerificationGas,
                         userOp.gasFees,
-                        userOp.paymasterVerificationGasLimit(),
-                        userOp.paymasterPostOpGasLimit(),
+                        paymasterGasLimits >> 128,
+                        uint256(uint128(paymasterGasLimits)),
                         validAfter,
                         validUntil
                     )


### PR DESCRIPTION
> [!NOTE]
> **AI-generated** with the [Solidity Gas Optimizer skill](https://github.com/gonzaotc/solidity-gas-optimizer-skill) in council mode: 4 models (Composer, Fable 5, GPT-5.6 Sol, Grok 4.5) each ran the full audit independently, the runs were merged and adjudicated, and every finding below was re-measured on this branch. All tests pass, but it's encouraged to review before merging to confirm behavior is unaffected.

### Run

- **Measurement:** Hardhat, solc 0.8.35, runs 200, via-IR false; runtime deltas from deterministic whole-transaction `handleOps` probes, since the gas reporter cannot attribute calls made through the EntryPoint predeploy
- **Tests:** Full project suite: 8,007 passing and 1 pending (pre-existing); paymaster suite 90 passing
- **Source runs:** 4 independent audits at `db06a6ef` / `d017d3e5`; the scope tree is byte-identical across both commits
- **Scope:**
  ```
  contracts/account/paymaster/
    Paymaster.sol
    extensions/
      PaymasterERC20.sol
      PaymasterERC20Guarantor.sol
      PaymasterERC721Owner.sol
      PaymasterSigner.sol
  ```

### Results

Five independent gas optimization candidates survived adjudication, one commit each and keyed by the IDs below. It's recommended to review them one by one, via the [commits view](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/6614/commits).

| ID | Change | Function | Δ runtime /call | Δ deploy gas | Found by |
|----|--------|----------|-----------------|--------------|----------|
| GAS-H-01 | parse both paymaster gas limits with one calldata load | `PaymasterSigner._signableUserOpHash` | −712 | −20,547 / −20,558 | Fable 5, GPT-5.6 Sol |
| GAS-H-02 | skip the `mulDiv` 512-bit path when the product fits one word | `PaymasterERC20._erc20Cost` | −966 base, −1,932 guaranteed | +17,102 | Fable 5, GPT-5.6 Sol |
| GAS-M-01 | one-window timestamp decode | `PaymasterSigner._decodePaymasterUserOp` | −199 | +876 / +864 | Grok 4.5, Composer, GPT-5.6 Sol |
| GAS-L-01 | unchecked refund subtraction under the EntryPoint invariant | `PaymasterERC20._refund` | −72 per postOp | within noise | Fable 5 |
| GAS-L-02 | branchless validation data via `SafeCast.toUint` | `PaymasterERC721Owner._validatePaymasterUserOp` | −12 | −3,458 / −3,465 | Fable 5 |

#### GAS-H-01 · parse both paymaster gas limits with one calldata load (`PaymasterSigner._signableUserOpHash`)
- **What it does:** replaces the two `ERC4337Utils` accessor calls with one `length < 52` check and one 32-byte load of `paymasterAndData[20:52]`, split on the stack into the verification and postOp gas limits; the encoded hash is byte-identical, including the zero fallback for short data.
- **Why it's cheaper:** each accessor re-derived the calldata slice, re-checked the length, and loaded overlapping bytes of the same word; one load removes the duplicated bounds checks and slice construction, and dropping the accessor code removes about 20.5k of deployment bytecode.
- **Tradeoff:** the `[20:52]` offsets and the 128-bit split are spelled out locally in EIP-712 hashing code, duplicating layout knowledge the `ERC4337Utils` accessors centralize. Cherry-picks independently.
- **Found by:** Fable 5 and GPT-5.6 Sol, independently at the same base commit; the deploy delta was reproduced by both runs and again on this branch.

#### GAS-H-02 · skip the `mulDiv` 512-bit path when the product fits one word (`PaymasterERC20._erc20Cost`)
- **What it does:** branches on `high == 0` from the already-computed `mul512` and finishes the common case with `Math.ceilDiv`, keeping `mulDiv` for the genuine multi-word case and preserving the `type(uint256).max` saturation sentinel, including the `denominator == 0` edge.
- **Why it's cheaper:** the overflow guard already computes the full 512-bit product and `Math.mulDiv` recomputes it internally; the one-word case needs only a ceiling division. The function runs twice per sponsored operation and four times per guaranteed one.
- **Tradeoff:** a second ceiling-division path in money math that must stay congruent with `mulDiv` (the equivalence at the `high == 0` boundary and both sentinel edges was independently verified in review), plus +17.1k deployment gas per concrete paymaster. Cherry-picks independently.
- **Found by:** Fable 5 (measured); GPT-5.6 Sol raised the same waste as an advisory proposing a shared single-pass `mulDiv` primitive in `Math`, which remains the API-level alternative.

#### GAS-M-01 · one-window timestamp decode (`PaymasterSigner._decodePaymasterUserOp`)
- **What it does:** reads the 12-byte validity window once as `bytes12` and splits it with casts (`uint48(bytes6(validity))`, `uint48(bytes6(validity << 48))`) instead of two adjacent bounds-checked 6-byte slices; the short-data path is unchanged.
- **Why it's cheaper:** one calldata slice and one bounds check replace two of each, on the decode executed by every signed user operation.
- **Tradeoff:** roughly 870 gas more at deployment and one shift-based byte offset in place of two explicit slice ranges, an idiom this file already uses for the gas-limits split. Cherry-picks independently.
- **Found by:** Grok 4.5, Composer, and GPT-5.6 Sol (whose isolated-function probe measured it flat; the whole-transaction re-measurement on this branch shows −199 per signed operation).

#### GAS-L-01 · unchecked refund subtraction under the EntryPoint invariant (`PaymasterERC20._refund`)
- **What it does:** wraps `prefundAmount - actualAmount_` in `unchecked`.
- **Why it's cheaper:** the EntryPoint guarantees `actualGasCost <= maxCost`, so `actualAmount_ <= prefundAmount` holds and the compiler's underflow check is unreachable; removing it saves 72 gas on every postOp refund.
- **Tradeoff:** the no-underflow guarantee moves from local code to the EntryPoint invariant; a non-compliant caller that breaks it now produces a wrapped amount that fails inside `trySafeTransfer` (reverting with `PaymasterERC20FailedRefund`) instead of a `Panic`. Cherry-picks independently.
- **Found by:** Fable 5.

#### GAS-L-02 · branchless validation data via `SafeCast.toUint` (`PaymasterERC721Owner._validatePaymasterUserOp`)
- **What it does:** returns `SafeCast.toUint(token().balanceOf(userOp.sender) == 0)` instead of a ternary selecting between `SIG_VALIDATION_FAILED` and `SIG_VALIDATION_SUCCESS`.
- **Why it's cheaper:** the two constants are exactly 1 and 0, so the conditional jump becomes a bool-to-uint cast, saving 12 gas per operation and 3.4k deployment gas.
- **Tradeoff:** the named constants leave the return expression; the failure-to-1 mapping is documented by an inline comment and relies on the constants' numeric values. Cherry-picks independently.
- **Found by:** Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
