### PR TITLE
Let ERC-7579 modules control their own uninstallation (revert #6390 and #6142)

### DIFF
--- a/.changeset/chatty-dryers-joke.md
+++ b/.changeset/chatty-dryers-joke.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': minor
----
-
-`AccountERC7579Hooked`: Do not revert if hook checks fail during the hook module uninstallation.

--- a/.changeset/lazy-hooks-return.md
+++ b/.changeset/lazy-hooks-return.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`AccountERC7579`: Revert the module uninstallation if the module's `onUninstall` hook reverts, giving modules control over their own uninstallation. A forced uninstallation that bypasses the hook can still be performed through a delegate call via `execute`.

--- a/.changeset/lazy-hooks-return.md
+++ b/.changeset/lazy-hooks-return.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`AccountERC7579`: Revert the module uninstallation if the module's `onUninstall` hook reverts, giving modules control over their own uninstallation. A forced uninstallation that bypasses the hook can still be performed through a delegate call via `execute`.
+`AccountERC7579`: Revert the uninstallation of any module (validator, executor, fallback, or hook) if its `onUninstall` callback reverts, giving modules control over their own uninstallation. A forced uninstallation that bypasses the callback can still be performed through a delegate call via `execute`.

--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -284,6 +284,11 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
      * Requirements:
      *
      * * Module must be already installed. Reverts with {ERC7579Utils-ERC7579UninstalledModule} otherwise.
+     *
+     * NOTE: The module's {IERC7579Module-onUninstall} hook is invoked without catching reverts, so a buggy or
+     * malicious module can block its own uninstallation by reverting. A forced uninstallation that bypasses this
+     * hook can still be performed through a delegate call (`CALLTYPE_DELEGATECALL`) via {execute}, running logic
+     * in the account's context that clears the module from storage directly.
      */
     function _uninstallModule(uint256 moduleTypeId, address module, bytes memory deInitData) internal virtual {
         require(supportsModule(moduleTypeId), ERC7579Utils.ERC7579UnsupportedModuleType(moduleTypeId));
@@ -302,8 +307,7 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
             delete _fallbacks[selector];
         }
 
-        // Ignores success purposely to avoid modules that revert on uninstall
-        LowLevelCall.callNoReturn(module, abi.encodeCall(IERC7579Module.onUninstall, (deInitData)));
+        IERC7579Module(module).onUninstall(deInitData);
         emit ModuleUninstalled(moduleTypeId, module);
     }
 

--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -285,9 +285,9 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
      *
      * * Module must be already installed. Reverts with {ERC7579Utils-ERC7579UninstalledModule} otherwise.
      *
-     * NOTE: The module's {IERC7579Module-onUninstall} hook is invoked without catching reverts, so a buggy or
+     * NOTE: The module's {IERC7579Module-onUninstall} callback is invoked without catching reverts, so a buggy or
      * malicious module can block its own uninstallation by reverting. A forced uninstallation that bypasses this
-     * hook can still be performed through a delegate call (`CALLTYPE_DELEGATECALL`) via {execute}, running logic
+     * callback can still be performed through a delegate call (`CALLTYPE_DELEGATECALL`) via {execute}, running logic
      * in the account's context that clears the module from storage directly.
      */
     function _uninstallModule(uint256 moduleTypeId, address module, bytes memory deInitData) internal virtual {

--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -284,6 +284,7 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
      * Requirements:
      *
      * * Module must be already installed. Reverts with {ERC7579Utils-ERC7579UninstalledModule} otherwise.
+     * The module's own {IERC7579Module-onUninstall} function must succeed
      *
      * NOTE: The module's {IERC7579Module-onUninstall} callback is invoked without catching reverts, so a buggy or
      * malicious module can block its own uninstallation by reverting. A forced uninstallation that bypasses this

--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -284,7 +284,7 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
      * Requirements:
      *
      * * Module must be already installed. Reverts with {ERC7579Utils-ERC7579UninstalledModule} otherwise.
-     * The module's own {IERC7579Module-onUninstall} function must succeed
+     * * The module's own {IERC7579Module-onUninstall} function must succeed.
      *
      * NOTE: The module's {IERC7579Module-onUninstall} callback is invoked without catching reverts, so a buggy or
      * malicious module can block its own uninstallation by reverting. A forced uninstallation that bypasses this

--- a/contracts/account/extensions/draft-AccountERC7579Hooked.sol
+++ b/contracts/account/extensions/draft-AccountERC7579Hooked.sol
@@ -6,8 +6,6 @@ pragma solidity ^0.8.26;
 import {IERC7579Hook, MODULE_TYPE_HOOK} from "../../interfaces/draft-IERC7579.sol";
 import {ERC7579Utils, Mode} from "../../account/utils/draft-ERC7579Utils.sol";
 import {AccountERC7579} from "./draft-AccountERC7579.sol";
-import {Bytes} from "../../utils/Bytes.sol";
-import {LowLevelCall} from "../../utils/LowLevelCall.sol";
 
 /**
  * @dev Extension of {AccountERC7579} with support for a single hook module (type 4).
@@ -82,52 +80,16 @@ abstract contract AccountERC7579Hooked is AccountERC7579 {
     }
 
     /// @dev Uninstalls a module with support for hook modules. See {AccountERC7579-_uninstallModule}
-    function _uninstallModule(uint256 moduleTypeId, address module, bytes memory deInitData) internal virtual override {
-        // Inline a variant of the `withHook` modifier that doesn't revert if the hook reverts and the moduleTypeId is `MODULE_TYPE_HOOK`.
-
-        // === Beginning of the precheck ===
-
-        address hook_ = hook();
-        bytes memory hookData;
-        bool preCheckSuccess;
-
-        // slither-disable-next-line reentrancy-no-eth
-        if (hook_ != address(0)) {
-            preCheckSuccess = LowLevelCall.callNoReturn(
-                hook_,
-                abi.encodeCall(IERC7579Hook.preCheck, (msg.sender, msg.value, msg.data))
-            );
-            if (preCheckSuccess) {
-                // Note: abi.decode could revert, and we wouldn't be able to catch it.
-                // If could be leveraged by a malicious hook to force a revert.
-                // So we have to do the decode manually.
-                (preCheckSuccess, hookData) = _tryInPlaceAbiDecodeBytes(LowLevelCall.returnData());
-            } else if (moduleTypeId != MODULE_TYPE_HOOK) {
-                LowLevelCall.bubbleRevert();
-            }
-        }
-
-        // === End of the precheck -- Beginning of the body (`_` part of the modifier) ===
-
+    function _uninstallModule(
+        uint256 moduleTypeId,
+        address module,
+        bytes memory deInitData
+    ) internal virtual override withHook {
         if (moduleTypeId == MODULE_TYPE_HOOK) {
             require(_hook == module, ERC7579Utils.ERC7579UninstalledModule(moduleTypeId, module));
             _hook = address(0);
         }
         super._uninstallModule(moduleTypeId, module, deInitData);
-
-        // === End of the body (`_` part of the modifier) -- Beginning of the postcheck ===
-
-        if (hook_ != address(0) && preCheckSuccess) {
-            bool postCheckSuccess = LowLevelCall.callNoReturn(
-                hook_,
-                abi.encodeCall(IERC7579Hook.postCheck, (hookData))
-            );
-            if (!postCheckSuccess && moduleTypeId != MODULE_TYPE_HOOK) {
-                LowLevelCall.bubbleRevert();
-            }
-        }
-
-        // === End of the postcheck ===
     }
 
     /// @dev Hooked version of {AccountERC7579-_execute}.
@@ -141,31 +103,5 @@ abstract contract AccountERC7579Hooked is AccountERC7579 {
     /// @dev Hooked version of {AccountERC7579-_fallback}.
     function _fallback() internal virtual override withHook returns (bytes memory) {
         return super._fallback();
-    }
-
-    /**
-     * @dev Try to abi.decode a bytes array. If successful, the decoding is done in place, overriding the original
-     * data. If decoding fails, the original data is left untouched.
-     */
-    function _tryInPlaceAbiDecodeBytes(
-        bytes memory data
-    ) private pure returns (bool success, bytes memory passthrough) {
-        unchecked {
-            if (data.length < 0x20) return (false, data);
-            uint256 offset = uint256(_unsafeReadBytesOffset(data, 0));
-            if (data.length - 0x20 < offset) return (false, data);
-            uint256 length = uint256(_unsafeReadBytesOffset(data, offset));
-            if (data.length - 0x20 - offset < length) return (false, data);
-            Bytes.splice(data, 0x20 + offset, 0x20 + offset + length);
-            return (true, data);
-        }
-    }
-
-    /// @dev Copied from Bytes.sol
-    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {
-        // This is not memory safe in the general case, but all calls to this private function are within bounds.
-        assembly ("memory-safe") {
-            value := mload(add(add(buffer, 0x20), offset))
-        }
     }
 }

--- a/contracts/account/extensions/draft-AccountERC7579Hooked.sol
+++ b/contracts/account/extensions/draft-AccountERC7579Hooked.sol
@@ -79,7 +79,13 @@ abstract contract AccountERC7579Hooked is AccountERC7579 {
         super._installModule(moduleTypeId, module, initData);
     }
 
-    /// @dev Uninstalls a module with support for hook modules. See {AccountERC7579-_uninstallModule}
+    /**
+    * @dev Uninstalls a module with support for hook modules. See {AccountERC7579-_uninstallModule}.
+    *  
+    * NOTE: Uninstalling the hook runs through its own `withHook` `preCheck`/`postCheck`, so a hook that reverts 
+    * there blocks its removal. Since `_execute` is `withHook`-gated too, the delegatecall escape hatch does not
+    * apply, and such a hook may be impossible to uninstall. 
+    */
     function _uninstallModule(
         uint256 moduleTypeId,
         address module,

--- a/contracts/account/extensions/draft-AccountERC7579Hooked.sol
+++ b/contracts/account/extensions/draft-AccountERC7579Hooked.sol
@@ -80,12 +80,12 @@ abstract contract AccountERC7579Hooked is AccountERC7579 {
     }
 
     /**
-    * @dev Uninstalls a module with support for hook modules. See {AccountERC7579-_uninstallModule}.
-    *  
-    * NOTE: Uninstalling the hook runs through its own `withHook` `preCheck`/`postCheck`, so a hook that reverts 
-    * there blocks its removal. Since `_execute` is `withHook`-gated too, the delegatecall escape hatch does not
-    * apply, and such a hook may be impossible to uninstall. 
-    */
+     * @dev Uninstalls a module with support for hook modules. See {AccountERC7579-_uninstallModule}.
+     *
+     * NOTE: Uninstalling the hook runs through its own `withHook` `preCheck`/`postCheck`, so a hook that reverts
+     * there blocks its removal. Since `_execute` is `withHook`-gated too, the delegatecall escape hatch does not
+     * apply, and such a hook may be impossible to uninstall.
+     */
     function _uninstallModule(
         uint256 moduleTypeId,
         address module,

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -146,7 +146,7 @@ index c225e6ea8..3fdfb4e70 100644
 +  }
  }
 diff --git a/contracts/token/ERC20/extensions/ERC20TransferAuthorization.sol b/contracts/token/ERC20/extensions/ERC20TransferAuthorization.sol
-index fda256d28..2d6b555ca 100644
+index fda256d28..61afd72c3 100644
 --- a/contracts/token/ERC20/extensions/ERC20TransferAuthorization.sol
 +++ b/contracts/token/ERC20/extensions/ERC20TransferAuthorization.sol
 @@ -14,6 +14,14 @@ import {NoncesKeyed} from "../../../utils/NoncesKeyed.sol";
@@ -207,7 +207,7 @@ index c156fa1cc..895e39342 100644
       * @dev Prevents a contract from calling itself, directly or indirectly.
       * Calling a `nonReentrant` function from another `nonReentrant`
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index 5daec8e1b..a5aa41d21 100644
+index a8215e399..a5aa41d21 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -218,7 +218,7 @@ index 5daec8e1b..a5aa41d21 100644
  import {IERC5267} from "../../interfaces/IERC5267.sol";
  
  /**
-@@ -25,41 +24,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+@@ -25,43 +24,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
   * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
   * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
   *
@@ -252,11 +252,13 @@ index 5daec8e1b..a5aa41d21 100644
 -    ShortString private immutable _name;
 -    ShortString private immutable _version;
 -
--    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+-    // IMPORTANT: Deprecated. Kept to preserve the storage layout of inheriting contracts used as an
+-    // implementation behind a proxy.
 -    // slither-disable-next-line constable-states
 -    string private _nameFallback;
 -
--    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+-    // IMPORTANT: Deprecated. Kept to preserve the storage layout of inheriting contracts used as an
+-    // implementation behind a proxy.
 -    // slither-disable-next-line constable-states
 -    string private _versionFallback;
 +    string private _name;
@@ -264,7 +266,7 @@ index 5daec8e1b..a5aa41d21 100644
  
      /**
       * @dev Initializes the domain separator and parameter caches.
-@@ -74,29 +50,19 @@ abstract contract EIP712 is IERC5267 {
+@@ -76,29 +50,19 @@ abstract contract EIP712 is IERC5267 {
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
@@ -298,7 +300,7 @@ index 5daec8e1b..a5aa41d21 100644
      }
  
      /**
-@@ -147,20 +113,38 @@ abstract contract EIP712 is IERC5267 {
+@@ -149,20 +113,38 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *

--- a/test/account/extensions/AccountERC7579.behavior.js
+++ b/test/account/extensions/AccountERC7579.behavior.js
@@ -273,7 +273,7 @@ function shouldBehaveLikeAccountERC7579({ withHooks = false } = {}) {
           .withArgs(MODULE_TYPE_FALLBACK, anotherInstance);
       });
 
-      it("should revert if a module's onUninstall hook reverts", async function () {
+      it('should revert if a module\'s onUninstall hook reverts', async function () {
         const revertingModule = await ethers.deployContract('$ERC7579ModuleMaliciousMock', [MODULE_TYPE_EXECUTOR]);
 
         // Install the reverting module

--- a/test/account/extensions/AccountERC7579.behavior.js
+++ b/test/account/extensions/AccountERC7579.behavior.js
@@ -1,6 +1,5 @@
 const { ethers, predeploy } = require('hardhat');
 const { expect } = require('chai');
-const { setCode } = require('@nomicfoundation/hardhat-network-helpers');
 const { impersonate } = require('../../helpers/account');
 const { selector } = require('../../helpers/methods');
 const { zip } = require('../../helpers/iterate');
@@ -342,82 +341,34 @@ function shouldBehaveLikeAccountERC7579({ withHooks = false } = {}) {
             ).to.be.revertedWith('postCheck reverts');
           });
 
-          it('can uninstall a hook module that reverts during its pre-check', async function () {
+          it('hook module can prevent its own uninstallation by reverting during the pre-check', async function () {
             const instance = this.modules[MODULE_TYPE_HOOK];
             const initData = ethers.hexlify(ethers.randomBytes(256));
 
             // Set the hook to revert on preCheck
             await instance.revertOnPreCheck(true);
 
-            // Should uninstall
-            await expect(this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_HOOK, instance, initData))
-              .to.emit(this.mock, 'ModuleUninstalled')
-              .withArgs(MODULE_TYPE_HOOK, instance)
-              .to.not.emit(instance, 'PreCheck')
-              .to.not.emit(instance, 'PostCheck');
+            // Should not uninstall
+            await expect(
+              this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_HOOK, instance, initData),
+            ).to.be.revertedWith('preCheck reverts');
 
-            await expect(this.mock.isModuleInstalled(MODULE_TYPE_HOOK, instance, initData)).to.eventually.equal(false);
+            await expect(this.mock.isModuleInstalled(MODULE_TYPE_HOOK, instance, initData)).to.eventually.equal(true);
           });
 
-          it('can uninstall a hook module that reverts during its post-check', async function () {
+          it('hook module can prevent its own uninstallation by reverting during the post-check', async function () {
             const instance = this.modules[MODULE_TYPE_HOOK];
             const initData = ethers.hexlify(ethers.randomBytes(256));
 
             // Set the hook to revert on postCheck
             await instance.revertOnPostCheck(true);
 
-            // Should uninstall
-            await expect(this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_HOOK, instance, initData))
-              .to.emit(this.mock, 'ModuleUninstalled')
-              .withArgs(MODULE_TYPE_HOOK, instance)
-              .to.emit(instance, 'PreCheck')
-              .withArgs(
-                predeploy.entrypoint.v09,
-                0n,
-                this.mock.interface.encodeFunctionData('uninstallModule', [
-                  MODULE_TYPE_HOOK,
-                  instance.target,
-                  initData,
-                ]),
-              )
-              .to.not.emit(instance, 'PostCheck');
+            // Should not uninstall
+            await expect(
+              this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_HOOK, instance, initData),
+            ).to.be.revertedWith('postCheck reverts');
 
-            await expect(this.mock.isModuleInstalled(MODULE_TYPE_HOOK, instance, initData)).to.eventually.equal(false);
-          });
-
-          it('can uninstall a hook module that reverts during both pre-check and post-check', async function () {
-            const instance = this.modules[MODULE_TYPE_HOOK];
-            const initData = ethers.hexlify(ethers.randomBytes(256));
-
-            // Set the hook to revert on preCheck and postCheck
-            await instance.revertOnPreCheck(true);
-            await instance.revertOnPostCheck(true);
-
-            // Should uninstall
-            await expect(this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_HOOK, instance, initData))
-              .to.emit(this.mock, 'ModuleUninstalled')
-              .withArgs(MODULE_TYPE_HOOK, instance)
-              .to.not.emit(instance, 'PreCheck')
-              .to.not.emit(instance, 'PostCheck');
-
-            await expect(this.mock.isModuleInstalled(MODULE_TYPE_HOOK, instance, initData)).to.eventually.equal(false);
-          });
-
-          it('can uninstall a hook module that has no code (removed delegation)', async function () {
-            const instance = this.modules[MODULE_TYPE_HOOK];
-            const initData = ethers.hexlify(ethers.randomBytes(256));
-
-            // Delete the code of the module to simulate a removed delegation
-            await setCode(instance.target, '0x');
-
-            // Should uninstall
-            await expect(this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_HOOK, instance, initData))
-              .to.emit(this.mock, 'ModuleUninstalled')
-              .withArgs(MODULE_TYPE_HOOK, instance)
-              .to.not.emit(instance, 'PreCheck')
-              .to.not.emit(instance, 'PostCheck');
-
-            await expect(this.mock.isModuleInstalled(MODULE_TYPE_HOOK, instance, initData)).to.eventually.equal(false);
+            await expect(this.mock.isModuleInstalled(MODULE_TYPE_HOOK, instance, initData)).to.eventually.equal(true);
           });
         });
     });

--- a/test/account/extensions/AccountERC7579.behavior.js
+++ b/test/account/extensions/AccountERC7579.behavior.js
@@ -273,24 +273,20 @@ function shouldBehaveLikeAccountERC7579({ withHooks = false } = {}) {
           .withArgs(MODULE_TYPE_FALLBACK, anotherInstance);
       });
 
-      it('should uninstall a module even if its onUninstall hook reverts', async function () {
-        const maliciousModule = await ethers.deployContract('$ERC7579ModuleMaliciousMock', [MODULE_TYPE_EXECUTOR]);
+      it("should revert if a module's onUninstall hook reverts", async function () {
+        const revertingModule = await ethers.deployContract('$ERC7579ModuleMaliciousMock', [MODULE_TYPE_EXECUTOR]);
 
-        // Install the malicious module
-        await this.mock.$_installModule(MODULE_TYPE_EXECUTOR, maliciousModule, '0x');
+        // Install the reverting module
+        await this.mock.$_installModule(MODULE_TYPE_EXECUTOR, revertingModule, '0x');
 
-        await expect(this.mock.isModuleInstalled(MODULE_TYPE_EXECUTOR, maliciousModule, '0x')).to.eventually.equal(
+        await expect(this.mock.isModuleInstalled(MODULE_TYPE_EXECUTOR, revertingModule, '0x')).to.eventually.equal(
           true,
         );
 
-        // Uninstall the malicious module
-        await expect(this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_EXECUTOR, maliciousModule, '0x'))
-          .to.emit(this.mock, 'ModuleUninstalled')
-          .withArgs(MODULE_TYPE_EXECUTOR, maliciousModule);
-
-        await expect(this.mock.isModuleInstalled(MODULE_TYPE_EXECUTOR, maliciousModule, '0x')).to.eventually.equal(
-          false,
-        );
+        // Uninstall the reverting module fails
+        await expect(
+          this.mockFromEntrypoint.uninstallModule(MODULE_TYPE_EXECUTOR, revertingModule, '0x'),
+        ).to.be.revertedWith('uninstall reverts');
       });
 
       withHooks &&

--- a/test/account/extensions/AccountERC7579.behavior.js
+++ b/test/account/extensions/AccountERC7579.behavior.js
@@ -273,7 +273,7 @@ function shouldBehaveLikeAccountERC7579({ withHooks = false } = {}) {
           .withArgs(MODULE_TYPE_FALLBACK, anotherInstance);
       });
 
-      it('should revert if a module\'s onUninstall hook reverts', async function () {
+      it("should revert if a module's onUninstall hook reverts", async function () {
         const revertingModule = await ethers.deployContract('$ERC7579ModuleMaliciousMock', [MODULE_TYPE_EXECUTOR]);
 
         // Install the reverting module


### PR DESCRIPTION
## Summary

Give ERC-7579 modules full control over their own uninstallation, reverting two previously merged behaviors that stripped that control away. In both cases the account is not stuck: a module that blocks its own removal can still be force-removed through a delegate call via `execute`.

### Revert #6390 — hook modules (`AccountERC7579Hooked`)

#6390 special-cased hook-module uninstallation so a bugged or malicious hook could not block its own removal by reverting in `preCheck`/`postCheck`. This reverts that: `_uninstallModule` goes back to the plain `withHook`-modified override (removing the inlined precheck/postcheck handling, the in-place `abi.decode` helper, and the `Bytes`/`LowLevelCall` imports it required), so a hook can prevent its own uninstallation by reverting.

#6390 was never released, so its pending changeset is dropped and it needs no new changeset.

### Revert #6142 — base modules (`AccountERC7579`)

#6142 (released in 5.6.0) swallowed reverts from a module's `onUninstall` hook so a buggy or malicious module could not block its own removal. This reverts that: `onUninstall` is called without catching reverts, so a module can now prevent its own uninstallation by reverting.

The `_uninstallModule` NatSpec now documents that a forced uninstallation bypassing the `onUninstall` hook can still be performed through a delegate call (`CALLTYPE_DELEGATECALL`) via `execute`.

#6142 shipped in 5.6.0, so this reversal carries a `patch` changeset.

## Notes

- Mock helpers `revertOnPreCheck`/`revertOnPostCheck` (from #6390) and `ERC7579ModuleMaliciousMock` (from #6142) are kept — still used by the updated tests.
- Dropped the now-unused `setCode` test import left over from #6390.
- All `AccountERC7579` / `AccountERC7579Hooked` tests pass; lint clean.
