### PR TITLE
PaymasterERC20: price the EntryPoint postOp unused-gas penalty

### DIFF
--- a/.changeset/paymaster-erc20-price-postop-penalty.md
+++ b/.changeset/paymaster-erc20-price-postop-penalty.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-solidity': patch
----
-
-`PaymasterERC20`: Price the EntryPoint's unused-gas penalty on the user-controlled `paymasterPostOpGasLimit` into the token charge, preventing an inflated limit from draining the paymaster's deposit.

--- a/.changeset/paymaster-erc20-price-postop-penalty.md
+++ b/.changeset/paymaster-erc20-price-postop-penalty.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`PaymasterERC20`: Price the EntryPoint's unused-gas penalty on the user-controlled `paymasterPostOpGasLimit` into the token charge, preventing an inflated limit from draining the paymaster's deposit.

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -85,8 +85,8 @@ abstract contract PaymasterERC20 is Paymaster {
      * Attempts to retrieve the `token` and `tokenPerNative` from the user operation (see {_fetchDetails})
      * and prefund the user operation using these values and the `maxCost` argument (see {_prefund}).
      *
-     * Returns `abi.encodePacked(userOpHash, token, tokenPerNative, prefundAmount, prefunder, prefundContext)` in
-     * `context` if the prefund is successful. Otherwise, it returns empty bytes.
+     * Returns `abi.encodePacked(userOpHash, token, tokenPerNative, prefundAmount, prefunder, penaltyGas, prefundContext)`
+     * in `context` if the prefund is successful. Otherwise, it returns empty bytes.
      */
     function _validatePaymasterUserOp(
         PackedUserOperation calldata userOp,
@@ -101,9 +101,23 @@ abstract contract PaymasterERC20 is Paymaster {
         if (uint160(validationData) == ERC4337Utils.SIG_VALIDATION_FAILED || tokenPerNative < _minTokensPerNative())
             return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
 
+        // Worst-case unused-gas penalty that the EntryPoint may debit from the paymaster's deposit for the
+        // user-controlled `paymasterPostOpGasLimit` (see {_postOpGasPenalty}). The EntryPoint computes this penalty
+        // only after `postOp` returns, so it is absent from the `actualGasCost` reported to {_postOp}. We price it
+        // into the charge here and retain it in {_postOp}, so a user cannot inflate `paymasterPostOpGasLimit` to
+        // drain the paymaster's deposit.
+        uint256 penaltyGas = _postOpGasPenalty(userOp.paymasterPostOpGasLimit());
+
         // If the _erc20Cost math fails, the returned value will be type(uint256).max, which we will never be able
         // to charge as a prefund. The `trySafeTransferFrom` in the `_prefund` will fail, causing success to be false.
-        uint256 maxTokenCost = _erc20Cost(maxCost + _postOpCost() * userOp.maxFeePerGas(), tokenPerNative);
+        // Saturating arithmetic keeps an overflow in the native cost from wrapping: it saturates to
+        // `type(uint256).max`, which `_erc20Cost` also returns, and fails the prefund instead of undercharging.
+        //
+        // native cost is computed as: maxCost + ((_postOpCost() + penaltyGas) * userOp.maxFeePerGas())
+        uint256 maxTokenCost = _erc20Cost(
+            _postOpCost().saturatingAdd(penaltyGas).saturatingMul(userOp.maxFeePerGas()).saturatingAdd(maxCost),
+            tokenPerNative
+        );
         (bool success, address prefunder, uint256 prefundAmount, bytes memory prefundContext) = _prefund(
             userOp,
             userOpHash,
@@ -116,7 +130,15 @@ abstract contract PaymasterERC20 is Paymaster {
         return
             success
                 ? (
-                    abi.encodePacked(userOpHash, token, tokenPerNative, prefundAmount, prefunder, prefundContext),
+                    abi.encodePacked(
+                        userOpHash,
+                        token,
+                        tokenPerNative,
+                        prefundAmount,
+                        prefunder,
+                        penaltyGas,
+                        prefundContext
+                    ),
                     validationData
                 )
                 : (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
@@ -166,11 +188,19 @@ abstract contract PaymasterERC20 is Paymaster {
         uint256 tokenPerNative = uint256(bytes32(context[0x34:0x54]));
         uint256 prefundAmount = uint256(bytes32(context[0x54:0x74]));
         address prefunder = address(bytes20(context[0x74:0x88]));
-        bytes calldata prefundContext = context[0x88:];
+        uint256 penaltyGas = uint256(bytes32(context[0x88:0xA8]));
+        bytes calldata prefundContext = context[0xA8:];
 
         // If the _erc20Cost math fails, the returned value will be type(uint256).max, which we will never be able
-        // to charge as a refund. The `trySafeTransferFrom` in the `_refund` will fail, causing success to be false.
-        uint256 actualTokenCost = _erc20Cost(actualGasCost + _postOpCost() * actualUserOpFeePerGas, tokenPerNative);
+        // to charge as a refund. The `trySafeTransfer` in the `_refund` will fail, causing success to be false.
+        // `penaltyGas` covers the EntryPoint's unused-gas penalty on `paymasterPostOpGasLimit`, which is excluded
+        // from `actualGasCost` (the EntryPoint computes it only after `postOp` returns). See {_postOpGasPenalty}.
+        //
+        // native cost is computed as: actualGasCost + ((_postOpCost() + penaltyGas) * actualUserOpFeePerGas)
+        uint256 actualTokenCost = _erc20Cost(
+            _postOpCost().saturatingAdd(penaltyGas).saturatingMul(actualUserOpFeePerGas).saturatingAdd(actualGasCost),
+            tokenPerNative
+        );
         (bool success, uint256 actualAmount) = _refund(
             token,
             tokenPerNative,
@@ -254,6 +284,23 @@ abstract contract PaymasterERC20 is Paymaster {
      */
     function _postOpCost() internal view virtual returns (uint256) {
         return 30_000;
+    }
+
+    /**
+     * @dev Worst-case unused-gas penalty (in gas units) that the EntryPoint charges the paymaster's deposit for an
+     * over-provisioned, user-controlled `paymasterPostOpGasLimit`. This penalty is excluded from the `actualGasCost`
+     * reported to {_postOp} (the EntryPoint computes it only after `postOp` returns), so it is priced into the charge
+     * during validation and retained in {_postOp}. Without it, a user could inflate `paymasterPostOpGasLimit` and
+     * have the paymaster absorb the resulting penalty on every operation, draining its deposit.
+     *
+     * The default mirrors the EntryPoint (v0.7-v0.9): a 10% penalty on unused postOp gas, applied only once the
+     * unused amount reaches 40_000 gas. The worst case is a `postOp` that consumes ~0 gas (e.g. it reverts and the
+     * maximum penalty is charged), leaving the whole limit unused.
+     *
+     * NOTE: Override to return 0 when targeting an EntryPoint that has no unused-gas penalty.
+     */
+    function _postOpGasPenalty(uint256 postOpGasLimit) internal view virtual returns (uint256) {
+        return Math.ternary(postOpGasLimit > 40_000, postOpGasLimit / 10, 0);
     }
 
     /// @dev Denominator used for interpreting the `tokenPerNative` returned by {_fetchDetails} as "fixed point" in {_erc20Cost}.

--- a/test/account/paymaster/PaymasterERC20.test.js
+++ b/test/account/paymaster/PaymasterERC20.test.js
@@ -189,6 +189,41 @@ describe('PaymasterERC20', function () {
       }
     });
 
+    it('prices the postOp unused-gas penalty so an inflated paymasterPostOpGasLimit cannot drain the paymaster', async function () {
+      // fund account
+      await this.token.$_mint(this.account, value);
+      await this.token.$_approve(this.account, this.paymaster, ethers.MaxUint256);
+
+      const signedUserOp = await this.account
+        .createUserOp({
+          ...this.userOp,
+          // user inflates the postOp gas limit far beyond what postOp actually consumes
+          paymasterPostOpGasLimit: 500_000n,
+          callData: this.account.interface.encodeFunctionData('execute', [
+            encodeMode({ callType: CALL_TYPE_BATCH }),
+            encodeBatch({
+              target: this.target,
+              data: this.target.interface.encodeFunctionData('mockFunctionExtra'),
+            }),
+          ]),
+        })
+        .then(op => this.paymasterSignUserOp(op, { tokenPrice: 2n * ethers.WeiPerEther }))
+        .then(op => this.signUserOp(op));
+
+      const logs = await predeploy.entrypoint.v09
+        .handleOps([signedUserOp.packed], this.receiver)
+        .then(tx => tx.wait())
+        .then(({ logs }) => logs.map(ev => this.paymaster.interface.parseLog(ev) ?? ev));
+
+      const { tokenAmount } = logs.find(ev => ev.fragment?.name == 'UserOperationSponsored').args;
+      const { actualGasCost } = logs.find(ev => ev.fragment?.name == 'UserOperationEvent').args;
+
+      // The EntryPoint debits the paymaster's deposit `actualGasCost`, which *includes* the unused-gas penalty on
+      // the inflated postOp limit. The token charge (tokenPrice = 2) must cover it, i.e. the user pays for the
+      // penalty they induced rather than the paymaster subsidizing it out of its deposit.
+      expect(tokenAmount).to.be.greaterThanOrEqual(2n * actualGasCost);
+    });
+
     it('reverts with PaymasterERC20FailedRefund when token refund fails', async function () {
       const erc20Blocklist = await ethers.deployContract('$ERC20BlocklistMock', ['Token', 'TKN']);
 
@@ -325,6 +360,13 @@ describe('PaymasterERC20', function () {
   });
 
   describe('edge cases', function () {
+    it('_postOpGasPenalty prices the worst-case unused-gas penalty only above the threshold', async function () {
+      await expect(this.paymaster.$_postOpGasPenalty(0n)).to.eventually.equal(0n);
+      await expect(this.paymaster.$_postOpGasPenalty(40_000n)).to.eventually.equal(0n); // threshold is exclusive
+      await expect(this.paymaster.$_postOpGasPenalty(40_001n)).to.eventually.equal(4_000n); // 10% of the limit
+      await expect(this.paymaster.$_postOpGasPenalty(1_000_000n)).to.eventually.equal(100_000n);
+    });
+
     it('_erc20Cost returns max uint256 without reverting when muldiv overflows', async function () {
       const tokenPerNative = ethers.MaxUint256;
       const nativeCost = ethers.MaxUint256;


### PR DESCRIPTION
## Problem

The EntryPoint (v0.7–v0.9) debits the paymaster's deposit a **10% penalty on the unused portion of the user-controlled `paymasterPostOpGasLimit`**. Crucially, that penalty is computed *after* `postOp` returns:

```solidity
// EntryPoint._postExecution (v0.9)
actualGasCost = actualGas * gasPrice;
try IPaymaster(paymaster).postOp{gas: mUserOp.paymasterPostOpGasLimit}(mode, context, actualGasCost, gasPrice) {}
...
uint256 postOpGasUsed = postOpPreGas - gasleft();
postOpUnusedGasPenalty = _getUnusedGasPenalty(postOpGasUsed, mUserOp.paymasterPostOpGasLimit); // <-- after postOp
actualGas += preGas - gasleft() + postOpUnusedGasPenalty;
```

So the penalty is **absent from the `actualGasCost` reported to `_postOp`**. `PaymasterERC20` settles the token charge from that penalty-free `actualGasCost` and refunds the rest, while `_postOpCost()` is a constant that cannot scale with a user-chosen limit. A user can therefore inflate `paymasterPostOpGasLimit`, have the EntryPoint burn ~10% of it from the paymaster's deposit each op, and the paymaster never bills for it — draining the deposit (and, if the attacker controls the bundler, capturing the penalty as profit).

## Fix

Price the **worst-case** penalty into the charge, at the only point where the limit is knowable and refundable — validation:

- New `internal virtual _postOpGasPenalty(postOpGasLimit)` returning the worst-case penalty in gas. Default mirrors the EntryPoint (`limit > 40_000 ? limit / 10 : 0`); overridable to `0` for EntryPoints without a penalty.
- Validation folds it into `maxTokenCost` using saturating arithmetic (an overflow saturates to `type(uint256).max` and fails the prefund rather than wrapping into an undercharge).
- The penalty-gas amount is threaded through `context` and retained in `_postOp`, so the refund no longer gives it back.

The `actualTokenCost <= prefundAmount` invariant `_refund` relies on is preserved (validation basis uses `maxCost`/`maxFeePerGas`, both upper bounds). `PaymasterERC20Guarantor` needs no changes.

## Behavior / compatibility

- Only affects ops whose `paymasterPostOpGasLimit` exceeds the 40k threshold; well-scoped ops pay a small premium bounded by 10% of the limit they chose (incentive-aligned with the EntryPoint's own penalty).
- Worst-case pricing is the safe choice (paymaster never loses); it can slightly overcharge an op whose real unused gas lands below the threshold. `_postOpGasPenalty` is virtual so integrators can tune this.

## Tests

- Added a unit test for the `_postOpGasPenalty` boundaries.
- Added an integration test with an inflated `paymasterPostOpGasLimit = 500_000`; it asserts the token charge covers `actualGasCost` (penalty included). Verified it **fails without the fix** (paymaster charged ~11% less than its deposit is debited).
- All existing `PaymasterERC20` / `PaymasterERC20Guarantor` tests pass unchanged.

---

Note: `PaymasterERC20` is not yet in a release. Opening as a draft for design review — the main open question is worst-case pricing vs. an estimate-based variant (see the "Behavior" section). Happy to also add a validation-time hard cap as an alternative.
