### PR TITLE
PaymasterERC20: fail validation early on _erc20Cost overflow

### DIFF
--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -101,9 +101,8 @@ abstract contract PaymasterERC20 is Paymaster {
         if (uint160(validationData) == ERC4337Utils.SIG_VALIDATION_FAILED || tokenPerNative < _minTokensPerNative())
             return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
 
-        // If the _erc20Cost math fails, the returned value will be type(uint256).max, which we will never be able
-        // to charge as a prefund. The `trySafeTransferFrom` in the `_prefund` will fail, causing success to be false.
-        uint256 maxTokenCost = _erc20Cost(maxCost + _postOpCost() * userOp.maxFeePerGas(), tokenPerNative);
+        // If the _erc20Cost math fails, it returns type(uint256).max. Treat this as an invalid/unchargeable amount and
+        // fail validation early to avoid relying on token behavior when asked to `transferFrom(..., type(uint256).max)`.
 
         // Fail early if the maxTokenCost is type(uint256).max, which indicates an overflow in the _erc20Cost
         // calculation. Avoids issues with possibly malicious tokens not failing the

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -104,6 +104,14 @@ abstract contract PaymasterERC20 is Paymaster {
         // If the _erc20Cost math fails, the returned value will be type(uint256).max, which we will never be able
         // to charge as a prefund. The `trySafeTransferFrom` in the `_prefund` will fail, causing success to be false.
         uint256 maxTokenCost = _erc20Cost(maxCost + _postOpCost() * userOp.maxFeePerGas(), tokenPerNative);
+
+        // Fail early if the maxTokenCost is type(uint256).max, which indicates an overflow in the _erc20Cost
+        // calculation. Avoids issues with possibly malicious tokens not failing the
+        // `transferFrom(..., type(uint256).max)` operation in _prefund.
+        if (maxTokenCost == type(uint256).max) {
+            return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
+        }
+
         (bool success, address prefunder, uint256 prefundAmount, bytes memory prefundContext) = _prefund(
             userOp,
             userOpHash,

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -117,7 +117,6 @@ abstract contract PaymasterERC20 is Paymaster {
             _postOpCost().saturatingAdd(penaltyGas).saturatingMul(userOp.maxFeePerGas()).saturatingAdd(maxCost),
             tokenPerNative
         );
-        uint256 maxTokenCost = _erc20Cost(maxCost + _postOpCost() * userOp.maxFeePerGas(), tokenPerNative);
         if (maxTokenCost == type(uint256).max) {
             return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
         }

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -103,10 +103,7 @@ abstract contract PaymasterERC20 is Paymaster {
 
         // If the _erc20Cost math fails, it returns type(uint256).max. Treat this as an invalid/unchargeable amount and
         // fail validation early to avoid relying on token behavior when asked to `transferFrom(..., type(uint256).max)`.
-
-        // Fail early if the maxTokenCost is type(uint256).max, which indicates an overflow in the _erc20Cost
-        // calculation. Avoids issues with possibly malicious tokens not failing the
-        // `transferFrom(..., type(uint256).max)` operation in _prefund.
+        uint256 maxTokenCost = _erc20Cost(maxCost + _postOpCost() * userOp.maxFeePerGas(), tokenPerNative);
         if (maxTokenCost == type(uint256).max) {
             return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
         }


### PR DESCRIPTION
Follow-up to #6655 (L-15).

`_erc20Cost` returns `type(uint256).max` when its math overflows. Until now, `_validatePaymasterUserOp` relied on the subsequent `trySafeTransferFrom` in `_prefund` to fail when charging that amount as a prefund. That is unsafe against non-compliant tokens that do not revert on a `transferFrom(..., type(uint256).max)`.

This change fails validation explicitly (returns `SIG_VALIDATION_FAILED`) as soon as `maxTokenCost == type(uint256).max`, rather than depending on the prefund transfer to catch the overflow.

No changeset: `PaymasterERC20` is not yet part of a release (introduced in this cycle), consistent with #6655 which also shipped without one.
