### PR TITLE
Add MessageHashUtils.domainBytes helper for EIP-712 domain encoding

### DIFF
--- a/.changeset/tame-actors-jog.md
+++ b/.changeset/tame-actors-jog.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`MessageHashUtils`: Add a `domainBytes` function that abi-encodes the EIP-712 domain fields, and use it in `ERC7739` to build the `TypedDataSign` domain payload.

--- a/contracts/utils/cryptography/MessageHashUtils.sol
+++ b/contracts/utils/cryptography/MessageHashUtils.sol
@@ -178,6 +178,37 @@ library MessageHashUtils {
         }
     }
 
+    /**
+     * @dev Returns the abi-encoded EIP-712 domain fields (hashed name, hashed version, chainId,
+     * verifyingContract and salt), matching the `TypedDataSign` extension defined by
+     * https://eips.ethereum.org/EIPS/eip-5267[ERC-5267] and used to bind a nested typed data signature (e.g.
+     * https://ercs.ethereum.org/ERCS/erc-7739[ERC-7739]) to a specific EIP-712 domain.
+     *
+     * NOTE: Unlike {toDomainSeparator}, this function always includes all five domain fields. The
+     * `TypedDataSign` typehash this bytes payload is combined with hardcodes all five fields, so there is no
+     * `fields`-aware variant.
+     */
+    function domainBytes(
+        string memory name,
+        string memory version,
+        uint256 chainId,
+        address verifyingContract,
+        bytes32 salt
+    ) internal pure returns (bytes memory) {
+        return domainBytes(keccak256(bytes(name)), keccak256(bytes(version)), chainId, verifyingContract, salt);
+    }
+
+    /// @dev Variant of {domainBytes-string-string-uint256-address-bytes32} that uses hashed name and version.
+    function domainBytes(
+        bytes32 nameHash,
+        bytes32 versionHash,
+        uint256 chainId,
+        address verifyingContract,
+        bytes32 salt
+    ) internal pure returns (bytes memory) {
+        return abi.encode(nameHash, versionHash, chainId, verifyingContract, salt);
+    }
+
     /// @dev Builds an EIP-712 domain type hash depending on the `fields` provided, following https://eips.ethereum.org/EIPS/eip-5267[ERC-5267]
     function toDomainTypeHash(bytes1 fields) internal pure returns (bytes32 hash) {
         if (fields & 0x20 == 0x20) revert ERC5267ExtensionsNotSupported();

--- a/contracts/utils/cryptography/signers/draft-ERC7739.sol
+++ b/contracts/utils/cryptography/signers/draft-ERC7739.sol
@@ -84,6 +84,10 @@ abstract contract ERC7739 is AbstractSigner, EIP712, IERC1271 {
             );
     }
 
+    /**
+     * @dev Builds the abi-encoded EIP-712 domain fields used to bind a nested typed data signature to this
+     * contract's domain. See {MessageHashUtils-domainBytes}.
+     */
     function _buildDomainBytes() private view returns (bytes memory) {
         (
             ,
@@ -94,6 +98,6 @@ abstract contract ERC7739 is AbstractSigner, EIP712, IERC1271 {
             bytes32 salt,
 
         ) = eip712Domain();
-        return abi.encode(keccak256(bytes(name)), keccak256(bytes(version)), chainId, verifyingContract, salt);
+        return MessageHashUtils.domainBytes(name, version, chainId, verifyingContract, salt);
     }
 }

--- a/test/utils/cryptography/MessageHashUtils.test.js
+++ b/test/utils/cryptography/MessageHashUtils.test.js
@@ -145,5 +145,61 @@ describe('MessageHashUtils', function () {
         });
       });
     }
+
+    describe('domainBytes', function () {
+      const expected = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['bytes32', 'bytes32', 'uint256', 'address', 'bytes32'],
+        [
+          ethers.id(fullDomain.name),
+          ethers.id(fullDomain.version),
+          fullDomain.chainId,
+          fullDomain.verifyingContract,
+          fullDomain.salt,
+        ],
+      );
+
+      it('domainBytes(string,string,uint256,address,bytes32)', async function () {
+        await expect(
+          this.mock.getFunction('$domainBytes(string,string,uint256,address,bytes32)')(
+            fullDomain.name,
+            fullDomain.version,
+            fullDomain.chainId,
+            fullDomain.verifyingContract,
+            fullDomain.salt,
+          ),
+        ).to.eventually.equal(expected);
+      });
+
+      it('domainBytes(bytes32,bytes32,uint256,address,bytes32)', async function () {
+        await expect(
+          this.mock.getFunction('$domainBytes(bytes32,bytes32,uint256,address,bytes32)')(
+            ethers.id(fullDomain.name),
+            ethers.id(fullDomain.version),
+            fullDomain.chainId,
+            fullDomain.verifyingContract,
+            fullDomain.salt,
+          ),
+        ).to.eventually.equal(expected);
+      });
+
+      it('version match', async function () {
+        const fromStrings = await this.mock.getFunction('$domainBytes(string,string,uint256,address,bytes32)')(
+          fullDomain.name,
+          fullDomain.version,
+          fullDomain.chainId,
+          fullDomain.verifyingContract,
+          fullDomain.salt,
+        );
+        const fromHashes = await this.mock.getFunction('$domainBytes(bytes32,bytes32,uint256,address,bytes32)')(
+          ethers.id(fullDomain.name),
+          ethers.id(fullDomain.version),
+          fullDomain.chainId,
+          fullDomain.verifyingContract,
+          fullDomain.salt,
+        );
+
+        expect(fromStrings).to.equal(fromHashes);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #6620.

`ERC7739._buildDomainBytes` abi-encodes the five EIP-712 domain fields into the payload consumed by `ERC7739Utils.typedDataSignStructHash`. This extracts that encoding into `MessageHashUtils.domainBytes`, next to `toDomainSeparator`, and has `_buildDomainBytes` delegate to it.

As noted in the issue, this always encodes all five fields — the `TypedDataSign` typehash it feeds into is normative and doesn't support the ERC-5267 `fields` subset selection that `toDomainSeparator` supports.

## Test plan

- [x] `npm run compile`
- [x] `npx hardhat test test/utils/cryptography/MessageHashUtils.test.js test/utils/cryptography/ERC7739.test.js test/utils/cryptography/ERC7739Utils.test.js test/utils/cryptography/ERC1271.behavior.js`
- [x] `npm run lint`
- [x] `npm run test:inheritance`
- [x] Added `domainBytes` coverage in `MessageHashUtils.test.js`