### PR TITLE
MultiSignerERC7913: decode signature from calldata to avoid abi.decode reverts (M-08)

### DIFF
--- a/.changeset/multisignererc7913-calldata-decode.md
+++ b/.changeset/multisignererc7913-calldata-decode.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`MultiSignerERC7913`: Decode the multisignature payload directly from calldata and return `false` on malformed encoding instead of reverting during `abi.decode`, so paymaster/account validation can surface `SIG_VALIDATION_FAILED` rather than bubble up a revert. The `_validateSignatures` and `_validateThreshold` override parameters change from `bytes[] memory` to `bytes[] calldata`.

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
@@ -267,41 +267,58 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
     function _tryDecodeMultisignatureCalldata(
         bytes calldata signature
     ) private pure returns (bool success, bytes[] calldata signers, bytes[] calldata signatures) {
-        uint256 bufferLength = signature.length;
+        unchecked {
+            uint256 bufferLength = signature.length;
 
-        // Minimum length: offset1(32) + offset2(32) + length1(32) + length2(32) = 128 bytes.
-        if (bufferLength < 0x80) return (false, _emptyBytesArray(), _emptyBytesArray());
+            // Check #1: Theoretical minimum length of a valid multisignature encoding is 0x40 bytes.
+            // 64 bytes of zero is a valid encoding for two empty arrays.
+            if (bufferLength < 0x40) return (false, _emptyBytesArray(), _emptyBytesArray());
 
-        uint256 signersOffset = uint256(bytes32(signature[:0x20]));
-        uint256 signaturesOffset = uint256(bytes32(signature[0x20:0x40]));
+            // Read the offset pointers to the signers and signatures arrays
+            // Read is done in assembly to avoid the cost of creating calldata slices.
+            uint256 signersOffset;
+            uint256 signaturesOffset;
+            assembly ("memory-safe") {
+                signersOffset := calldataload(signature.offset)
+                signaturesOffset := calldataload(add(signature.offset, 0x20))
+            }
 
-        if (signersOffset > bufferLength - 0x20 || signaturesOffset > bufferLength - 0x20)
-            return (false, _emptyBytesArray(), _emptyBytesArray());
+            // Check #2: The length fields that the offset pointers point to must be within the bounds of the buffer.
+            if (signersOffset > bufferLength - 0x20 || signaturesOffset > bufferLength - 0x20)
+                return (false, _emptyBytesArray(), _emptyBytesArray());
 
-        uint256 signersDataOffset = signersOffset + 0x20;
-        uint256 signaturesDataOffset = signaturesOffset + 0x20;
+            // Read the length fields
+            // Read is done in assembly to avoid the cost of creating calldata slices.
+            uint256 signersLength;
+            uint256 signaturesLength;
+            assembly ("memory-safe") {
+                signersLength := calldataload(add(signature.offset, signersOffset))
+                signaturesLength := calldataload(add(signature.offset, signaturesOffset))
+            }
 
-        uint256 signersLength = uint256(bytes32(signature[signersOffset:signersDataOffset]));
-        uint256 signaturesLength = uint256(bytes32(signature[signaturesOffset:signaturesDataOffset]));
+            // Data is just after the length fields
+            uint256 signersDataOffset = signersOffset + 0x20;
+            uint256 signaturesDataOffset = signaturesOffset + 0x20;
 
-        // Cap lengths at 2**64-1 (Solidity's own dynamic-array limit) so `length * 0x20` cannot overflow.
-        if (signersLength > type(uint64).max || signaturesLength > type(uint64).max) {
-            return (false, _emptyBytesArray(), _emptyBytesArray());
+            // Check #3 & #4:
+            // - Cap lengths at 2**64-1 (Solidity's own dynamic-array limit) so `length * 0x20` cannot overflow.
+            // - The data for each array must fit within the bounds of the buffer.
+            if (
+                signersLength > type(uint64).max ||
+                signaturesLength > type(uint64).max ||
+                0x20 * signersLength > bufferLength - signersDataOffset ||
+                0x20 * signaturesLength > bufferLength - signaturesDataOffset
+            ) return (false, _emptyBytesArray(), _emptyBytesArray());
+
+            // Assembly cast
+            assembly ("memory-safe") {
+                success := 1 // true
+                signers.offset := add(signature.offset, signersDataOffset)
+                signers.length := signersLength
+                signatures.offset := add(signature.offset, signaturesDataOffset)
+                signatures.length := signaturesLength
+            }
         }
-
-        if (
-            signersDataOffset + signersLength * 0x20 > bufferLength ||
-            signaturesDataOffset + signaturesLength * 0x20 > bufferLength
-        ) return (false, _emptyBytesArray(), _emptyBytesArray());
-
-        assembly ("memory-safe") {
-            signers.offset := add(signature.offset, signersDataOffset)
-            signers.length := signersLength
-            signatures.offset := add(signature.offset, signaturesDataOffset)
-            signatures.length := signaturesLength
-        }
-
-        return (true, signers, signatures);
     }
 
     /// @dev Returns an empty `bytes[]` calldata slice, used as a placeholder on decode failure.

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
@@ -275,12 +275,8 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
         uint256 signersOffset = uint256(bytes32(signature[:0x20]));
         uint256 signaturesOffset = uint256(bytes32(signature[0x20:0x40]));
 
-        if (
-            signersOffset < 0x40 ||
-            signersOffset > bufferLength - 0x20 ||
-            signaturesOffset < 0x40 ||
-            signaturesOffset > bufferLength - 0x20
-        ) return (false, _emptyBytesArray(), _emptyBytesArray());
+        if (signersOffset > bufferLength - 0x20 || signaturesOffset > bufferLength - 0x20)
+            return (false, _emptyBytesArray(), _emptyBytesArray());
 
         uint256 signersDataOffset = signersOffset + 0x20;
         uint256 signaturesDataOffset = signaturesOffset + 0x20;

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
@@ -221,8 +221,10 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
         bytes calldata signature
     ) internal view virtual override returns (bool) {
         if (signature.length == 0) return false; // For ERC-7739 compatibility
-        (bytes[] memory signers, bytes[] memory signatures) = abi.decode(signature, (bytes[], bytes[]));
-        return _validateThreshold(signers) && _validateSignatures(hash, signers, signatures);
+        (bool success, bytes[] calldata signers, bytes[] calldata signatures) = _tryDecodeMultisignatureCalldata(
+            signature
+        );
+        return success && _validateThreshold(signers) && _validateSignatures(hash, signers, signatures);
     }
 
     /**
@@ -238,8 +240,8 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
      */
     function _validateSignatures(
         bytes32 hash,
-        bytes[] memory signers,
-        bytes[] memory signatures
+        bytes[] calldata signers,
+        bytes[] calldata signatures
     ) internal view virtual returns (bool valid) {
         for (uint256 i = 0; i < signers.length; ++i) {
             if (!isSigner(signers[i])) {
@@ -253,7 +255,56 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
      * @dev Validates that the number of signers meets the {threshold} requirement.
      * Assumes the signers were already validated. See {_validateSignatures} for more details.
      */
-    function _validateThreshold(bytes[] memory validatingSigners) internal view virtual returns (bool) {
+    function _validateThreshold(bytes[] calldata validatingSigners) internal view virtual returns (bool) {
         return validatingSigners.length >= threshold();
+    }
+
+    /**
+     * @dev Decodes an `abi.encode(bytes[], bytes[])` multisignature payload from calldata without memory
+     * allocation. Returns `success = false` on malformed encoding so callers can report an invalid
+     * signature instead of reverting during validation (see ERC-4337 `SIG_VALIDATION_FAILED` semantics).
+     */
+    function _tryDecodeMultisignatureCalldata(
+        bytes calldata signature
+    ) private pure returns (bool success, bytes[] calldata signers, bytes[] calldata signatures) {
+        // Minimum length: offset1(32) + offset2(32) + length1(32) + length2(32) = 128 bytes.
+        if (signature.length < 0x80) return (false, _emptyBytesArray(), _emptyBytesArray());
+
+        uint256 signersOffset = uint256(bytes32(signature[:0x20]));
+        uint256 signaturesOffset = uint256(bytes32(signature[0x20:0x40]));
+        uint256 signersDataOffset = signersOffset + 0x20;
+        uint256 signaturesDataOffset = signaturesOffset + 0x20;
+
+        if (
+            signersOffset < 0x40 ||
+            signersDataOffset > signature.length ||
+            signaturesOffset < 0x40 ||
+            signaturesDataOffset > signature.length
+        ) return (false, _emptyBytesArray(), _emptyBytesArray());
+
+        uint256 signersLength = uint256(bytes32(signature[signersOffset:signersDataOffset]));
+        uint256 signaturesLength = uint256(bytes32(signature[signaturesOffset:signaturesDataOffset]));
+
+        if (
+            signersOffset + signersLength * 0x20 > signature.length ||
+            signaturesOffset + signaturesLength * 0x20 > signature.length
+        ) return (false, _emptyBytesArray(), _emptyBytesArray());
+
+        assembly ("memory-safe") {
+            signers.offset := add(signature.offset, signersDataOffset)
+            signers.length := signersLength
+            signatures.offset := add(signature.offset, signaturesDataOffset)
+            signatures.length := signaturesLength
+        }
+
+        return (true, signers, signatures);
+    }
+
+    /// @dev Returns an empty `bytes[]` calldata slice, used as a placeholder on decode failure.
+    function _emptyBytesArray() private pure returns (bytes[] calldata result) {
+        assembly ("memory-safe") {
+            result.offset := 0
+            result.length := 0
+        }
     }
 }

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
@@ -267,27 +267,35 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
     function _tryDecodeMultisignatureCalldata(
         bytes calldata signature
     ) private pure returns (bool success, bytes[] calldata signers, bytes[] calldata signatures) {
+        uint256 bufferLength = signature.length;
+
         // Minimum length: offset1(32) + offset2(32) + length1(32) + length2(32) = 128 bytes.
-        if (signature.length < 0x80) return (false, _emptyBytesArray(), _emptyBytesArray());
+        if (bufferLength < 0x80) return (false, _emptyBytesArray(), _emptyBytesArray());
 
         uint256 signersOffset = uint256(bytes32(signature[:0x20]));
         uint256 signaturesOffset = uint256(bytes32(signature[0x20:0x40]));
-        uint256 signersDataOffset = signersOffset + 0x20;
-        uint256 signaturesDataOffset = signaturesOffset + 0x20;
 
         if (
             signersOffset < 0x40 ||
-            signersDataOffset > signature.length ||
+            signersOffset > bufferLength - 0x20 ||
             signaturesOffset < 0x40 ||
-            signaturesDataOffset > signature.length
+            signaturesOffset > bufferLength - 0x20
         ) return (false, _emptyBytesArray(), _emptyBytesArray());
+
+        uint256 signersDataOffset = signersOffset + 0x20;
+        uint256 signaturesDataOffset = signaturesOffset + 0x20;
 
         uint256 signersLength = uint256(bytes32(signature[signersOffset:signersDataOffset]));
         uint256 signaturesLength = uint256(bytes32(signature[signaturesOffset:signaturesDataOffset]));
 
+        // Cap lengths at 2**64-1 (Solidity's own dynamic-array limit) so `length * 0x20` cannot overflow.
+        if (signersLength > type(uint64).max || signaturesLength > type(uint64).max) {
+            return (false, _emptyBytesArray(), _emptyBytesArray());
+        }
+
         if (
-            signersOffset + signersLength * 0x20 > signature.length ||
-            signaturesOffset + signaturesLength * 0x20 > signature.length
+            signersDataOffset + signersLength * 0x20 > bufferLength ||
+            signaturesDataOffset + signaturesLength * 0x20 > bufferLength
         ) return (false, _emptyBytesArray(), _emptyBytesArray());
 
         assembly ("memory-safe") {

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913Weighted.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913Weighted.sol
@@ -195,7 +195,7 @@ abstract contract MultiSignerERC7913Weighted is MultiSignerERC7913 {
      * implementations of this function may exist in the contract, so important side effects may be missed
      * depending on the linearization order.
      */
-    function _validateThreshold(bytes[] memory signers) internal view virtual override returns (bool) {
+    function _validateThreshold(bytes[] calldata signers) internal view virtual override returns (bool) {
         unchecked {
             uint64 weight = 0;
             for (uint256 i = 0; i < signers.length; ++i) {

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -293,29 +293,41 @@ describe('AccountMultiSigner', function () {
 
     describe('returns false (does not revert) on malformed outer encoding', function () {
       const word = v => ethers.zeroPadValue(ethers.toBeHex(v), 0x20);
+      const encode = (...items) => ethers.concat(items.map(word));
+
+      it('supports minimal encoding', async function () {
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0, 0))).to.eventually.be.false;
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x20, 0))).to.eventually.be.false;
+      });
 
       it('shorter than the minimum head layout (128 bytes)', async function () {
         await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, '0xdeadbeef')).to.eventually.be.false;
       });
 
       it('offset points past the calldata', async function () {
-        const payload = ethers.concat([word(0xffff), word(0xffff), word(0), word(0)]);
-        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0xffff, 0xffff, 0, 0))).to.eventually.be
+          .false;
       });
 
       it('offset near type(uint256).max (would overflow in checked arithmetic)', async function () {
-        const payload = ethers.concat([word(ethers.MaxUint256), word(ethers.MaxUint256), word(0), word(0)]);
-        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+        await expect(
+          this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(ethers.MaxUint256, ethers.MaxUint256, 0, 0)),
+        ).to.eventually.be.false;
       });
 
-      it('array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
-        const payload = ethers.concat([word(0x40), word(0x60), word(MAX_UINT64 + 1n), word(MAX_UINT64 + 1n)]);
-        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+      it('signer array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, MAX_UINT64 + 1n, 0))).to
+          .eventually.be.false;
+      });
+
+      it('signature array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, 0, MAX_UINT64 + 1n))).to
+          .eventually.be.false;
       });
 
       it('array length exceeds the remaining buffer', async function () {
-        const payload = ethers.concat([word(0x40), word(0x60), word(10), word(0)]);
-        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, 10, 0))).to.eventually.be
+          .false;
       });
     });
   });

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -290,5 +290,23 @@ describe('AccountMultiSigner', function () {
       await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, prepareMultisig(signers, signatures))).to.eventually
         .be.false;
     });
+
+    it('returns false (does not revert) on malformed signature encoding', async function () {
+      // Under 0x80 bytes: too short to carry the minimum abi.encode(bytes[], bytes[]) shape.
+      await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, '0xdeadbeef')).to.eventually.be.false;
+
+      // Well-formed length but truncated array-length words.
+      await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, ethers.zeroPadValue('0x00', 0x80))).to.eventually.be
+        .false;
+
+      // Offsets point past the calldata (would panic in abi.decode).
+      const malformedOffsets = ethers.concat([
+        ethers.zeroPadValue(ethers.toBeHex(0xffff), 0x20),
+        ethers.zeroPadValue(ethers.toBeHex(0xffff), 0x20),
+        ethers.zeroPadValue('0x00', 0x20),
+        ethers.zeroPadValue('0x00', 0x20),
+      ]);
+      await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, malformedOffsets)).to.eventually.be.false;
+    });
   });
 });

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -325,6 +325,8 @@ describe('AccountMultiSigner', function () {
       it('array length exceeds the remaining buffer', async function () {
         await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, 10, 0))).to.eventually.be
           .false;
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, 0, 10))).to.eventually.be
+          .false;
       });
     });
   });

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -291,22 +291,32 @@ describe('AccountMultiSigner', function () {
         .be.false;
     });
 
-    it('returns false (does not revert) on malformed signature encoding', async function () {
-      // Under 0x80 bytes: too short to carry the minimum abi.encode(bytes[], bytes[]) shape.
-      await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, '0xdeadbeef')).to.eventually.be.false;
+    describe('returns false (does not revert) on malformed outer encoding', function () {
+      const word = v => ethers.zeroPadValue(ethers.toBeHex(v), 0x20);
 
-      // Well-formed length but truncated array-length words.
-      await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, ethers.zeroPadValue('0x00', 0x80))).to.eventually.be
-        .false;
+      it('shorter than the minimum head layout (128 bytes)', async function () {
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, '0xdeadbeef')).to.eventually.be.false;
+      });
 
-      // Offsets point past the calldata (would panic in abi.decode).
-      const malformedOffsets = ethers.concat([
-        ethers.zeroPadValue(ethers.toBeHex(0xffff), 0x20),
-        ethers.zeroPadValue(ethers.toBeHex(0xffff), 0x20),
-        ethers.zeroPadValue('0x00', 0x20),
-        ethers.zeroPadValue('0x00', 0x20),
-      ]);
-      await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, malformedOffsets)).to.eventually.be.false;
+      it('offset points past the calldata', async function () {
+        const payload = ethers.concat([word(0xffff), word(0xffff), word(0), word(0)]);
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+      });
+
+      it('offset near type(uint256).max (would overflow in checked arithmetic)', async function () {
+        const payload = ethers.concat([word(ethers.MaxUint256), word(ethers.MaxUint256), word(0), word(0)]);
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+      });
+
+      it('array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
+        const payload = ethers.concat([word(0x40), word(0x60), word(MAX_UINT64 + 1n), word(MAX_UINT64 + 1n)]);
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+      });
+
+      it('array length exceeds the remaining buffer', async function () {
+        const payload = ethers.concat([word(0x40), word(0x60), word(10), word(0)]);
+        await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, payload)).to.eventually.be.false;
+      });
     });
   });
 });

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -294,7 +294,7 @@ describe('AccountMultiSigner', function () {
     describe('returns false (does not revert) on malformed outer encoding', function () {
       const word = v => ethers.zeroPadValue(ethers.toBeHex(v), 0x20);
 
-      it('shorter than the minimum head layout (128 bytes)', async function () {
+      it('shorter than the minimum head layout (64 bytes)', async function () {
         await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, '0xdeadbeef')).to.eventually.be.false;
       });
 

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -315,12 +315,9 @@ describe('AccountMultiSigner', function () {
         ).to.eventually.be.false;
       });
 
-      it('signer array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
+      it('array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
         await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, MAX_UINT64 + 1n, 0))).to
           .eventually.be.false;
-      });
-
-      it('signature array length exceeds Solidity dynamic-array cap (2**64-1)', async function () {
         await expect(this.mock.$_rawSignatureValidation(MESSAGE_HASH, encode(0x40, 0x60, 0, MAX_UINT64 + 1n))).to
           .eventually.be.false;
       });


### PR DESCRIPTION
Partial fix for the audit finding **M-08: Unbounded `signature` forwarding can make paymaster validation revert instead of returning `SIG_VALIDATION_FAILED`** ([scan issue](https://audits.openzeppelin.com/openzeppelin-solidity/project/openzeppelin-contracts/9cf3855f-6a0e-4609-8f75-24b670ac3a06/issues/unbounded-signature-forwarding-can-make-paymaster-validation-revert-instead-of-returning-sig-validation-failed)).

## Summary

`MultiSignerERC7913._rawSignatureValidation` used `abi.decode(signature, (bytes[], bytes[]))`, which reverts on malformed calldata. When invoked through `PaymasterSigner` (or any ERC-4337 account/paymaster flow), an attacker-controlled signature could turn a "should return `SIG_VALIDATION_FAILED`" into a revert, degrading the paymaster into a griefable state.

This PR follows the audit's recommendation to prefer calldata decoding: it inlines a `_tryDecodeMultisignatureCalldata` (adapted from `openzeppelin-accounts`'s [`Multisig.tryDecodeMultisignatureCalldata`](https://github.com/OpenZeppelin/openzeppelin-accounts/blob/main/packages/contracts/src/utils/Multisig.sol)) that validates the `abi.encode(bytes[], bytes[])` shape from calldata and returns a success flag. Malformed outer encodings now return `false` cleanly instead of reverting.

## Changes

- New private `_tryDecodeMultisignatureCalldata(bytes calldata)` in `MultiSignerERC7913` returning `(bool success, bytes[] calldata signers, bytes[] calldata signatures)`.
- Bounds checks are structured to avoid checked-arithmetic reverts on attacker-controlled offsets: the offset bound is `signersOffset > signature.length - 0x20` (safe subtraction, since `signature.length >= 0x80`), the array head bound uses the correct `signersDataOffset + length * 0x20`, and array lengths are capped at `type(uint64).max` (Solidity's own dynamic-array limit) so `length * 0x20` cannot overflow.
- `_rawSignatureValidation` uses the try-decoder; on failure returns `false`.
- `_validateSignatures` and `_validateThreshold` parameter types updated from `bytes[] memory` to `bytes[] calldata`. `MultiSignerERC7913Weighted._validateThreshold` override updated in kind.
- Regression tests covering the 5 outer-decode failure branches: input shorter than the minimum head layout, offset past the calldata, offset near `type(uint256).max`, array length above `type(uint64).max`, and array length larger than the remaining buffer.

## Out of scope

- The OOG concern in the finding (unbounded calldata-to-memory copy costs) is not addressed here. Bundlers control gas and can reject or raise appropriately; the reverts-instead-of-return path was the actionable half.
- Broader "signer backend revert containment" via `staticcall` wrapper (as suggested in the finding) is left for a follow-up.
- Inner-element validation: `signers[i]` / `signatures[i]` bounds are still checked by Solidity at element-access time (same contract as `draft-ERC7579Utils.decodeBatch`). Fully validating each element would require re-implementing `abi.decode` and is better addressed at the paymaster layer via revert containment.
- Bringing `openzeppelin-accounts`'s full `Multisig` library into core is a separate refactor to discuss.

## Test plan

- [x] `npm run compile`
- [x] `npx hardhat test test/account/AccountMultiSigner.test.js test/account/AccountMultiSignerWeighted.test.js` — 195 passing (includes 5 outer-decode regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)