### PR TITLE
Use hashed name/version getters in EIP712 domain derivation

### DIFF
--- a/.changeset/eip712-name-version-hash-getters.md
+++ b/.changeset/eip712-name-version-hash-getters.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`EIP712`: Add internal `_EIP712NameHash` and `_EIP712VersionHash` getters and use them when building the domain separator. `ERC7739` now relies on these getters as well, making the domain derivation robust when the signer is used behind a proxy or clone with a name or version longer than 31 characters.

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -23,9 +23,9 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  * the chain id to protect against replay attacks on an eventual fork of the chain.
  *
  * While the non-upgradeable version is designed to work when used in conjunction with proxies, the ERC-5267 domain
- * getter will fail to retrieve the name and version if they do not fit in the immutable ShortString, and are instead
- * stored in the fallback storage. Developers that plan on using the non-upgradeable version with proxy or clones
- * should make sure they use name and version strings that are at most 31 characters long.
+ * getter will fail to retrieve the name and version if they do not fit in the immutable ShortString and are instead
+ * stored in fallback storage. Developers that plan on using the non-upgradeable version with a proxy or clone should
+ * make sure they use name and version strings that are at most 31 bytes long.
  *
  * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
  * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -22,6 +22,11 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  * The implementation of the domain separator was designed to be as efficient as possible while still properly updating
  * the chain id to protect against replay attacks on an eventual fork of the chain.
  *
+ * While the non-upgradeable version is designed to work when used in conjunction with proxies, the ERC-5267 domain
+ * getter will fail to retrieve the name and version if they do not fit in the immutable ShortString, and are instead
+ * stored in the fallback storage. Developers that plan on using the non-upgradeable version with proxy or clones
+ * should make sure they use name and version strings that are at most 31 characters long.
+ *
  * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
  * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
  *
@@ -88,7 +93,7 @@ abstract contract EIP712 is IERC5267 {
     }
 
     function _buildDomainSeparator() private view returns (bytes32) {
-        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));
+        return keccak256(abi.encode(TYPE_HASH, _EIP712NameHash(), _EIP712VersionHash(), block.chainid, address(this)));
     }
 
     /**
@@ -156,5 +161,17 @@ abstract contract EIP712 is IERC5267 {
     // solhint-disable-next-line func-name-mixedcase
     function _EIP712Version() internal view returns (string memory) {
         return _version.toStringWithFallback(_versionFallback);
+    }
+
+    /// @dev The hash of the name parameter for the EIP712 domain.
+    // solhint-disable-next-line func-name-mixedcase
+    function _EIP712NameHash() internal view returns (bytes32) {
+        return _hashedName;
+    }
+
+    /// @dev The hash of the version parameter for the EIP712 domain.
+    // solhint-disable-next-line func-name-mixedcase
+    function _EIP712VersionHash() internal view returns (bytes32) {
+        return _hashedVersion;
     }
 }

--- a/contracts/utils/cryptography/signers/draft-ERC7739.sol
+++ b/contracts/utils/cryptography/signers/draft-ERC7739.sol
@@ -85,15 +85,7 @@ abstract contract ERC7739 is AbstractSigner, EIP712, IERC1271 {
     }
 
     function _buildDomainBytes() private view returns (bytes memory) {
-        (
-            ,
-            string memory name,
-            string memory version,
-            uint256 chainId,
-            address verifyingContract,
-            bytes32 salt,
-
-        ) = eip712Domain();
-        return abi.encode(keccak256(bytes(name)), keccak256(bytes(version)), chainId, verifyingContract, salt);
+        (, , , uint256 chainId, address verifyingContract, bytes32 salt, ) = eip712Domain();
+        return abi.encode(_EIP712NameHash(), _EIP712VersionHash(), chainId, verifyingContract, salt);
     }
 }

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -116,7 +116,7 @@ index 6a01f5616..b01c6e88f 100644
  }
  ```
 diff --git a/contracts/package.json b/contracts/package.json
-index 3535a2f56..9a73abc22 100644
+index c225e6ea8..3fdfb4e70 100644
 --- a/contracts/package.json
 +++ b/contracts/package.json
 @@ -1,5 +1,5 @@
@@ -124,7 +124,7 @@ index 3535a2f56..9a73abc22 100644
 -  "name": "@openzeppelin/contracts",
 +  "name": "@openzeppelin/contracts-upgradeable",
    "description": "Secure Smart Contract library for Solidity",
-   "version": "5.5.0",
+   "version": "5.6.1",
    "files": [
 @@ -13,7 +13,7 @@
    },
@@ -173,7 +173,7 @@ index c156fa1cc..895e39342 100644
       * @dev Prevents a contract from calling itself, directly or indirectly.
       * Calling a `nonReentrant` function from another `nonReentrant`
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index 2bc45a4b2..a5aa41d21 100644
+index 9a13afcf2..13a2dae02 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -184,7 +184,7 @@ index 2bc45a4b2..a5aa41d21 100644
  import {IERC5267} from "../../interfaces/IERC5267.sol";
  
  /**
-@@ -25,33 +24,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+@@ -30,33 +29,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
   * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
   * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
   *
@@ -222,7 +222,7 @@ index 2bc45a4b2..a5aa41d21 100644
  
      /**
       * @dev Initializes the domain separator and parameter caches.
-@@ -66,29 +50,19 @@ abstract contract EIP712 is IERC5267 {
+@@ -71,25 +55,15 @@ abstract contract EIP712 is IERC5267 {
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
@@ -251,12 +251,7 @@ index 2bc45a4b2..a5aa41d21 100644
      }
  
      function _buildDomainSeparator() private view returns (bytes32) {
--        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));
-+        return keccak256(abi.encode(TYPE_HASH, _EIP712NameHash(), _EIP712VersionHash(), block.chainid, address(this)));
-     }
- 
-     /**
-@@ -139,22 +113,38 @@ abstract contract EIP712 is IERC5267 {
+@@ -144,34 +118,38 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *
@@ -279,34 +274,40 @@ index 2bc45a4b2..a5aa41d21 100644
 -     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
 +     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
 +     * are a concern.
-+     */
+      */
+-    // solhint-disable-next-line func-name-mixedcase
+-    function _EIP712Version() internal view returns (string memory) {
+-        return _version.toStringWithFallback(_versionFallback);
 +    function _EIP712Version() internal view virtual returns (string memory) {
 +        return _version;
-+    }
-+
+     }
+ 
+-    /// @dev The hash of the name parameter for the EIP712 domain.
+-    // solhint-disable-next-line func-name-mixedcase
 +    /**
 +     * @dev The hash of the name parameter for the EIP712 domain.
 +     *
 +     * NOTE: In previous versions this function was virtual. In this version you should override `_EIP712Name` instead.
 +     */
-+    function _EIP712NameHash() internal view returns (bytes32) {
+     function _EIP712NameHash() internal view returns (bytes32) {
+-        return _hashedName;
 +        return keccak256(bytes(_EIP712Name()));
-+    }
-+
+     }
+ 
+-    /// @dev The hash of the version parameter for the EIP712 domain.
+-    // solhint-disable-next-line func-name-mixedcase
 +    /**
 +     * @dev The hash of the version parameter for the EIP712 domain.
 +     *
 +     * NOTE: In previous versions this function was virtual. In this version you should override `_EIP712Version` instead.
-      */
--    // solhint-disable-next-line func-name-mixedcase
--    function _EIP712Version() internal view returns (string memory) {
--        return _version.toStringWithFallback(_versionFallback);
-+    function _EIP712VersionHash() internal view returns (bytes32) {
++     */
+     function _EIP712VersionHash() internal view returns (bytes32) {
+-        return _hashedVersion;
 +        return keccak256(bytes(_EIP712Version()));
      }
  }
 diff --git a/package.json b/package.json
-index 6f2d411dd..956933f33 100644
+index c52bc6541..1ec73d8fa 100644
 --- a/package.json
 +++ b/package.json
 @@ -35,7 +35,7 @@


### PR DESCRIPTION
## Summary

Introduces two internal getters on `EIP712` — `_EIP712NameHash()` and `_EIP712VersionHash()` — and routes both the domain separator construction (`_buildDomainSeparator`) and `ERC7739._buildDomainBytes()` through them instead of reading the `_hashedName`/`_hashedVersion` immutables (resp. re-hashing the strings returned by `eip712Domain()`).

## Motivation

The non-upgradeable `EIP712` is designed to work behind proxies/clones, but its ERC-5267 getters (`_EIP712Name`/`_EIP712Version`) fall back to storage when the name or version does not fit in an immutable `ShortString` (> 31 characters). Behind a clone that storage is empty, so any code deriving the domain from `eip712Domain()` breaks.

`ERC7739._buildDomainBytes()` previously destructured `name`/`version` from `eip712Domain()` and re-hashed them, inheriting that failure mode. It now uses `_EIP712NameHash()`/`_EIP712VersionHash()`, which read the immutables directly and are preserved across clones. A doc note on `EIP712` documents the 31-character guidance for clone/proxy usage.

## Changes

- `EIP712`: add `_EIP712NameHash()` / `_EIP712VersionHash()`; use them in `_buildDomainSeparator`.
- `ERC7739`: derive `_buildDomainBytes()` from the new getters.
- Doc note on the proxy/clone name/version length constraint.

## Testing

`EIP712.test.js` and `ERC7739.test.js` pass (34 tests).