### PR TITLE
ci: harden composite action inputs before shell use

### DIFF
--- a/.github/actions/gas-compare/action.yml
+++ b/.github/actions/gas-compare/action.yml
@@ -45,7 +45,7 @@ runs:
         REPORT: ${{ inputs.report }}
         OUT_REPORT: ${{ inputs.out_report }}
       run: |
-        mv "$REPORT" "$OUT_REPORT"
+        mv -- "$REPORT" "$OUT_REPORT"
       shell: bash
     - name: Save report
       if: github.event_name != 'pull_request'

--- a/.github/actions/gas-compare/action.yml
+++ b/.github/actions/gas-compare/action.yml
@@ -32,15 +32,20 @@ runs:
       id: reference
     - name: Compare reports
       if: steps.reference.outcome == 'success' && github.event_name == 'pull_request'
-      run: |
-        node scripts/checks/compareGasReports.js ${{ inputs.report }} ${{ inputs.ref_report }} >> $GITHUB_STEP_SUMMARY
       env:
         STYLE: markdown
+        REPORT: ${{ inputs.report }}
+        REF_REPORT: ${{ inputs.ref_report }}
+      run: |
+        node scripts/checks/compareGasReports.js "$REPORT" "$REF_REPORT" >> $GITHUB_STEP_SUMMARY
       shell: bash
     - name: Rename report for upload
       if: github.event_name != 'pull_request'
+      env:
+        REPORT: ${{ inputs.report }}
+        OUT_REPORT: ${{ inputs.out_report }}
       run: |
-        mv ${{ inputs.report }} ${{ inputs.out_report }}
+        mv "$REPORT" "$OUT_REPORT"
       shell: bash
     - name: Save report
       if: github.event_name != 'pull_request'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,30 +32,35 @@ runs:
     - name: "Determine versions to install"
       id: versions
       shell: bash
-      run: |
-        (
-          [[ "${{ inputs.node }}" = "on" ]] \
-            && echo "node=$NODE_DEFAULT_VERSION" \
-            || echo "node=${{ inputs.node }}"
-          [[ "${{ inputs.foundry }}" = "on" ]] \
-            && echo "foundry=$FOUNDRY_DEFAULT_VERSION" \
-            || echo "foundry=${{ inputs.foundry }}"
-          [[ "${{ inputs.java }}" = "on" ]] \
-            && echo "java=$JAVA_DEFAULT_VERSION" \
-            || echo "java=${{ inputs.java }}"
-          [[ "${{ inputs.python }}" = "on" ]] \
-            && echo "python=$PYTHON_DEFAULT_VERSION" \
-            || echo "python=${{ inputs.python }}"
-          [[ "${{ inputs.solc }}" = "on" ]] \
-            && echo "solc=$SOLC_DEFAULT_VERSION" \
-            || echo "solc=${{ inputs.solc }}"
-        ) > $GITHUB_OUTPUT
       env:
+        INPUT_NODE: ${{ inputs.node }}
+        INPUT_FOUNDRY: ${{ inputs.foundry }}
+        INPUT_JAVA: ${{ inputs.java }}
+        INPUT_PYTHON: ${{ inputs.python }}
+        INPUT_SOLC: ${{ inputs.solc }}
         NODE_DEFAULT_VERSION: "24.x"
         FOUNDRY_DEFAULT_VERSION: "stable"
         JAVA_DEFAULT_VERSION: "21"
         PYTHON_DEFAULT_VERSION: "3.13"
         SOLC_DEFAULT_VERSION: "0.8.35"
+      run: |
+        (
+          [[ "$INPUT_NODE" = "on" ]] \
+            && echo "node=$NODE_DEFAULT_VERSION" \
+            || echo "node=$INPUT_NODE"
+          [[ "$INPUT_FOUNDRY" = "on" ]] \
+            && echo "foundry=$FOUNDRY_DEFAULT_VERSION" \
+            || echo "foundry=$INPUT_FOUNDRY"
+          [[ "$INPUT_JAVA" = "on" ]] \
+            && echo "java=$JAVA_DEFAULT_VERSION" \
+            || echo "java=$INPUT_JAVA"
+          [[ "$INPUT_PYTHON" = "on" ]] \
+            && echo "python=$PYTHON_DEFAULT_VERSION" \
+            || echo "python=$INPUT_PYTHON"
+          [[ "$INPUT_SOLC" = "on" ]] \
+            && echo "solc=$SOLC_DEFAULT_VERSION" \
+            || echo "solc=$INPUT_SOLC"
+        ) > $GITHUB_OUTPUT
     # Node & npm setup
     - name: Install Node (${{ steps.versions.outputs.node }})
       if: inputs.node != 'off'
@@ -97,7 +102,9 @@ runs:
     - name: Install python packages
       if: inputs.python != 'off'
       shell: bash
-      run: pip install -r ${{ inputs.python-requirements }}
+      env:
+        PYTHON_REQUIREMENTS: ${{ inputs.python-requirements }}
+      run: pip install -r "$PYTHON_REQUIREMENTS"
     # Solc setup
     - name: Install solc (${{ steps.versions.outputs.solc }})
       if: inputs.solc != 'off'

--- a/.github/actions/storage-layout/action.yml
+++ b/.github/actions/storage-layout/action.yml
@@ -25,8 +25,11 @@ runs:
   using: composite
   steps:
     - name: Extract layout
+      env:
+        BUILDINFO: ${{ inputs.buildinfo }}
+        LAYOUT: ${{ inputs.layout }}
       run: |
-        node scripts/checks/extract-layout.js ${{ inputs.buildinfo }} > ${{ inputs.layout }}
+        node scripts/checks/extract-layout.js $BUILDINFO > "$LAYOUT"
       shell: bash
     - name: Download reference
       if: github.event_name == 'pull_request'
@@ -40,13 +43,19 @@ runs:
       id: reference
     - name: Compare layouts
       if: steps.reference.outcome == 'success' && github.event_name == 'pull_request'
+      env:
+        LAYOUT: ${{ inputs.layout }}
+        REF_LAYOUT: ${{ inputs.ref_layout }}
       run: |
-        node scripts/checks/compare-layout.js --head ${{ inputs.layout }} --ref ${{ inputs.ref_layout }}
+        node scripts/checks/compare-layout.js --head "$LAYOUT" --ref "$REF_LAYOUT"
       shell: bash
     - name: Rename artifacts for upload
       if: github.event_name != 'pull_request'
+      env:
+        LAYOUT: ${{ inputs.layout }}
+        OUT_LAYOUT: ${{ inputs.out_layout }}
       run: |
-        mv ${{ inputs.layout }} ${{ inputs.out_layout }}
+        mv "$LAYOUT" "$OUT_LAYOUT"
       shell: bash
     - name: Save artifacts
       if: github.event_name != 'pull_request'

--- a/.github/actions/storage-layout/action.yml
+++ b/.github/actions/storage-layout/action.yml
@@ -29,7 +29,11 @@ runs:
         BUILDINFO: ${{ inputs.buildinfo }}
         LAYOUT: ${{ inputs.layout }}
       run: |
-        node scripts/checks/extract-layout.js $BUILDINFO > "$LAYOUT"
+        mapfile -t buildinfo_files < <(compgen -G "$BUILDINFO" || true)
+        if (( ${#buildinfo_files[@]} == 0 )); then
+          buildinfo_files=("$BUILDINFO")
+        fi
+        node scripts/checks/extract-layout.js "${buildinfo_files[@]}" > "$LAYOUT"
       shell: bash
     - name: Download reference
       if: github.event_name == 'pull_request'
@@ -55,7 +59,7 @@ runs:
         LAYOUT: ${{ inputs.layout }}
         OUT_LAYOUT: ${{ inputs.out_layout }}
       run: |
-        mv "$LAYOUT" "$OUT_LAYOUT"
+        mv -- "$LAYOUT" "$OUT_LAYOUT"
       shell: bash
     - name: Save artifacts
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/actions/setup`, `gas-compare`, and `storage-layout`.
- Bind free-string composite inputs under `env:` before `run:` script use (quoted env vars).
- `with:` / `path:` / `if:` expressions left as-is (not shell script text).
- `storage-layout` `BUILDINFO` stays unquoted so the default `artifacts/build-info/*.json` glob still expands.
- Defense-in-depth for Actions composites — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Existing checks that invoke `setup` / `gas-compare` / `storage-layout` still behave the same

#### PR Checklist
- [x] Tests (N/A — CI composite hygiene only)
- [x] Documentation (N/A)
- [x] Changeset entry (N/A — no package/API change)

Made with [Cursor](https://cursor.com)