### PR TITLE
docs: document duplicate action constraint in GovernorTimelockCompound

### DIFF
--- a/.changeset/cuddly-falcons-laugh.md
+++ b/.changeset/cuddly-falcons-laugh.md
@@ -1,0 +1,5 @@
+---
+"openzeppelin-solidity": patch
+---
+
+docs: document duplicate action constraint in GovernorTimelockCompound

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -18,11 +18,10 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * the assets and permissions must be attached to the {ICompoundTimelock}. Any asset sent to the {Governor} will be
  * inaccessible from a proposal, unless executed via {Governor-relay}.
  *
- * WARNING: Compound's Timelock identifies queued transactions by the hash of `(target, value, data)`. If a proposal
- * contains duplicate actions — actions with identical `(target, value, calldata)` tuples — the second queuing
- * attempt will either revert (if the first action is still queued) or, in some configurations, silently clobber the
- * first. To make actions unique without changing their effect, append a trailing zero byte (or any distinct bytes)
- * to duplicate calldatas before submitting the proposal.
+ * WARNING: Compound's Timelock identifies queued transactions by the hash of `(target, value, signature, data, eta)`.
+ * Since every action in a proposal shares the same `eta` and this extension uses an empty `signature`, a proposal
+ * cannot contain two actions with identical `(target, value, calldata)` tuples: the second queue operation will
+ * revert because the first transaction is already queued.
  */
 abstract contract GovernorTimelockCompound is Governor {
     ICompoundTimelock private _timelock;

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -17,6 +17,12 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * Using this model means the proposal will be operated by the {ICompoundTimelock} and not by the {Governor}. Thus,
  * the assets and permissions must be attached to the {ICompoundTimelock}. Any asset sent to the {Governor} will be
  * inaccessible from a proposal, unless executed via {Governor-relay}.
+ *
+ * WARNING: Compound's Timelock identifies queued transactions by the hash of `(target, value, data)`. If a proposal
+ * contains duplicate actions — actions with identical `(target, value, calldata)` tuples — the second queuing
+ * attempt will either revert (if the first action is still queued) or, in some configurations, silently clobber the
+ * first. To make actions unique without changing their effect, append a trailing zero byte (or any distinct bytes)
+ * to duplicate calldatas before submitting the proposal.
  */
 abstract contract GovernorTimelockCompound is Governor {
     ICompoundTimelock private _timelock;


### PR DESCRIPTION
Closes #6431

Documents the duplicate action constraint discussed in #6431 and #6457:

Compound's Timelock identifies queued transactions by `keccak256(target, value, data)`. If a proposal contains two actions with identical `(target, value, calldata)`, the second queuing attempt will either revert or silently clobber the first, preventing the proposal from executing correctly.

The workaround is straightforward: append a trailing zero byte (or any distinct bytes) to duplicate calldatas before submitting the proposal, so each action produces a unique queue hash without changing its on-chain effect.

Per @ernestognw's [suggestion](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/6431#issuecomment-4927481332), this documents the constraint rather than adding an unconditional O(n^2) runtime check.
