### PR TITLE
Return the effective prefund amount from `PaymasterERC20Guarantor._prefund`

### DIFF
--- a/.changeset/paymaster-guarantor-effective-prefund.md
+++ b/.changeset/paymaster-guarantor-effective-prefund.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`PaymasterERC20Guarantor`: Return the effective `prefundAmount` propagated by `super._prefund` instead of the input amount, so extensions composed below the guarantor that pull less than requested serialize the actual pulled amount into the postOp context.

--- a/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
@@ -93,6 +93,11 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
      *   (priced in tokens), pull it from `userOp.sender`, and call {PaymasterERC20-_refund} with
      *   `actualAmount = 0` so the guarantor gets the full `prefundAmount` back. If the user fails to pay,
      *   the guarantor absorbs the GUARANTEED cost (not the base cost).
+     *
+     * NOTE: For guaranteed ops, the returned `effectiveAmount` mirrors the value emitted in
+     * {UserOperationGuaranteed}: the guarantor's inflated `actualAmount`, not necessarily the
+     * amount that `super._refund` settled. Only the non-guaranteed branch propagates what a
+     * downstream extension actually charged.
      */
     function _refund(
         IERC20 token,

--- a/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
@@ -86,8 +86,9 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
     /**
      * @dev Handles the refund process for guaranteed operations.
      *
-     * * **Non-guaranteed** (`prefunder == userOp.sender`): pass the base `actualAmount` through to
-     *   {PaymasterERC20-_refund}.
+     * * **Non-guaranteed** (`prefunder == userOp.sender`): forward to {PaymasterERC20-_refund} and
+     *   propagate the effective amount returned by `super._refund` so downstream extensions can
+     *   report their actual charge (e.g. a fixed-credit policy that reduces the settlement).
      * * **Guaranteed**: augment `actualAmount` by {_guaranteedPostOpCost} * `actualUserOpFeePerGas`
      *   (priced in tokens), pull it from `userOp.sender`, and call {PaymasterERC20-_refund} with
      *   `actualAmount = 0` so the guarantor gets the full `prefundAmount` back. If the user fails to pay,
@@ -123,21 +124,20 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
             if (token.trySafeTransferFrom(userOpSender, address(this), actualAmount)) {
                 actualAmount = 0;
             }
-        } else {
-            effectiveAmount = actualAmount;
         }
 
-        (refunded, ) = super._refund(
+        uint256 returnedEffectiveAmount;
+        bytes calldata forwardedContext = prefundContext[:prefundContext.length - 20];
+        (refunded, returnedEffectiveAmount) = super._refund(
             token,
             tokenPrice,
             actualAmount,
             actualUserOpFeePerGas,
             prefunder,
             prefundAmount,
-            prefundContext[:prefundContext.length - 20]
+            forwardedContext
         );
-
-        return (refunded, effectiveAmount);
+        return (refunded, Math.ternary(prefunder != userOpSender, effectiveAmount, returnedEffectiveAmount));
     }
 
     /**

--- a/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
@@ -80,7 +80,7 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
         if (prefunder == guarantor) {
             emit UserOperationGuaranteed(userOpHash, prefunder, prefundAmount);
         }
-        return (success, prefunder, prefundAmount_, abi.encodePacked(prefundContext, userOp.sender));
+        return (success, prefunder, prefundAmount, abi.encodePacked(prefundContext, userOp.sender));
     }
 
     /**

--- a/contracts/mocks/account/paymaster/PaymasterERC20Mock.sol
+++ b/contracts/mocks/account/paymaster/PaymasterERC20Mock.sol
@@ -190,3 +190,99 @@ abstract contract PaymasterERC20GuarantorMock is PaymasterERC20Mock, PaymasterER
         return super._minTokensPerNative();
     }
 }
+
+abstract contract PaymasterERC20ReducingMock is PaymasterERC20 {
+    function _prefund(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash,
+        IERC20 token,
+        uint256 tokenPrice,
+        address prefunder_,
+        uint256 prefundAmount_
+    ) internal virtual override returns (bool, address, uint256, bytes memory) {
+        return
+            super._prefund(
+                userOp,
+                userOpHash,
+                token,
+                tokenPrice,
+                prefunder_,
+                prefundAmount_ == 0 ? 0 : prefundAmount_ - 1
+            );
+    }
+
+    function _refund(
+        IERC20 token,
+        uint256 tokenPrice,
+        uint256 actualAmount_,
+        uint256 actualUserOpFeePerGas,
+        address prefunder,
+        uint256 prefundAmount,
+        bytes calldata prefundContext
+    ) internal virtual override returns (bool, uint256) {
+        return
+            super._refund(
+                token,
+                tokenPrice,
+                actualAmount_ == 0 ? 0 : actualAmount_ - 1,
+                actualUserOpFeePerGas,
+                prefunder,
+                prefundAmount,
+                prefundContext
+            );
+    }
+}
+
+contract PaymasterERC20GuarantorReducingMock is PaymasterERC20ReducingMock, PaymasterERC20Guarantor {
+    function _fetchDetails(
+        PackedUserOperation calldata,
+        bytes32
+    ) internal view virtual override returns (uint256 validationData, IERC20 token, uint256 tokenPerNative) {
+        return (ERC4337Utils.SIG_VALIDATION_SUCCESS, IERC20(address(0)), 1);
+    }
+
+    function _fetchGuarantor(PackedUserOperation calldata) internal pure override returns (address) {
+        return address(0);
+    }
+
+    function _guaranteedPostOpCost() internal pure override returns (uint256) {
+        return 0;
+    }
+
+    function _prefund(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash,
+        IERC20 token,
+        uint256 tokenPrice,
+        address prefunder_,
+        uint256 prefundAmount_
+    )
+        internal
+        virtual
+        override(PaymasterERC20ReducingMock, PaymasterERC20Guarantor)
+        returns (bool, address, uint256, bytes memory)
+    {
+        return super._prefund(userOp, userOpHash, token, tokenPrice, prefunder_, prefundAmount_);
+    }
+
+    function _refund(
+        IERC20 token,
+        uint256 tokenPrice,
+        uint256 actualAmount_,
+        uint256 actualUserOpFeePerGas,
+        address prefunder,
+        uint256 prefundAmount,
+        bytes calldata prefundContext
+    ) internal virtual override(PaymasterERC20ReducingMock, PaymasterERC20Guarantor) returns (bool, uint256) {
+        return
+            super._refund(
+                token,
+                tokenPrice,
+                actualAmount_,
+                actualUserOpFeePerGas,
+                prefunder,
+                prefundAmount,
+                prefundContext
+            );
+    }
+}

--- a/test/account/paymaster/PaymasterERC20Guarantor.test.js
+++ b/test/account/paymaster/PaymasterERC20Guarantor.test.js
@@ -428,4 +428,90 @@ describe('PaymasterERC20Guarantor', function () {
         .withArgs(0n, 'AA34 signature error');
     });
   });
+
+  describe('propagates effective amounts from downstream extensions', function () {
+    // Composition: Mock → PaymasterERC20Guarantor → PaymasterERC20ReducingMock → PaymasterERC20.
+    // The reducing helper subtracts 1 from the amount passed to super, simulating a downstream
+    // extension (e.g. a fixed-credit policy) that legitimately settles for less than requested.
+    // Guarantor must propagate the reduced value returned by super, otherwise the postOp context
+    // would record an unbacked amount and the refund path would pay out of the paymaster balance.
+    const userOp = sender => ({
+      sender,
+      nonce: 0n,
+      initCode: '0x',
+      callData: '0x',
+      accountGasLimits: ethers.ZeroHash,
+      preVerificationGas: 0n,
+      gasFees: ethers.ZeroHash,
+      paymasterAndData: '0x',
+      signature: '0x',
+    });
+
+    beforeEach(async function () {
+      this.reducingPaymaster = await ethers.deployContract('$PaymasterERC20GuarantorReducingMock');
+    });
+
+    it('_prefund returns the amount pulled by super, not the input', async function () {
+      const requested = 100n;
+      const effective = requested - 1n; // reducing helper subtracts 1
+
+      await this.token.$_mint(this.other, effective);
+      await this.token.$_approve(this.other, this.reducingPaymaster, ethers.MaxUint256);
+
+      // Return value carries the effective amount (99), matching what super pulled.
+      // Without the fix, this would be `requested` (100) — one token more than actually entered
+      // the paymaster, and that inflated value would be serialized into the postOp context.
+      const packedSender = ethers.solidityPacked(['address'], [this.other.address]);
+      await expect(
+        this.reducingPaymaster.$_prefund(
+          userOp(this.other.address),
+          ethers.ZeroHash,
+          this.token,
+          ethers.WeiPerEther, // tokenPrice
+          this.other.address,
+          requested,
+        ),
+      )
+        .to.emit(this.reducingPaymaster, 'return$_prefund')
+        .withArgs(true, this.other.address, effective, packedSender);
+
+      // Token movements confirm only the effective amount actually entered the paymaster.
+      expect(await this.token.balanceOf(this.other)).to.equal(0n);
+      expect(await this.token.balanceOf(this.reducingPaymaster)).to.equal(effective);
+    });
+
+    it('_refund returns the amount charged by super for non-guaranteed operations', async function () {
+      // Seed the paymaster so the refund transfer succeeds.
+      const prefundAmount = 100n;
+      const inputActual = 40n;
+      const effectiveActual = inputActual - 1n; // reducing helper subtracts 1
+      await this.token.$_mint(this.reducingPaymaster, prefundAmount);
+
+      // prefunder == userOpSender in the context tail → the non-guaranteed branch runs.
+      const prefundContext = ethers.solidityPacked(['address'], [this.other.address]);
+
+      // Return value carries the effective charge (39), matching what super actually charged.
+      // Without the fix, this would be `inputActual` (40) — the pre-reduction value — so
+      // `UserOperationSponsored.tokenAmount` would disagree with the actual settlement.
+      await expect(
+        this.reducingPaymaster.$_refund(
+          this.token,
+          ethers.WeiPerEther, // tokenPrice
+          inputActual, // actualAmount
+          1n, // actualUserOpFeePerGas
+          this.other.address, // prefunder
+          prefundAmount,
+          prefundContext,
+        ),
+      )
+        .to.emit(this.reducingPaymaster, 'return$_refund')
+        .withArgs(true, effectiveActual);
+
+      // The base refunded `prefundAmount - effectiveActual`. Paymaster keeps only the effective
+      // amount; if the return value had reported the pre-reduction 40, the recorded charge would
+      // not match the token balance change.
+      expect(await this.token.balanceOf(this.other)).to.equal(prefundAmount - effectiveActual);
+      expect(await this.token.balanceOf(this.reducingPaymaster)).to.equal(effectiveActual);
+    });
+  });
 });


### PR DESCRIPTION
The wrapper captures the effective `prefundAmount` returned by `super._prefund()` but returned the input `prefundAmount_` in the outer tuple. In the base composition the two are equal, so the shipped contract is unaffected. When an extension composed underneath the guarantor returns a smaller effective amount than requested, the inflated value is serialized into the postOp context and the refund path pays out an amount that was never pulled in — funded from the paymaster's existing ERC-20 balance.

Also fixes a latent inconsistency where the `UserOperationGuaranteed` event and the returned `prefundAmount` disagreed for the same call: the event already used the effective value.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
