### PR TITLE
Reject invalid EVM receiver addresses in crosschain bridges

### DIFF
--- a/.changeset/crosschain-receiver-length.md
+++ b/.changeset/crosschain-receiver-length.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`BridgeFungible`, `BridgeNonFungible`, `BridgeMultiToken`: reject crosschain messages whose receiver address is not exactly 20 bytes instead of silently truncating via `bytes20`
+`BridgeFungible`, `BridgeNonFungible`, `BridgeMultiToken`: reject EVM receivers that are not exactly 20 non-zero bytes on both send and receive (wrong-length send would lock funds against the length-checked receive path; `bytes20` truncation and unlock-to-zero are irreversible mis-deliveries)

--- a/.changeset/crosschain-receiver-length.md
+++ b/.changeset/crosschain-receiver-length.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`BridgeFungible`, `BridgeNonFungible`, `BridgeMultiToken`: reject crosschain messages whose receiver address is not exactly 20 bytes instead of silently truncating via `bytes20`

--- a/contracts/crosschain/bridges/abstract/BridgeFungible.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeFungible.sol
@@ -29,6 +29,9 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
     /// @dev Revert reason when the address part of the interoperable address is empty.
     error CrosschainFungibleEmptyAddress();
 
+    /// @dev The receiver address in the payload is not exactly 20 bytes.
+    error CrosschainFungibleInvalidAddress();
+
     /**
      * @dev Transfer `amount` tokens to a crosschain receiver.
      *
@@ -71,6 +74,9 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
 
         // split payload
         (bytes memory from, bytes memory toEvm, uint256 amount) = abi.decode(payload, (bytes, bytes, uint256));
+        // `toEvm` comes from the ERC-7786 payload; `bytes20(...)` would silently truncate
+        // a longer (e.g. non-EVM) address, mis-delivering the assets to a wrong account.
+        require(toEvm.length == 20, CrosschainFungibleInvalidAddress());
         address to = address(bytes20(toEvm));
 
         _onReceive(to, amount);

--- a/contracts/crosschain/bridges/abstract/BridgeFungible.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeFungible.sol
@@ -29,7 +29,7 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
     /// @dev Revert reason when the address part of the interoperable address is empty.
     error CrosschainFungibleEmptyAddress();
 
-    /// @dev The receiver address in the payload is not exactly 20 bytes.
+    /// @dev The receiver address is not a valid EVM address (wrong length or zero).
     error CrosschainFungibleInvalidAddress();
 
     /**
@@ -47,10 +47,15 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
      * Note: The `to` parameter is the full InteroperableAddress (chain ref + address).
      */
     function _crosschainTransfer(address from, bytes memory to, uint256 amount) internal virtual returns (bytes32) {
-        _onSend(from, amount);
-
         (bytes2 chainType, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(to);
         require(addr.length > 0, CrosschainFungibleEmptyAddress());
+        // EIP-155 destinations use 20-byte non-zero addresses (see {InteroperableAddress-tryParseEvmV1}).
+        // Accepting other lengths (or the zero address) would lock funds once the receive path rejects them.
+        if (chainType == bytes2(0x0000)) {
+            require(addr.length == 20 && address(bytes20(addr)) != address(0), CrosschainFungibleInvalidAddress());
+        }
+
+        _onSend(from, amount);
 
         bytes32 sendId = _sendMessageToCounterpart(
             InteroperableAddress.formatV1(chainType, chainReference, hex""),
@@ -76,8 +81,10 @@ abstract contract BridgeFungible is Context, CrosschainLinked {
         (bytes memory from, bytes memory toEvm, uint256 amount) = abi.decode(payload, (bytes, bytes, uint256));
         // `toEvm` comes from the ERC-7786 payload; `bytes20(...)` would silently truncate
         // a longer (e.g. non-EVM) address, mis-delivering the assets to a wrong account.
+        // The zero address is also rejected: unlocking/minting there is irreversible fund loss.
         require(toEvm.length == 20, CrosschainFungibleInvalidAddress());
         address to = address(bytes20(toEvm));
+        require(to != address(0), CrosschainFungibleInvalidAddress());
 
         _onReceive(to, amount);
 

--- a/contracts/crosschain/bridges/abstract/BridgeMultiToken.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeMultiToken.sol
@@ -44,6 +44,9 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
     /// @dev Revert reason when the address part of the interoperable address is empty.
     error CrosschainMultiTokenEmptyAddress();
 
+    /// @dev The receiver address in the payload is not exactly 20 bytes.
+    error CrosschainMultiTokenInvalidAddress();
+
     /**
      * @dev Internal crosschain transfer function. `data` is forwarded through the ERC-7786 payload to
      * {_onReceive} on the destination chain.
@@ -84,6 +87,9 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
         // split payload
         (bytes memory from, bytes memory toEvm, uint256[] memory ids, uint256[] memory values, bytes memory data) = abi
             .decode(payload, (bytes, bytes, uint256[], uint256[], bytes));
+        // `toEvm` comes from the ERC-7786 payload; `bytes20(...)` would silently truncate
+        // a longer (e.g. non-EVM) address, mis-delivering the assets to a wrong account.
+        require(toEvm.length == 20, CrosschainMultiTokenInvalidAddress());
         address to = address(bytes20(toEvm));
 
         _onReceive(to, ids, values, data);

--- a/contracts/crosschain/bridges/abstract/BridgeMultiToken.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeMultiToken.sol
@@ -44,7 +44,7 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
     /// @dev Revert reason when the address part of the interoperable address is empty.
     error CrosschainMultiTokenEmptyAddress();
 
-    /// @dev The receiver address in the payload is not exactly 20 bytes.
+    /// @dev The receiver address is not a valid EVM address (wrong length or zero).
     error CrosschainMultiTokenInvalidAddress();
 
     /**
@@ -60,10 +60,15 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
         uint256[] memory values,
         bytes memory data
     ) internal virtual returns (bytes32) {
-        _onSend(from, ids, values);
-
         (bytes2 chainType, bytes memory chainReference, bytes memory addr) = to.parseV1();
         require(addr.length > 0, CrosschainMultiTokenEmptyAddress());
+        // EIP-155 destinations use 20-byte non-zero addresses (see {InteroperableAddress-tryParseEvmV1}).
+        // Accepting other lengths (or the zero address) would lock funds once the receive path rejects them.
+        if (chainType == bytes2(0x0000)) {
+            require(addr.length == 20 && address(bytes20(addr)) != address(0), CrosschainMultiTokenInvalidAddress());
+        }
+
+        _onSend(from, ids, values);
 
         bytes32 sendId = _sendMessageToCounterpart(
             InteroperableAddress.formatV1(chainType, chainReference, hex""),
@@ -89,8 +94,10 @@ abstract contract BridgeMultiToken is Context, CrosschainLinked {
             .decode(payload, (bytes, bytes, uint256[], uint256[], bytes));
         // `toEvm` comes from the ERC-7786 payload; `bytes20(...)` would silently truncate
         // a longer (e.g. non-EVM) address, mis-delivering the assets to a wrong account.
+        // The zero address is also rejected: unlocking/minting there is irreversible fund loss.
         require(toEvm.length == 20, CrosschainMultiTokenInvalidAddress());
         address to = address(bytes20(toEvm));
+        require(to != address(0), CrosschainMultiTokenInvalidAddress());
 
         _onReceive(to, ids, values, data);
 

--- a/contracts/crosschain/bridges/abstract/BridgeNonFungible.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeNonFungible.sol
@@ -33,6 +33,9 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
     /// @dev Revert reason when the address part of the interoperable address is empty.
     error CrosschainNonFungibleEmptyAddress();
 
+    /// @dev The receiver address in the payload is not exactly 20 bytes.
+    error CrosschainNonFungibleInvalidAddress();
+
     /**
      * @dev Internal crosschain transfer function.
      *
@@ -64,6 +67,9 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
     ) internal virtual override {
         // split payload
         (bytes memory from, bytes memory toEvm, uint256 tokenId) = abi.decode(payload, (bytes, bytes, uint256));
+        // `toEvm` comes from the ERC-7786 payload; `bytes20(...)` would silently truncate
+        // a longer (e.g. non-EVM) address, mis-delivering the assets to a wrong account.
+        require(toEvm.length == 20, CrosschainNonFungibleInvalidAddress());
         address to = address(bytes20(toEvm));
 
         _onReceive(to, tokenId);

--- a/contracts/crosschain/bridges/abstract/BridgeNonFungible.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeNonFungible.sol
@@ -33,7 +33,7 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
     /// @dev Revert reason when the address part of the interoperable address is empty.
     error CrosschainNonFungibleEmptyAddress();
 
-    /// @dev The receiver address in the payload is not exactly 20 bytes.
+    /// @dev The receiver address is not a valid EVM address (wrong length or zero).
     error CrosschainNonFungibleInvalidAddress();
 
     /**
@@ -42,10 +42,15 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
      * NOTE: The `to` parameter is the full InteroperableAddress (chain ref + address).
      */
     function _crosschainTransfer(address from, bytes memory to, uint256 tokenId) internal virtual returns (bytes32) {
-        _onSend(from, tokenId);
-
         (bytes2 chainType, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(to);
         require(addr.length > 0, CrosschainNonFungibleEmptyAddress());
+        // EIP-155 destinations use 20-byte non-zero addresses (see {InteroperableAddress-tryParseEvmV1}).
+        // Accepting other lengths (or the zero address) would lock funds once the receive path rejects them.
+        if (chainType == bytes2(0x0000)) {
+            require(addr.length == 20 && address(bytes20(addr)) != address(0), CrosschainNonFungibleInvalidAddress());
+        }
+
+        _onSend(from, tokenId);
 
         bytes32 sendId = _sendMessageToCounterpart(
             InteroperableAddress.formatV1(chainType, chainReference, hex""),
@@ -69,8 +74,10 @@ abstract contract BridgeNonFungible is Context, CrosschainLinked {
         (bytes memory from, bytes memory toEvm, uint256 tokenId) = abi.decode(payload, (bytes, bytes, uint256));
         // `toEvm` comes from the ERC-7786 payload; `bytes20(...)` would silently truncate
         // a longer (e.g. non-EVM) address, mis-delivering the assets to a wrong account.
+        // The zero address is also rejected: unlocking/minting there is irreversible fund loss.
         require(toEvm.length == 20, CrosschainNonFungibleInvalidAddress());
         address to = address(bytes20(toEvm));
+        require(to != address(0), CrosschainNonFungibleInvalidAddress());
 
         _onReceive(to, tokenId);
 

--- a/test/crosschain/BridgeERC1155.behavior.js
+++ b/test/crosschain/BridgeERC1155.behavior.js
@@ -398,6 +398,22 @@ function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chainBIsCust
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
           .withArgs(this.gateway, this.chain.toErc7930(invalid));
       });
+
+      it('rejects a receiver address that is not exactly 20 bytes', async function () {
+        const [alice] = this.accounts;
+        // a 32-byte receiver (e.g. a non-EVM address) must not be silently truncated
+        const longReceiver = ethers.zeroPadValue(alice.address, 32);
+        const payload = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['bytes', 'bytes', 'uint256[]', 'uint256[]', 'bytes'],
+          [this.chain.toErc7930(alice), longReceiver, ids, values, '0x'],
+        );
+
+        await expect(
+          this.bridgeA
+            .connect(this.gatewayAsEOA)
+            .receiveMessage(ethers.ZeroHash, this.chain.toErc7930(this.bridgeB), payload),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainMultiTokenInvalidAddress');
+      });
     });
 
     describe('reconfiguration', function () {

--- a/test/crosschain/BridgeERC1155.behavior.js
+++ b/test/crosschain/BridgeERC1155.behavior.js
@@ -368,6 +368,50 @@ function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chainBIsCust
           ), // No address
         ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainMultiTokenEmptyAddress');
       });
+
+      it('reverts if an EIP-155 receiver address is not exactly 20 bytes', async function () {
+        const [alice, bruce] = this.accounts;
+
+        await this.tokenA.$_mintBatch(alice, ids, values, '0x');
+        await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
+
+        let refHex = BigInt(this.chain.reference).toString(16);
+        if (refHex.length % 2) refHex = `0${refHex}`;
+        const ref = ethers.getBytes(`0x${refHex}`);
+        const longReceiver = ethers.concat([
+          '0x0001',
+          '0x0000',
+          ethers.toBeHex(ref.length, 1),
+          ref,
+          ethers.toBeHex(32, 1),
+          ethers.zeroPadValue(bruce.address, 32),
+        ]);
+
+        await expect(
+          this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
+            alice,
+            longReceiver,
+            ids,
+            values,
+          ),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainMultiTokenInvalidAddress');
+      });
+
+      it('reverts if an EIP-155 receiver is the zero address', async function () {
+        const [alice] = this.accounts;
+
+        await this.tokenA.$_mintBatch(alice, ids, values, '0x');
+        await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
+
+        await expect(
+          this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
+            alice,
+            this.chain.toErc7930(ethers.ZeroAddress),
+            ids,
+            values,
+          ),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainMultiTokenInvalidAddress');
+      });
     });
 
     describe('restrictions', function () {
@@ -406,6 +450,20 @@ function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chainBIsCust
         const payload = ethers.AbiCoder.defaultAbiCoder().encode(
           ['bytes', 'bytes', 'uint256[]', 'uint256[]', 'bytes'],
           [this.chain.toErc7930(alice), longReceiver, ids, values, '0x'],
+        );
+
+        await expect(
+          this.bridgeA
+            .connect(this.gatewayAsEOA)
+            .receiveMessage(ethers.ZeroHash, this.chain.toErc7930(this.bridgeB), payload),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainMultiTokenInvalidAddress');
+      });
+
+      it('rejects a zero receiver address', async function () {
+        const [alice] = this.accounts;
+        const payload = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['bytes', 'bytes', 'uint256[]', 'uint256[]', 'bytes'],
+          [this.chain.toErc7930(alice), ethers.ZeroAddress, ids, values, '0x'],
         );
 
         await expect(

--- a/test/crosschain/BridgeERC20.behavior.js
+++ b/test/crosschain/BridgeERC20.behavior.js
@@ -118,6 +118,22 @@ function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustod
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
           .withArgs(this.gateway, this.chain.toErc7930(invalid));
       });
+
+      it('rejects a receiver address that is not exactly 20 bytes', async function () {
+        const [alice] = this.accounts;
+        // a 32-byte receiver (e.g. a non-EVM address) must not be silently truncated
+        const longReceiver = ethers.zeroPadValue(alice.address, 32);
+        const payload = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['bytes', 'bytes', 'uint256'],
+          [this.chain.toErc7930(alice), longReceiver, amount],
+        );
+
+        await expect(
+          this.bridgeA
+            .connect(this.gatewayAsEOA)
+            .receiveMessage(ethers.ZeroHash, this.chain.toErc7930(this.bridgeB), payload),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleInvalidAddress');
+      });
     });
 
     describe('reconfiguration', function () {

--- a/test/crosschain/BridgeERC20.behavior.js
+++ b/test/crosschain/BridgeERC20.behavior.js
@@ -74,6 +74,22 @@ function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustod
     });
 
     describe('invalid transfer', function () {
+      // ERC-7930 v1: version=0x0001, chainType=eip155(0x0000), then ref + addr TLVs.
+      const encodeEip155Receiver = (chainId, addressBytes) => {
+        let refHex = BigInt(chainId).toString(16);
+        if (refHex.length % 2) refHex = `0${refHex}`;
+        const ref = ethers.getBytes(`0x${refHex}`);
+        const addr = ethers.getBytes(addressBytes);
+        return ethers.concat([
+          '0x0001',
+          '0x0000',
+          ethers.toBeHex(ref.length, 1),
+          ref,
+          ethers.toBeHex(addr.length, 1),
+          addr,
+        ]);
+      };
+
       it('reverts if the address part of the interoperable address is empty', async function () {
         const [alice] = this.accounts;
 
@@ -83,6 +99,34 @@ function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustod
         await expect(
           this.bridgeA.connect(alice).crosschainTransfer(this.chain.toErc7930(undefined), amount), // No address
         ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleEmptyAddress');
+      });
+
+      it('reverts if an EIP-155 receiver address is not exactly 20 bytes', async function () {
+        const [alice, bruce] = this.accounts;
+
+        await this.tokenA.$_mint(alice, amount);
+        await this.tokenA.connect(alice).approve(this.bridgeA, ethers.MaxUint256);
+
+        // Without this check, send would lock tokens and the length-checked receive path would reject forever.
+        const longReceiver = encodeEip155Receiver(
+          this.chain.reference,
+          ethers.zeroPadValue(bruce.address, 32),
+        );
+
+        await expect(
+          this.bridgeA.connect(alice).crosschainTransfer(longReceiver, amount),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleInvalidAddress');
+      });
+
+      it('reverts if an EIP-155 receiver is the zero address', async function () {
+        const [alice] = this.accounts;
+
+        await this.tokenA.$_mint(alice, amount);
+        await this.tokenA.connect(alice).approve(this.bridgeA, ethers.MaxUint256);
+
+        await expect(
+          this.bridgeA.connect(alice).crosschainTransfer(this.chain.toErc7930(ethers.ZeroAddress), amount),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleInvalidAddress');
       });
     });
 
@@ -126,6 +170,20 @@ function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustod
         const payload = ethers.AbiCoder.defaultAbiCoder().encode(
           ['bytes', 'bytes', 'uint256'],
           [this.chain.toErc7930(alice), longReceiver, amount],
+        );
+
+        await expect(
+          this.bridgeA
+            .connect(this.gatewayAsEOA)
+            .receiveMessage(ethers.ZeroHash, this.chain.toErc7930(this.bridgeB), payload),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleInvalidAddress');
+      });
+
+      it('rejects a zero receiver address', async function () {
+        const [alice] = this.accounts;
+        const payload = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['bytes', 'bytes', 'uint256'],
+          [this.chain.toErc7930(alice), ethers.ZeroAddress, amount],
         );
 
         await expect(

--- a/test/crosschain/BridgeERC20.behavior.js
+++ b/test/crosschain/BridgeERC20.behavior.js
@@ -108,10 +108,7 @@ function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustod
         await this.tokenA.connect(alice).approve(this.bridgeA, ethers.MaxUint256);
 
         // Without this check, send would lock tokens and the length-checked receive path would reject forever.
-        const longReceiver = encodeEip155Receiver(
-          this.chain.reference,
-          ethers.zeroPadValue(bruce.address, 32),
-        );
+        const longReceiver = encodeEip155Receiver(this.chain.reference, ethers.zeroPadValue(bruce.address, 32));
 
         await expect(
           this.bridgeA.connect(alice).crosschainTransfer(longReceiver, amount),

--- a/test/crosschain/BridgeERC721.behavior.js
+++ b/test/crosschain/BridgeERC721.behavior.js
@@ -186,6 +186,22 @@ function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCusto
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
           .withArgs(this.gateway, this.chain.toErc7930(invalid));
       });
+
+      it('rejects a receiver address that is not exactly 20 bytes', async function () {
+        const [alice] = this.accounts;
+        // a 32-byte receiver (e.g. a non-EVM address) must not be silently truncated
+        const longReceiver = ethers.zeroPadValue(alice.address, 32);
+        const payload = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['bytes', 'bytes', 'uint256'],
+          [this.chain.toErc7930(alice), longReceiver, tokenId],
+        );
+
+        await expect(
+          this.bridgeA
+            .connect(this.gatewayAsEOA)
+            .receiveMessage(ethers.ZeroHash, this.chain.toErc7930(this.bridgeB), payload),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleInvalidAddress');
+      });
     });
 
     describe('reconfiguration', function () {

--- a/test/crosschain/BridgeERC721.behavior.js
+++ b/test/crosschain/BridgeERC721.behavior.js
@@ -156,6 +156,40 @@ function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCusto
           this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.chain.toErc7930(undefined), tokenId), // No address
         ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleEmptyAddress');
       });
+
+      it('reverts if an EIP-155 receiver address is not exactly 20 bytes', async function () {
+        const [alice, bruce] = this.accounts;
+
+        await this.tokenA.$_mint(alice, tokenId);
+        await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
+
+        let refHex = BigInt(this.chain.reference).toString(16);
+        if (refHex.length % 2) refHex = `0${refHex}`;
+        const ref = ethers.getBytes(`0x${refHex}`);
+        const longReceiver = ethers.concat([
+          '0x0001',
+          '0x0000',
+          ethers.toBeHex(ref.length, 1),
+          ref,
+          ethers.toBeHex(32, 1),
+          ethers.zeroPadValue(bruce.address, 32),
+        ]);
+
+        await expect(
+          this.bridgeA.connect(alice).crosschainTransferFrom(alice, longReceiver, tokenId),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleInvalidAddress');
+      });
+
+      it('reverts if an EIP-155 receiver is the zero address', async function () {
+        const [alice] = this.accounts;
+
+        await this.tokenA.$_mint(alice, tokenId);
+        await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
+
+        await expect(
+          this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.chain.toErc7930(ethers.ZeroAddress), tokenId),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleInvalidAddress');
+      });
     });
 
     describe('restrictions', function () {
@@ -194,6 +228,20 @@ function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCusto
         const payload = ethers.AbiCoder.defaultAbiCoder().encode(
           ['bytes', 'bytes', 'uint256'],
           [this.chain.toErc7930(alice), longReceiver, tokenId],
+        );
+
+        await expect(
+          this.bridgeA
+            .connect(this.gatewayAsEOA)
+            .receiveMessage(ethers.ZeroHash, this.chain.toErc7930(this.bridgeB), payload),
+        ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleInvalidAddress');
+      });
+
+      it('rejects a zero receiver address', async function () {
+        const [alice] = this.accounts;
+        const payload = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['bytes', 'bytes', 'uint256'],
+          [this.chain.toErc7930(alice), ethers.ZeroAddress, tokenId],
         );
 
         await expect(


### PR DESCRIPTION
## Summary

The ERC-7786 receive path in `BridgeFungible`, `BridgeNonFungible`, and `BridgeMultiToken` previously coerced the payload receiver via `address(bytes20(toEvm))`. Two adjacent gaps remained after the length check:

1. **Receive truncation / wrong length** (original): a receiver longer than 20 bytes was silently truncated, mis-delivering assets.
2. **Send / receive consistency** (this update): EIP-155 send accepted any non-empty address length and the zero address. Once receive rejects non-20-byte receivers, a wrong-length send locks funds in custody forever. Unlocking/minting to `address(0)` is irreversible fund loss.

## Fix

- Receive: require `toEvm.length == 20` and `to != address(0)`.
- Send (EIP-155 / `chainType == 0x0000`): require `addr.length == 20` and non-zero before `_onSend` takes custody. Non-EVM destinations keep the existing non-empty check.

## Tests

- Wrong-length and zero-address cases on send and receive for ERC-20 / ERC-721 / ERC-1155 behavior suites.
- `npx hardhat test test/crosschain/BridgeERC20.test.js test/crosschain/BridgeERC721.test.js test/crosschain/BridgeERC1155.test.js` → 53 passing.

Reported via Elacity CodeRED Amber review.