### PR TITLE
Remove EIP712 storage fallback for name/version

### DIFF
--- a/.changeset/eip712-drop-string-fallback.md
+++ b/.changeset/eip712-drop-string-fallback.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`EIP712`: Drop the storage fallback for long `name`/`version` values. Both parameters must now fit in a `ShortString` (at most 31 bytes) or the constructor reverts with `ShortStrings.StringTooLong`. Storing the domain exclusively in immutables keeps the domain (and downstream `ERC7739` verification) consistent when the contract is used behind a proxy or clone without an initializer.

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -53,6 +53,14 @@ abstract contract EIP712 is IERC5267 {
     ShortString private immutable _name;
     ShortString private immutable _version;
 
+    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+    // slither-disable-next-line constable-states
+    string private _nameFallback;
+
+    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+    // slither-disable-next-line constable-states
+    string private _versionFallback;
+
     /**
      * @dev Initializes the domain separator and parameter caches.
      *

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -29,6 +29,10 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
  * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
  *
+ * IMPORTANT: The `name` and `version` must each fit in a `ShortString` (at most 31 bytes). Longer values cause the
+ * constructor to revert with a `ShortStrings.StringTooLong` error. Because the values are stored exclusively in
+ * immutables, the domain is preserved when the contract is used behind a proxy or clone without an initializer.
+ *
  * @custom:oz-upgrades-unsafe-allow state-variable-immutable
  */
 abstract contract EIP712 is IERC5267 {
@@ -48,10 +52,6 @@ abstract contract EIP712 is IERC5267 {
 
     ShortString private immutable _name;
     ShortString private immutable _version;
-    // slither-disable-next-line constable-states
-    string private _nameFallback;
-    // slither-disable-next-line constable-states
-    string private _versionFallback;
 
     /**
      * @dev Initializes the domain separator and parameter caches.
@@ -66,8 +66,8 @@ abstract contract EIP712 is IERC5267 {
      * contract upgrade].
      */
     constructor(string memory name, string memory version) {
-        _name = name.toShortStringWithFallback(_nameFallback);
-        _version = version.toShortStringWithFallback(_versionFallback);
+        _name = name.toShortString();
+        _version = version.toShortString();
         _hashedName = keccak256(bytes(name));
         _hashedVersion = keccak256(bytes(version));
 
@@ -127,8 +127,8 @@ abstract contract EIP712 is IERC5267 {
     {
         return (
             hex"0f", // 01111
-            _EIP712Name(),
-            _EIP712Version(),
+            _name.toString(),
+            _version.toString(),
             block.chainid,
             address(this),
             bytes32(0),
@@ -139,22 +139,20 @@ abstract contract EIP712 is IERC5267 {
     /**
      * @dev The name parameter for the EIP712 domain.
      *
-     * NOTE: By default this function reads _name which is an immutable value.
-     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+     * NOTE: This function reads `_name`, which is an immutable value.
      */
     // solhint-disable-next-line func-name-mixedcase
     function _EIP712Name() internal view returns (string memory) {
-        return _name.toStringWithFallback(_nameFallback);
+        return _name.toString();
     }
 
     /**
      * @dev The version parameter for the EIP712 domain.
      *
-     * NOTE: By default this function reads _version which is an immutable value.
-     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+     * NOTE: This function reads `_version`, which is an immutable value.
      */
     // solhint-disable-next-line func-name-mixedcase
     function _EIP712Version() internal view returns (string memory) {
-        return _version.toStringWithFallback(_versionFallback);
+        return _version.toString();
     }
 }

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -127,8 +127,8 @@ abstract contract EIP712 is IERC5267 {
     {
         return (
             hex"0f", // 01111
-            _name.toString(),
-            _version.toString(),
+            _EIP712Name(),
+            _EIP712Version(),
             block.chainid,
             address(this),
             bytes32(0),

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -53,11 +53,13 @@ abstract contract EIP712 is IERC5267 {
     ShortString private immutable _name;
     ShortString private immutable _version;
 
-    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+    // IMPORTANT: Deprecated. Kept to preserve the storage layout of inheriting contracts used as an
+    // implementation behind a proxy.
     // slither-disable-next-line constable-states
     string private _nameFallback;
 
-    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+    // IMPORTANT: Deprecated. Kept to preserve the storage layout of inheriting contracts used as an
+    // implementation behind a proxy.
     // slither-disable-next-line constable-states
     string private _versionFallback;
 

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -116,7 +116,7 @@ index 6a01f5616..b01c6e88f 100644
  }
  ```
 diff --git a/contracts/package.json b/contracts/package.json
-index 3535a2f56..9a73abc22 100644
+index c225e6ea8..3fdfb4e70 100644
 --- a/contracts/package.json
 +++ b/contracts/package.json
 @@ -1,5 +1,5 @@
@@ -124,7 +124,7 @@ index 3535a2f56..9a73abc22 100644
 -  "name": "@openzeppelin/contracts",
 +  "name": "@openzeppelin/contracts-upgradeable",
    "description": "Secure Smart Contract library for Solidity",
-   "version": "5.5.0",
+   "version": "5.6.1",
    "files": [
 @@ -13,7 +13,7 @@
    },
@@ -173,7 +173,7 @@ index c156fa1cc..895e39342 100644
       * @dev Prevents a contract from calling itself, directly or indirectly.
       * Calling a `nonReentrant` function from another `nonReentrant`
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index 2bc45a4b2..a5aa41d21 100644
+index adb2835e0..a5aa41d21 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -191,6 +191,10 @@ index 2bc45a4b2..a5aa41d21 100644
 - * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain
 - * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
 - * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
+- *
+- * IMPORTANT: The `name` and `version` must each fit in a `ShortString` (at most 31 bytes). Longer values cause the
+- * constructor to revert with a `ShortStrings.StringTooLong` error. Because the values are stored exclusively in
+- * immutables, the domain is preserved when the contract is used behind a proxy or clone without an initializer.
 - *
 - * @custom:oz-upgrades-unsafe-allow state-variable-immutable
 + * NOTE: The upgradeable version of this contract does not use an immutable cache and recomputes the domain separator
@@ -213,10 +217,6 @@ index 2bc45a4b2..a5aa41d21 100644
  
 -    ShortString private immutable _name;
 -    ShortString private immutable _version;
--    // slither-disable-next-line constable-states
--    string private _nameFallback;
--    // slither-disable-next-line constable-states
--    string private _versionFallback;
 +    string private _name;
 +    string private _version;
  
@@ -226,8 +226,8 @@ index 2bc45a4b2..a5aa41d21 100644
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
--        _name = name.toShortStringWithFallback(_nameFallback);
--        _version = version.toShortStringWithFallback(_versionFallback);
+-        _name = name.toShortString();
+-        _version = version.toShortString();
 -        _hashedName = keccak256(bytes(name));
 -        _hashedVersion = keccak256(bytes(version));
 -
@@ -256,18 +256,17 @@ index 2bc45a4b2..a5aa41d21 100644
      }
  
      /**
-@@ -139,22 +113,38 @@ abstract contract EIP712 is IERC5267 {
+@@ -139,20 +113,38 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *
--     * NOTE: By default this function reads _name which is an immutable value.
--     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+-     * NOTE: This function reads `_name`, which is an immutable value.
 +     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
 +     * are a concern.
       */
 -    // solhint-disable-next-line func-name-mixedcase
 -    function _EIP712Name() internal view returns (string memory) {
--        return _name.toStringWithFallback(_nameFallback);
+-        return _name.toString();
 +    function _EIP712Name() internal view virtual returns (string memory) {
 +        return _name;
      }
@@ -275,8 +274,7 @@ index 2bc45a4b2..a5aa41d21 100644
      /**
       * @dev The version parameter for the EIP712 domain.
       *
--     * NOTE: By default this function reads _version which is an immutable value.
--     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+-     * NOTE: This function reads `_version`, which is an immutable value.
 +     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
 +     * are a concern.
 +     */
@@ -300,13 +298,13 @@ index 2bc45a4b2..a5aa41d21 100644
       */
 -    // solhint-disable-next-line func-name-mixedcase
 -    function _EIP712Version() internal view returns (string memory) {
--        return _version.toStringWithFallback(_versionFallback);
+-        return _version.toString();
 +    function _EIP712VersionHash() internal view returns (bytes32) {
 +        return keccak256(bytes(_EIP712Version()));
      }
  }
 diff --git a/package.json b/package.json
-index 6f2d411dd..956933f33 100644
+index c52bc6541..1ec73d8fa 100644
 --- a/package.json
 +++ b/package.json
 @@ -35,7 +35,7 @@
@@ -357,34 +355,69 @@ index 86816e55e..de6adc2c5 100644
      verifyingContract: mock.address,
    };
 diff --git a/test/utils/cryptography/EIP712.test.js b/test/utils/cryptography/EIP712.test.js
-index 2b6e7fa97..268e0d29d 100644
+index 54e5b78ec..13a859b16 100644
 --- a/test/utils/cryptography/EIP712.test.js
 +++ b/test/utils/cryptography/EIP712.test.js
-@@ -47,27 +47,6 @@ describe('EIP712', function () {
-           const rebuildDomain = await getDomain(this.eip712);
-           expect(rebuildDomain).to.be.deep.equal(this.domain);
-         });
+@@ -31,7 +31,6 @@ describe('EIP712', function () {
+     describe('domain separator', function () {
+       it('is internally available', async function () {
+         const expected = await domainSeparator(this.domain);
 -
--        if (shortOrLong === 'short') {
--          // Long strings are in storage, and the proxy will not be properly initialized unless
--          // the upgradeable contract variant is used and the initializer is invoked.
--
--          it('adjusts when behind proxy', async function () {
--            const factory = await ethers.deployContract('$Clones');
--
--            const clone = await factory
--              .$clone(this.eip712)
--              .then(tx => tx.wait())
--              .then(receipt => receipt.logs.find(ev => ev.fragment.name == 'return$clone_address').args.instance)
--              .then(address => ethers.getContractAt('$EIP712Verifier', address));
--
--            const expectedDomain = { ...this.domain, verifyingContract: clone.target };
--            expect(await getDomain(clone)).to.be.deep.equal(expectedDomain);
--
--            const expectedSeparator = await domainSeparator(expectedDomain);
--            expect(await clone.$_domainSeparatorV4()).to.equal(expectedSeparator);
--          });
--        }
+         expect(await this.eip712.$_domainSeparatorV4()).to.equal(expected);
        });
  
-       it('hash digest', async function () {
+@@ -39,22 +38,6 @@ describe('EIP712', function () {
+         const rebuildDomain = await getDomain(this.eip712);
+         expect(rebuildDomain).to.be.deep.equal(this.domain);
+       });
+-
+-      it('adjusts when behind proxy', async function () {
+-        const factory = await ethers.deployContract('$Clones');
+-
+-        const clone = await factory
+-          .$clone(this.eip712)
+-          .then(tx => tx.wait())
+-          .then(receipt => receipt.logs.find(ev => ev.fragment.name == 'return$clone_address').args.instance)
+-          .then(address => ethers.getContractAt('$EIP712Verifier', address));
+-
+-        const expectedDomain = { ...this.domain, verifyingContract: clone.target };
+-        expect(await getDomain(clone)).to.be.deep.equal(expectedDomain);
+-
+-        const expectedSeparator = await domainSeparator(expectedDomain);
+-        expect(await clone.$_domainSeparatorV4()).to.equal(expectedSeparator);
+-      });
+     });
+ 
+     it('hash digest', async function () {
+@@ -90,18 +73,23 @@ describe('EIP712', function () {
+   });
+ 
+   describe('with long name and version', function () {
+-    it('deployment fails with long name', async function () {
++    it('upgradeable version supports long name', async function () {
+       const longName = 'A'.repeat(32);
+-      await expect(ethers.deployContract('$EIP712Verifier', [longName, version]))
+-        .to.be.revertedWithCustomError(this.eip712, 'StringTooLong')
+-        .withArgs(longName);
++      const instance = await ethers.deployContract('$EIP712Verifier', [longName, version]);
++
++      await expect(instance.$_EIP712Name()).to.eventually.equal(longName);
++      await expect(instance.$_EIP712Version()).to.eventually.equal(version);
++      await expect(getDomain(instance)).to.eventually.be.deep.equal({ ...this.domain, name: longName });
++
+     });
+ 
+-    it('deployment fails with long version', async function () {
++    it('upgradeable version supports long version', async function () {
+       const longVersion = 'B'.repeat(32);
+-      await expect(ethers.deployContract('$EIP712Verifier', [name, longVersion]))
+-        .to.be.revertedWithCustomError(this.eip712, 'StringTooLong')
+-        .withArgs(longVersion);
++      const instance = await ethers.deployContract('$EIP712Verifier', [name, longVersion]);
++
++      await expect(instance.$_EIP712Name()).to.eventually.equal(name);
++      await expect(instance.$_EIP712Version()).to.eventually.equal(longVersion);
++      await expect(getDomain(instance)).to.eventually.be.deep.equal({ ...this.domain, version: longVersion });
+     });
+   });
+ });

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -173,7 +173,7 @@ index c156fa1cc..895e39342 100644
       * @dev Prevents a contract from calling itself, directly or indirectly.
       * Calling a `nonReentrant` function from another `nonReentrant`
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index adb2835e0..a5aa41d21 100644
+index 5daec8e1b..d637e9746 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -220,9 +220,9 @@ index adb2835e0..a5aa41d21 100644
 +    string private _name;
 +    string private _version;
  
-     /**
-      * @dev Initializes the domain separator and parameter caches.
-@@ -66,29 +50,19 @@ abstract contract EIP712 is IERC5267 {
+     // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+     // slither-disable-next-line constable-states
+@@ -74,29 +58,19 @@ abstract contract EIP712 is IERC5267 {
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
@@ -256,7 +256,7 @@ index adb2835e0..a5aa41d21 100644
      }
  
      /**
-@@ -139,20 +113,38 @@ abstract contract EIP712 is IERC5267 {
+@@ -147,20 +121,38 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -355,7 +355,7 @@ index 86816e55e..de6adc2c5 100644
      verifyingContract: mock.address,
    };
 diff --git a/test/utils/cryptography/EIP712.test.js b/test/utils/cryptography/EIP712.test.js
-index 54e5b78ec..13a859b16 100644
+index 54e5b78ec..ea9e0ca39 100644
 --- a/test/utils/cryptography/EIP712.test.js
 +++ b/test/utils/cryptography/EIP712.test.js
 @@ -31,7 +31,6 @@ describe('EIP712', function () {
@@ -389,7 +389,7 @@ index 54e5b78ec..13a859b16 100644
      });
  
      it('hash digest', async function () {
-@@ -90,18 +73,23 @@ describe('EIP712', function () {
+@@ -90,18 +73,30 @@ describe('EIP712', function () {
    });
  
    describe('with long name and version', function () {
@@ -403,8 +403,11 @@ index 54e5b78ec..13a859b16 100644
 +
 +      await expect(instance.$_EIP712Name()).to.eventually.equal(longName);
 +      await expect(instance.$_EIP712Version()).to.eventually.equal(version);
-+      await expect(getDomain(instance)).to.eventually.be.deep.equal({ ...this.domain, name: longName });
-+
++      await expect(getDomain(instance)).to.eventually.be.deep.equal({
++        ...this.domain,
++        name: longName,
++        verifyingContract: instance.target,
++      });
      });
  
 -    it('deployment fails with long version', async function () {
@@ -417,7 +420,11 @@ index 54e5b78ec..13a859b16 100644
 +
 +      await expect(instance.$_EIP712Name()).to.eventually.equal(name);
 +      await expect(instance.$_EIP712Version()).to.eventually.equal(longVersion);
-+      await expect(getDomain(instance)).to.eventually.be.deep.equal({ ...this.domain, version: longVersion });
++      await expect(getDomain(instance)).to.eventually.be.deep.equal({
++        ...this.domain,
++        version: longVersion,
++        verifyingContract: instance.target,
++      });
      });
    });
  });

--- a/scripts/upgradeable/upgradeable.patch
+++ b/scripts/upgradeable/upgradeable.patch
@@ -173,7 +173,7 @@ index c156fa1cc..895e39342 100644
       * @dev Prevents a contract from calling itself, directly or indirectly.
       * Calling a `nonReentrant` function from another `nonReentrant`
 diff --git a/contracts/utils/cryptography/EIP712.sol b/contracts/utils/cryptography/EIP712.sol
-index 5daec8e1b..d637e9746 100644
+index 5daec8e1b..a5aa41d21 100644
 --- a/contracts/utils/cryptography/EIP712.sol
 +++ b/contracts/utils/cryptography/EIP712.sol
 @@ -4,7 +4,6 @@
@@ -184,7 +184,7 @@ index 5daec8e1b..d637e9746 100644
  import {IERC5267} from "../../interfaces/IERC5267.sol";
  
  /**
-@@ -25,33 +24,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
+@@ -25,41 +24,18 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
   * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
   * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
   *
@@ -217,12 +217,20 @@ index 5daec8e1b..d637e9746 100644
  
 -    ShortString private immutable _name;
 -    ShortString private immutable _version;
+-
+-    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+-    // slither-disable-next-line constable-states
+-    string private _nameFallback;
+-
+-    // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
+-    // slither-disable-next-line constable-states
+-    string private _versionFallback;
 +    string private _name;
 +    string private _version;
  
-     // IMPORTANT: Deprecated. Kept for storage compliance when used behind a proxy or clone.
-     // slither-disable-next-line constable-states
-@@ -74,29 +58,19 @@ abstract contract EIP712 is IERC5267 {
+     /**
+      * @dev Initializes the domain separator and parameter caches.
+@@ -74,29 +50,19 @@ abstract contract EIP712 is IERC5267 {
       * contract upgrade].
       */
      constructor(string memory name, string memory version) {
@@ -256,7 +264,7 @@ index 5daec8e1b..d637e9746 100644
      }
  
      /**
-@@ -147,20 +121,38 @@ abstract contract EIP712 is IERC5267 {
+@@ -147,20 +113,38 @@ abstract contract EIP712 is IERC5267 {
      /**
       * @dev The name parameter for the EIP712 domain.
       *

--- a/test/utils/cryptography/EIP712.test.js
+++ b/test/utils/cryptography/EIP712.test.js
@@ -5,101 +5,103 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { getDomain, domainSeparator, hashTypedData } = require('../../helpers/eip712');
 const { formatType } = require('../../helpers/eip712-types');
 
-const LENGTHS = {
-  short: ['A Name', '1'],
-  long: ['A'.repeat(40), 'B'.repeat(40)],
-};
+const name = 'A Name';
+const version = '1';
 
 const fixture = async () => {
   const [from, to] = await ethers.getSigners();
 
-  const lengths = {};
-  for (const [shortOrLong, [name, version]] of Object.entries(LENGTHS)) {
-    lengths[shortOrLong] = { name, version };
-    lengths[shortOrLong].eip712 = await ethers.deployContract('$EIP712Verifier', [name, version]);
-    lengths[shortOrLong].domain = {
-      name,
-      version,
-      chainId: await ethers.provider.getNetwork().then(({ chainId }) => chainId),
-      verifyingContract: lengths[shortOrLong].eip712.target,
-    };
-  }
+  const eip712 = await ethers.deployContract('$EIP712Verifier', [name, version]);
+  const domain = await ethers.provider.getNetwork().then(({ chainId }) => ({
+    name,
+    version,
+    chainId,
+    verifyingContract: eip712.target,
+  }));
 
-  return { from, to, lengths };
+  return { from, to, eip712, domain };
 };
 
 describe('EIP712', function () {
-  for (const [shortOrLong, [name, version]] of Object.entries(LENGTHS)) {
-    describe(`with ${shortOrLong} name and version`, function () {
-      beforeEach('deploying', async function () {
-        Object.assign(this, await loadFixture(fixture));
-        Object.assign(this, this.lengths[shortOrLong]);
+  beforeEach('deploying', async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  describe('with short name and version', function () {
+    describe('domain separator', function () {
+      it('is internally available', async function () {
+        const expected = await domainSeparator(this.domain);
+
+        expect(await this.eip712.$_domainSeparatorV4()).to.equal(expected);
       });
 
-      describe('domain separator', function () {
-        it('is internally available', async function () {
-          const expected = await domainSeparator(this.domain);
-
-          expect(await this.eip712.$_domainSeparatorV4()).to.equal(expected);
-        });
-
-        it("can be rebuilt using EIP-5267's eip712Domain", async function () {
-          const rebuildDomain = await getDomain(this.eip712);
-          expect(rebuildDomain).to.be.deep.equal(this.domain);
-        });
-
-        if (shortOrLong === 'short') {
-          // Long strings are in storage, and the proxy will not be properly initialized unless
-          // the upgradeable contract variant is used and the initializer is invoked.
-
-          it('adjusts when behind proxy', async function () {
-            const factory = await ethers.deployContract('$Clones');
-
-            const clone = await factory
-              .$clone(this.eip712)
-              .then(tx => tx.wait())
-              .then(receipt => receipt.logs.find(ev => ev.fragment.name == 'return$clone_address').args.instance)
-              .then(address => ethers.getContractAt('$EIP712Verifier', address));
-
-            const expectedDomain = { ...this.domain, verifyingContract: clone.target };
-            expect(await getDomain(clone)).to.be.deep.equal(expectedDomain);
-
-            const expectedSeparator = await domainSeparator(expectedDomain);
-            expect(await clone.$_domainSeparatorV4()).to.equal(expectedSeparator);
-          });
-        }
+      it("can be rebuilt using EIP-5267's eip712Domain", async function () {
+        const rebuildDomain = await getDomain(this.eip712);
+        expect(rebuildDomain).to.be.deep.equal(this.domain);
       });
 
-      it('hash digest', async function () {
-        const structhash = ethers.hexlify(ethers.randomBytes(32));
-        expect(await this.eip712.$_hashTypedDataV4(structhash)).to.equal(hashTypedData(this.domain, structhash));
-      });
+      it('adjusts when behind proxy', async function () {
+        const factory = await ethers.deployContract('$Clones');
 
-      it('digest', async function () {
-        const types = {
-          Mail: formatType({
-            to: 'address',
-            contents: 'string',
-          }),
-        };
+        const clone = await factory
+          .$clone(this.eip712)
+          .then(tx => tx.wait())
+          .then(receipt => receipt.logs.find(ev => ev.fragment.name == 'return$clone_address').args.instance)
+          .then(address => ethers.getContractAt('$EIP712Verifier', address));
 
-        const message = {
-          to: this.to.address,
-          contents: 'very interesting',
-        };
+        const expectedDomain = { ...this.domain, verifyingContract: clone.target };
+        expect(await getDomain(clone)).to.be.deep.equal(expectedDomain);
 
-        const signature = await this.from.signTypedData(this.domain, types, message);
-
-        await expect(this.eip712.verify(signature, this.from.address, message.to, message.contents)).to.not.be.reverted;
-      });
-
-      it('name', async function () {
-        expect(await this.eip712.$_EIP712Name()).to.equal(name);
-      });
-
-      it('version', async function () {
-        expect(await this.eip712.$_EIP712Version()).to.equal(version);
+        const expectedSeparator = await domainSeparator(expectedDomain);
+        expect(await clone.$_domainSeparatorV4()).to.equal(expectedSeparator);
       });
     });
-  }
+
+    it('hash digest', async function () {
+      const structhash = ethers.hexlify(ethers.randomBytes(32));
+      expect(await this.eip712.$_hashTypedDataV4(structhash)).to.equal(hashTypedData(this.domain, structhash));
+    });
+
+    it('digest', async function () {
+      const types = {
+        Mail: formatType({
+          to: 'address',
+          contents: 'string',
+        }),
+      };
+
+      const message = {
+        to: this.to.address,
+        contents: 'very interesting',
+      };
+
+      const signature = await this.from.signTypedData(this.domain, types, message);
+
+      await expect(this.eip712.verify(signature, this.from.address, message.to, message.contents)).to.not.be.reverted;
+    });
+
+    it('name', async function () {
+      expect(await this.eip712.$_EIP712Name()).to.equal(name);
+    });
+
+    it('version', async function () {
+      expect(await this.eip712.$_EIP712Version()).to.equal(version);
+    });
+  });
+
+  describe('with long name and version', function () {
+    it('deployment fails with long name', async function () {
+      const longName = 'A'.repeat(32);
+      await expect(ethers.deployContract('$EIP712Verifier', [longName, version]))
+        .to.be.revertedWithCustomError(this.eip712, 'StringTooLong')
+        .withArgs(longName);
+    });
+
+    it('deployment fails with long version', async function () {
+      const longVersion = 'B'.repeat(32);
+      await expect(ethers.deployContract('$EIP712Verifier', [name, longVersion]))
+        .to.be.revertedWithCustomError(this.eip712, 'StringTooLong')
+        .withArgs(longVersion);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Alternative to #6629.

Both PRs address the same problem: the non-upgradeable `EIP712` is meant to work behind proxies/clones, but its ERC-5267 getters (`_EIP712Name`/`_EIP712Version`) fall back to storage when `name`/`version` exceed 31 bytes. Behind a clone that storage is empty, so any code deriving the domain from `eip712Domain()` — including `ERC7739._buildDomainBytes()` — breaks.

Where #6629 keeps the storage fallback and works around it by adding `_EIP712NameHash()`/`_EIP712VersionHash()` getters that read the immutables directly, this PR removes the storage fallback entirely and fixes the issue at its root.

## Changes

- `EIP712`: replace `toShortStringWithFallback`/`toStringWithFallback` with `toShortString`/`toString`. The `_nameFallback`/`_versionFallback` storage strings are removed. `name` and `version` must now fit in a `ShortString` (≤ 31 bytes); longer values revert in the constructor with `ShortStrings.StringTooLong`.
- Because the domain now lives exclusively in immutables (which survive `delegatecall` / clones), `eip712Domain()` is correct behind a proxy or clone with no initializer. `ERC7739._buildDomainBytes()` is therefore fixed with no change to `ERC7739`.
- Doc note documenting the 31-byte constraint and the proxy/clone guarantee; the stale "reads from storage" NOTE on the getters is removed.

## Trade-off vs #6629

- This PR is simpler (no new API surface, less storage/code) and makes the clone-safety guarantee structural rather than dependent on callers using the right getter.
- The cost is that names/versions longer than 31 bytes are no longer supported — a behavioral change for any deployment relying on the storage fallback. This is the maintainer decision to make between the two approaches.

## Testing

`EIP712.test.js` updated (long name/version now assert the `StringTooLong` revert; the clone test runs unconditionally). `EIP712.test.js` + `ERC7739.test.js` pass (30 tests), the latter unmodified.
