### PR TITLE
Make  fail closed on modexp failure

### DIFF
--- a/.changeset/twenty-states-taste.md
+++ b/.changeset/twenty-states-taste.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Return `false` from `pkcs1Sha256` instead of reverting when modular exponentiation fails (e.g. the precompile runs out of gas on oversized inputs).

--- a/.changeset/twenty-states-taste.md
+++ b/.changeset/twenty-states-taste.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-Return `false` from `pkcs1Sha256` instead of reverting when modular exponentiation fails (e.g. the precompile runs out of gas on oversized inputs).
+`RSA`: Return `false` from `pkcs1Sha256` instead of reverting when modular exponentiation fails.

--- a/contracts/utils/cryptography/RSA.sol
+++ b/contracts/utils/cryptography/RSA.sol
@@ -78,8 +78,12 @@ library RSA {
             }
 
             // RSAVP1 https://datatracker.ietf.org/doc/html/rfc8017#section-5.2.2
-            // The previous check guarantees that n > 0. Therefore modExp cannot revert.
-            bytes memory buffer = Math.modExp(s, e, n);
+            // The previous check guarantees that n > 0. Therefore tryModExp can only fail if the precompile runs
+            // out of gas (e.g. oversized inputs); fail closed in that case.
+            (bool success, bytes memory buffer) = Math.tryModExp(s, e, n);
+            if (!success) {
+                return false;
+            }
 
             // Check that buffer is well encoded:
             // buffer ::= 0x00 | 0x01 | PS | 0x00 | DigestInfo

--- a/test/utils/cryptography/RSA.test.js
+++ b/test/utils/cryptography/RSA.test.js
@@ -99,4 +99,22 @@ describe('RSA', function () {
       });
     }
   });
+
+  // Regression: a modexp precompile failure must make verification fail closed (return false) rather than revert.
+  // The precompile can only fail by running out of gas, so we force that with an oversized exponent whose modexp
+  // gas cost far exceeds the gas forwarded to the precompile under a capped gas limit. Because the staticcall keeps
+  // the EIP-150 1/64th gas reserve, the outer call still has enough gas to return false.
+  describe('modexp failure', function () {
+    it('returns false instead of reverting when the modexp precompile runs out of gas', async function () {
+      const digest = ethers.ZeroHash;
+      // n = 2048-bit modulus (all ones), s = 1 so that the `s < n` check passes and modexp is reached.
+      const mod = '0x' + 'ff'.repeat(0x100);
+      const sig = '0x' + '00'.repeat(0xff) + '01';
+      // Oversized exponent: makes the modexp gas cost tens of millions, exceeding the forwarded gas below.
+      const exp = '0x' + 'ff'.repeat(20000);
+
+      await expect(this.mock.$pkcs1Sha256(bytes32(digest), sig, exp, mod, { gasLimit: 16_000_000n })).to.eventually.be
+        .false;
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

`RSA.pkcs1Sha256` runs the RSA verification through `Math.modExp(s, e, n)`, which reverts whenever the underlying `tryModExp` reports failure. The `s < n` check guarantees a non-zero modulus, so `modexp` can't fail on a zero modulus, but it doesn't prevent the precompile (0x05) from running out of gas on oversized `e`/`n`. In that case the function reverts instead of returning `false`, which is inconsistent with its boolean contract and can turn an oversized/invalid key into a revert in callers that expect a fail-closed result (e.g. `SignerRSA`, `ERC7913RSAVerifier`).

This switches to `Math.tryModExp` and returns `false` when the operation fails, so verification consistently fails closed rather than reverting.

Behavior is unchanged for all valid inputs; only pathological, gas-exhausting inputs now return `false` instead of reverting. 

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
