### PR TITLE
Document postOp cost estimate tuning in PaymasterERC20 NatSpec

### DIFF
--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -243,7 +243,13 @@ abstract contract PaymasterERC20 is Paymaster {
         bytes32 userOpHash
     ) internal view virtual returns (uint256 validationData, IERC20 token, uint256 tokenPerNative);
 
-    /// @dev Over-estimates the cost of the post-operation logic.
+    /**
+     * @dev Over-estimates the cost of the post-operation logic, which the EntryPoint charges to the paymaster but
+     * excludes from the `actualGasCost` reported to {_postOp}.
+     *
+     * NOTE: The default assumes an standard ERC-20. Override with a higher value for gas-heavier tokens; a persistent
+     * underestimate drains the paymaster's deposit.
+     */
     function _postOpCost() internal view virtual returns (uint256) {
         return 30_000;
     }

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -247,7 +247,7 @@ abstract contract PaymasterERC20 is Paymaster {
      * @dev Over-estimates the cost of the post-operation logic, which the EntryPoint charges to the paymaster but
      * excludes from the `actualGasCost` reported to {_postOp}.
      *
-     * NOTE: The default assumes an standard ERC-20. Override with a higher value for gas-heavier tokens; a persistent
+     * NOTE: The default assumes a standard ERC-20. Override with a higher value for gas-heavier tokens; a persistent
      * underestimate drains the paymaster's deposit.
      */
     function _postOpCost() internal view virtual returns (uint256) {

--- a/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
@@ -147,7 +147,12 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
      */
     function _fetchGuarantor(PackedUserOperation calldata userOp) internal view virtual returns (address guarantor);
 
-    /// @dev Over-estimates the cost of the post-operation logic. Added on top of {PaymasterERC20-_postOpCost} for guaranteed userOps.
+    /**
+     * @dev Over-estimates the cost of the post-operation logic. Added on top of {PaymasterERC20-_postOpCost} for
+     * guaranteed userOps.
+     *
+     * NOTE: Like {PaymasterERC20-_postOpCost}, override with a higher value for gas-heavier tokens.
+     */
     function _guaranteedPostOpCost() internal view virtual returns (uint256) {
         return 15_000;
     }


### PR DESCRIPTION
Fixes issue **M-09**

Clarifies the NatSpec for `PaymasterERC20._postOpCost()` and `PaymasterERC20Guarantor._guaranteedPostOpCost()`.

These values price the paymaster's own postOp gas into the token charge. ERC-4337 charges that gas to the paymaster's EntryPoint deposit but does not include it in the `actualGasCost` reported to `_postOp`, so the fixed estimates are what bridge the gap. The defaults (30_000 / 15_000) are calibrated for a standard ERC-20 transfer over warm storage; gas-heavier tokens (upgradeable/proxy tokens, transfer hooks, fee-on-transfer, cold access) can exceed them, and a persistent underestimate slowly drains the paymaster's deposit.

The natspec now state the reason the estimate matters and direct integrators to raise it for such tokens. No behavior change — the defaults and the `virtual` override points are unchanged.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
