### PR TITLE
Refactor `ITransparentUpgradeableProxy` to its own file

### DIFF
--- a/.changeset/loud-cups-shake.md
+++ b/.changeset/loud-cups-shake.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`ITransparentUpgradeableProxy`: Move to a dedicated file. Developers must update import paths that previously imported this interface from `TransparentUpgradeableProxy.sol`.
+`ITransparentUpgradeableProxy`: Move to a dedicated file.

--- a/.changeset/loud-cups-shake.md
+++ b/.changeset/loud-cups-shake.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`ITransparentUpgradeableProxy`: Move to a dedicated file. Developers must update import paths that previously imported this interface from `TransparentUpgradeableProxy.sol`.

--- a/contracts/proxy/README.adoc
+++ b/contracts/proxy/README.adoc
@@ -67,6 +67,8 @@ The current implementation of this security mechanism uses https://eips.ethereum
 
 == Transparent Proxy
 
+{{ITransparentUpgradeableProxy}}
+
 {{TransparentUpgradeableProxy}}
 
 {{ProxyAdmin}}

--- a/contracts/proxy/transparent/ITransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/ITransparentUpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.4;
+pragma solidity >=0.6.2;
 
 import {IERC1967} from "../../interfaces/IERC1967.sol";
 

--- a/contracts/proxy/transparent/ITransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/ITransparentUpgradeableProxy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.4;
+
+import {IERC1967} from "../../interfaces/IERC1967.sol";
+
+/**
+ * @dev Interface for {TransparentUpgradeableProxy}. In order to implement transparency, {TransparentUpgradeableProxy}
+ * does not implement this interface directly, and its upgradeability mechanism is implemented by an internal dispatch
+ * mechanism. The compiler is unaware that these functions are implemented by {TransparentUpgradeableProxy} and will not
+ * include them in the ABI so this interface must be used to interact with it.
+ */
+interface ITransparentUpgradeableProxy is IERC1967 {
+    /// @dev See {UUPSUpgradeable-upgradeToAndCall}
+    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable;
+}

--- a/contracts/proxy/transparent/ProxyAdmin.sol
+++ b/contracts/proxy/transparent/ProxyAdmin.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.22;
 
-import {ITransparentUpgradeableProxy} from "./TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from "./ITransparentUpgradeableProxy.sol";
 import {Ownable} from "../../access/Ownable.sol";
 
 /**

--- a/contracts/proxy/transparent/ProxyAdmin.sol
+++ b/contracts/proxy/transparent/ProxyAdmin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.2.0) (proxy/transparent/ProxyAdmin.sol)
 
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.20;
 
 import {ITransparentUpgradeableProxy} from "./ITransparentUpgradeableProxy.sol";
 import {Ownable} from "../../access/Ownable.sol";

--- a/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+++ b/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
@@ -5,19 +5,8 @@ pragma solidity ^0.8.22;
 
 import {ERC1967Utils} from "../ERC1967/ERC1967Utils.sol";
 import {ERC1967Proxy} from "../ERC1967/ERC1967Proxy.sol";
-import {IERC1967} from "../../interfaces/IERC1967.sol";
+import {ITransparentUpgradeableProxy} from "./ITransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "./ProxyAdmin.sol";
-
-/**
- * @dev Interface for {TransparentUpgradeableProxy}. In order to implement transparency, {TransparentUpgradeableProxy}
- * does not implement this interface directly, and its upgradeability mechanism is implemented by an internal dispatch
- * mechanism. The compiler is unaware that these functions are implemented by {TransparentUpgradeableProxy} and will not
- * include them in the ABI so this interface must be used to interact with it.
- */
-interface ITransparentUpgradeableProxy is IERC1967 {
-    /// @dev See {UUPSUpgradeable-upgradeToAndCall}
-    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable;
-}
 
 /**
  * @dev This contract implements a proxy that is upgradeable through an associated {ProxyAdmin} instance.


### PR DESCRIPTION
Fixes #6652.

Draft implementation to remove circular dependency between `TransparentUpgradeableProxy.sol` and `ProxyAdmin.sol`.

#### PR Checklist

- [ ] Tests
- [X] Documentation
- [X] Changeset entry (run `npx changeset add`)
