### PR TITLE
Validate non-empty address in crosschain bridge transfers

### DIFF
--- a/contracts/crosschain/bridges/abstract/BridgeFungible.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeFungible.sol
@@ -26,6 +26,9 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
     /// @dev Emitted when a crosschain ERC-20 transfer is received.
     event CrosschainFungibleTransferReceived(bytes32 indexed receiveId, bytes from, address indexed to, uint256 amount);
 
+    /// @dev Revert reason when the address part of the interoperable address is empty.
+    error CrosschainFungibleEmptyAddress();
+
     /**
      * @dev Transfer `amount` tokens to a crosschain receiver.
      *
@@ -44,10 +47,10 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
         _onSend(from, amount);
 
         (bytes2 chainType, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(to);
-        bytes memory chain = InteroperableAddress.formatV1(chainType, chainReference, hex"");
+        require(addr.length > 0, CrosschainFungibleEmptyAddress());
 
         bytes32 sendId = _sendMessageToCounterpart(
-            chain,
+            InteroperableAddress.formatV1(chainType, chainReference, hex""),
             abi.encode(InteroperableAddress.formatEvmV1(block.chainid, from), addr, amount),
             new bytes[](0)
         );

--- a/contracts/crosschain/bridges/abstract/BridgeMultiToken.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeMultiToken.sol
@@ -40,6 +40,9 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
         bytes data
     );
 
+    /// @dev Revert reason when the address part of the interoperable address is empty.
+    error CrosschainMultiTokenEmptyAddress();
+
     /**
      * @dev Internal crosschain transfer function. `data` is forwarded through the ERC-7786 payload to
      * {_onReceive} on the destination chain.
@@ -56,10 +59,10 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
         _onSend(from, ids, values);
 
         (bytes2 chainType, bytes memory chainReference, bytes memory addr) = to.parseV1();
-        bytes memory chain = InteroperableAddress.formatV1(chainType, chainReference, hex"");
+        require(addr.length > 0, CrosschainMultiTokenEmptyAddress());
 
         bytes32 sendId = _sendMessageToCounterpart(
-            chain,
+            InteroperableAddress.formatV1(chainType, chainReference, hex""),
             abi.encode(InteroperableAddress.formatEvmV1(block.chainid, from), addr, ids, values, data),
             new bytes[](0)
         );

--- a/contracts/crosschain/bridges/abstract/BridgeNonFungible.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeNonFungible.sol
@@ -29,6 +29,9 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
         uint256 tokenId
     );
 
+    /// @dev Revert reason when the address part of the interoperable address is empty.
+    error CrosschainNonFungibleEmptyAddress();
+
     /**
      * @dev Internal crosschain transfer function.
      *
@@ -38,10 +41,10 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
         _onSend(from, tokenId);
 
         (bytes2 chainType, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(to);
-        bytes memory chain = InteroperableAddress.formatV1(chainType, chainReference, hex"");
+        require(addr.length > 0, CrosschainNonFungibleEmptyAddress());
 
         bytes32 sendId = _sendMessageToCounterpart(
-            chain,
+            InteroperableAddress.formatV1(chainType, chainReference, hex""),
             abi.encode(InteroperableAddress.formatEvmV1(block.chainid, from), addr, tokenId),
             new bytes[](0)
         );

--- a/test/crosschain/BridgeERC1155.behavior.js
+++ b/test/crosschain/BridgeERC1155.behavior.js
@@ -352,6 +352,22 @@ function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chainBIsCust
           .to.be.revertedWithCustomError(this.tokenA, 'ERC1155InsufficientBalance')
           .withArgs(alice, 0n, values[0], ids[0]);
       });
+
+      it('reverts if the address part of the interoperable address is empty', async function () {
+        const [alice] = this.accounts;
+
+        await this.tokenA.$_mintBatch(alice, ids, values, '0x');
+        await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
+
+        await expect(
+          this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
+            alice,
+            this.chain.toErc7930(undefined),
+            ids,
+            values,
+          ), // No address
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainMultiTokenEmptyAddress');
+      });
     });
 
     describe('restrictions', function () {

--- a/test/crosschain/BridgeERC20.behavior.js
+++ b/test/crosschain/BridgeERC20.behavior.js
@@ -73,6 +73,19 @@ function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustod
         .withArgs(chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress, chris, amount);
     });
 
+    describe('invalid transfer', function () {
+      it('reverts if the address part of the interoperable address is empty', async function () {
+        const [alice] = this.accounts;
+
+        await this.tokenA.$_mint(alice, amount);
+        await this.tokenA.connect(alice).approve(this.bridgeA, ethers.MaxUint256);
+
+        await expect(
+          this.bridgeA.connect(alice).crosschainTransfer(this.chain.toErc7930(undefined), amount), // No address
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleEmptyAddress');
+      });
+    });
+
     describe('restrictions', function () {
       beforeEach(async function () {
         await this.tokenA.$_mint(this.bridgeA, 1_000_000_000n);

--- a/test/crosschain/BridgeERC721.behavior.js
+++ b/test/crosschain/BridgeERC721.behavior.js
@@ -126,7 +126,6 @@ function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCusto
     describe('invalid transfer', function () {
       it('token not minted', async function () {
         const [alice, bruce] = this.accounts;
-        const tokenId = 17n;
 
         await expect(
           this.bridgeA.connect(alice).crosschainTransferFrom(ethers.ZeroAddress, this.chain.toErc7930(bruce), tokenId),
@@ -137,7 +136,6 @@ function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCusto
 
       it('incorrect from argument', async function () {
         const [alice, bruce] = this.accounts;
-        const tokenId = 17n;
 
         await this.tokenA.$_mint(alice, tokenId);
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -146,6 +144,17 @@ function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCusto
         await expect(this.bridgeA.connect(bruce).crosschainTransferFrom(bruce, this.chain.toErc7930(bruce), tokenId))
           .to.be.revertedWithCustomError(this.tokenA, 'ERC721IncorrectOwner')
           .withArgs(bruce, tokenId, alice);
+      });
+
+      it('reverts if the address part of the interoperable address is empty', async function () {
+        const [alice] = this.accounts;
+
+        await this.tokenA.$_mint(alice, tokenId);
+        await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
+
+        await expect(
+          this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.chain.toErc7930(undefined), tokenId), // No address
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleEmptyAddress');
       });
     });
 

--- a/test/helpers/chains.js
+++ b/test/helpers/chains.js
@@ -40,7 +40,7 @@ const format = ({ namespace, reference }) => ({
   erc7930: addressCoder.encode({ chainType: namespace, reference }),
   toCaip10: other => `${namespace}:${reference}:${ethers.getAddress(other.target ?? other.address ?? other)}`,
   toErc7930: other =>
-    addressCoder.encode({ chainType: namespace, reference, address: other.target ?? other.address ?? other }),
+    addressCoder.encode({ chainType: namespace, reference, address: other?.target ?? other?.address ?? other }),
 });
 
 module.exports = {


### PR DESCRIPTION
## Motivation

The abstract crosschain bridges (`BridgeFungible`, `BridgeNonFungible`, `BridgeMultiToken`) parse the destination as an ERC-7930 interoperable address and forward its address part in the ERC-7786 payload. If the address part is empty, the transfer would be sent with no recipient on the destination chain, silently locking the tokens.

## Changes

- Add an `Crosschain*EmptyAddress` custom error to each of the three abstract bridges and `require` that the parsed address part is non-empty before dispatching the crosschain message.
- Add tests covering the empty-address case for ERC-20, ERC-721 and ERC-1155 bridges.
- Allow `chains.toErc7930(undefined)` in the test helper so the empty-address case can be constructed.

## Notes

No changeset: these contracts are unreleased (`contracts/crosschain/bridges/`), so there is no user-visible behavior change to a shipped API.