### PR TITLE
Use Math.mulDiv in ERC2981.royaltyInfo to avoid overflow on large salePrice

### DIFF
--- a/contracts/token/common/ERC2981.sol
+++ b/contracts/token/common/ERC2981.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 
 import {IERC2981} from "../../interfaces/IERC2981.sol";
 import {IERC165, ERC165} from "../../utils/introspection/ERC165.sol";
+import {Math} from "../../utils/math/Math.sol";
 
 /**
  * @dev Implementation of the NFT Royalty Standard, a standardized way to retrieve royalty payment information.
@@ -67,7 +68,7 @@ abstract contract ERC2981 is IERC2981, ERC165 {
             royaltyFraction = _defaultRoyaltyInfo.royaltyFraction;
         }
 
-        uint256 royaltyAmount = (salePrice * royaltyFraction) / _feeDenominator();
+        uint256 royaltyAmount = Math.mulDiv(salePrice, royaltyFraction, _feeDenominator());
 
         return (royaltyReceiver, royaltyAmount);
     }


### PR DESCRIPTION
## Summary

`ERC2981.royaltyInfo` computes `(salePrice * royaltyFraction) / _feeDenominator()` using checked arithmetic. When `royaltyFraction` is non-zero, a sufficiently large (attacker-controlled) `salePrice` overflows the intermediate multiplication and reverts, which can block settlement flows in integrators that call `royaltyInfo` inside state-changing paths without handling a revert.

This replaces the manual `mul`/`div` with `Math.mulDiv`, which uses a full-precision (512-bit) intermediate so no overflow occurs, while preserving the intended truncation (floor division) semantics.

## Reference

Addresses issue N-07.