### PR TITLE
Add ERC-7535 Native Asset Vault as an ERC-4626 extension

### DIFF
--- a/.changeset/native-harbors-drift.md
+++ b/.changeset/native-harbors-drift.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`ERC7535`: Add an implementation of the ERC-7535 Native Asset Tokenized Vault standard as a thin extension of `ERC4626`, using the chain's native asset (e.g. Ether) as the underlying. `deposit`/`mint` accept the native asset as `msg.value` (requiring it to cover the deposit, with any excess kept as a donation), withdrawals send it out via `Address.sendValue` under the inherited checks-effects-interactions ordering, and a `virtual` `receive()` rejects unsolicited plain transfers.
+`ERC7535`: Add an implementation of the ERC-7535 Native Asset Tokenized Vault standard as a thin extension of `ERC4626`, using the chain's native asset (e.g. Ether) as the underlying. `deposit` prices shares off the entire `msg.value` (ignoring its `assets` argument, per ERC-7535) and `mint` requires `msg.value` to cover the previewed cost (keeping any excess as a donation); withdrawals send the native asset out via `Address.sendValue` under the inherited checks-effects-interactions ordering, and a `virtual` `receive()` rejects unsolicited plain transfers.

--- a/.changeset/native-harbors-drift.md
+++ b/.changeset/native-harbors-drift.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ERC7535`: Add an implementation of the ERC-7535 Native Asset Tokenized Vault standard as a thin extension of `ERC4626`, using the chain's native asset (e.g. Ether) as the underlying. `deposit`/`mint` accept the native asset as `msg.value` (requiring it to cover the deposit, with any excess kept as a donation), withdrawals send it out via `Address.sendValue` under the inherited checks-effects-interactions ordering, and a `virtual` `receive()` rejects unsolicited plain transfers.

--- a/.changeset/quiet-vaults-sail.md
+++ b/.changeset/quiet-vaults-sail.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`IERC4626`, `ERC4626`: Make `deposit` and `mint` `payable` and add an internal `_checkPayment` hook that validates the native value (`msg.value`) sent with them. This enables vaults whose underlying is the chain's native asset (see `ERC7535`) without changing the function selectors or the ERC-165 interface id. The default `_checkPayment` reverts on any non-zero `msg.value`, so ERC-20 vaults keep rejecting native value exactly as before.
+`IERC4626`, `ERC4626`: Make `deposit` and `mint` `payable` and add an internal `_checkPayment` hook that validates the native value (`msg.value`) sent with them. This enables vaults whose underlying is the chain's native asset (see `ERC7535`) without changing the function selectors or the ERC-165 interface id. The default `_checkPayment` reverts on any non-zero `msg.value`, so ERC-20 vaults keep rejecting native value exactly as before. NOTE: because Solidity does not allow a `payable` function to be overridden as `nonpayable`, contracts that override or implement `IERC4626.deposit`/`mint` as `nonpayable` must add `payable` to keep compiling.

--- a/.changeset/quiet-vaults-sail.md
+++ b/.changeset/quiet-vaults-sail.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`IERC4626`, `ERC4626`: Make `deposit` and `mint` `payable` and add an internal `_checkPayment` hook that validates the native value (`msg.value`) sent with them. This enables vaults whose underlying is the chain's native asset (see `ERC7535`) without changing the function selectors or the ERC-165 interface id. The default `_checkPayment` reverts on any non-zero `msg.value`, so ERC-20 vaults keep rejecting native value exactly as before.

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.5.0) (interfaces/IERC4626.sol)
+// OpenZeppelin Contracts (last updated v5.7.0) (interfaces/IERC4626.sol)
 
 pragma solidity >=0.6.2;
 
@@ -105,8 +105,12 @@ interface IERC4626 is IERC20, IERC20Metadata {
      *   approving enough underlying tokens to the Vault contract, etc).
      *
      * NOTE: most implementations will require pre-approval of the Vault with the Vault’s underlying asset token.
+     *
+     * NOTE: This function is `payable` to support vaults whose underlying is the chain's native asset (see
+     * ERC-7535). Vaults over an ERC-20 underlying do not expect a native value and should reject a non-zero
+     * `msg.value`.
      */
-    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+    function deposit(uint256 assets, address receiver) external payable returns (uint256 shares);
 
     /**
      * @dev Returns the maximum amount of the Vault shares that can be minted for the receiver, through a mint call.
@@ -143,8 +147,12 @@ interface IERC4626 is IERC20, IERC20Metadata {
      *   approving enough underlying tokens to the Vault contract, etc).
      *
      * NOTE: most implementations will require pre-approval of the Vault with the Vault’s underlying asset token.
+     *
+     * NOTE: This function is `payable` to support vaults whose underlying is the chain's native asset (see
+     * ERC-7535). Vaults over an ERC-20 underlying do not expect a native value and should reject a non-zero
+     * `msg.value`.
      */
-    function mint(uint256 shares, address receiver) external returns (uint256 assets);
+    function mint(uint256 shares, address receiver) external payable returns (uint256 assets);
 
     /**
      * @dev Returns the maximum amount of the underlying asset that can be withdrawn from the owner balance in the

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.7.0) (interfaces/IERC4626.sol)
+// OpenZeppelin Contracts (last updated v5.5.0) (interfaces/IERC4626.sol)
 
 pragma solidity >=0.6.2;
 

--- a/contracts/mocks/token/ERC7535OffsetMock.sol
+++ b/contracts/mocks/token/ERC7535OffsetMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.24;
+
+import {ERC7535} from "../../token/ERC20/extensions/ERC7535.sol";
+
+abstract contract ERC7535OffsetMock is ERC7535 {
+    uint8 private immutable _offset;
+
+    constructor(uint8 offset_) {
+        _offset = offset_;
+    }
+
+    function _decimalsOffset() internal view virtual override returns (uint8) {
+        return _offset;
+    }
+}

--- a/contracts/token/ERC20/README.adoc
+++ b/contracts/token/ERC20/README.adoc
@@ -29,6 +29,7 @@ Additionally there are multiple custom extensions, including:
 * {ERC20TemporaryApproval}: support for approvals lasting for only one transaction, as defined in ERC-7674.
 * {ERC1363}: support for calling the target of a transfer or approval, enabling code execution on the receiver within a single transaction.
 * {ERC4626}: tokenized vault that manages shares (represented as ERC-20) that are backed by assets (another ERC-20).
+* {ERC7535}: tokenized vault (extending {ERC4626}) whose underlying asset is the chain's native asset (e.g. Ether) instead of an ERC-20.
 
 Finally, there are some utilities to interact with ERC-20 contracts in various ways:
 
@@ -83,6 +84,8 @@ NOTE: This core set of contracts is designed to be unopinionated, allowing devel
 {{ERC1363}}
 
 {{ERC4626}}
+
+{{ERC7535}}
 
 == Utilities
 

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.6.0) (token/ERC20/extensions/ERC4626.sol)
+// OpenZeppelin Contracts (last updated v5.7.0) (token/ERC20/extensions/ERC4626.sol)
 
 pragma solidity ^0.8.24;
 
@@ -92,6 +92,13 @@ abstract contract ERC4626 is ERC20, IERC4626 {
     error ERC4626ExceededMaxRedeem(address owner, uint256 shares, uint256 max);
 
     /**
+     * @dev Attempted to {deposit} or {mint} with a native value (`msg.value`) the vault does not expect. The
+     * default {_checkPayment} reverts with this error on any non-zero `msg.value`; native-asset vaults (see
+     * ERC-7535) override {_checkPayment} and do not use it.
+     */
+    error ERC4626UnexpectedNativeValue(uint256 value);
+
+    /**
      * @dev Set the underlying asset contract. This must be an ERC20-compatible contract (ERC-20 or ERC-777).
      */
     constructor(IERC20 asset_) {
@@ -172,26 +179,28 @@ abstract contract ERC4626 is ERC20, IERC4626 {
     }
 
     /// @inheritdoc IERC4626
-    function deposit(uint256 assets, address receiver) public virtual returns (uint256) {
+    function deposit(uint256 assets, address receiver) public payable virtual returns (uint256) {
         uint256 maxAssets = maxDeposit(receiver);
         if (assets > maxAssets) {
             revert ERC4626ExceededMaxDeposit(receiver, assets, maxAssets);
         }
 
         uint256 shares = previewDeposit(assets);
+        _checkPayment(assets);
         _deposit(_msgSender(), receiver, assets, shares);
 
         return shares;
     }
 
     /// @inheritdoc IERC4626
-    function mint(uint256 shares, address receiver) public virtual returns (uint256) {
+    function mint(uint256 shares, address receiver) public payable virtual returns (uint256) {
         uint256 maxShares = maxMint(receiver);
         if (shares > maxShares) {
             revert ERC4626ExceededMaxMint(receiver, shares, maxShares);
         }
 
         uint256 assets = previewMint(shares);
+        _checkPayment(assets);
         _deposit(_msgSender(), receiver, assets, shares);
 
         return assets;
@@ -288,6 +297,17 @@ abstract contract ERC4626 is ERC20, IERC4626 {
     /// @dev Performs a transfer out of underlying assets. The default implementation uses `SafeERC20`. Used by {_withdraw}.
     function _transferOut(address to, uint256 assets) internal virtual {
         SafeERC20.safeTransfer(IERC20(asset()), to, assets);
+    }
+
+    /// @dev Validates the native value (`msg.value`) sent with a {deposit} or {mint} call. The `uint256` argument
+    /// is the amount being deposited (or the cost of the shares being minted), expressed in the underlying asset.
+    ///
+    /// {deposit} and {mint} are `payable` so that vaults whose underlying IS the chain's native asset (see
+    /// ERC-7535) can receive it as `msg.value`. The default implementation, used by ERC-20 vaults, expects no
+    /// native value and reverts if any is sent — preserving the behavior of a non-`payable` entry point. Native
+    /// asset vaults override this to require `msg.value` to cover the deposited amount.
+    function _checkPayment(uint256) internal virtual {
+        if (msg.value != 0) revert ERC4626UnexpectedNativeValue(msg.value);
     }
 
     function _decimalsOffset() internal view virtual returns (uint8) {

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.7.0) (token/ERC20/extensions/ERC4626.sol)
+// OpenZeppelin Contracts (last updated v5.6.0) (token/ERC20/extensions/ERC4626.sol)
 
 pragma solidity ^0.8.24;
 

--- a/contracts/token/ERC20/extensions/ERC7535.sol
+++ b/contracts/token/ERC20/extensions/ERC7535.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.7.0) (token/ERC20/extensions/ERC7535.sol)
 
 pragma solidity ^0.8.24;
 
@@ -23,8 +22,9 @@ import {Math} from "../../../utils/math/Math.sol";
  * * {asset} returns the ERC-7528 native-asset placeholder `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
  * * {totalAssets} returns the contract's own native-asset balance (`address(this).balance`).
  * * {deposit} and {mint} are `payable` (as declared by `IERC4626`): the native asset is provided as `msg.value`
- * rather than pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying. The
- * inherited {ERC4626-_checkPayment} hook is overridden to require `msg.value` to cover the deposit.
+ * rather than pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying. {deposit}
+ * prices shares off `msg.value` and ignores its `assets` argument (per ERC-7535); {mint} requires `msg.value` to
+ * cover the previewed cost through the inherited {ERC4626-_checkPayment} hook.
  * * {ERC4626-_transferIn} is a no-op (the value has already arrived as `msg.value`) and {ERC4626-_transferOut}
  * sends the native asset out with `Address.sendValue`.
  *
@@ -44,9 +44,10 @@ import {Math} from "../../../utils/math/Math.sol";
  * the defense.
  * ====
  *
- * NOTE: `deposit(assets, receiver)` and `mint(shares, receiver)` require `msg.value` to be at least the amount
- * (resp. the previewed cost) being deposited. Any excess `msg.value` is kept by the vault as a donation, raising
- * the share price for existing holders.
+ * NOTE: `deposit(assets, receiver)` deposits the entire `msg.value` and mints `previewDeposit(msg.value)` shares,
+ * ignoring the `assets` argument (per ERC-7535). `mint(shares, receiver)` requires `msg.value` to be at least the
+ * previewed cost; any excess `msg.value` on a `mint` is kept by the vault as a donation, raising the share price
+ * for existing holders.
  *
  * To learn more, check out our xref:ROOT:erc7535.adoc[ERC-7535 guide].
  */
@@ -76,8 +77,30 @@ abstract contract ERC7535 is ERC4626 {
         return address(this).balance;
     }
 
-    /// @dev See {ERC4626-_checkPayment}. Requires the native value sent to cover `assets`; any excess is kept by
-    /// the vault (raising the share price for existing holders, like a donation).
+    /**
+     * @inheritdoc IERC4626
+     *
+     * @dev Per ERC-7535, the deposited amount is the entire `msg.value`: shares are priced off `msg.value` and the
+     * `assets` argument is ignored, so the full native value sent is always converted to shares (none is silently
+     * retained as a donation). Reverts via {maxDeposit} if `msg.value` exceeds the maximum.
+     */
+    function deposit(uint256, address receiver) public payable virtual override returns (uint256) {
+        uint256 assets = msg.value;
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert ERC4626ExceededMaxDeposit(receiver, assets, maxAssets);
+        }
+
+        uint256 shares = previewDeposit(assets);
+        _deposit(_msgSender(), receiver, assets, shares);
+
+        return shares;
+    }
+
+    /// @dev See {ERC4626-_checkPayment}. Used by the inherited {mint} (and the base deposit/mint flow): requires the
+    /// native value to cover the previewed cost `assets`; any excess is kept by the vault, raising the share price
+    /// for existing holders. {deposit} is overridden to price shares directly off `msg.value` and does not route
+    /// through this hook.
     function _checkPayment(uint256 assets) internal virtual override {
         if (msg.value < assets) {
             revert ERC7535InsufficientNativeValue(msg.value, assets);

--- a/contracts/token/ERC20/extensions/ERC7535.sol
+++ b/contracts/token/ERC20/extensions/ERC7535.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.7.0) (token/ERC20/extensions/ERC7535.sol)
+
+pragma solidity ^0.8.24;
+
+import {IERC20} from "../IERC20.sol";
+import {IERC4626} from "../../../interfaces/IERC4626.sol";
+import {ERC4626} from "./ERC4626.sol";
+import {Address} from "../../../utils/Address.sol";
+import {Math} from "../../../utils/math/Math.sol";
+
+/**
+ * @dev Implementation of the ERC-7535 "Native Asset ERC-4626 Tokenized Vault" as defined in
+ * https://eips.ethereum.org/EIPS/eip-7535[ERC-7535].
+ *
+ * ERC-7535 is an adaptation of {ERC4626} that uses the chain's native asset (e.g. Ether) as the underlying
+ * asset instead of an ERC-20 token. It is implemented as a thin extension of {ERC4626}: the share accounting,
+ * rounding directions, virtual-offset inflation mitigation, preview functions, and checks-effects-interactions
+ * ordering are all inherited unchanged. Only the asset-movement seams differ.
+ *
+ * Relative to {ERC4626}:
+ *
+ * * {asset} returns the ERC-7528 native-asset placeholder `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
+ * * {totalAssets} returns the contract's own native-asset balance (`address(this).balance`).
+ * * {deposit} and {mint} are `payable` (as declared by `IERC4626`): the native asset is provided as `msg.value`
+ * rather than pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying. The
+ * inherited {ERC4626-_checkPayment} hook is overridden to require `msg.value` to cover the deposit.
+ * * {ERC4626-_transferIn} is a no-op (the value has already arrived as `msg.value`) and {ERC4626-_transferOut}
+ * sends the native asset out with `Address.sendValue`.
+ *
+ * IMPORTANT: A vault backed by a wrapped native asset (such as WETH9) MUST NOT use this contract; per ERC-7528
+ * and ERC-7535 such a vault is a plain {ERC4626} over the wrapper ERC-20 and MUST report that wrapper's address
+ * from {asset}, not the native-asset placeholder.
+ *
+ * [CAUTION]
+ * ====
+ * Like {ERC4626}, an empty (or nearly empty) vault is exposed to a donation / inflation attack, and the same
+ * configurable virtual shares and assets mitigate it. Override `_decimalsOffset()` to harden a deployment; see
+ * the {ERC4626} documentation for the underlying math.
+ *
+ * A native asset vault can additionally be force-fed value (e.g. through `SELFDESTRUCT` or block-reward
+ * payments) that bypasses the {receive} guard. Because {totalAssets} is balance-based it tracks such donations
+ * exactly as a direct ERC-20 transfer would for {ERC4626}; the virtual-offset math, not the {receive} revert, is
+ * the defense.
+ * ====
+ *
+ * NOTE: `deposit(assets, receiver)` and `mint(shares, receiver)` require `msg.value` to be at least the amount
+ * (resp. the previewed cost) being deposited. Any excess `msg.value` is kept by the vault as a donation, raising
+ * the share price for existing holders.
+ *
+ * To learn more, check out our xref:ROOT:erc7535.adoc[ERC-7535 guide].
+ */
+abstract contract ERC7535 is ERC4626 {
+    using Math for uint256;
+
+    /// @dev The ERC-7528 placeholder address representing the native asset; exposed through {asset}.
+    address private constant NATIVE_ASSET = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @dev Attempted to {deposit} or {mint} with a `msg.value` below the required native amount.
+    error ERC7535InsufficientNativeValue(uint256 value, uint256 expected);
+
+    /// @dev Reverts on a plain native-asset transfer to the vault — value enters only via {deposit} or {mint}.
+    error ERC7535UnsolicitedDeposit();
+
+    /// @dev Configures the vault for the native asset. The placeholder address has no `decimals()`, so the
+    /// inherited {ERC4626} decimals detection falls back to 18, the native asset's decimals.
+    constructor() ERC4626(IERC20(NATIVE_ASSET)) {}
+
+    /// @inheritdoc IERC4626
+    function asset() public view virtual override returns (address) {
+        return NATIVE_ASSET;
+    }
+
+    /// @inheritdoc IERC4626
+    function totalAssets() public view virtual override returns (uint256) {
+        return address(this).balance;
+    }
+
+    /// @dev See {ERC4626-_checkPayment}. Requires the native value sent to cover `assets`; any excess is kept by
+    /// the vault (raising the share price for existing holders, like a donation).
+    function _checkPayment(uint256 assets) internal virtual override {
+        if (msg.value < assets) {
+            revert ERC7535InsufficientNativeValue(msg.value, assets);
+        }
+    }
+
+    /// @inheritdoc ERC4626
+    function _convertToShares(uint256 assets, Math.Rounding rounding) internal view virtual override returns (uint256) {
+        return assets.mulDiv(totalSupply() + 10 ** _decimalsOffset(), _pretotalAssets() + 1, rounding);
+    }
+
+    /// @inheritdoc ERC4626
+    function _convertToAssets(uint256 shares, Math.Rounding rounding) internal view virtual override returns (uint256) {
+        return shares.mulDiv(_pretotalAssets() + 1, totalSupply() + 10 ** _decimalsOffset(), rounding);
+    }
+
+    /**
+     * @dev Returns the value of {totalAssets} the share math is priced against — the contract's balance excluding
+     * any in-flight `msg.value` from the current `payable` call. In any non-`payable` context `msg.value` is `0`
+     * and this equals {totalAssets}; inside {deposit}/{mint} it yields the pre-call balance, so a standalone
+     * {previewDeposit} returns exactly the shares a subsequent {deposit} mints. Overrides MUST return a value less
+     * than or equal to {totalAssets}.
+     */
+    function _pretotalAssets() internal view virtual returns (uint256) {
+        return totalAssets() - msg.value;
+    }
+
+    /// @dev No-op: the native asset has already been received as `msg.value`. See {ERC4626-_transferIn}.
+    function _transferIn(address /* from */, uint256 /* assets */) internal virtual override {}
+
+    /// @dev Sends the native asset out with `Address.sendValue`, which forwards all remaining gas. See
+    /// {ERC4626-_transferOut}.
+    function _transferOut(address to, uint256 assets) internal virtual override {
+        Address.sendValue(payable(to), assets);
+    }
+
+    /// @dev Reverts on plain native-asset transfers; value must enter via {deposit} or {mint}. This does not stop
+    /// protocol-level force-feeds (`SELFDESTRUCT`, block-reward payments), which bypass `receive` entirely.
+    receive() external payable virtual {
+        revert ERC7535UnsolicitedDeposit();
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -19,6 +19,7 @@
 ** xref:erc721.adoc[ERC-721]
 ** xref:erc1155.adoc[ERC-1155]
 ** xref:erc4626.adoc[ERC-4626]
+** xref:erc7535.adoc[ERC-7535]
 ** xref:erc6909.adoc[ERC-6909]
 
 * xref:governance.adoc[Governance]

--- a/docs/modules/ROOT/pages/erc4626.adoc
+++ b/docs/modules/ROOT/pages/erc4626.adoc
@@ -206,3 +206,12 @@ The following example describes how fees proportional to the deposited/withdrawn
 ```solidity
 include::api:example$ERC4626Fees.sol[]
 ```
+
+== Custom behavior: Native and alternative payment assets
+
+`deposit` and `mint` are `payable`, and the asset movement is factored behind virtual hooks, so a vault can use a payment asset other than a pulled ERC-20. Making the functions `payable` changes neither their selectors nor the ERC-165 interface id; a plain ERC-20 vault is unaffected because the default `_checkPayment` hook reverts on any non-zero `msg.value`.
+
+* `_checkPayment(uint256 assets)` validates the native value (`msg.value`) sent with a `deposit`/`mint`. Override it to accept (and require) native value.
+* `_transferIn` / `_transferOut` move the underlying in and out. The defaults use `SafeERC20`; override them to move a different asset (for example the native asset, via `Address.sendValue`).
+
+The canonical use of these hooks is xref:erc7535.adoc[ERC-7535], a vault whose underlying asset is the chain's native asset (e.g. Ether).

--- a/docs/modules/ROOT/pages/erc7535.adoc
+++ b/docs/modules/ROOT/pages/erc7535.adoc
@@ -9,7 +9,7 @@ https://eips.ethereum.org/EIPS/eip-7535[ERC-7535] is an adaptation of xref:erc46
 `ERC7535` behaves like `ERC4626`, with the following changes:
 
 * `asset()` returns the placeholder address `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` defined by https://eips.ethereum.org/EIPS/eip-7528[ERC-7528], and the vault uses 18 decimals (those of the native asset) as its base before applying the optional decimals offset.
-* `deposit` and `mint` are `payable`. The native asset is provided as `msg.value` instead of being pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying asset. `deposit(assets, receiver)` requires `msg.value >= assets`; `mint(shares, receiver)` requires `msg.value >= previewMint(shares)`.
+* `deposit` and `mint` are `payable`. The native asset is provided as `msg.value` instead of being pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying asset. `deposit(assets, receiver)` deposits the entire `msg.value` and ignores its `assets` argument (per ERC-7535), minting `previewDeposit(msg.value)` shares; `mint(shares, receiver)` requires `msg.value >= previewMint(shares)`.
 * Withdrawals and redemptions send the native asset out with a low-level `call` (xref:api:utils.adoc#Address-sendValue-address-payable-uint256-[`Address.sendValue`]) instead of an ERC-20 `transfer`.
 
 [source,solidity]
@@ -45,7 +45,7 @@ ERC-4626's `deposit` and `mint` are declared `payable` on `IERC4626` (this does 
 
 `totalAssets()` returns `address(this).balance`. Because `deposit` and `mint` are `payable`, the deposited `msg.value` is already part of that balance when the exchange rate is computed — unlike an ERC-4626 vault, where the assets are only pulled in *after* the share amount is computed from the pre-deposit balance.
 
-To keep the behavior identical, `ERC7535` overrides the internal `_convertToShares`/`_convertToAssets` to price against `_pretotalAssets()` (= `totalAssets() - msg.value`, the pre-call balance), while all preview and conversion functions remain balance-based outside a `payable` call. As a result, a standalone `previewDeposit(assets)` returns exactly the number of shares a subsequent `deposit` of `assets` mints. The adjustment lives in an internal hook because `msg.value` cannot be read from a `view` function such as `totalAssets`.
+To keep the behavior identical, `ERC7535` overrides the internal `_convertToShares`/`_convertToAssets` to price against `_pretotalAssets()` (= `totalAssets() - msg.value`, the pre-call balance), while all preview and conversion functions remain balance-based outside a `payable` call. As a result, a standalone `previewDeposit(value)` returns exactly the number of shares a subsequent `deposit` with `msg.value == value` mints. The adjustment lives in an internal hook because `msg.value` cannot be read from a `view` function such as `totalAssets`.
 
 [[inflation-attack]]
 == Security concern: Inflation attack
@@ -64,11 +64,11 @@ Value must enter the vault through the standardized `deposit` or `mint` entry po
 
 The `receive()` function is `virtual`. An integrator whose vault must accept plain native-asset payments — for example a rewards distributor that pays the vault periodically on a chain without beacon-layer withdrawals — can override it to admit a known sender, accepting that such payments raise the share price for existing holders like a donation.
 
-Note that this guard cannot stop the protocol-level force-feeds: native asset routed through `SELFDESTRUCT` or paid out as block-reward / `coinbase` tips bypasses `receive()` entirely and lands on `address(this).balance`. Because `totalAssets()` is balance-based, such donations are tracked exactly as a direct ERC-20 transfer would be for an ERC-4626 vault; the defense is the same virtual-offset math described in xref:#inflation-attack[Security concern: Inflation attack], not the `receive` revert.
+Note that this guard cannot stop the protocol-level force-feeds: native asset routed through `SELFDESTRUCT` or paid out as block-reward / `coinbase` tips bypasses `receive()` entirely and lands on `address(this).balance`. Because `totalAssets()` is balance-based, such donations are tracked exactly as a direct ERC-20 transfer would be for an ERC-4626 vault; the defense is the same virtual-offset math described in <<inflation-attack, Security concern: Inflation attack>>, not the `receive` revert.
 
 == The `msg.value` requirement
 
-`deposit(assets, receiver)` requires `msg.value >= assets` and `mint(shares, receiver)` requires `msg.value >= previewMint(shares)`; calls that send too little revert with the typed error `ERC7535InsufficientNativeValue`. Any *excess* `msg.value` above the required amount is kept by the vault — it is not refunded — and behaves like a donation, raising the share price for existing holders. A refund path is intentionally avoided: refunding would add an outbound native call inside `deposit`/`mint`, reopening the reentrancy / refund-griefing surface that the inherited checks-effects-interactions design is built to avoid. To pay an exact amount, send `msg.value == assets` (resp. `previewMint(shares)`); prefer `deposit` over `mint` for an ETH-in flow, since `previewMint` can shift between an off-chain quote and the on-chain transaction.
+`deposit(assets, receiver)` deposits the entire `msg.value` and prices shares off it, ignoring the `assets` argument (per ERC-7535): there is no underpayment to revert on and no excess to retain — the full value sent is always converted to `previewDeposit(msg.value)` shares. `mint(shares, receiver)` instead requires `msg.value >= previewMint(shares)` and reverts with the typed error `ERC7535InsufficientNativeValue` if too little is sent; any *excess* `msg.value` on a `mint` is kept by the vault — it is not refunded — and behaves like a donation, raising the share price for existing holders. A refund path is intentionally avoided: refunding would add an outbound native call inside `mint`, reopening the reentrancy / refund-griefing surface that the inherited checks-effects-interactions design is built to avoid. Prefer `deposit` over `mint` for an ETH-in flow, since `deposit` consumes exactly the value sent, while `previewMint` can shift between an off-chain quote and the on-chain transaction.
 
 == Override checklist
 

--- a/docs/modules/ROOT/pages/erc7535.adoc
+++ b/docs/modules/ROOT/pages/erc7535.adoc
@@ -1,0 +1,84 @@
+= ERC-7535
+
+https://eips.ethereum.org/EIPS/eip-7535[ERC-7535] is an adaptation of xref:erc4626.adoc[ERC-4626] in which the underlying asset of the vault is the chain's native asset (e.g. Ether) instead of an ERC-20 token. It keeps the ERC-4626 share-accounting model, rounding rules, and interface, so the same mental model, security considerations, and customizations apply, with a few native-asset specific differences.
+
+`ERC7535` is implemented as a thin extension of `ERC4626`: share accounting, rounding, the virtual-shares inflation mitigation, the preview functions, and the checks-effects-interactions withdraw path are all inherited. Only the asset-movement seams change.
+
+== Differences with ERC-4626
+
+`ERC7535` behaves like `ERC4626`, with the following changes:
+
+* `asset()` returns the placeholder address `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` defined by https://eips.ethereum.org/EIPS/eip-7528[ERC-7528], and the vault uses 18 decimals (those of the native asset) as its base before applying the optional decimals offset.
+* `deposit` and `mint` are `payable`. The native asset is provided as `msg.value` instead of being pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying asset. `deposit(assets, receiver)` requires `msg.value >= assets`; `mint(shares, receiver)` requires `msg.value >= previewMint(shares)`.
+* Withdrawals and redemptions send the native asset out with a low-level `call` (xref:api:utils.adoc#Address-sendValue-address-payable-uint256-[`Address.sendValue`]) instead of an ERC-20 `transfer`.
+
+[source,solidity]
+----
+contract NativeVault is ERC7535 {
+    constructor() ERC20("Native Vault", "nvETH") {}
+}
+----
+
+To raise the resistance to the inflation attack, override `_decimalsOffset()` exactly as for `ERC4626`:
+
+[source,solidity]
+----
+contract HardenedNativeVault is ERC7535 {
+    constructor() ERC20("Hardened Native Vault", "hnvETH") {}
+
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return 6;
+    }
+}
+----
+
+IMPORTANT: A vault backed by a wrapped native asset (such as WETH9) MUST NOT use this contract. Per ERC-7528 and ERC-7535 such a vault is a plain xref:erc4626.adoc[ERC-4626] over the wrapper ERC-20 and must report that wrapper's address from `asset()`.
+
+== How it extends ERC-4626
+
+ERC-4626's `deposit` and `mint` are declared `payable` on `IERC4626` (this does not change their selectors or the ERC-165 interface id) and route through two virtual seams that `ERC7535` overrides:
+
+* `_checkPayment(uint256 assets)`: validates the native value. The `ERC4626` default expects none and reverts on any `msg.value`; `ERC7535` overrides it to require `msg.value` to cover the deposit. A plain ERC-20 vault is therefore unchanged — it still rejects native value.
+* `_transferIn` / `_transferOut`: `ERC7535` makes `_transferIn` a no-op (the value already arrived as `msg.value`) and routes `_transferOut` through `Address.sendValue`.
+
+== Accounting and `msg.value`
+
+`totalAssets()` returns `address(this).balance`. Because `deposit` and `mint` are `payable`, the deposited `msg.value` is already part of that balance when the exchange rate is computed — unlike an ERC-4626 vault, where the assets are only pulled in *after* the share amount is computed from the pre-deposit balance.
+
+To keep the behavior identical, `ERC7535` overrides the internal `_convertToShares`/`_convertToAssets` to price against `_pretotalAssets()` (= `totalAssets() - msg.value`, the pre-call balance), while all preview and conversion functions remain balance-based outside a `payable` call. As a result, a standalone `previewDeposit(assets)` returns exactly the number of shares a subsequent `deposit` of `assets` mints. The adjustment lives in an internal hook because `msg.value` cannot be read from a `view` function such as `totalAssets`.
+
+[[inflation-attack]]
+== Security concern: Inflation attack
+
+Native asset vaults are exposed to the same xref:erc4626.adoc#inflation-attack[donation / inflation attack] as ERC-4626 vaults, and `ERC7535` uses the same mitigation: configurable virtual shares and assets parameterized by `_decimalsOffset()`. The default offset of `0` makes the attack non-profitable, and a larger offset makes it orders of magnitude more expensive than profitable.
+
+Note that a native asset vault cannot keep its balance strictly equal to the sum of deposits: it can always be force-fed extra native asset, for example by being a block's `coinbase` or through the `SELFDESTRUCT` opcode. `totalAssets()` is balance-based and therefore tracks such donations, exactly like a direct ERC-20 transfer would for an ERC-4626 vault; the virtual-offset mitigation — not internal balance accounting — is the defense.
+
+== Security concern: Reentrancy
+
+Sending the native asset out uses a low-level `call` via xref:api:utils.adoc#Address-sendValue-address-payable-uint256-[`Address.sendValue`], which forwards all remaining gas. The full-gas forward is deliberate: it keeps the vault compatible with smart-contract receivers (multisigs, account-abstraction wallets, proxies) whose `receive()` typically costs more than the spec's suggested 2300-gas stipend. The reentrancy risk that the full-gas forward opens is handled by the inherited checks-effects-interactions ordering: on withdrawals and redemptions the shares are burned *before* the value is sent, so a reentrant call from the receiver observes a consistent, already-reduced share price. As in `ERC4626`, reentrancy safety relies on this ordering rather than on a reentrancy guard. Integrators adding custom logic to `_deposit`/`_withdraw` should preserve this ordering, or add an explicit reentrancy guard.
+
+== Plain native-asset transfers
+
+Value must enter the vault through the standardized `deposit` or `mint` entry points so it is matched with newly issued shares. To make accidental misuse fail loudly, `ERC7535` implements a `receive()` function that reverts with the named error `ERC7535UnsolicitedDeposit`: plain `.transfer`, `.send` or `call{value: x}("")` to the vault revert with a reason wallets and UIs can decode, instead of being silently absorbed as a donation that would skew the next deposit's exchange rate.
+
+The `receive()` function is `virtual`. An integrator whose vault must accept plain native-asset payments — for example a rewards distributor that pays the vault periodically on a chain without beacon-layer withdrawals — can override it to admit a known sender, accepting that such payments raise the share price for existing holders like a donation.
+
+Note that this guard cannot stop the protocol-level force-feeds: native asset routed through `SELFDESTRUCT` or paid out as block-reward / `coinbase` tips bypasses `receive()` entirely and lands on `address(this).balance`. Because `totalAssets()` is balance-based, such donations are tracked exactly as a direct ERC-20 transfer would be for an ERC-4626 vault; the defense is the same virtual-offset math described in xref:#inflation-attack[Security concern: Inflation attack], not the `receive` revert.
+
+== The `msg.value` requirement
+
+`deposit(assets, receiver)` requires `msg.value >= assets` and `mint(shares, receiver)` requires `msg.value >= previewMint(shares)`; calls that send too little revert with the typed error `ERC7535InsufficientNativeValue`. Any *excess* `msg.value` above the required amount is kept by the vault — it is not refunded — and behaves like a donation, raising the share price for existing holders. A refund path is intentionally avoided: refunding would add an outbound native call inside `deposit`/`mint`, reopening the reentrancy / refund-griefing surface that the inherited checks-effects-interactions design is built to avoid. To pay an exact amount, send `msg.value == assets` (resp. `previewMint(shares)`); prefer `deposit` over `mint` for an ETH-in flow, since `previewMint` can shift between an off-chain quote and the on-chain transaction.
+
+== Override checklist
+
+When customizing `ERC7535`, keep the following invariants in mind in addition to the inherited xref:erc4626.adoc[ERC-4626] ones:
+
+* `_pretotalAssets()` MUST return a value less than or equal to `totalAssets()` in every context. Overstating it inflates the share price during `deposit`/`mint`; understating it during a `view` call misprices the public previews.
+* Custom `_convertToShares`/`_convertToAssets` MUST source the "total assets" value from `_pretotalAssets()` (not `totalAssets()` or `msg.value` directly). Otherwise the in-flight `msg.value` is re-mixed into the rate.
+* `totalAssets()` MUST NOT revert. When sourcing the total from an external oracle, wrap the call in `try/catch` and return a safe fallback. Overstating `totalAssets()` will make `withdraw`/`redeem` attempt to send more than `address(this).balance` and revert in `Address.sendValue`, locking exits until the balance catches up with the reported total.
+* `_deposit` overrides MUST NOT introduce an outbound native-asset call (e.g. a refund of "excess" `msg.value`) before `_mint`: that reopens the reentrancy / refund-griefing class this design avoids.
+* `_withdraw` overrides MUST preserve the checks-effects-interactions ordering (allowance spent and shares burned BEFORE the outbound transfer).
+* `_decimalsOffset()` overrides MUST keep `offset <= 77`. The conversion math computes `10 ** offset`, which overflows `uint256` from `offset >= 78` onwards: the vault would deploy but every deposit, mint, preview and conversion would revert with an arithmetic panic. (The `uint8` range of `decimals()` alone would allow up to `237`, but the conversion arithmetic is the binding constraint. This bound applies to `ERC4626` as well.)
+
+Off-chain previews must be performed *before* sending value, since the public `view` functions cannot account for an in-flight `msg.value`.

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -46,6 +46,37 @@ describe('ERC4626', function () {
     }
   });
 
+  describe('payable deposit/mint reject unexpected native value', function () {
+    // deposit/mint are payable (so native-asset vaults like ERC7535 can override the payment hook), but a plain
+    // ERC-20 vault must keep rejecting any native value sent to it, exactly as the previously non-payable entry
+    // points did.
+    const value = 1000n;
+
+    beforeEach(async function () {
+      this.token = await ethers.deployContract('$ERC20DecimalsMock', [name, symbol, decimals]);
+      this.vault = await ethers.deployContract('$ERC4626', [name, symbol, this.token]);
+      await this.token.$_mint(this.holder, value);
+      await this.token.connect(this.holder).approve(this.vault, ethers.MaxUint256);
+    });
+
+    it('deposit reverts when native value is sent', async function () {
+      await expect(this.vault.connect(this.holder).deposit(value, this.holder, { value: 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC4626UnexpectedNativeValue')
+        .withArgs(1n);
+    });
+
+    it('mint reverts when native value is sent', async function () {
+      const shares = await this.vault.previewDeposit(value);
+      await expect(this.vault.connect(this.holder).mint(shares, this.holder, { value: 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC4626UnexpectedNativeValue')
+        .withArgs(1n);
+    });
+
+    it('deposit succeeds with zero native value', async function () {
+      await expect(this.vault.connect(this.holder).deposit(value, this.holder)).to.not.be.reverted;
+    });
+  });
+
   describe('reentrancy', function () {
     const reenterType = Enum('No', 'Before', 'After');
 

--- a/test/token/ERC20/extensions/ERC4626.test.js
+++ b/test/token/ERC20/extensions/ERC4626.test.js
@@ -4,6 +4,7 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const { Enum } = require('../../../helpers/enums');
+const { selector, interfaceId } = require('../../../helpers/methods');
 
 const name = 'My Token';
 const symbol = 'MTKN';
@@ -44,6 +45,58 @@ describe('ERC4626', function () {
       const vault = await ethers.deployContract('$ERC4626OffsetMock', ['', '', token, offset]);
       await expect(vault.decimals()).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
     }
+  });
+
+  // The share-conversion math computes `10 ** _decimalsOffset()`, which overflows uint256 from offset 78 onwards
+  // (10 ** 77 < 2 ** 256 <= 10 ** 78). This is a tighter ceiling than the `decimals()` overflow above (offset >= 238)
+  // and bricks every deposit/mint/preview/conversion, not just `decimals()`.
+  it('conversions work at the largest supported offset (77)', async function () {
+    const token = await ethers.deployContract('$ERC20DecimalsMock', ['', '', decimals]);
+    const vault = await ethers.deployContract('$ERC4626OffsetMock', ['', '', token, 77n]);
+    expect(await vault.decimals()).to.equal(decimals + 77n);
+    // empty vault: previewDeposit(1) equals the virtual shares, 10 ** 77
+    expect(await vault.previewDeposit(1n)).to.equal(10n ** 77n);
+  });
+
+  it('conversions revert with an arithmetic panic at offset 78', async function () {
+    const token = await ethers.deployContract('$ERC20DecimalsMock', ['', '', decimals]);
+    const vault = await ethers.deployContract('$ERC4626OffsetMock', ['', '', token, 78n]);
+    // `decimals()` still fits (18 + 78 = 96 <= 255), but the conversion math overflows
+    expect(await vault.decimals()).to.equal(decimals + 78n);
+    await expect(vault.previewDeposit(1n)).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+  });
+
+  describe('payable does not change deposit/mint selectors or the IERC4626 interface id', function () {
+    // Confirms the maintainer ask: making deposit/mint payable breaks neither the 4-byte function selector nor the
+    // ERC-165 interface id. Both derive from the function signature (name + parameter types), never from state
+    // mutability, so they are unchanged. These constants lock that guarantee against future edits.
+    const IERC4626_INTERFACE = [
+      'asset()',
+      'totalAssets()',
+      'convertToShares(uint256)',
+      'convertToAssets(uint256)',
+      'maxDeposit(address)',
+      'previewDeposit(uint256)',
+      'deposit(uint256,address)',
+      'maxMint(address)',
+      'previewMint(uint256)',
+      'mint(uint256,address)',
+      'maxWithdraw(address)',
+      'previewWithdraw(uint256)',
+      'withdraw(uint256,address,address)',
+      'maxRedeem(address)',
+      'previewRedeem(uint256)',
+      'redeem(uint256,address,address)',
+    ];
+
+    it('deposit and mint keep their selectors', function () {
+      expect(selector('deposit(uint256,address)')).to.equal('0x6e553f65');
+      expect(selector('mint(uint256,address)')).to.equal('0x94bf804d');
+    });
+
+    it('IERC4626 interface id is unchanged', function () {
+      expect(interfaceId(IERC4626_INTERFACE)).to.equal('0x87dfe5a0');
+    });
   });
 
   describe('payable deposit/mint reject unexpected native value', function () {

--- a/test/token/ERC20/extensions/ERC7535.t.sol
+++ b/test/token/ERC20/extensions/ERC7535.t.sol
@@ -23,9 +23,9 @@ contract ERC7535VaultMock is ERC7535 {
 ///
 /// With the CEI-only design (no reentrancy guard, inherited from ERC4626), the reentrant call is NOT blocked by a
 /// guard. Instead this receiver observes the vault's state *during* the outbound ETH push and attempts a second,
-/// full-amount redeem of the very shares that triggered the payout. The tests prove that checks-effects-interactions
-/// makes such a reentry harmless: the shares are already burned when the callback fires, so the receiver cannot
-/// extract more than its shares entitled it to, and cannot drain other users.
+/// full-amount withdraw/redeem of the very position that triggered the payout. The tests prove that
+/// checks-effects-interactions makes such a reentry harmless: the shares are already burned when the callback fires,
+/// so the receiver cannot extract more than its shares entitled it to, and cannot drain other users.
 contract ReentrantReceiver {
     enum Kind {
         None,
@@ -35,7 +35,7 @@ contract ReentrantReceiver {
 
     ERC7535VaultMock public vault;
     Kind public kind;
-    uint256 public reenterShares; // shares the receiver tries to re-redeem during the callback
+    uint256 public reenterAmount; // assets (Kind.Withdraw) or shares (Kind.Redeem) re-extracted during the callback
 
     bool public reentered;
     bool public reentryReverted;
@@ -44,10 +44,10 @@ contract ReentrantReceiver {
     uint256 public observedSelfBalance;
     uint256 public observedTotalSupply;
 
-    function setup(ERC7535VaultMock vault_, Kind kind_, uint256 reenterShares_) external {
+    function setup(ERC7535VaultMock vault_, Kind kind_, uint256 reenterAmount_) external {
         vault = vault_;
         kind = kind_;
-        reenterShares = reenterShares_;
+        reenterAmount = reenterAmount_;
     }
 
     receive() external payable {
@@ -58,7 +58,7 @@ contract ReentrantReceiver {
         observedSelfBalance = vault.balanceOf(address(this));
         observedTotalSupply = vault.totalSupply();
 
-        // Attempt to re-extract the *same* shares again, mid-payout. CEI must make this fail (the shares were
+        // Attempt to re-extract the *same* amount again, mid-payout. CEI must make this fail (the shares were
         // already burned) or otherwise be unable to over-drain. We swallow the revert so the outer call can
         // complete and the test can assert the resulting accounting.
         try this.reenter() {
@@ -70,9 +70,9 @@ contract ReentrantReceiver {
 
     function reenter() external {
         if (kind == Kind.Withdraw) {
-            vault.withdraw(reenterShares, address(this), address(this));
+            vault.withdraw(reenterAmount, address(this), address(this));
         } else if (kind == Kind.Redeem) {
-            vault.redeem(reenterShares, address(this), address(this));
+            vault.redeem(reenterAmount, address(this), address(this));
         }
     }
 }
@@ -397,24 +397,45 @@ contract ERC7535Test is Test {
         uint256 attackerDeposit = 5 ether;
         uint256 attackerShares = _fundReceiver(r, attackerDeposit);
 
-        // The attacker will try to re-redeem its FULL share balance again during the payout callback.
-        r.setup(vault, kind, attackerShares);
-
         uint256 vaultBalBefore = address(vault).balance;
         uint256 totalSupplyBefore = vault.totalSupply();
-        uint256 expectedPayout = vault.previewRedeem(attackerShares);
+
+        // Exercise the entry point matching `kind`: `withdraw` is parameterized in assets, `redeem` in shares.
+        // Rounding favors the vault, so the withdraw path may leave dust shares — derive the exact burned amount
+        // instead of assuming the full balance burns.
+        uint256 expectedPayout;
+        uint256 expectedBurned;
+        if (kind == ReentrantReceiver.Kind.Withdraw) {
+            expectedPayout = vault.maxWithdraw(address(r));
+            expectedBurned = vault.previewWithdraw(expectedPayout);
+        } else {
+            expectedPayout = vault.previewRedeem(attackerShares);
+            expectedBurned = attackerShares;
+        }
+
+        // The attacker will try to re-extract the same amount again (assets for withdraw, shares for redeem)
+        // during the payout callback.
+        r.setup(vault, kind, kind == ReentrantReceiver.Kind.Withdraw ? expectedPayout : attackerShares);
 
         vm.prank(address(r));
-        vault.redeem(attackerShares, address(r), address(r));
+        if (kind == ReentrantReceiver.Kind.Withdraw) {
+            vault.withdraw(expectedPayout, address(r), address(r));
+        } else {
+            vault.redeem(attackerShares, address(r), address(r));
+        }
 
         assertTrue(r.reentered(), "callback never fired");
 
-        // CEI: shares are burned BEFORE the ETH send, so the reentrant party observes zero balance for
-        // itself and a totalSupply already reduced by exactly its shares.
-        assertEq(r.observedSelfBalance(), 0, "attacker shares not burned before ETH send (CEI violated)");
+        // CEI: shares are burned BEFORE the ETH send, so the reentrant party observes an already-reduced
+        // balance for itself and a totalSupply already reduced by exactly the burned shares.
+        assertEq(
+            r.observedSelfBalance(),
+            attackerShares - expectedBurned,
+            "attacker shares not burned before ETH send (CEI violated)"
+        );
         assertEq(
             r.observedTotalSupply(),
-            totalSupplyBefore - attackerShares,
+            totalSupplyBefore - expectedBurned,
             "totalSupply not reduced before ETH send (CEI violated)"
         );
 
@@ -433,8 +454,12 @@ contract ERC7535Test is Test {
             "vault cannot honor the honest depositor after the reentrant attempt (insolvent)"
         );
 
-        assertEq(vault.balanceOf(address(r)), 0, "attacker still holds shares");
-        assertEq(vault.totalSupply(), otherShares, "share supply inconsistent after attack");
+        assertEq(vault.balanceOf(address(r)), attackerShares - expectedBurned, "attacker share balance inconsistent");
+        assertEq(
+            vault.totalSupply(),
+            otherShares + attackerShares - expectedBurned,
+            "share supply inconsistent after attack"
+        );
 
         // The honest depositor can still fully withdraw afterwards (funds not bricked).
         uint256 otherPayout = vault.previewRedeem(otherShares);

--- a/test/token/ERC20/extensions/ERC7535.t.sol
+++ b/test/token/ERC20/extensions/ERC7535.t.sol
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC7535} from "@openzeppelin/contracts/token/ERC20/extensions/ERC7535.sol";
+
+/// @dev Concrete deployable ERC7535 vault with a configurable decimals offset.
+contract ERC7535VaultMock is ERC7535 {
+    uint8 private immutable _offset;
+
+    constructor(uint8 offset_) ERC20("Native Vault", "nVLT") {
+        _offset = offset_;
+    }
+
+    function _decimalsOffset() internal view virtual override returns (uint8) {
+        return _offset;
+    }
+}
+
+/// @dev Malicious share owner / receiver that attempts to reenter the vault on the ETH `sendValue` callback.
+///
+/// With the CEI-only design (no reentrancy guard, inherited from ERC4626), the reentrant call is NOT blocked by a
+/// guard. Instead this receiver observes the vault's state *during* the outbound ETH push and attempts a second,
+/// full-amount redeem of the very shares that triggered the payout. The tests prove that checks-effects-interactions
+/// makes such a reentry harmless: the shares are already burned when the callback fires, so the receiver cannot
+/// extract more than its shares entitled it to, and cannot drain other users.
+contract ReentrantReceiver {
+    enum Kind {
+        None,
+        Withdraw,
+        Redeem
+    }
+
+    ERC7535VaultMock public vault;
+    Kind public kind;
+    uint256 public reenterShares; // shares the receiver tries to re-redeem during the callback
+
+    bool public reentered;
+    bool public reentryReverted;
+
+    // State snapshot observed *inside* the reentrant callback (i.e. mid-`_withdraw`, after the burn).
+    uint256 public observedSelfBalance;
+    uint256 public observedTotalSupply;
+
+    function setup(ERC7535VaultMock vault_, Kind kind_, uint256 reenterShares_) external {
+        vault = vault_;
+        kind = kind_;
+        reenterShares = reenterShares_;
+    }
+
+    receive() external payable {
+        if (kind == Kind.None) return;
+        reentered = true;
+
+        // Observe the vault state as seen by a reentrant party during the ETH push.
+        observedSelfBalance = vault.balanceOf(address(this));
+        observedTotalSupply = vault.totalSupply();
+
+        // Attempt to re-extract the *same* shares again, mid-payout. CEI must make this fail (the shares were
+        // already burned) or otherwise be unable to over-drain. We swallow the revert so the outer call can
+        // complete and the test can assert the resulting accounting.
+        try this.reenter() {
+            reentryReverted = false;
+        } catch {
+            reentryReverted = true;
+        }
+    }
+
+    function reenter() external {
+        if (kind == Kind.Withdraw) {
+            vault.withdraw(reenterShares, address(this), address(this));
+        } else if (kind == Kind.Redeem) {
+            vault.redeem(reenterShares, address(this), address(this));
+        }
+    }
+}
+
+contract ERC7535Test is Test {
+    uint256 internal constant MAX_ETH = 1e27; // ~1B ETH worth of wei, keeps fuzz inputs realistic
+
+    ERC7535VaultMock internal vault;
+
+    address internal attacker = makeAddr("attacker");
+    address internal victim = makeAddr("victim");
+    address internal other = makeAddr("other");
+
+    receive() external payable {}
+
+    function setUp() public {
+        vault = new ERC7535VaultMock(0);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata / asset semantics
+    // --------------------------------------------------------------------------------------------
+
+    function testAssetSentinel() public view {
+        assertEq(vault.asset(), 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    }
+
+    function testFuzzDecimals(uint8 offset) public {
+        // Bound across the full uint8 range so the fuzzer also exercises the documented overflow at
+        // 18 + offset > 255 (i.e. offset >= 238), mirroring the ERC4626 decimals overflow assertion.
+        offset = uint8(bound(offset, 0, 255));
+        ERC7535VaultMock v = new ERC7535VaultMock(offset);
+        if (uint256(18) + uint256(offset) > type(uint8).max) {
+            // 0x11 is the Panic code for arithmetic over/underflow.
+            vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+            v.decimals();
+        } else {
+            assertEq(v.decimals(), uint256(18) + offset);
+        }
+    }
+
+    function testTotalAssetsTracksBalance() public {
+        assertEq(vault.totalAssets(), 0);
+        vm.deal(address(vault), 5 ether);
+        assertEq(vault.totalAssets(), 5 ether);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Decimals offset arithmetic ceiling: 10 ** offset overflows uint256 from offset 78 onwards,
+    // tighter than the uint8 ceiling of 237 on decimals().
+    // --------------------------------------------------------------------------------------------
+
+    function testOffset77IsTheLargestWorkingOffset() public {
+        ERC7535VaultMock v = new ERC7535VaultMock(77);
+
+        assertEq(v.decimals(), 18 + 77);
+        assertEq(v.previewDeposit(1), 10 ** 77);
+
+        vm.deal(address(this), 1);
+        uint256 minted = v.deposit{value: 1}(1, address(this));
+        assertEq(minted, 10 ** 77);
+    }
+
+    function testOffset78BricksConversionsWithArithmeticPanic() public {
+        // Deploys fine — the failure only surfaces on the first conversion-dependent call.
+        ERC7535VaultMock v = new ERC7535VaultMock(78);
+
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        v.previewDeposit(1);
+
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        v.previewMint(1);
+
+        vm.deal(address(this), 1);
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        v.deposit{value: 1}(1, address(this));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // msg.value enforcement (>= policy: underpayment reverts, exact and overpayment succeed)
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzDepositRevertsWhenValueBelowAssets(uint256 assets, uint256 value) public {
+        assets = bound(assets, 1, MAX_ETH);
+        value = bound(value, 0, assets - 1);
+        vm.deal(address(this), value);
+        vm.expectRevert(abi.encodeWithSelector(ERC7535.ERC7535InsufficientNativeValue.selector, value, assets));
+        vault.deposit{value: value}(assets, victim);
+    }
+
+    function testFuzzMintRevertsWhenValueBelowCost(uint256 shares, uint256 value) public {
+        shares = bound(shares, 1, MAX_ETH);
+        uint256 cost = vault.previewMint(shares); // empty vault, queried before sending value
+        vm.assume(cost > 0);
+        value = bound(value, 0, cost - 1);
+        vm.deal(address(this), value);
+        vm.expectRevert(abi.encodeWithSelector(ERC7535.ERC7535InsufficientNativeValue.selector, value, cost));
+        vault.mint{value: value}(shares, victim);
+    }
+
+    function testFuzzDepositOverpaymentIsDonation(uint256 assets, uint256 extra) public {
+        assets = bound(assets, 0, MAX_ETH);
+        extra = bound(extra, 0, MAX_ETH);
+
+        // Empty vault: shares are priced on `assets`, not on the in-flight value.
+        uint256 previewed = vault.previewDeposit(assets);
+
+        vm.deal(attacker, assets + extra);
+        vm.prank(attacker);
+        uint256 minted = vault.deposit{value: assets + extra}(assets, attacker);
+
+        assertEq(minted, previewed, "overpayment changed the minted shares");
+        assertEq(vault.balanceOf(attacker), previewed);
+        // The full msg.value entered the vault; the excess is an unminted donation.
+        assertEq(vault.totalAssets(), assets + extra, "vault did not retain the full msg.value");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // previewDeposit (queried standalone, before value is sent) == shares actually minted.
+    // This is the msg.value / totalAssets correctness property.
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzPreviewDepositEqualsMinted(uint256 seed, uint256 assets) public {
+        // Seed the vault with some real balance and supply so totalAssets() and totalSupply() are non-trivial.
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        assets = bound(assets, 0, MAX_ETH);
+
+        // Off-chain preview MUST be computed before sending value (view cannot see in-flight msg.value).
+        uint256 previewed = vault.previewDeposit(assets);
+
+        vm.deal(attacker, assets);
+        vm.prank(attacker);
+        uint256 minted = vault.deposit{value: assets}(assets, attacker);
+
+        assertEq(minted, previewed, "previewDeposit != minted shares");
+        assertEq(vault.balanceOf(attacker), previewed);
+    }
+
+    function testFuzzPreviewMintEqualsActualCost(uint256 seed, uint256 shares) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        shares = bound(shares, 0, 1e24);
+        uint256 cost = vault.previewMint(shares);
+        vm.assume(cost <= MAX_ETH);
+
+        vm.deal(attacker, cost);
+        vm.prank(attacker);
+        uint256 actual = vault.mint{value: cost}(shares, attacker);
+
+        assertEq(actual, cost, "mint returned assets != previewMint");
+        assertEq(vault.balanceOf(attacker), shares);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Inflation / donation attack non-profitability at offset 0 (force-feed via vm.deal)
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzInflationAttackNotProfitable(uint256 donation, uint256 victimDeposit) public {
+        donation = bound(donation, 0, MAX_ETH);
+        victimDeposit = bound(victimDeposit, 1, MAX_ETH);
+
+        // 1. Attacker makes the canonical 1 wei first deposit.
+        vm.deal(attacker, 1);
+        vm.prank(attacker);
+        vault.deposit{value: 1}(1, attacker);
+        uint256 attackerShares = vault.balanceOf(attacker);
+
+        // 2. Attacker force-feeds a donation directly into the vault balance (SELFDESTRUCT/coinbase analogue).
+        vm.deal(address(vault), address(vault).balance + donation);
+        uint256 attackerSpent = 1 + donation;
+
+        // 3. Victim deposits.
+        vm.deal(victim, victimDeposit);
+        vm.prank(victim);
+        vault.deposit{value: victimDeposit}(victimDeposit, victim);
+
+        // 4. Attacker redeems everything they hold.
+        uint256 attackerPayout = vault.previewRedeem(attackerShares);
+
+        // Property: at offset 0 the attacker can never come out ahead of what they put in.
+        assertLe(attackerPayout, attackerSpent, "inflation attack was profitable at offset 0");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Round-trips: a user never extracts more than they put in.
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzDepositRedeemRoundTrip(uint256 seed, uint256 assets) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        assets = bound(assets, 0, MAX_ETH);
+        vm.deal(victim, assets);
+        vm.prank(victim);
+        uint256 shares = vault.deposit{value: assets}(assets, victim);
+
+        vm.prank(victim);
+        uint256 redeemed = vault.redeem(shares, victim, victim);
+
+        assertLe(redeemed, assets, "deposit->redeem extracted more than deposited");
+    }
+
+    function testFuzzMintRedeemRoundTrip(uint256 seed, uint256 shares) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        shares = bound(shares, 0, 1e24);
+        uint256 cost = vault.previewMint(shares);
+        vm.assume(cost <= MAX_ETH);
+
+        vm.deal(victim, cost);
+        vm.prank(victim);
+        vault.mint{value: cost}(shares, victim);
+
+        vm.prank(victim);
+        uint256 redeemed = vault.redeem(shares, victim, victim);
+
+        assertLe(redeemed, cost, "mint->redeem extracted more than paid");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // convertToShares ∘ convertToAssets is a contraction (rounding favors the vault).
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzConvertRoundTripContraction(uint256 seed, uint256 shares) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        shares = bound(shares, 0, vault.totalSupply() == 0 ? MAX_ETH : vault.totalSupply());
+
+        uint256 assets = vault.convertToAssets(shares);
+        uint256 backToShares = vault.convertToShares(assets);
+
+        assertLe(backToShares, shares, "convertToShares(convertToAssets(s)) > s: rounding favored user");
+    }
+
+    function testFuzzConvertAssetsRoundTripContraction(uint256 seed, uint256 assets) public {
+        seed = bound(seed, 1, MAX_ETH);
+        vm.deal(address(this), seed);
+        vault.deposit{value: seed}(seed, other);
+
+        assets = bound(assets, 0, MAX_ETH);
+
+        uint256 shares = vault.convertToShares(assets);
+        uint256 backToAssets = vault.convertToAssets(shares);
+
+        assertLe(backToAssets, assets, "convertToAssets(convertToShares(a)) > a: rounding favored user");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Force-fed ETH does not break accounting (view functions still answer, withdraw still works).
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzForceFedEthDoesNotBreakAccounting(uint256 deposit, uint256 forceFed) public {
+        deposit = bound(deposit, 1, MAX_ETH);
+        forceFed = bound(forceFed, 0, MAX_ETH);
+
+        vm.deal(victim, deposit);
+        vm.prank(victim);
+        uint256 shares = vault.deposit{value: deposit}(deposit, victim);
+
+        // Force-feed extra ETH that mints no shares.
+        vm.deal(address(vault), address(vault).balance + forceFed);
+
+        assertEq(vault.totalAssets(), deposit + forceFed);
+        assertEq(vault.totalSupply(), shares);
+
+        // Victim can still redeem; payout is well-defined and never reverts.
+        uint256 expected = vault.previewRedeem(shares);
+        vm.prank(victim);
+        uint256 redeemed = vault.redeem(shares, victim, victim);
+        assertEq(redeemed, expected);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Reentrancy (CEI-only, no guard): a malicious receiver that reenters withdraw/redeem during the
+    // ETH `sendValue` push MUST NOT (a) extract more native asset than its shares entitle it to, or
+    // (b) drain other users' funds. `_withdraw` (inherited from ERC4626) burns shares BEFORE the
+    // outbound transfer, so the reentrant call observes an already-reduced state.
+    // --------------------------------------------------------------------------------------------
+
+    function _fundReceiver(ReentrantReceiver r, uint256 deposit) internal returns (uint256 shares) {
+        vm.deal(address(r), deposit);
+        vm.prank(address(r));
+        shares = vault.deposit{value: deposit}(deposit, address(r));
+    }
+
+    function _assertReentrancyCEI(ReentrantReceiver.Kind kind) internal {
+        ReentrantReceiver r = new ReentrantReceiver();
+
+        // Seed a second, honest depositor so the vault holds extra ETH the attacker could try to steal.
+        uint256 otherDeposit = 10 ether;
+        vm.deal(other, otherDeposit);
+        vm.prank(other);
+        uint256 otherShares = vault.deposit{value: otherDeposit}(otherDeposit, other);
+
+        // Attacker becomes a share owner.
+        uint256 attackerDeposit = 5 ether;
+        uint256 attackerShares = _fundReceiver(r, attackerDeposit);
+
+        // The attacker will try to re-redeem its FULL share balance again during the payout callback.
+        r.setup(vault, kind, attackerShares);
+
+        uint256 vaultBalBefore = address(vault).balance;
+        uint256 totalSupplyBefore = vault.totalSupply();
+        uint256 expectedPayout = vault.previewRedeem(attackerShares);
+
+        vm.prank(address(r));
+        vault.redeem(attackerShares, address(r), address(r));
+
+        assertTrue(r.reentered(), "callback never fired");
+
+        // CEI: shares are burned BEFORE the ETH send, so the reentrant party observes zero balance for
+        // itself and a totalSupply already reduced by exactly its shares.
+        assertEq(r.observedSelfBalance(), 0, "attacker shares not burned before ETH send (CEI violated)");
+        assertEq(
+            r.observedTotalSupply(),
+            totalSupplyBefore - attackerShares,
+            "totalSupply not reduced before ETH send (CEI violated)"
+        );
+
+        // (a) No over-extraction.
+        assertEq(
+            address(r).balance,
+            expectedPayout,
+            "attacker extracted more native asset than its shares entitled it to"
+        );
+
+        // (b) No drain of other users.
+        assertEq(address(vault).balance, vaultBalBefore - expectedPayout, "vault over-drained");
+        assertGe(
+            address(vault).balance,
+            vault.previewRedeem(otherShares),
+            "vault cannot honor the honest depositor after the reentrant attempt (insolvent)"
+        );
+
+        assertEq(vault.balanceOf(address(r)), 0, "attacker still holds shares");
+        assertEq(vault.totalSupply(), otherShares, "share supply inconsistent after attack");
+
+        // The honest depositor can still fully withdraw afterwards (funds not bricked).
+        uint256 otherPayout = vault.previewRedeem(otherShares);
+        vm.prank(other);
+        uint256 redeemed = vault.redeem(otherShares, other, other);
+        assertEq(redeemed, otherPayout, "honest depositor could not redeem after attack");
+    }
+
+    function testReentrancyWithdrawCannotOverDrain() public {
+        _assertReentrancyCEI(ReentrantReceiver.Kind.Withdraw);
+    }
+
+    function testReentrancyRedeemCannotOverDrain() public {
+        _assertReentrancyCEI(ReentrantReceiver.Kind.Redeem);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Plain native-asset transfers hit receive() and MUST revert with ERC7535UnsolicitedDeposit.
+    // Force-feeding via SELFDESTRUCT / coinbase / vm.deal bypasses the EVM code path and still works
+    // (totalAssets rises) — the documented limitation the inflation-attack analysis accounts for.
+    // --------------------------------------------------------------------------------------------
+
+    function testPlainEthTransferRevertsWithUnsolicitedDeposit() public {
+        address sender = makeAddr("plainSender");
+        vm.deal(sender, 1 ether);
+
+        uint256 totalAssetsBefore = vault.totalAssets();
+        uint256 vaultBalBefore = address(vault).balance;
+
+        vm.prank(sender);
+        (bool ok, bytes memory ret) = address(vault).call{value: 1}("");
+
+        assertFalse(ok, "plain ETH transfer to vault should fail");
+        assertEq(
+            bytes4(ret),
+            ERC7535.ERC7535UnsolicitedDeposit.selector,
+            "revert selector should be ERC7535UnsolicitedDeposit"
+        );
+
+        assertEq(address(vault).balance, vaultBalBefore, "vault balance changed despite revert");
+        assertEq(vault.totalAssets(), totalAssetsBefore, "totalAssets changed despite revert");
+        assertEq(sender.balance, 1 ether, "sender lost ETH despite revert");
+
+        // Force-feeding via vm.deal (the SELFDESTRUCT / coinbase analogue) bypasses receive() and still raises
+        // totalAssets — documented limitation of the receive() guard.
+        uint256 forceFed = 7 ether;
+        vm.deal(address(vault), vaultBalBefore + forceFed);
+        assertEq(vault.totalAssets(), totalAssetsBefore + forceFed, "force-feed via vm.deal did not raise totalAssets");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Allowance path: third-party redeem must spend share allowance and cannot move another's shares.
+    // --------------------------------------------------------------------------------------------
+
+    function testThirdPartyRedeemRequiresAllowance() public {
+        vm.deal(victim, 3 ether);
+        vm.prank(victim);
+        uint256 shares = vault.deposit{value: 3 ether}(3 ether, victim);
+
+        // attacker has no allowance over victim's shares.
+        vm.prank(attacker);
+        vm.expectRevert();
+        vault.redeem(shares, attacker, victim);
+
+        // With allowance, it succeeds and burns exactly `shares` worth.
+        vm.prank(victim);
+        vault.approve(attacker, shares);
+        vm.prank(attacker);
+        vault.redeem(shares, attacker, victim);
+        assertEq(vault.balanceOf(victim), 0);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Outbound send failure: a receiver whose receive() reverts must bubble the failure and roll back.
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzWithdrawToRevertingReceiverReverts(uint256 assets) public {
+        assets = bound(assets, 1, MAX_ETH);
+        vm.deal(victim, assets);
+        vm.prank(victim);
+        vault.deposit{value: assets}(assets, victim);
+
+        RevertingReceiver rj = new RevertingReceiver();
+
+        uint256 balanceBefore = address(vault).balance;
+        uint256 supplyBefore = vault.totalSupply();
+        uint256 sharesBefore = vault.balanceOf(victim);
+
+        vm.prank(victim);
+        vm.expectRevert();
+        vault.withdraw(assets, address(rj), victim);
+
+        assertEq(address(vault).balance, balanceBefore, "balance changed on a reverted withdraw");
+        assertEq(vault.totalSupply(), supplyBefore, "totalSupply changed on a reverted withdraw");
+        assertEq(vault.balanceOf(victim), sharesBefore, "shares changed on a reverted withdraw");
+    }
+}
+
+/// @dev Receiver whose `receive` always reverts — used to drive `Address.sendValue` into its failure branch.
+contract RevertingReceiver {
+    receive() external payable {
+        revert("nope");
+    }
+}
+
+// =================================================================================================
+// Invariant test: a handler that randomly deposits / withdraws / donates / redeems, with the core
+// solvency and no-profit invariants asserted on top.
+// =================================================================================================
+
+contract ERC7535Handler is Test {
+    ERC7535VaultMock public vault;
+
+    address[] public actors;
+    mapping(address => uint256) public netInvested; // sum(deposits) − sum(redeemPayouts)
+    uint256 public totalDonated;
+
+    constructor(ERC7535VaultMock vault_, address[] memory actors_) {
+        vault = vault_;
+        actors = actors_;
+    }
+
+    function _pickActor(uint256 seed) internal view returns (address) {
+        return actors[seed % actors.length];
+    }
+
+    function handlerDeposit(uint256 seed, uint256 assets) external {
+        address actor = _pickActor(seed);
+        assets = bound(assets, 0, 1e22);
+        vm.deal(actor, actor.balance + assets);
+        vm.prank(actor);
+        vault.deposit{value: assets}(assets, actor);
+        netInvested[actor] += assets;
+    }
+
+    function handlerRedeem(uint256 seed, uint256 shares) external {
+        address actor = _pickActor(seed);
+        uint256 maxShares = vault.maxRedeem(actor);
+        if (maxShares == 0) return;
+        shares = bound(shares, 0, maxShares);
+        uint256 balBefore = actor.balance;
+        vm.prank(actor);
+        vault.redeem(shares, actor, actor);
+        uint256 payout = actor.balance - balBefore;
+        if (payout >= netInvested[actor]) {
+            netInvested[actor] = 0;
+        } else {
+            netInvested[actor] -= payout;
+        }
+    }
+
+    function handlerDonate(uint256 amount) external {
+        amount = bound(amount, 0, 1e18);
+        // Force-feed (SELFDESTRUCT/coinbase analogue): raises balance without minting shares.
+        vm.deal(address(vault), address(vault).balance + amount);
+        totalDonated += amount;
+    }
+
+    function sumNetInvested() external view returns (uint256 sum) {
+        for (uint256 i; i < actors.length; ++i) sum += netInvested[actors[i]];
+    }
+}
+
+contract ERC7535InvariantTest is Test {
+    ERC7535VaultMock internal vault;
+    ERC7535Handler internal handler;
+    address[] internal actors;
+
+    function setUp() public {
+        vault = new ERC7535VaultMock(0);
+
+        actors = new address[](3);
+        actors[0] = makeAddr("alice");
+        actors[1] = makeAddr("bob");
+        actors[2] = makeAddr("carol");
+
+        handler = new ERC7535Handler(vault, actors);
+
+        bytes4[] memory selectors = new bytes4[](3);
+        selectors[0] = handler.handlerDeposit.selector;
+        selectors[1] = handler.handlerRedeem.selector;
+        selectors[2] = handler.handlerDonate.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+        targetContract(address(handler));
+    }
+
+    /// @dev Solvency: the vault's native balance must always cover what every holder could redeem RIGHT NOW.
+    function invariantSolvency() public view {
+        uint256 owed = 0;
+        for (uint256 i; i < actors.length; ++i) {
+            owed += vault.previewRedeem(vault.balanceOf(actors[i]));
+        }
+        assertGe(address(vault).balance, owed, "vault balance < sum(previewRedeem(holders))");
+    }
+
+    /// @dev No value creation: redeemable assets across holders are bounded by deposits + donations.
+    function invariantNoValueCreation() public view {
+        uint256 redeemable = 0;
+        for (uint256 i; i < actors.length; ++i) {
+            redeemable += vault.previewRedeem(vault.balanceOf(actors[i]));
+        }
+        assertLe(
+            redeemable,
+            handler.sumNetInvested() + handler.totalDonated(),
+            "holders can extract more than was put in"
+        );
+    }
+}

--- a/test/token/ERC20/extensions/ERC7535.t.sol
+++ b/test/token/ERC20/extensions/ERC7535.t.sol
@@ -152,15 +152,38 @@ contract ERC7535Test is Test {
     }
 
     // --------------------------------------------------------------------------------------------
-    // msg.value enforcement (>= policy: underpayment reverts, exact and overpayment succeed)
+    // Payment policy: deposit prices off msg.value (the `assets` argument is ignored, per ERC-7535);
+    // mint requires msg.value >= previewMint(shares).
     // --------------------------------------------------------------------------------------------
 
-    function testFuzzDepositRevertsWhenValueBelowAssets(uint256 assets, uint256 value) public {
-        assets = bound(assets, 1, MAX_ETH);
-        value = bound(value, 0, assets - 1);
-        vm.deal(address(this), value);
-        vm.expectRevert(abi.encodeWithSelector(ERC7535.ERC7535InsufficientNativeValue.selector, value, assets));
-        vault.deposit{value: value}(assets, victim);
+    function testFuzzDepositIgnoresAssetsArgument(uint256 value, uint256 assetsArg) public {
+        value = bound(value, 0, MAX_ETH);
+
+        // Shares are priced off msg.value; the `assets` argument is ignored.
+        uint256 previewed = vault.previewDeposit(value);
+
+        vm.deal(attacker, value);
+        vm.prank(attacker);
+        uint256 minted = vault.deposit{value: value}(assetsArg, attacker);
+
+        assertEq(minted, previewed, "shares not priced off msg.value");
+        assertEq(vault.balanceOf(attacker), previewed);
+        // The full msg.value is deposited and converted to shares; nothing is retained as a donation.
+        assertEq(vault.totalAssets(), value, "vault did not deposit the full msg.value");
+    }
+
+    function testDepositZeroAssetsArgumentMintsForFullValue() public {
+        uint256 value = 1 ether;
+        uint256 previewed = vault.previewDeposit(value);
+        assertGt(previewed, 0, "preview should be non-zero for 1 ether");
+
+        vm.deal(attacker, value);
+        vm.prank(attacker);
+        // A zero `assets` argument must NOT mint 0 shares and donate the value (the pre-fix, non-conformant behavior).
+        uint256 minted = vault.deposit{value: value}(0, attacker);
+
+        assertEq(minted, previewed, "deposit(value)(0) did not mint for the full msg.value");
+        assertEq(vault.balanceOf(attacker), previewed);
     }
 
     function testFuzzMintRevertsWhenValueBelowCost(uint256 shares, uint256 value) public {
@@ -171,23 +194,6 @@ contract ERC7535Test is Test {
         vm.deal(address(this), value);
         vm.expectRevert(abi.encodeWithSelector(ERC7535.ERC7535InsufficientNativeValue.selector, value, cost));
         vault.mint{value: value}(shares, victim);
-    }
-
-    function testFuzzDepositOverpaymentIsDonation(uint256 assets, uint256 extra) public {
-        assets = bound(assets, 0, MAX_ETH);
-        extra = bound(extra, 0, MAX_ETH);
-
-        // Empty vault: shares are priced on `assets`, not on the in-flight value.
-        uint256 previewed = vault.previewDeposit(assets);
-
-        vm.deal(attacker, assets + extra);
-        vm.prank(attacker);
-        uint256 minted = vault.deposit{value: assets + extra}(assets, attacker);
-
-        assertEq(minted, previewed, "overpayment changed the minted shares");
-        assertEq(vault.balanceOf(attacker), previewed);
-        // The full msg.value entered the vault; the excess is an unminted donation.
-        assertEq(vault.totalAssets(), assets + extra, "vault did not retain the full msg.value");
     }
 
     // --------------------------------------------------------------------------------------------

--- a/test/token/ERC20/extensions/ERC7535.test.js
+++ b/test/token/ERC20/extensions/ERC7535.test.js
@@ -185,9 +185,12 @@ describe('ERC7535', function () {
 
     it('withdraw to address(0) succeeds and sends value to the zero address', async function () {
       const value = ethers.parseEther('1');
+      const shares = await this.vault.previewWithdraw(value);
       const tx = this.vault.connect(this.holder).withdraw(value, ethers.ZeroAddress, this.holder);
       await expect(tx).to.changeEtherBalances([this.vault, ethers.ZeroAddress], [-value, value]);
-      await expect(tx).to.emit(this.vault, 'Withdraw');
+      await expect(tx)
+        .to.emit(this.vault, 'Withdraw')
+        .withArgs(this.holder, ethers.ZeroAddress, this.holder, value, shares);
     });
   });
 
@@ -414,11 +417,11 @@ describe('ERC7535', function () {
         });
 
         it('withdraw with approval', async function () {
-          const assets = await this.vault.previewWithdraw(parseAsset(1n));
+          const shares = await this.vault.previewWithdraw(parseAsset(1n));
 
           await expect(this.vault.connect(this.other).withdraw(parseAsset(1n), this.recipient, this.holder))
             .to.be.revertedWithCustomError(this.vault, 'ERC20InsufficientAllowance')
-            .withArgs(this.other, 0n, assets);
+            .withArgs(this.other, 0n, shares);
 
           await expect(this.vault.connect(this.spender).withdraw(parseAsset(1n), this.recipient, this.holder)).to.not.be
             .reverted;

--- a/test/token/ERC20/extensions/ERC7535.test.js
+++ b/test/token/ERC20/extensions/ERC7535.test.js
@@ -1,0 +1,499 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture, setBalance } = require('@nomicfoundation/hardhat-network-helpers');
+const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
+
+const name = 'My Native Vault';
+const symbol = 'MNV';
+const decimals = 18n;
+
+// ERC-7528 native-asset placeholder (EIP-55 checksummed).
+const NATIVE_ASSET = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
+async function fixture() {
+  const [holder, recipient, spender, other, ...accounts] = await ethers.getSigners();
+  return { holder, recipient, spender, other, accounts };
+}
+
+describe('ERC7535', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  it('asset is the native-asset sentinel', async function () {
+    const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+    expect(await vault.asset()).to.equal(NATIVE_ASSET);
+  });
+
+  it('decimals are 18 + offset', async function () {
+    for (const offset of [0n, 6n, 18n]) {
+      const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, offset]);
+      expect(await vault.decimals()).to.equal(decimals + offset);
+    }
+  });
+
+  describe('native value (msg.value) handling', function () {
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('1000'));
+    });
+
+    it('deposit reverts when msg.value < assets', async function () {
+      const assets = ethers.parseEther('1');
+      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets - 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC7535InsufficientNativeValue')
+        .withArgs(assets - 1n, assets);
+    });
+
+    it('deposit succeeds when msg.value == assets', async function () {
+      const assets = ethers.parseEther('1');
+      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets })).to.not.be
+        .reverted;
+    });
+
+    it('deposit keeps the excess as a donation when msg.value > assets', async function () {
+      const assets = ethers.parseEther('1');
+      const extra = ethers.parseEther('0.5');
+      // Shares are priced on `assets` (the in-flight value is excluded from the rate via _pretotalAssets).
+      const expectedShares = await this.vault.previewDeposit(assets);
+
+      const tx = this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets + extra });
+
+      await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-(assets + extra), assets + extra]);
+      await expect(tx).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
+      // The full msg.value entered the vault; the excess is an unminted donation.
+      expect(await this.vault.totalAssets()).to.equal(assets + extra);
+    });
+
+    it('mint reverts when msg.value < cost', async function () {
+      const shares = ethers.parseEther('1');
+      const cost = await this.vault.previewMint(shares);
+      await expect(this.vault.connect(this.holder).mint(shares, this.recipient, { value: cost - 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC7535InsufficientNativeValue')
+        .withArgs(cost - 1n, cost);
+    });
+
+    it('mint succeeds when msg.value == cost', async function () {
+      const shares = ethers.parseEther('1');
+      const cost = await this.vault.previewMint(shares);
+      await expect(this.vault.connect(this.holder).mint(shares, this.recipient, { value: cost })).to.not.be.reverted;
+    });
+
+    it('mint keeps the excess as a donation when msg.value > cost', async function () {
+      const shares = ethers.parseEther('1');
+      const cost = await this.vault.previewMint(shares);
+      const extra = ethers.parseEther('0.5');
+
+      const tx = this.vault.connect(this.holder).mint(shares, this.recipient, { value: cost + extra });
+
+      await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-(cost + extra), cost + extra]);
+      await expect(tx).to.changeTokenBalance(this.vault, this.recipient, shares);
+      expect(await this.vault.totalAssets()).to.equal(cost + extra);
+    });
+  });
+
+  describe('rejects plain ETH transfers', function () {
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('1000'));
+    });
+
+    it('receive() reverts with ERC7535UnsolicitedDeposit on a plain transfer', async function () {
+      await expect(this.holder.sendTransaction({ to: this.vault.target, value: 1n })).to.be.revertedWithCustomError(
+        this.vault,
+        'ERC7535UnsolicitedDeposit',
+      );
+    });
+
+    it('receive() reverts on a non-trivial plain transfer', async function () {
+      await expect(
+        this.holder.sendTransaction({ to: this.vault.target, value: ethers.parseEther('1') }),
+      ).to.be.revertedWithCustomError(this.vault, 'ERC7535UnsolicitedDeposit');
+    });
+
+    it('totalAssets does not increase after a rejected plain transfer', async function () {
+      const before = await this.vault.totalAssets();
+      await expect(this.holder.sendTransaction({ to: this.vault.target, value: 1n })).to.be.reverted;
+      expect(await this.vault.totalAssets()).to.equal(before);
+    });
+  });
+
+  describe('decimals offset bounds', function () {
+    // decimals() = 18 + _decimalsOffset() overflows the uint8 return type above 237.
+    for (const offset of [238n, 243n, 250n, 255n]) {
+      it(`decimals() reverts at offset ${offset}`, async function () {
+        const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, offset]);
+        await expect(vault.decimals()).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+      });
+    }
+
+    // The conversion math computes 10 ** offset, which overflows uint256 from offset 78 onwards — a tighter
+    // ceiling than the uint8 bound on decimals(). Pin both sides of the boundary.
+    it('conversions work at offset 77 (largest supported)', async function () {
+      const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 77n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+
+      expect(await vault.decimals()).to.equal(18n + 77n);
+      expect(await vault.previewDeposit(1n)).to.equal(10n ** 77n);
+      await expect(vault.connect(this.holder).deposit(1n, this.recipient, { value: 1n })).to.not.be.reverted;
+      expect(await vault.balanceOf(this.recipient)).to.equal(10n ** 77n);
+    });
+
+    it('conversions revert with an arithmetic panic at offset 78', async function () {
+      const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 78n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+
+      // The vault deploys but every conversion-dependent entry point is bricked.
+      await expect(vault.previewDeposit(1n)).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+      await expect(vault.previewMint(1n)).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+      await expect(vault.connect(this.holder).deposit(1n, this.recipient, { value: 1n })).to.be.revertedWithPanic(
+        PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW,
+      );
+    });
+  });
+
+  describe('outbound send failure', function () {
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+      await this.vault.connect(this.holder).deposit(ethers.parseEther('1'), this.holder, {
+        value: ethers.parseEther('1'),
+      });
+      // A contract whose `receive()` always reverts — exercises the `Address.sendValue` failure path.
+      this.rejector = await ethers.deployContract('$EtherReceiverMock');
+      await this.rejector.setAcceptEther(false);
+    });
+
+    it('withdraw to a receiver whose receive() reverts bubbles the failure', async function () {
+      await expect(this.vault.connect(this.holder).withdraw(ethers.parseEther('1'), this.rejector, this.holder)).to.be
+        .reverted;
+    });
+
+    it('redeem to a receiver whose receive() reverts bubbles the failure', async function () {
+      const shares = await this.vault.balanceOf(this.holder);
+      await expect(this.vault.connect(this.holder).redeem(shares, this.rejector, this.holder)).to.be.reverted;
+    });
+  });
+
+  describe('receiver == address(0) (documenting test)', function () {
+    // ERC4626 / ERC7535 don't require receiver != address(0) on withdraw/redeem; pin the current behavior
+    // (ETH sent to the zero address, which has no code and accepts the value silently) so a future change
+    // is forced to be deliberate.
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+      await this.vault.connect(this.holder).deposit(ethers.parseEther('1'), this.holder, {
+        value: ethers.parseEther('1'),
+      });
+    });
+
+    it('withdraw to address(0) succeeds and sends value to the zero address', async function () {
+      const value = ethers.parseEther('1');
+      const tx = this.vault.connect(this.holder).withdraw(value, ethers.ZeroAddress, this.holder);
+      await expect(tx).to.changeEtherBalances([this.vault, ethers.ZeroAddress], [-value, value]);
+      await expect(tx).to.emit(this.vault, 'Withdraw');
+    });
+  });
+
+  for (const offset of [0n, 6n, 18n]) {
+    const parseAsset = asset => asset * 10n ** decimals;
+    const parseShare = share => share * 10n ** (decimals + offset);
+
+    const virtualAssets = 1n;
+    const virtualShares = 10n ** offset;
+
+    describe(`offset: ${offset}`, function () {
+      beforeEach(async function () {
+        const vault = await ethers.deployContract('$ERC7535OffsetMock', [name + ' Vault', symbol + 'V', offset]);
+
+        // Fund the holder with plenty of native asset.
+        await setBalance(this.holder.address, ethers.MaxUint256 / 2n);
+        // Approve spender over holder's shares for third-party withdraw/redeem paths.
+        await vault.$_approve(this.holder, this.spender, ethers.MaxUint256);
+
+        Object.assign(this, { vault });
+      });
+
+      it('metadata', async function () {
+        expect(await this.vault.name()).to.equal(name + ' Vault');
+        expect(await this.vault.symbol()).to.equal(symbol + 'V');
+        expect(await this.vault.decimals()).to.equal(decimals + offset);
+        expect(await this.vault.asset()).to.equal(NATIVE_ASSET);
+      });
+
+      describe('empty vault: no assets & no shares', function () {
+        it('status', async function () {
+          expect(await this.vault.totalAssets()).to.equal(0n);
+        });
+
+        it('deposit', async function () {
+          expect(await this.vault.maxDeposit(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewDeposit(parseAsset(1n))).to.equal(parseShare(1n));
+
+          const tx = this.vault.connect(this.holder).deposit(parseAsset(1n), this.recipient, { value: parseAsset(1n) });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-parseAsset(1n), parseAsset(1n)]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, parseShare(1n));
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, parseShare(1n))
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, parseAsset(1n), parseShare(1n));
+        });
+
+        it('mint', async function () {
+          expect(await this.vault.maxMint(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewMint(parseShare(1n))).to.equal(parseAsset(1n));
+
+          const tx = this.vault.connect(this.holder).mint(parseShare(1n), this.recipient, { value: parseAsset(1n) });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-parseAsset(1n), parseAsset(1n)]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, parseShare(1n));
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, parseShare(1n))
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, parseAsset(1n), parseShare(1n));
+        });
+
+        it('withdraw', async function () {
+          expect(await this.vault.maxWithdraw(this.holder)).to.equal(0n);
+          expect(await this.vault.previewWithdraw(0n)).to.equal(0n);
+
+          const tx = this.vault.connect(this.holder).withdraw(0n, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [0n, 0n]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, 0n);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, 0n)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, 0n, 0n);
+        });
+
+        it('redeem', async function () {
+          expect(await this.vault.maxRedeem(this.holder)).to.equal(0n);
+          expect(await this.vault.previewRedeem(0n)).to.equal(0n);
+
+          const tx = this.vault.connect(this.holder).redeem(0n, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [0n, 0n]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, 0n);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, 0n)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, 0n, 0n);
+        });
+      });
+
+      describe('inflation attack: offset price by direct donation of native asset', function () {
+        beforeEach(async function () {
+          // Force-feed 1 unit of native asset into the vault (SELFDESTRUCT / coinbase analogue): no shares minted.
+          await setBalance(this.vault.target, parseAsset(1n));
+        });
+
+        it('status', async function () {
+          expect(await this.vault.totalSupply()).to.equal(0n);
+          expect(await this.vault.totalAssets()).to.equal(parseAsset(1n));
+        });
+
+        it('deposit', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const depositAssets = parseAsset(1n);
+          const expectedShares = (depositAssets * effectiveShares) / effectiveAssets;
+
+          expect(await this.vault.maxDeposit(this.holder)).to.equal(ethers.MaxUint256);
+          // previewDeposit is queried BEFORE sending value: it sees the donated balance, not the in-flight value.
+          expect(await this.vault.previewDeposit(depositAssets)).to.equal(expectedShares);
+
+          const tx = this.vault.connect(this.holder).deposit(depositAssets, this.recipient, { value: depositAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-depositAssets, depositAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, expectedShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, depositAssets, expectedShares);
+        });
+
+        it('mint', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const mintShares = parseShare(1n);
+          const expectedAssets = (mintShares * effectiveAssets) / effectiveShares;
+
+          expect(await this.vault.maxMint(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewMint(mintShares)).to.equal(expectedAssets);
+
+          const tx = this.vault.connect(this.holder).mint(mintShares, this.recipient, { value: expectedAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-expectedAssets, expectedAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, mintShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, mintShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, expectedAssets, mintShares);
+        });
+      });
+
+      describe('full vault: assets & shares', function () {
+        beforeEach(async function () {
+          // 1 unit of native asset balance and 100 shares.
+          await setBalance(this.vault.target, parseAsset(1n));
+          await this.vault.$_mint(this.holder, parseShare(100n));
+        });
+
+        it('status', async function () {
+          expect(await this.vault.totalSupply()).to.equal(parseShare(100n));
+          expect(await this.vault.totalAssets()).to.equal(parseAsset(1n));
+        });
+
+        it('deposit', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const depositAssets = parseAsset(1n);
+          const expectedShares = (depositAssets * effectiveShares) / effectiveAssets;
+
+          expect(await this.vault.maxDeposit(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewDeposit(depositAssets)).to.equal(expectedShares);
+
+          const tx = this.vault.connect(this.holder).deposit(depositAssets, this.recipient, { value: depositAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-depositAssets, depositAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, expectedShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, depositAssets, expectedShares);
+        });
+
+        it('mint', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const mintShares = parseShare(1n);
+          const expectedAssets = (mintShares * effectiveAssets) / effectiveShares + 1n; // round up
+
+          expect(await this.vault.maxMint(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewMint(mintShares)).to.equal(expectedAssets);
+
+          const tx = this.vault.connect(this.holder).mint(mintShares, this.recipient, { value: expectedAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-expectedAssets, expectedAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, mintShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, mintShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, expectedAssets, mintShares);
+        });
+
+        it('withdraw', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const withdrawAssets = parseAsset(1n);
+          const expectedShares = (withdrawAssets * effectiveShares) / effectiveAssets + 1n; // round up
+
+          expect(await this.vault.maxWithdraw(this.holder)).to.equal(withdrawAssets);
+          expect(await this.vault.previewWithdraw(withdrawAssets)).to.equal(expectedShares);
+
+          const tx = this.vault.connect(this.holder).withdraw(withdrawAssets, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [-withdrawAssets, withdrawAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, -expectedShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, expectedShares)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, withdrawAssets, expectedShares);
+        });
+
+        it('withdraw with approval', async function () {
+          const assets = await this.vault.previewWithdraw(parseAsset(1n));
+
+          await expect(this.vault.connect(this.other).withdraw(parseAsset(1n), this.recipient, this.holder))
+            .to.be.revertedWithCustomError(this.vault, 'ERC20InsufficientAllowance')
+            .withArgs(this.other, 0n, assets);
+
+          await expect(this.vault.connect(this.spender).withdraw(parseAsset(1n), this.recipient, this.holder)).to.not.be
+            .reverted;
+        });
+
+        it('redeem', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const redeemShares = parseShare(100n);
+          const expectedAssets = (redeemShares * effectiveAssets) / effectiveShares;
+
+          expect(await this.vault.maxRedeem(this.holder)).to.equal(redeemShares);
+          expect(await this.vault.previewRedeem(redeemShares)).to.equal(expectedAssets);
+
+          const tx = this.vault.connect(this.holder).redeem(redeemShares, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [-expectedAssets, expectedAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, -redeemShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, redeemShares)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, expectedAssets, redeemShares);
+        });
+
+        it('redeem with approval', async function () {
+          await expect(this.vault.connect(this.other).redeem(parseShare(100n), this.recipient, this.holder))
+            .to.be.revertedWithCustomError(this.vault, 'ERC20InsufficientAllowance')
+            .withArgs(this.other, 0n, parseShare(100n));
+
+          await expect(this.vault.connect(this.spender).redeem(parseShare(100n), this.recipient, this.holder)).to.not.be
+            .reverted;
+        });
+      });
+    });
+  }
+
+  // Yield scenario adapted from the ERC-4626 suite to the native asset.
+  it('full vault: yield accrual via force-fed native asset', async function () {
+    const vault = await ethers.deployContract('$ERC7535', [name, symbol]);
+    const [alice, bruce] = this.accounts;
+
+    await setBalance(alice.address, ethers.parseEther('1000'));
+    await setBalance(bruce.address, ethers.parseEther('1000'));
+
+    // 1. Alice deposits 2000 wei
+    await vault.connect(alice).deposit(2000n, alice, { value: 2000n });
+    expect(await vault.balanceOf(alice)).to.equal(2000n);
+    expect(await vault.totalSupply()).to.equal(2000n);
+    expect(await vault.totalAssets()).to.equal(2000n);
+
+    // 2. Bruce deposits 4000 wei
+    await vault.connect(bruce).deposit(4000n, bruce, { value: 4000n });
+    expect(await vault.balanceOf(bruce)).to.equal(4000n);
+    expect(await vault.totalSupply()).to.equal(6000n);
+    expect(await vault.totalAssets()).to.equal(6000n);
+
+    // 3. Vault mutates by +3000 wei (simulated yield force-fed into the balance)
+    await setBalance(vault.target, 9000n);
+
+    // Virtual assets/shares capture a sliver of the yield (mirrors ERC-4626 behavior)
+    expect(await vault.convertToAssets(await vault.balanceOf(alice))).to.equal(2999n);
+    expect(await vault.convertToAssets(await vault.balanceOf(bruce))).to.equal(5999n);
+    expect(await vault.totalSupply()).to.equal(6000n);
+    expect(await vault.totalAssets()).to.equal(9000n);
+
+    // 4. Alice redeems all her shares; never extracts more than her fair share.
+    await expect(vault.connect(alice).redeem(2000n, alice, alice))
+      .to.emit(vault, 'Withdraw')
+      .withArgs(alice, alice, alice, 2999n, 2000n);
+    expect(await vault.balanceOf(alice)).to.equal(0n);
+  });
+});

--- a/test/token/ERC20/extensions/ERC7535.test.js
+++ b/test/token/ERC20/extensions/ERC7535.test.js
@@ -38,31 +38,27 @@ describe('ERC7535', function () {
       await setBalance(this.holder.address, ethers.parseEther('1000'));
     });
 
-    it('deposit reverts when msg.value < assets', async function () {
-      const assets = ethers.parseEther('1');
-      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets - 1n }))
-        .to.be.revertedWithCustomError(this.vault, 'ERC7535InsufficientNativeValue')
-        .withArgs(assets - 1n, assets);
-    });
+    it('deposit mints previewDeposit(msg.value) shares, ignoring the assets argument', async function () {
+      const value = ethers.parseEther('1');
+      const expectedShares = await this.vault.previewDeposit(value);
 
-    it('deposit succeeds when msg.value == assets', async function () {
-      const assets = ethers.parseEther('1');
-      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets })).to.not.be
-        .reverted;
-    });
+      // Per ERC-7535 the `assets` argument is advisory; shares are priced off `msg.value`. Passing 0 — which under
+      // an assets-based implementation would mint 0 shares and donate the ether — still mints for the full value.
+      const tx = this.vault.connect(this.holder).deposit(0n, this.recipient, { value });
 
-    it('deposit keeps the excess as a donation when msg.value > assets', async function () {
-      const assets = ethers.parseEther('1');
-      const extra = ethers.parseEther('0.5');
-      // Shares are priced on `assets` (the in-flight value is excluded from the rate via _pretotalAssets).
-      const expectedShares = await this.vault.previewDeposit(assets);
-
-      const tx = this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets + extra });
-
-      await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-(assets + extra), assets + extra]);
+      await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-value, value]);
       await expect(tx).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
-      // The full msg.value entered the vault; the excess is an unminted donation.
-      expect(await this.vault.totalAssets()).to.equal(assets + extra);
+      expect(await this.vault.totalAssets()).to.equal(value);
+    });
+
+    it('deposit converts the entire msg.value to shares (no excess donation)', async function () {
+      const value = ethers.parseEther('1.5');
+      const expectedShares = await this.vault.previewDeposit(value);
+
+      // Even with a smaller `assets` argument, the full msg.value is priced into shares (not retained as a donation).
+      await expect(
+        this.vault.connect(this.holder).deposit(ethers.parseEther('1'), this.recipient, { value }),
+      ).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
     });
 
     it('mint reverts when msg.value < cost', async function () {


### PR DESCRIPTION
Fixes #5808

Implements [ERC-7535](https://eips.ethereum.org/EIPS/eip-7535) (Native Asset ERC-4626 Tokenized Vault) as a **thin extension of `ERC4626`**, inheriting all share accounting instead of duplicating it.

## Approach

The only thing that prevented ERC-7535 from extending `ERC4626` was that `IERC4626.deposit`/`mint` are `nonpayable` (Solidity forbids a `payable` override of a `nonpayable` function). This PR removes that blocker:

- **`IERC4626` / `ERC4626`**: `deposit` and `mint` become `payable`. This changes neither the function selectors nor the ERC-165 interface id, so it is ABI-compatible. A new internal hook `_checkPayment(uint256 assets)` validates the native value; the default reverts on any non-zero `msg.value`, so existing ERC-20 vaults keep rejecting native value exactly as the previously non-payable entry points did.
- `ERC4626` already exposed `_transferIn` / `_transferOut` virtual seams, so the asset-movement layer was already overridable.

`ERC7535` then collapses to a small override set over `ERC4626`:

- `asset()` → ERC-7528 placeholder `0xEeee…EEeE`; `totalAssets()` → `address(this).balance`.
- `_checkPayment` → require `msg.value` to cover the deposit.
- `_transferIn` → no-op (value arrived as `msg.value`); `_transferOut` → `Address.sendValue`.
- `_convertToShares`/`_convertToAssets` → price against `_pretotalAssets()` (`totalAssets() - msg.value`) so a standalone `previewDeposit` matches the shares a subsequent `deposit` mints.
- `receive()` (virtual) → revert `ERC7535UnsolicitedDeposit`.

All share accounting, rounding, the virtual-offset inflation mitigation, the preview/max functions, and the CEI withdraw path are inherited unchanged — no duplication.

## Design notes

- **`msg.value` policy**: `deposit`/`mint` require `msg.value >= assets` (resp. the previewed cost); too little reverts with `ERC7535InsufficientNativeValue`. Excess is kept as a donation rather than refunded — a refund would add an outbound native call inside the deposit flow, reopening the reentrancy / refund-griefing surface the inherited CEI ordering avoids.
- **Inflation attack**: same virtual-offset mitigation as `ERC4626`; force-feeds (`SELFDESTRUCT`, block rewards) are tracked by the balance-based `totalAssets()` and handled by the offset math, not by the `receive` guard.
- **`_decimalsOffset` ceiling**: documented as `offset <= 77` — `10 ** offset` overflows `uint256` beyond that (the `uint8` `decimals()` bound of 237 is not the binding constraint). Pinned with tests on both sides of the 77/78 boundary. (Applies to `ERC4626` too.)

## Tests

- **Hardhat (143 passing across the ERC4626 + ERC7535 suites)**: ERC7535 over offsets `[0, 6, 18]` × empty/donated/populated states; the `>=` policy (underpay reverts, exact + overpay succeed, overpay donates); unsolicited-transfer rejection; outbound-send failure; the 77/78 boundary; a yield-accrual scenario. Plus a new ERC4626 test asserting a token vault reverts (`ERC4626UnexpectedNativeValue`) on a non-zero `msg.value`.
- **Foundry (23 passing)**: msg.value enforcement, preview==minted under non-trivial state, inflation non-profitability at offset 0, round-trip contraction, force-fed accounting, CEI reentrancy with a malicious receiver, and `invariantSolvency` / `invariantNoValueCreation` (5000 runs × 500 calls, 0 reverts).

Local: `lint`, `test:inheritance`, `test:generation` green; docs build resolves the `{{ERC7535}}` placeholder.

## Changeset classification

Both changesets are marked `minor`. The selector + interface id are unchanged and no in-repo subclass overrides `deposit`/`mint`, so this is non-breaking here — but an external subclass that overrides `deposit`/`mint` as `nonpayable` would need a recompile, so a `major` classification is defensible if maintainers prefer.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
