### PR TITLE
Remove NPM token dependency from publish script

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -132,6 +132,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write
     if: needs.state.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -153,6 +154,7 @@ jobs:
         env:
           TARBALL: ${{ steps.pack.outputs.tarball }}
           TAG: ${{ steps.pack.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release
         uses: actions/github-script@v9
         env:

--- a/scripts/release/workflow/publish.sh
+++ b/scripts/release/workflow/publish.sh
@@ -11,16 +11,26 @@ echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 # Actual publish
 npm publish "$TARBALL" --tag "$TAG"
 
-# Clean up tags
-delete_tag() {
-  npm dist-tag rm "$PACKAGE_JSON_NAME" "$1"
+# CI can no longer remove dist-tags (OIDC publish tokens have no tag-write access).
+# Surface the manual cleanup with a run annotation and a tracking issue.
+notify_manual_tag_cleanup() {
+  local tag="$1"
+  local command="npm dist-tag rm $PACKAGE_JSON_NAME $tag"
+
+  echo "::warning title=Manual npm tag cleanup required::$command"
+
+  # Best-effort: a failed issue-create must not fail the job after a successful publish
+  gh issue create \
+    --title "Remove npm dist-tag \`$tag\` after $PACKAGE_JSON_NAME@$PACKAGE_JSON_VERSION release" \
+    --body "$(printf 'CI no longer has npm tag-write access, so the `%s` dist-tag must be removed manually:\n\n```sh\n%s\n```\n' "$tag" "$command")" \
+    || true
 }
 
 if [ "$TAG" = tmp ]; then
-  delete_tag "$TAG"
+  notify_manual_tag_cleanup "$TAG"
 elif [ "$TAG" = latest ]; then
-  # Delete the next tag if it exists and is a prerelease for what is currently being published
+  # The next tag needs cleanup if it exists and is a prerelease for what is currently being published
   if npm dist-tag ls "$PACKAGE_JSON_NAME" | grep -q "next: $PACKAGE_JSON_VERSION"; then
-    delete_tag next
+    notify_manual_tag_cleanup next
   fi
 fi


### PR DESCRIPTION
Will be testing functionality first on my repo. Will mark as ready for review once I confirm it functions as desired.