### PR TITLE
Prune orphaned hardhat-exposed contracts on generation

### DIFF
--- a/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
+++ b/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
@@ -36,6 +36,18 @@ export default async function generateExposedContracts(
   const inclusionResults = await Promise.all(rootPaths.map(root => includes(root)));
   const rootPathsToExpose = rootPaths.filter((_, i) => inclusionResults[i]);
 
+  // Remove orphaned wrappers whose source was renamed or removed, otherwise their stale
+  // import breaks compilation. Runs before the cache-based early return, as orphans persist
+  // even when no source changed.
+  const sourceNames = new Set(
+    rootPaths.filter(p => !isInExposedOutDir(p)).map(p => path.relative(hre.config.paths.root, p)),
+  );
+  for (const wrapper of rootPaths.filter(isInExposedOutDir)) {
+    if (!sourceNames.has(path.relative(hre.config.exposed.outDir, wrapper))) {
+      fs.rmSync(wrapper);
+    }
+  }
+
   const compilationJobs = await hre.solidity.getCompilationJobs(rootPathsToExpose, { force: args.force });
 
   if (!compilationJobs.success) {


### PR DESCRIPTION
The hardhat-exposed generator only writes wrappers but doesn't automatically remove them. When a source is renamed or deleted, its stale wrapper lingers in the output directory and still imports the missing source, breaking compilation with HHE902 until a manual clean.

This PR change prunes wrappers whose source is no longer a project root file before the cache-based early return, so orphans are removed even on builds where nothing changed.