### PR TITLE
SignatureChecker: zero-pad ERC-1271 calldata to 32-byte boundary (L-08)

### DIFF
--- a/.changeset/thick-mails-shave.md
+++ b/.changeset/thick-mails-shave.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`SignatureChecker`: Zero-pad the ERC-1271 signature calldata to a 32-byte boundary when performing the ERC-1271 static call, so the encoded `bytes` argument conforms to the ABI spec.

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -75,12 +75,16 @@ library SignatureChecker {
             // [ 0x04 - 0x23 ] <hash>
             // [ 0x24 - 0x43 ] <signature offset> (0x40)
             // [ 0x44 - 0x63 ] <signature length>
-            // [ 0x64 - ...  ] <signature data>
+            // [ 0x64 - ...  ] <signature data> | <zero padding>
             let ptr := mload(0x40)
             mstore(ptr, selector)
             mstore(add(ptr, 0x04), hash)
             mstore(add(ptr, 0x24), 0x40)
             mcopy(add(ptr, 0x44), signature, add(length, 0x20))
+            mstore(add(add(ptr, 0x64), length), 0)
+
+            // round up the length to the next multiple of 32 bytes to ensure that the calldata is properly padded
+            length := shl(5, shr(5, add(length, 0x1F)))
 
             let success := staticcall(gas(), signer, ptr, add(length, 0x64), 0x00, 0x20)
             result := and(success, and(gt(returndatasize(), 0x1f), eq(mload(0x00), selector)))
@@ -101,13 +105,17 @@ library SignatureChecker {
             // [ 0x04 - 0x23 ] <hash>
             // [ 0x24 - 0x43 ] <signature offset> (0x40)
             // [ 0x44 - 0x63 ] <signature length>
-            // [ 0x64 - ...  ] <signature data>
+            // [ 0x64 - ...  ] <signature data> | <zero padding>
             let ptr := mload(0x40)
             mstore(ptr, selector)
             mstore(add(ptr, 0x04), hash)
             mstore(add(ptr, 0x24), 0x40)
             mstore(add(ptr, 0x44), length)
             calldatacopy(add(ptr, 0x64), signature.offset, length)
+            mstore(add(add(ptr, 0x64), length), 0)
+
+            // round up the length to the next multiple of 32 bytes to ensure that the calldata is properly padded
+            length := shl(5, shr(5, add(length, 0x1F)))
 
             let success := staticcall(gas(), signer, ptr, add(length, 0x64), 0x00, 0x20)
             result := and(success, and(gt(returndatasize(), 0x1f), eq(mload(0x00), selector)))

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -70,7 +70,7 @@ library SignatureChecker {
         uint256 length = signature.length;
 
         assembly ("memory-safe") {
-            // Encoded calldata is :
+            // Encoded calldata following https://docs.soliditylang.org/en/v0.8.35/abi-spec.html:
             // [ 0x00 - 0x03 ] <selector>
             // [ 0x04 - 0x23 ] <hash>
             // [ 0x24 - 0x43 ] <signature offset> (0x40)
@@ -100,7 +100,7 @@ library SignatureChecker {
         uint256 length = signature.length;
 
         assembly ("memory-safe") {
-            // Encoded calldata is :
+            // Encoded calldata following https://docs.soliditylang.org/en/v0.8.35/abi-spec.html:
             // [ 0x00 - 0x03 ] <selector>
             // [ 0x04 - 0x23 ] <hash>
             // [ 0x24 - 0x43 ] <signature offset> (0x40)


### PR DESCRIPTION
Fixes **L-08**.

## Problem

The hand-encoded calldata for the `IERC1271.isValidSignature(bytes32,bytes)` static call in `isValidERC1271SignatureNow` and `isValidERC1271SignatureNowCalldata` did not pad the dynamic `bytes` signature tail to a 32-byte boundary:

- The call size was `add(length, 0x64)` using the **raw** signature length, so the dynamic tail was not padded to a whole number of words as required by the ABI spec.
- The trailing partial word was left as uninitialized memory (garbage in the `memory` variant; unwritten by `calldatacopy` in the `calldata` variant).

Strict ERC-1271 verifiers decoding the `bytes` argument could revert or misbehave on the malformed/short tail or on non-zero padding bytes.

## Fix

In both variants:

- Zero the trailing padding word: `mstore(add(add(ptr, 0x64), length), 0)`.
- Round the length up to the next multiple of 32 before computing the call size: `length := shl(5, shr(5, add(length, 0x1F)))`.

The zeroed region `[0x64+length, 0x64+length+0x20)` fully covers the padded region `[0x64+length, 0x64+ceil32(length))` since `ceil32(length) - length ≤ 31`. The `memory-safe` annotation remains honest (all writes at/above the free-memory pointer).

A `patch` changeset is included.