### PR TITLE
EIP7702Utils: read a bounded 32-byte window of the account code

### DIFF
--- a/.changeset/eip7702utils-bounded-code-read.md
+++ b/.changeset/eip7702utils-bounded-code-read.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`EIP7702Utils`: Read only the first word of the account's code in `fetchDelegate` instead of copying the code in full, so the cost of the call no longer scales with the size of that code.

--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -51,6 +51,11 @@ import {Account} from "../Account.sol";
  * * When combined with {ERC7739}, resolution ordering of {isValidSignature} may have an impact ({ERC7739} does not
  *   call super). Manual resolution might be necessary.
  * * Static calls (using callType `0xfe`) are currently NOT supported.
+ * * Installing a fallback handler for a selector that collides with a function defined on the account (or any
+ *   derived contract) will result in the handler being unreachable, since Solidity dispatches to concrete functions
+ *   before `fallback()`. This includes unrelated function signatures whose 4-byte selector happens to collide.
+ *   The {isModuleInstalled} function only reflects configuration state and does not guarantee selector
+ *   reachability.
  * ====
  *
  * WARNING: Removing all validator modules will render the account inoperable, as no user operations can be validated thereafter.

--- a/contracts/account/utils/EIP7702Utils.sol
+++ b/contracts/account/utils/EIP7702Utils.sol
@@ -13,8 +13,6 @@ library EIP7702Utils {
 
     /**
      * @dev Returns the address of the delegate if `account` has an EIP-7702 delegation setup, or address(0) otherwise.
-     *
-     * NOTE: Only the first word of `account`'s code is read, so the cost does not depend on the size of that code.
      */
     function fetchDelegate(address account) internal view returns (address) {
         bytes32 word;

--- a/contracts/account/utils/EIP7702Utils.sol
+++ b/contracts/account/utils/EIP7702Utils.sol
@@ -13,9 +13,17 @@ library EIP7702Utils {
 
     /**
      * @dev Returns the address of the delegate if `account` has an EIP-7702 delegation setup, or address(0) otherwise.
+     *
+     * NOTE: Only the first word of `account`'s code is read, so the cost does not depend on the size of that code.
      */
     function fetchDelegate(address account) internal view returns (address) {
-        bytes23 delegation = bytes23(account.code);
+        bytes32 word;
+        assembly ("memory-safe") {
+            extcodecopy(account, 0x00, 0x00, 0x20)
+            word := mload(0x00)
+        }
+        // A delegation designator is 23 bytes. `extcodecopy` zero-pads, so shorter code can't match the prefix.
+        bytes23 delegation = bytes23(word);
         return bytes3(delegation) == EIP7702_PREFIX ? address(bytes20(delegation << 24)) : address(0);
     }
 }

--- a/contracts/account/utils/EIP7702Utils.sol
+++ b/contracts/account/utils/EIP7702Utils.sol
@@ -15,13 +15,11 @@ library EIP7702Utils {
      * @dev Returns the address of the delegate if `account` has an EIP-7702 delegation setup, or address(0) otherwise.
      */
     function fetchDelegate(address account) internal view returns (address) {
-        bytes32 word;
+        bytes32 delegation;
         assembly ("memory-safe") {
             extcodecopy(account, 0x00, 0x00, 0x20)
-            word := mload(0x00)
+            delegation := mload(0x00)
         }
-        // A delegation designator is 23 bytes. `extcodecopy` zero-pads, so shorter code can't match the prefix.
-        bytes23 delegation = bytes23(word);
         return bytes3(delegation) == EIP7702_PREFIX ? address(bytes20(delegation << 24)) : address(0);
     }
 }

--- a/test/account/utils/EIP7702Utils.test.js
+++ b/test/account/utils/EIP7702Utils.test.js
@@ -1,6 +1,6 @@
 const { ethers, config } = require('hardhat');
 const { expect } = require('chai');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { loadFixture, setCode } = require('@nomicfoundation/hardhat-network-helpers');
 
 // [NOTE]
 //
@@ -48,6 +48,15 @@ describe('EIP7702Utils', function () {
 
     it('other smart contract', async function () {
       await expect(this.mock.$fetchDelegate(this.mock)).to.eventually.equal(ethers.ZeroAddress);
+    });
+
+    // code shorter than a delegation designator is zero-padded, and never resolves to a delegate
+    it('code shorter than a delegation designator', async function () {
+      for (const code of ['0x60', '0x6001600155', '0x60016001556000']) {
+        const account = ethers.Wallet.createRandom().address;
+        await setCode(account, code);
+        await expect(this.mock.$fetchDelegate(account)).to.eventually.equal(ethers.ZeroAddress);
+      }
     });
   });
 });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

**Problem**

`fetchDelegate` truncated account.code to `bytes23. <address>.code` materializes the full runtime bytecode as bytes memory, so the compiler emits `EXTCODESIZE`, an allocation, and a full `EXTCODECOPY` — the truncation happens only afterwards. The cost scales with the account's code size even though 23 bytes are read.

Warm, against a max-size 24,576-byte contract that is **~5,920 gas (~2,300 word-copy + ~3,470 memory expansion)** against ~215 for a real 23-byte designator: a ~5,760 amplification controlled entirely by the target's bytecode. Memory is never freed, so repeated calls in one frame compound quadratically.

**Fix**


```solidity
bytes32 delegation;
assembly ("memory-safe") {
    extcodecopy(account, 0x00, 0x00, 0x20)
    delegation := mload(0x00)
}
```

`EXTCODECOPY` zero-pads past end-of-code, so `EXTCODESIZE` is no longer needed and shorter code still fails the prefix check. The write targets the reserved scratch space, so nothing is allocated and no memory expansion is charged. Copying a full word rather than 23 bytes costs the same — both round to one copied word — and leaves the narrowing, and its cleanup, to solidity.

Now **~115** gas, flat in code size, and ~110 cheaper on an actual designator. Behavior is unchanged on every input; a patch changeset is included.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
