### PR TITLE
Remove async from describe blocks in paymaster tests

### DIFF
--- a/test/account/paymaster/PaymasterERC20.test.js
+++ b/test/account/paymaster/PaymasterERC20.test.js
@@ -106,7 +106,7 @@ describe('PaymasterERC20', function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
-  describe('core paymaster behavior', async function () {
+  describe('core paymaster behavior', function () {
     beforeEach(async function () {
       await this.token.$_mint(this.account, value);
       await this.token.$_approve(this.account, this.paymaster, ethers.MaxUint256);

--- a/test/account/paymaster/PaymasterERC20Guarantor.test.js
+++ b/test/account/paymaster/PaymasterERC20Guarantor.test.js
@@ -140,7 +140,7 @@ describe('PaymasterERC20Guarantor', function () {
     Object.assign(this, await loadFixture(fixture));
   });
 
-  describe('core paymaster behavior', async function () {
+  describe('core paymaster behavior', function () {
     beforeEach(async function () {
       await this.token.$_mint(this.account, value);
       await this.token.$_approve(this.account, this.paymaster, ethers.MaxUint256);


### PR DESCRIPTION
Removes the redundant `async` keyword from `describe('core paymaster behavior', ...)` blocks in the paymaster tests, consistent with the `no-async-describe-blocks` eslint rule added in #6438.

- `test/account/paymaster/PaymasterERC20.test.js`
- `test/account/paymaster/PaymasterERC20Guarantor.test.js`

No changeset needed (test-only cleanup).