### PR TITLE
Fix AccessManager FV spec for setAuthority admin delay

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -24,6 +24,8 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'formal-verification') || contains(github.event.pull_request.labels.*.name, 'formal-verification-force-all')
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Include history so the diff against the PR base resolves
       - name: Set up environment
         uses: ./.github/actions/setup
         with:

--- a/fv/specs/AccessManager.spec
+++ b/fv/specs/AccessManager.spec
@@ -172,13 +172,20 @@ rule canCall(env e) {
     address target;
     bytes4 selector;
 
+    // Calls to IAccessManaged.setAuthority are treated differently due to their sensitive nature: normal role
+    // management for this selector is bypassed: only the admin role can perform this call and any admin delay
+    // specific to this target is enforced.
+    bool isSetAuthorityCall = selector == to_bytes4(0x7a9e5e4b); // setAuthority(address)
+
     // Get relevant values
-    bool   immediate    = canCall_immediate(e, caller, target, selector);
-    uint32 delay        = canCall_delay(e, caller, target, selector);
-    bool   closed       = isTargetClosed(target);
-    uint64 roleId       = getTargetFunctionRole(target, selector);
-    bool   isMember     = hasRole_isMember(e, roleId, caller);
-    uint32 currentDelay = hasRole_executionDelay(e, roleId, caller);
+    bool    immediate    = canCall_immediate(e, caller, target, selector);
+    uint32  delay        = canCall_delay(e, caller, target, selector);
+    bool    closed       = isTargetClosed(target);
+    uint64  roleId       = isSetAuthorityCall ? ADMIN_ROLE() : getTargetFunctionRole(target, selector);
+    bool    isMember     = hasRole_isMember(e, roleId, caller);
+    uint32  memberDelay  = hasRole_executionDelay(e, roleId, caller);
+    uint32  targetDelay  = getTargetAdminDelay(e, target);
+    mathint currentDelay = max(memberDelay, isSetAuthorityCall ? targetDelay : 0);
 
     // Can only execute without delay in specific cases:
     // - target not closed
@@ -205,7 +212,7 @@ rule canCall(env e) {
     );
 
     // If there is a delay, then it must be the caller's execution delay
-    assert delay > 0 => delay == currentDelay;
+    assert delay > 0 => to_mathint(delay) == currentDelay;
 
     // Immediate execute means no delayed execution
     assert immediate => delay == 0;


### PR DESCRIPTION
This updates the `canCall` rule in `fv/specs/AccessManager.spec` to account for the special-case handling of `IAccessManaged.setAuthority(address)` in `AccessManager.canCall`.

For the `setAuthority` selector, the contract bypasses normal function-role management: only the `ADMIN_ROLE` can perform the call, and the effective delay is the maximum of the caller's admin execution delay and the target's admin delay (`getTargetAdminDelay`). The formal verification spec did not model this and was out of sync with the implementation.

This is a behavior change introduced in #6388 ("Fix bypassing target admin delay using execute") that the FV spec was not updated for.

Changes:
- Special-case the `setAuthority(address)` selector (`0x7a9e5e4b`), using `ADMIN_ROLE` as `roleId`.
- Compute `currentDelay` as `max(memberDelay, targetAdminDelay)` for `setAuthority`, matching `Math.max(executionDelay, adminDelay)` in the contract.
- Promote `currentDelay` to `mathint` and adjust the delay assertion accordingly.

Spec-only change; no changeset needed.

---

Link to certora run for the updated specs: https://prover.certora.com/output/71959/8f88b37ebae64e8e829d206bb0c123d7?anonymousKey=53a555805307674afbfb1afea80bf5fa2a0a3378