### PR TITLE
Documentation fixes for audit findings H-01, N-09, L-07

### DIFF
--- a/contracts/governance/extensions/GovernorCountingOverridable.sol
+++ b/contracts/governance/extensions/GovernorCountingOverridable.sol
@@ -13,9 +13,9 @@ import {IGovernor, Governor} from "../Governor.sol";
  * @dev Extension of {Governor} which enables delegators to override the vote of their delegates. This module requires a
  * token that inherits {VotesExtended}.
  *
- * NOTE: Override votes can only be cast while the proposal is {IGovernor-ProposalState-Active}. Mechanisms that
- * shorten the voting duration, such as the early closure implemented in {GovernorSuperQuorum}, may therefore prevent
- * token holders from overriding the votes cast with their tokens by their delegates.
+ * NOTE: Override votes can only be cast while the proposal is active. Mechanisms that shorten the voting duration,
+ * such as the early closure implemented in {GovernorSuperQuorum}, may therefore prevent token holders from overriding
+ * the votes cast with their tokens by their delegates.
  */
 abstract contract GovernorCountingOverridable is GovernorVotes {
     bytes32 public constant OVERRIDE_BALLOT_TYPEHASH =

--- a/contracts/governance/extensions/GovernorCountingOverridable.sol
+++ b/contracts/governance/extensions/GovernorCountingOverridable.sol
@@ -13,7 +13,7 @@ import {IGovernor, Governor} from "../Governor.sol";
  * @dev Extension of {Governor} which enables delegators to override the vote of their delegates. This module requires a
  * token that inherits {VotesExtended}.
  *
- * NOTE: Override votes can only be casted while the proposal is {IGovernor-ProposalState-Active}. Mechanisms that
+ * NOTE: Override votes can only be cast while the proposal is {IGovernor-ProposalState-Active}. Mechanisms that
  * shorten the voting duration, such as the early closure implemented in {GovernorSuperQuorum}, may therefore prevent
  * token holders from overriding the votes casted with their tokens by their delegates.
  */

--- a/contracts/governance/extensions/GovernorCountingOverridable.sol
+++ b/contracts/governance/extensions/GovernorCountingOverridable.sol
@@ -12,6 +12,10 @@ import {IGovernor, Governor} from "../Governor.sol";
 /**
  * @dev Extension of {Governor} which enables delegators to override the vote of their delegates. This module requires a
  * token that inherits {VotesExtended}.
+ *
+ * NOTE: Override votes can only be casted while the proposal is {IGovernor-ProposalState-Active}. Mechanisms that
+ * shorten the voting duration, such as the early closure implemented in {GovernorSuperQuorum}, may therefore prevent
+ * token holders from overriding the votes casted with their tokens by their delegates.
  */
 abstract contract GovernorCountingOverridable is GovernorVotes {
     bytes32 public constant OVERRIDE_BALLOT_TYPEHASH =

--- a/contracts/governance/extensions/GovernorCountingOverridable.sol
+++ b/contracts/governance/extensions/GovernorCountingOverridable.sol
@@ -15,7 +15,7 @@ import {IGovernor, Governor} from "../Governor.sol";
  *
  * NOTE: Override votes can only be cast while the proposal is {IGovernor-ProposalState-Active}. Mechanisms that
  * shorten the voting duration, such as the early closure implemented in {GovernorSuperQuorum}, may therefore prevent
- * token holders from overriding the votes casted with their tokens by their delegates.
+ * token holders from overriding the votes cast with their tokens by their delegates.
  */
 abstract contract GovernorCountingOverridable is GovernorVotes {
     bytes32 public constant OVERRIDE_BALLOT_TYPEHASH =

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -68,10 +68,9 @@ import {Math} from "../../../utils/math/Math.sol";
  * [CAUTION]
  * ====
  * Any mechanism that mints shares without a corresponding increase in the vault's assets (collateral) will alter the
- * exchange rate between shares and assets, and may open the door to vulnerabilities. In particular, this contract
+ * exchange rate and may open the door to vulnerabilities. In particular, this contract
  * must NOT be combined with {ERC20FlashMint}: flash-minting shares temporarily inflates the total supply without
- * backing it with additional assets, corrupting the exchange rate used by the deposit, mint, withdraw and redeem
- * conversions for the duration of the flash loan.
+ * increasing collateral, corrupting the exchange rate applied during the flash loan.
  * ====
  */
 abstract contract ERC4626 is ERC20, IERC4626 {

--- a/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/contracts/token/ERC20/extensions/ERC4626.sol
@@ -64,6 +64,15 @@ import {Math} from "../../../utils/math/Math.sol";
  * * If {previewRedeem} is overridden to revert, {maxWithdraw} must be overridden as necessary to ensure it
  * always return successfully.
  * ====
+ *
+ * [CAUTION]
+ * ====
+ * Any mechanism that mints shares without a corresponding increase in the vault's assets (collateral) will alter the
+ * exchange rate between shares and assets, and may open the door to vulnerabilities. In particular, this contract
+ * must NOT be combined with {ERC20FlashMint}: flash-minting shares temporarily inflates the total supply without
+ * backing it with additional assets, corrupting the exchange rate used by the deposit, mint, withdraw and redeem
+ * conversions for the duration of the flash loan.
+ * ====
  */
 abstract contract ERC4626 is ERC20, IERC4626 {
     using Math for uint256;

--- a/contracts/utils/cryptography/signers/SignerWebAuthn.sol
+++ b/contracts/utils/cryptography/signers/SignerWebAuthn.sol
@@ -10,8 +10,7 @@ import {WebAuthn} from "../WebAuthn.sol";
  * @dev Implementation of {SignerP256} that supports WebAuthn authentication assertions.
  *
  * This contract enables signature validation using WebAuthn authentication assertions,
- * leveraging the P256 public key stored in the contract. It allows for both WebAuthn
- * and raw P256 signature validation, providing compatibility with both signature types.
+ * leveraging the P256 public key stored in the contract.
  *
  * The signature is expected to be an abi-encoded {WebAuthn-WebAuthnAuth} struct.
  *


### PR DESCRIPTION
Documentation-only fixes addressing findings from the audit.

- **H-01** — `GovernorCountingOverridable`: document that override votes can only be cast while a proposal is `Active`, so mechanisms that shorten the voting window (e.g. the early closure in `GovernorSuperQuorum`) can prevent token holders from overriding votes cast by their delegates.
- **N-09** — `ERC4626`: document that any mechanism minting shares without a corresponding increase in collateral distorts the share/asset exchange rate, and that `ERC4626` must not be combined with `ERC20FlashMint`.
- **L-07** — `SignerWebAuthn`: fix the contract-level NatSpec that still advertised a raw P256 fallback, which was removed in #6337.

All changes are NatSpec-only, so no changeset is included.
