### PR TITLE
Add virtual `_deployProxyAdmin` to `TransparentUpgradeableProxy`

### DIFF
--- a/.changeset/tidy-socks-matter.md
+++ b/.changeset/tidy-socks-matter.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`TransparentUpgradeableProxy`: Add a virtual `_deployProxyAdmin` function to customize admin deployment during construction.

--- a/contracts/mocks/proxy/TransparentUpgradeableProxyExistingAdmin.sol
+++ b/contracts/mocks/proxy/TransparentUpgradeableProxyExistingAdmin.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.22;
+
+import {TransparentUpgradeableProxy} from "../../proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract TransparentUpgradeableProxyExistingAdmin is TransparentUpgradeableProxy {
+    constructor(
+        address logic,
+        address admin,
+        bytes memory data
+    ) payable TransparentUpgradeableProxy(logic, admin, data) {}
+
+    function _deployProxyAdmin(address initialOwner) internal pure override returns (address) {
+        return initialOwner;
+    }
+}

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -35,9 +35,10 @@ interface ITransparentUpgradeableProxy is IERC1967 {
  *
  * These properties mean that the admin account can only be used for upgrading the proxy, so it's best if it's a
  * dedicated account that is not used for anything else. This will avoid headaches due to sudden errors when trying to
- * call a function from the proxy implementation. For this reason, the proxy deploys an instance of {ProxyAdmin} and
- * allows upgrades only if they come through it. You should think of the `ProxyAdmin` instance as the administrative
- * interface of the proxy, including the ability to change who can trigger upgrades by transferring ownership.
+ * call a function from the proxy implementation. For this reason, the proxy deploys an instance of {ProxyAdmin} through
+ * {_deployProxyAdmin} and allows upgrades only if they come through it. You should think of the `ProxyAdmin` instance as
+ * the administrative interface of the proxy, including the ability to change who can trigger upgrades by transferring
+ * ownership.
  *
  * NOTE: The real interface of this proxy is that defined in `ITransparentUpgradeableProxy`. This contract does not
  * inherit from that interface, and instead `upgradeToAndCall` is implicitly implemented using a custom dispatch
@@ -77,9 +78,20 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * {ERC1967Proxy-constructor}.
      */
     constructor(address _logic, address initialOwner, bytes memory _data) payable ERC1967Proxy(_logic, _data) {
-        _admin = address(new ProxyAdmin(initialOwner));
+        _admin = _deployProxyAdmin(initialOwner);
         // Set the storage value and emit an event for ERC-1967 compatibility
         ERC1967Utils.changeAdmin(_proxyAdmin());
+    }
+
+    /**
+     * @dev Deploys a new {ProxyAdmin} owned by `initialOwner`. The returned address becomes this proxy's immutable
+     * admin.
+     *
+     * NOTE: Override this function to customize admin deployment, for example to reuse an existing {ProxyAdmin} or to
+     * deploy a different admin contract. The returned address cannot be changed thereafter.
+     */
+    function _deployProxyAdmin(address initialOwner) internal virtual returns (address) {
+        return address(new ProxyAdmin(initialOwner));
     }
 
     /**

--- a/test/proxy/transparent/TransparentUpgradeableProxy.behaviour.js
+++ b/test/proxy/transparent/TransparentUpgradeableProxy.behaviour.js
@@ -4,8 +4,8 @@ const { expect } = require('chai');
 const { impersonate } = require('../../helpers/account');
 const { getAddressInSlot, ImplementationSlot, AdminSlot } = require('../../helpers/storage');
 
-// createProxy, initialOwner, accounts
-module.exports = function shouldBehaveLikeTransparentUpgradeableProxy() {
+// createProxy, owner, accounts [, proxyAdmin if !deployProxyAdmin]
+module.exports = function shouldBehaveLikeTransparentUpgradeableProxy({ deployProxyAdmin = true } = {}) {
   before(async function () {
     const implementationV0 = await ethers.deployContract('DummyImplementation');
     const implementationV1 = await ethers.deployContract('DummyImplementation');
@@ -17,7 +17,7 @@ module.exports = function shouldBehaveLikeTransparentUpgradeableProxy() {
 
       const proxyAdmin = await ethers.getContractAt(
         'ProxyAdmin',
-        ethers.getCreateAddress({ from: proxy.target, nonce: 1n }),
+        deployProxyAdmin ? ethers.getCreateAddress({ from: proxy.target, nonce: 1n }) : this.proxyAdmin.target,
       );
       const proxyAdminAsSigner = await proxyAdmin.getAddress().then(impersonate);
 
@@ -67,6 +67,14 @@ module.exports = function shouldBehaveLikeTransparentUpgradeableProxy() {
 
       expect(await this.proxyAdmin.owner()).to.equal(this.owner);
     });
+
+    if (!deployProxyAdmin) {
+      it('does not deploy a new ProxyAdmin', async function () {
+        expect(await ethers.provider.getCode(ethers.getCreateAddress({ from: this.proxy.target, nonce: 1n }))).to.equal(
+          '0x',
+        );
+      });
+    }
 
     it('can overwrite the admin by the implementation', async function () {
       await this.instance.unsafeOverrideAdmin(this.other);

--- a/test/proxy/transparent/TransparentUpgradeableProxy.test.js
+++ b/test/proxy/transparent/TransparentUpgradeableProxy.test.js
@@ -4,25 +4,51 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const shouldBehaveLikeProxy = require('../Proxy.behaviour');
 const shouldBehaveLikeTransparentUpgradeableProxy = require('./TransparentUpgradeableProxy.behaviour');
 
-async function fixture() {
-  const [owner, other, ...accounts] = await ethers.getSigners();
-
-  const implementation = await ethers.deployContract('DummyImplementation');
-
-  const createProxy = function (logic, initData, opts = undefined) {
-    return ethers.deployContract('TransparentUpgradeableProxy', [logic, owner, initData], opts);
-  };
-
-  return { nonContractAddress: owner, owner, other, accounts, implementation, createProxy };
-}
-
 describe('TransparentUpgradeableProxy', function () {
-  beforeEach(async function () {
-    Object.assign(this, await loadFixture(fixture));
+  describe('(default) deploy ProxyAdmin', function () {
+    async function fixture() {
+      const [owner, other, ...accounts] = await ethers.getSigners();
+
+      const implementation = await ethers.deployContract('DummyImplementation');
+
+      const createProxy = function (logic, initData, opts = undefined) {
+        return ethers.deployContract('TransparentUpgradeableProxy', [logic, owner, initData], opts);
+      };
+
+      return { nonContractAddress: owner, owner, other, accounts, implementation, createProxy };
+    }
+
+    beforeEach(async function () {
+      Object.assign(this, await loadFixture(fixture));
+    });
+
+    shouldBehaveLikeProxy();
+
+    // createProxy, owner, accounts
+    shouldBehaveLikeTransparentUpgradeableProxy();
   });
 
-  shouldBehaveLikeProxy();
+  describe('(existing admin)', function () {
+    async function fixture() {
+      const [owner, other, ...accounts] = await ethers.getSigners();
 
-  // createProxy, owner, otherAccounts
-  shouldBehaveLikeTransparentUpgradeableProxy();
+      const implementation = await ethers.deployContract('DummyImplementation');
+      const proxyAdmin = await ethers.deployContract('ProxyAdmin', [owner]);
+
+      const createProxy = function (logic, initData, opts = undefined) {
+        return ethers.deployContract('TransparentUpgradeableProxyExistingAdmin', [logic, proxyAdmin, initData], opts);
+      };
+
+      return { nonContractAddress: owner, owner, other, accounts, implementation, proxyAdmin, createProxy };
+    }
+
+    beforeEach(async function () {
+      Object.assign(this, await loadFixture(fixture));
+    });
+
+    shouldBehaveLikeProxy();
+
+    // createProxy, owner, accounts, proxyAdmin
+    shouldBehaveLikeTransparentUpgradeableProxy({ deployProxyAdmin: false });
+  });
 });


### PR DESCRIPTION
Related to #5855

Draft for design discussion. Default behavior is unchanged: construction still deploys a new `{ProxyAdmin}`. This adds a virtual `_deployProxyAdmin` override point so inheritors can reuse an existing admin or deploy a different admin contract. The returned address remains the proxy's immutable admin.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)