### PR TITLE
Add fetchCloneArgs variants that read a slice of the immutable args

### DIFF
--- a/.changeset/clones-fetch-slice.md
+++ b/.changeset/clones-fetch-slice.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Clones`: Add `fetchCloneArgs` variants that return only a slice of the immutable args attached to a clone: one taking a start offset and a length, and one taking a start offset that reads to the end.

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 
 import {Create2} from "../utils/Create2.sol";
 import {Errors} from "../utils/Errors.sol";
+import {Math} from "../utils/math/Math.sol";
 
 /**
  * @dev https://eips.ethereum.org/EIPS/eip-1167[ERC-1167] is a standard for
@@ -259,9 +260,34 @@ library Clones {
      *   function should only be used to check addresses that are known to be clones.
      */
     function fetchCloneArgs(address instance) internal view returns (bytes memory) {
-        bytes memory result = new bytes(instance.code.length - 0x2d); // revert if length is too short
+        return fetchCloneArgs(instance, 0, type(uint256).max);
+    }
+
+    /**
+     * @dev Variant of {fetchCloneArgs-address-} that copies the immutable args starting at position `start` (included)
+     * to the end. This is useful (and cheaper) when only a portion of the immutable args is needed. The `start`
+     * argument is truncated to the length of the immutable args.
+     */
+    function fetchCloneArgs(address instance, uint256 start) internal view returns (bytes memory) {
+        return fetchCloneArgs(instance, start, type(uint256).max);
+    }
+
+    /**
+     * @dev Variant of {fetchCloneArgs-address-} that copies at most `length` bytes of the immutable args, starting at
+     * position `start`. This is useful (and cheaper) when only a portion of the immutable args is needed. The slice
+     * (bytes `start` to `start + length`) is truncated to the length of the immutable args, so the returned array may
+     * be shorter than `length`.
+     */
+    function fetchCloneArgs(address instance, uint256 start, uint256 length) internal view returns (bytes memory) {
+        uint256 argsLength = instance.code.length - 0x2d; // revert if instance code is too short
+
+        // sanitize
+        start = Math.min(start, argsLength);
+        length = Math.min(length, argsLength - start);
+
+        bytes memory result = new bytes(length);
         assembly ("memory-safe") {
-            extcodecopy(instance, add(result, 0x20), 0x2d, mload(result))
+            extcodecopy(instance, add(result, 0x20), add(0x2d, start), length)
         }
         return result;
     }

--- a/contracts/proxy/Clones.sol
+++ b/contracts/proxy/Clones.sol
@@ -264,7 +264,7 @@ library Clones {
     }
 
     /**
-     * @dev Variant of {fetchCloneArgs-address-} that copies the immutable args starting at position `start` (included)
+     * @dev Variant of {fetchCloneArgs-address} that copies the immutable args starting at position `start` (included)
      * to the end. This is useful (and cheaper) when only a portion of the immutable args is needed. The `start`
      * argument is truncated to the length of the immutable args.
      */
@@ -273,10 +273,10 @@ library Clones {
     }
 
     /**
-     * @dev Variant of {fetchCloneArgs-address-} that copies at most `length` bytes of the immutable args, starting at
+     * @dev Variant of {fetchCloneArgs-address} that copies at most `length` bytes of the immutable args, starting at
      * position `start`. This is useful (and cheaper) when only a portion of the immutable args is needed. The slice
-     * (bytes `start` to `start + length`) is truncated to the length of the immutable args, so the returned array may
-     * be shorter than `length`.
+     * [`start`, `start + length`) is truncated to the length of the immutable args, so the returned array may
+     * be shorter than `length`. The resulting slice is [`start`, `min(start + length, argsLength)`].
      */
     function fetchCloneArgs(address instance, uint256 start, uint256 length) internal view returns (bytes memory) {
         uint256 argsLength = instance.code.length - 0x2d; // revert if instance code is too short

--- a/test/proxy/Clones.t.sol
+++ b/test/proxy/Clones.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract ClonesTest is Test {
     function getNumber() external pure returns (uint256) {
@@ -81,6 +82,37 @@ contract ClonesTest is Test {
         assertEq(ClonesTest(instance2).getNumber(), this.getNumber());
         assertEq(Clones.fetchCloneArgs(instance1), args);
         assertEq(Clones.fetchCloneArgs(instance2), args);
+    }
+
+    function testFetchCloneArgsSlice(bytes memory args, uint256 start, uint256 length, bytes32 salt) external {
+        vm.assume(args.length < 0xbfd3);
+
+        address instance = Clones.cloneDeterministicWithImmutableArgs(address(this), args, salt);
+
+        // slice is truncated to the length of the immutable args
+        uint256 expectedStart = Math.min(start, args.length);
+        uint256 expectedLength = Math.min(length, args.length - expectedStart);
+
+        bytes memory expected = new bytes(expectedLength);
+        for (uint256 i = 0; i < expectedLength; ++i) {
+            expected[i] = args[expectedStart + i];
+        }
+        assertEq(Clones.fetchCloneArgs(instance, start, length), expected);
+    }
+
+    function testFetchCloneArgsSliceToEnd(bytes memory args, uint256 start, bytes32 salt) external {
+        vm.assume(args.length < 0xbfd3);
+
+        address instance = Clones.cloneDeterministicWithImmutableArgs(address(this), args, salt);
+
+        // start is truncated to the length of the immutable args
+        uint256 expectedStart = Math.min(start, args.length);
+
+        bytes memory expected = new bytes(args.length - expectedStart);
+        for (uint256 i = 0; i < expected.length; ++i) {
+            expected[i] = args[expectedStart + i];
+        }
+        assertEq(Clones.fetchCloneArgs(instance, start), expected);
     }
 
     function _dirty(address input) private pure returns (address output) {

--- a/test/proxy/Clones.test.js
+++ b/test/proxy/Clones.test.js
@@ -86,16 +86,51 @@ describe('Clones', function () {
 
   for (const args of [undefined, '0x', '0x11223344']) {
     describe(args ? `with immutable args: ${args}` : 'without immutable args', function () {
+      const argsLength = ethers.dataLength(args ?? '0x');
+
       describe('clone', function () {
         beforeEach(async function () {
           this.createClone = this.newClone(args);
+          this.instance = await this.createClone();
         });
 
         shouldBehaveLikeClone();
 
         it('get immutable arguments', async function () {
-          const instance = await this.createClone();
-          expect(await this.factory.$fetchCloneArgs(instance)).to.equal(args ?? '0x');
+          await expect(this.factory['$fetchCloneArgs(address)'](this.instance)).to.eventually.equal(args ?? '0x');
+        });
+
+        it('get immutable arguments (slice)', async function () {
+          const start = Math.floor(argsLength / 2);
+          const length = Math.floor(argsLength / 3);
+          await expect(
+            this.factory['$fetchCloneArgs(address,uint256,uint256)'](this.instance, start, length),
+          ).to.eventually.equal(ethers.dataSlice(args ?? '0x', start, start + length));
+        });
+
+        it('get immutable arguments (slice to end)', async function () {
+          const start = Math.floor(argsLength / 2);
+          await expect(this.factory['$fetchCloneArgs(address,uint256)'](this.instance, start)).to.eventually.equal(
+            ethers.dataSlice(args ?? '0x', start),
+          );
+        });
+
+        it('get immutable arguments (slice) truncates to the end', async function () {
+          // length past the end is capped
+          await expect(
+            this.factory['$fetchCloneArgs(address,uint256,uint256)'](this.instance, 0, argsLength + 1),
+          ).to.eventually.equal(args ?? '0x');
+
+          // start past the end returns an empty array
+          await expect(
+            this.factory['$fetchCloneArgs(address,uint256,uint256)'](this.instance, argsLength + 1, 1),
+          ).to.eventually.equal('0x');
+        });
+
+        it('get immutable arguments (slice to end) truncates start', async function () {
+          await expect(this.factory['$fetchCloneArgs(address,uint256)'](this.instance, argsLength)).to.eventually.equal(
+            '0x',
+          );
         });
       });
 
@@ -108,7 +143,7 @@ describe('Clones', function () {
 
         it('get immutable arguments', async function () {
           const instance = await this.createClone();
-          expect(await this.factory.$fetchCloneArgs(instance)).to.equal(args ?? '0x');
+          await expect(this.factory['$fetchCloneArgs(address)'](instance)).to.eventually.equal(args ?? '0x');
         });
 
         it('revert if address already used', async function () {

--- a/test/proxy/Clones.test.js
+++ b/test/proxy/Clones.test.js
@@ -128,9 +128,9 @@ describe('Clones', function () {
         });
 
         it('get immutable arguments (slice to end) truncates start', async function () {
-          await expect(this.factory['$fetchCloneArgs(address,uint256)'](this.instance, argsLength)).to.eventually.equal(
-            '0x',
-          );
+          await expect(
+            this.factory['$fetchCloneArgs(address,uint256)'](this.instance, argsLength + 1),
+          ).to.eventually.equal('0x');
         });
       });
 


### PR DESCRIPTION
Adds two overloads of `Clones.fetchCloneArgs` that read only part of the immutable args attached to a clone, avoiding allocation/copy of the full array when only a portion is needed:

- `fetchCloneArgs(address instance, uint256 start)` — copies from `start` (included) to the end.
- `fetchCloneArgs(address instance, uint256 start, uint256 length)` — copies at most `length` bytes starting at `start`.

Out-of-range arguments are truncated to the length of the immutable args (the returned array may be shorter than requested, or empty), matching the capping semantics of `Bytes.slice`/`Bytes.splice` rather than reverting. The existing `fetchCloneArgs(address)` is refactored to delegate to the new slicing overload, so all three share a single implementation.

#### PR Checklist

- [x] Tests (Hardhat + Foundry fuzz, covering in-range and truncated reads)
- [x] Documentation (NatSpec)
- [x] Changeset entry