### PR TITLE
Enhance IERC6372 NatSpec following the ERC definitions

### DIFF
--- a/contracts/interfaces/IERC6372.sol
+++ b/contracts/interfaces/IERC6372.sol
@@ -7,7 +7,7 @@ pragma solidity >=0.4.16;
  * @dev Interface for the Contract Clock standard.
  *
  * A standardized interface for a contract to expose the clock it uses internally, so that an external observer can
- * tell whether it tracks time using block numbers, timestamps, or some other mode, instead of assuming one.
+ * tell whether it tracks time using timestamps, block numbers, or some other mode, instead of assuming one.
  */
 interface IERC6372 {
     /**

--- a/contracts/interfaces/IERC6372.sol
+++ b/contracts/interfaces/IERC6372.sol
@@ -22,7 +22,7 @@ interface IERC6372 {
      * @dev Returns a machine-readable description of the clock, formatted as a URL query string.
      * Timestamps are described as `mode=timestamp` and block numbers as `mode=blocknumber&from=default`,
      * where `default` becomes a CAIP-2 chain ID (e.g. `eip155:1`) if the block number is not that of the
-     * `NUMBER` opcode. Any other mode uses a unique identifier for the `mode` field.
+     * `NUMBER` opcode (0x43). Any other mode uses a unique identifier for the `mode` field.
      */
     // solhint-disable-next-line func-name-mixedcase
     function CLOCK_MODE() external view returns (string memory);

--- a/contracts/interfaces/IERC6372.sol
+++ b/contracts/interfaces/IERC6372.sol
@@ -3,14 +3,24 @@
 
 pragma solidity >=0.4.16;
 
+/**
+ * @dev Interface for the Contract Clock standard.
+ *
+ * A standardized interface for a contract to expose the clock it uses internally, so that an external observer can
+ * tell whether it tracks time using block numbers, timestamps, or some other mode, instead of assuming one.
+ */
 interface IERC6372 {
     /**
-     * @dev Clock used for flagging checkpoints. Can be overridden to implement timestamp based checkpoints (and voting).
+     * @dev Returns the current timepoint according to the mode the contract is operating on.
+     * This is a non-decreasing function of the chain, such as `block.timestamp` or `block.number`.
      */
     function clock() external view returns (uint48);
 
     /**
-     * @dev Description of the clock
+     * @dev Returns a machine-readable description of the clock, formatted as a URL query string.
+     * Timestamps are described as `mode=timestamp` and block numbers as `mode=blocknumber&from=default`,
+     * where `default` becomes a CAIP-2 chain ID (e.g. `eip155:1`) if the block number is not that of the
+     * `NUMBER` opcode. Any other mode uses a unique identifier for the `mode` field.
      */
     // solhint-disable-next-line func-name-mixedcase
     function CLOCK_MODE() external view returns (string memory);


### PR DESCRIPTION
Alternative to https://github.com/OpenZeppelin/openzeppelin-contracts/pull/6648.

The `IERC6372` NatSpec was grabbed back then directly from `Votes.sol`, where it's NatSpec does fit: `clock()` is `virtual` there and the context is voting checkpoints. Neither holds in the interface, and ERC-6372 never mentions checkpoints or voting.

It also dropped the normative part of the spec: `clock()` must be non-decreasing, and `CLOCK_MODE()` must return a URL-query-string descriptor with specified values. That is where I think the doc matters, since the return type is just `string`.

This rewrites both to describe the standard, and adds a contract-level `@dev` for consistency with the other interfaces under `contracts/interfaces/` (`IERC5313`, `IERC6093`).