### PR TITLE
GovernorPreventLateQuorum: clamp extended deadline via maxExtendedDeadline (M-03)

### DIFF
--- a/.changeset/governor-prevent-late-quorum-max-deadline.md
+++ b/.changeset/governor-prevent-late-quorum-max-deadline.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`GovernorPreventLateQuorum`: Cap the extended deadline computed in `_tallyUpdated` by a new internal virtual `maxExtendedDeadline` (default `type(uint48).max`), and compute the sum in `uint256` before clamping. Prevents a `clock() + lateQuorumVoteExtension()` overflow from reverting quorum-reaching votes and bricking governance. Integrators can override `maxExtendedDeadline` to enforce a shorter cap.
+`GovernorPreventLateQuorum`: Cap the extended deadline computed in `_tallyUpdated` by a new internal virtual `_maxExtendedDeadline` (default `type(uint48).max`), and compute the sum in `uint256` before clamping. Prevents a `clock() + lateQuorumVoteExtension()` overflow from reverting quorum-reaching votes and bricking governance. Integrators can override `_maxExtendedDeadline` to enforce a shorter cap.

--- a/.changeset/governor-prevent-late-quorum-max-deadline.md
+++ b/.changeset/governor-prevent-late-quorum-max-deadline.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`GovernorPreventLateQuorum`: Cap the extended deadline computed in `_tallyUpdated` by a new internal virtual `_maxExtendedDeadline` (default `type(uint48).max`), and compute the sum in `uint256` before clamping. Prevents a `clock() + lateQuorumVoteExtension()` overflow from reverting quorum-reaching votes and bricking governance. Integrators can override `_maxExtendedDeadline` to enforce a shorter cap.
+`GovernorPreventLateQuorum`: Bound `lateQuorumVoteExtension` by a new internal virtual `_maxLateQuorumVoteExtension` (default `votingPeriod()`) to cap the total voting duration to twice the voting period, thus preventing a large extension from bricking governance. Integrators can override `_maxLateQuorumVoteExtension` to enforce a different bound.

--- a/.changeset/governor-prevent-late-quorum-max-deadline.md
+++ b/.changeset/governor-prevent-late-quorum-max-deadline.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`GovernorPreventLateQuorum`: Cap the extended deadline computed in `_tallyUpdated` by a new internal virtual `maxExtendedDeadline` (default `type(uint48).max`), and compute the sum in `uint256` before clamping. Prevents a `clock() + lateQuorumVoteExtension()` overflow from reverting quorum-reaching votes and bricking governance. Integrators can override `maxExtendedDeadline` to enforce a shorter cap.

--- a/contracts/governance/extensions/GovernorPreventLateQuorum.sol
+++ b/contracts/governance/extensions/GovernorPreventLateQuorum.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.24;
 
 import {Governor} from "../Governor.sol";
 import {Math} from "../../utils/math/Math.sol";
-import {SafeCast} from "../../utils/math/SafeCast.sol";
 
 /**
  * @dev A module that ensures there is a minimum voting period after quorum is reached. This prevents a large voter from
@@ -27,6 +26,9 @@ abstract contract GovernorPreventLateQuorum is Governor {
     /// @dev Emitted when the {lateQuorumVoteExtension} parameter is changed.
     event LateQuorumVoteExtensionSet(uint64 oldVoteExtension, uint64 newVoteExtension);
 
+    /// @dev Thrown when the {lateQuorumVoteExtension} parameter is set to a value larger than {_maxLateQuorumVoteExtension}.
+    error GovernorPreventLateQuorumVoteExtensionTooLarge(uint256 newVoteExtension, uint256 maxVoteExtension);
+
     /**
      * @dev Initializes the vote extension parameter: the time in either number of blocks or seconds (depending on the
      * governor clock mode) that is required to pass since the moment a proposal reaches quorum until its voting period
@@ -47,18 +49,16 @@ abstract contract GovernorPreventLateQuorum is Governor {
     /**
      * @dev Vote tally updated and detects if it caused quorum to be reached, potentially extending the voting period.
      *
-     * The extended deadline is computed as `clock() + lateQuorumVoteExtension()` in wider arithmetic and then
-     * clamped to {_maxExtendedDeadline}, so an extreme `lateQuorumVoteExtension` value cannot make this call
-     * revert with an arithmetic overflow and brick governance mid-vote.
+     * The extended deadline is computed as `clock() + lateQuorumVoteExtension()`. Since {lateQuorumVoteExtension}
+     * is bounded by {_maxLateQuorumVoteExtension} when set, this addition cannot overflow in practice and brick
+     * governance mid-vote.
      *
      * May emit a {ProposalExtended} event.
      */
     function _tallyUpdated(uint256 proposalId) internal virtual override {
         super._tallyUpdated(proposalId);
         if (_extendedDeadlines[proposalId] == 0 && _quorumReached(proposalId)) {
-            uint48 extendedDeadline = SafeCast.toUint48(
-                Math.min(uint256(clock()) + uint256(lateQuorumVoteExtension()), _maxExtendedDeadline())
-            );
+            uint48 extendedDeadline = clock() + lateQuorumVoteExtension();
 
             if (extendedDeadline > proposalDeadline(proposalId)) {
                 emit ProposalExtended(proposalId, extendedDeadline);
@@ -77,13 +77,12 @@ abstract contract GovernorPreventLateQuorum is Governor {
     }
 
     /**
-     * @dev Upper bound applied to the extended deadline computed in {_tallyUpdated}. Defaults to `type(uint48).max`,
-     * which is a no-op cap that still prevents `clock() + lateQuorumVoteExtension()` from overflowing `uint48`.
-     * Override to enforce a deployment-specific ceiling (for example, a few weeks of blocks or seconds) so an
-     * accidentally large {lateQuorumVoteExtension} cannot push proposal deadlines arbitrarily far into the future.
+     * @dev Upper bound applied to {lateQuorumVoteExtension} when it is set. Defaults to the voting period,
+     * resulting in a total maximum voting period of twice the governor's documented voting period.
+     * Can be overridden to provide a different upper bound.
      */
-    function _maxExtendedDeadline() internal view virtual returns (uint48) {
-        return type(uint48).max;
+    function _maxLateQuorumVoteExtension() internal view virtual returns (uint256) {
+        return votingPeriod();
     }
 
     /**
@@ -103,6 +102,11 @@ abstract contract GovernorPreventLateQuorum is Governor {
      * Emits a {LateQuorumVoteExtensionSet} event.
      */
     function _setLateQuorumVoteExtension(uint48 newVoteExtension) internal virtual {
+        uint256 maxVoteExtension = _maxLateQuorumVoteExtension();
+        require(
+            newVoteExtension <= maxVoteExtension,
+            GovernorPreventLateQuorumVoteExtensionTooLarge(newVoteExtension, maxVoteExtension)
+        );
         emit LateQuorumVoteExtensionSet(_voteExtension, newVoteExtension);
         _voteExtension = newVoteExtension;
     }

--- a/contracts/governance/extensions/GovernorPreventLateQuorum.sol
+++ b/contracts/governance/extensions/GovernorPreventLateQuorum.sol
@@ -48,8 +48,8 @@ abstract contract GovernorPreventLateQuorum is Governor {
      * @dev Vote tally updated and detects if it caused quorum to be reached, potentially extending the voting period.
      *
      * The extended deadline is computed as `clock() + lateQuorumVoteExtension()` in wider arithmetic and then
-     * clamped to {maxExtendedDeadline}, so an extreme `lateQuorumVoteExtension` value cannot make this call revert
-     * with an arithmetic overflow and brick governance mid-vote.
+     * clamped to {_maxExtendedDeadline}, so an extreme `lateQuorumVoteExtension` value cannot make this call
+     * revert with an arithmetic overflow and brick governance mid-vote.
      *
      * May emit a {ProposalExtended} event.
      */
@@ -57,7 +57,7 @@ abstract contract GovernorPreventLateQuorum is Governor {
         super._tallyUpdated(proposalId);
         if (_extendedDeadlines[proposalId] == 0 && _quorumReached(proposalId)) {
             uint48 extendedDeadline = SafeCast.toUint48(
-                Math.min(uint256(clock()) + uint256(lateQuorumVoteExtension()), maxExtendedDeadline())
+                Math.min(uint256(clock()) + uint256(lateQuorumVoteExtension()), _maxExtendedDeadline())
             );
 
             if (extendedDeadline > proposalDeadline(proposalId)) {
@@ -82,7 +82,7 @@ abstract contract GovernorPreventLateQuorum is Governor {
      * Override to enforce a deployment-specific ceiling (for example, a few weeks of blocks or seconds) so an
      * accidentally large {lateQuorumVoteExtension} cannot push proposal deadlines arbitrarily far into the future.
      */
-    function maxExtendedDeadline() public view virtual returns (uint48) {
+    function _maxExtendedDeadline() internal view virtual returns (uint48) {
         return type(uint48).max;
     }
 

--- a/contracts/governance/extensions/GovernorPreventLateQuorum.sol
+++ b/contracts/governance/extensions/GovernorPreventLateQuorum.sol
@@ -80,6 +80,10 @@ abstract contract GovernorPreventLateQuorum is Governor {
      * @dev Upper bound applied to {lateQuorumVoteExtension} when it is set. Defaults to the voting period,
      * resulting in a total maximum voting period of twice the governor's documented voting period.
      * Can be overridden to provide a different upper bound.
+     *
+     * NOTE: {_tallyUpdated} adds `lateQuorumVoteExtension()` to `clock()` using `uint48` arithmetic, which is
+     * safe under the default bound. Overriding this to a value close to (or greater than) `type(uint48).max`
+     * can make that addition overflow and revert the quorum-reaching vote, bricking governance.
      */
     function _maxLateQuorumVoteExtension() internal view virtual returns (uint256) {
         return votingPeriod();
@@ -103,10 +107,9 @@ abstract contract GovernorPreventLateQuorum is Governor {
      */
     function _setLateQuorumVoteExtension(uint48 newVoteExtension) internal virtual {
         uint256 maxVoteExtension = _maxLateQuorumVoteExtension();
-        require(
-            newVoteExtension <= maxVoteExtension,
-            GovernorPreventLateQuorumVoteExtensionTooLarge(newVoteExtension, maxVoteExtension)
-        );
+        if (newVoteExtension > maxVoteExtension) {
+            revert GovernorPreventLateQuorumVoteExtensionTooLarge(newVoteExtension, maxVoteExtension);
+        }
         emit LateQuorumVoteExtensionSet(_voteExtension, newVoteExtension);
         _voteExtension = newVoteExtension;
     }

--- a/contracts/governance/extensions/GovernorPreventLateQuorum.sol
+++ b/contracts/governance/extensions/GovernorPreventLateQuorum.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.24;
 
 import {Governor} from "../Governor.sol";
 import {Math} from "../../utils/math/Math.sol";
+import {SafeCast} from "../../utils/math/SafeCast.sol";
 
 /**
  * @dev A module that ensures there is a minimum voting period after quorum is reached. This prevents a large voter from
@@ -46,12 +47,18 @@ abstract contract GovernorPreventLateQuorum is Governor {
     /**
      * @dev Vote tally updated and detects if it caused quorum to be reached, potentially extending the voting period.
      *
+     * The extended deadline is computed as `clock() + lateQuorumVoteExtension()` in wider arithmetic and then
+     * clamped to {maxExtendedDeadline}, so an extreme `lateQuorumVoteExtension` value cannot make this call revert
+     * with an arithmetic overflow and brick governance mid-vote.
+     *
      * May emit a {ProposalExtended} event.
      */
     function _tallyUpdated(uint256 proposalId) internal virtual override {
         super._tallyUpdated(proposalId);
         if (_extendedDeadlines[proposalId] == 0 && _quorumReached(proposalId)) {
-            uint48 extendedDeadline = clock() + lateQuorumVoteExtension();
+            uint48 extendedDeadline = SafeCast.toUint48(
+                Math.min(uint256(clock()) + uint256(lateQuorumVoteExtension()), maxExtendedDeadline())
+            );
 
             if (extendedDeadline > proposalDeadline(proposalId)) {
                 emit ProposalExtended(proposalId, extendedDeadline);
@@ -67,6 +74,16 @@ abstract contract GovernorPreventLateQuorum is Governor {
      */
     function lateQuorumVoteExtension() public view virtual returns (uint48) {
         return _voteExtension;
+    }
+
+    /**
+     * @dev Upper bound applied to the extended deadline computed in {_tallyUpdated}. Defaults to `type(uint48).max`,
+     * which is a no-op cap that still prevents `clock() + lateQuorumVoteExtension()` from overflowing `uint48`.
+     * Override to enforce a deployment-specific ceiling (for example, a few weeks of blocks or seconds) so an
+     * accidentally large {lateQuorumVoteExtension} cannot push proposal deadlines arbitrarily far into the future.
+     */
+    function maxExtendedDeadline() public view virtual returns (uint48) {
+        return type(uint48).max;
     }
 
     /**

--- a/test/governance/extensions/GovernorPreventLateQuorum.test.js
+++ b/test/governance/extensions/GovernorPreventLateQuorum.test.js
@@ -181,51 +181,42 @@ describe('GovernorPreventLateQuorum', function () {
         });
       });
 
-      describe('extreme lateQuorumVoteExtension', function () {
-        const uint48Max = 2n ** 48n - 1n;
+      it('protection against large lateQuorumVoteExtension', async function () {
+        // bump the extension to votingPeriod: authorized
+        this.helper.setProposal(
+          [
+            {
+              target: this.mock.target,
+              data: this.mock.interface.encodeFunctionData('setLateQuorumVoteExtension', [votingPeriod]),
+            },
+          ],
+          'set-lateQuorumVoteExtension-to-match-votingPeriod',
+        );
+        await this.helper.propose();
+        await this.helper.waitForSnapshot();
+        await this.helper.connect(this.voter1).vote({ support: VoteType.For });
+        await this.helper.waitForDeadline();
+        await this.helper.execute();
 
-        beforeEach(async function () {
-          // bump the extension to uint48.max via governance using the fixture's initial proposal shape
-          this.helper.setProposal(
-            [
-              {
-                target: this.mock.target,
-                data: this.mock.interface.encodeFunctionData('setLateQuorumVoteExtension', [uint48Max]),
-              },
-            ],
-            'set-lateQuorumVoteExtension-to-max',
-          );
-          await this.helper.propose();
-          await this.helper.waitForSnapshot();
-          await this.helper.connect(this.voter1).vote({ support: VoteType.For });
-          await this.helper.waitForDeadline();
-          await this.helper.execute();
-          expect(await this.mock.lateQuorumVoteExtension()).to.equal(uint48Max);
-        });
+        expect(await this.mock.lateQuorumVoteExtension()).to.equal(votingPeriod);
 
-        it('quorum-reaching vote does not revert; deadline clamped by _maxExtendedDeadline', async function () {
-          // New proposal on top of the just-updated extension
-          this.proposal = this.helper.setProposal(
-            [
-              {
-                target: this.receiver.target,
-                data: this.receiver.interface.encodeFunctionData('mockFunction'),
-                value,
-              },
-            ],
-            'proposal-under-max-extension',
-          );
-          await this.helper.propose();
-          await this.helper.waitForSnapshot();
-
-          // Quorum-reaching vote used to revert with an arithmetic overflow panic; must now succeed.
-          const txVote = await this.helper.connect(this.voter1).vote({ support: VoteType.For });
-
-          // Deadline is clamped to the default maxExtendedDeadline (type(uint48).max).
-          await expect(this.mock.proposalDeadline(this.proposal.id)).to.eventually.equal(uint48Max);
-
-          await expect(txVote).to.emit(this.mock, 'ProposalExtended').withArgs(this.proposal.id, uint48Max);
-        });
+        // bump the extension to votingPeriod + 1: revert
+        this.helper.setProposal(
+          [
+            {
+              target: this.mock.target,
+              data: this.mock.interface.encodeFunctionData('setLateQuorumVoteExtension', [votingPeriod + 1n]),
+            },
+          ],
+          'set-lateQuorumVoteExtension-to-exceed-votingPeriod',
+        );
+        await this.helper.propose();
+        await this.helper.waitForSnapshot();
+        await this.helper.connect(this.voter1).vote({ support: VoteType.For });
+        await this.helper.waitForDeadline();
+        await expect(this.helper.execute())
+          .to.be.revertedWithCustomError(this.mock, 'GovernorPreventLateQuorumVoteExtensionTooLarge')
+          .withArgs(votingPeriod + 1n, votingPeriod);
       });
     });
   }

--- a/test/governance/extensions/GovernorPreventLateQuorum.test.js
+++ b/test/governance/extensions/GovernorPreventLateQuorum.test.js
@@ -203,7 +203,7 @@ describe('GovernorPreventLateQuorum', function () {
           expect(await this.mock.lateQuorumVoteExtension()).to.equal(uint48Max);
         });
 
-        it('quorum-reaching vote does not revert; deadline clamped by maxExtendedDeadline', async function () {
+        it('quorum-reaching vote does not revert; deadline clamped by _maxExtendedDeadline', async function () {
           // New proposal on top of the just-updated extension
           this.proposal = this.helper.setProposal(
             [

--- a/test/governance/extensions/GovernorPreventLateQuorum.test.js
+++ b/test/governance/extensions/GovernorPreventLateQuorum.test.js
@@ -222,7 +222,7 @@ describe('GovernorPreventLateQuorum', function () {
           const txVote = await this.helper.connect(this.voter1).vote({ support: VoteType.For });
 
           // Deadline is clamped to the default maxExtendedDeadline (type(uint48).max).
-          expect(await this.mock.proposalDeadline(this.proposal.id)).to.equal(uint48Max);
+          await expect(this.mock.proposalDeadline(this.proposal.id)).to.eventually.equal(uint48Max);
 
           await expect(txVote).to.emit(this.mock, 'ProposalExtended').withArgs(this.proposal.id, uint48Max);
         });

--- a/test/governance/extensions/GovernorPreventLateQuorum.test.js
+++ b/test/governance/extensions/GovernorPreventLateQuorum.test.js
@@ -180,6 +180,53 @@ describe('GovernorPreventLateQuorum', function () {
           expect(await this.mock.lateQuorumVoteExtension()).to.equal(0n);
         });
       });
+
+      describe('extreme lateQuorumVoteExtension', function () {
+        const uint48Max = 2n ** 48n - 1n;
+
+        beforeEach(async function () {
+          // bump the extension to uint48.max via governance using the fixture's initial proposal shape
+          this.helper.setProposal(
+            [
+              {
+                target: this.mock.target,
+                data: this.mock.interface.encodeFunctionData('setLateQuorumVoteExtension', [uint48Max]),
+              },
+            ],
+            'set-lateQuorumVoteExtension-to-max',
+          );
+          await this.helper.propose();
+          await this.helper.waitForSnapshot();
+          await this.helper.connect(this.voter1).vote({ support: VoteType.For });
+          await this.helper.waitForDeadline();
+          await this.helper.execute();
+          expect(await this.mock.lateQuorumVoteExtension()).to.equal(uint48Max);
+        });
+
+        it('quorum-reaching vote does not revert; deadline clamped by maxExtendedDeadline', async function () {
+          // New proposal on top of the just-updated extension
+          this.proposal = this.helper.setProposal(
+            [
+              {
+                target: this.receiver.target,
+                data: this.receiver.interface.encodeFunctionData('mockFunction'),
+                value,
+              },
+            ],
+            'proposal-under-max-extension',
+          );
+          await this.helper.propose();
+          await this.helper.waitForSnapshot();
+
+          // Quorum-reaching vote used to revert with an arithmetic overflow panic; must now succeed.
+          const txVote = await this.helper.connect(this.voter1).vote({ support: VoteType.For });
+
+          // Deadline is clamped to the default maxExtendedDeadline (type(uint48).max).
+          expect(await this.mock.proposalDeadline(this.proposal.id)).to.equal(uint48Max);
+
+          await expect(txVote).to.emit(this.mock, 'ProposalExtended').withArgs(this.proposal.id, uint48Max);
+        });
+      });
     });
   }
 });


### PR DESCRIPTION
Addresses the audit finding **M-03: Overflowing `lateQuorumVoteExtension` can make quorum-reaching votes revert and brick governance** ([scan issue](https://audits.openzeppelin.com/openzeppelin-solidity/project/openzeppelin-contracts/9cf3855f-6a0e-4609-8f75-24b670ac3a06/issues/overflowing-latequorumvoteextension-can-make-quorum-reaching-votes-revert-and-brick-governance)).

## Summary

`_tallyUpdated` used checked `uint48` arithmetic to compute `extendedDeadline = clock() + lateQuorumVoteExtension()`. If governance ever sets an extreme `lateQuorumVoteExtension` (e.g. `type(uint48).max`), the first quorum-reaching vote reverts on the addition — quorum is never recorded, and reducing the extension requires an `onlyGovernance` call that can no longer succeed. Governance is effectively bricked.

## Fix

Bound `lateQuorumVoteExtension` **at set time** rather than trying to clamp the computed deadline at compute time:

- New internal virtual `_maxLateQuorumVoteExtension()` returning the maximum allowed extension.
- Default is `votingPeriod()`, so the total voting duration cannot exceed twice the configured voting period. Integrators can override to enforce a different bound.
- `_setLateQuorumVoteExtension` reverts with `GovernorPreventLateQuorumVoteExtensionTooLarge` if the new value exceeds the bound.

This frames the bound as a fixed *duration* ("no extension can add more than X to the vote"), which composes cleanly with the existing `lateQuorumVoteExtension` semantics — as opposed to a fixed *point in time*, which would depend on when the proposal was created.

## Test plan

- [x] `npm run compile`
- [x] `npx hardhat test test/governance/extensions/GovernorPreventLateQuorum.test.js` — passes across `$ERC20Votes` / `$ERC20VotesTimestampMock` modes. The new regression test asserts that (a) setting `lateQuorumVoteExtension == votingPeriod` is accepted, and (b) setting `lateQuorumVoteExtension > votingPeriod` reverts with `GovernorPreventLateQuorumVoteExtensionTooLarge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)