### PR TITLE
Fix VestingWallet token vesting overflow

### DIFF
--- a/.changeset/hip-forks-fall.md
+++ b/.changeset/hip-forks-fall.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+Fix integer overflow in VestingWallet token vesting calculation

--- a/contracts/finance/VestingWallet.sol
+++ b/contracts/finance/VestingWallet.sol
@@ -3,6 +3,7 @@
 
 pragma solidity ^0.8.20;
 
+import {Math} from "../utils/math/Math.sol";
 import {IERC20} from "../token/ERC20/IERC20.sol";
 import {SafeERC20} from "../token/ERC20/utils/SafeERC20.sol";
 import {Address} from "../utils/Address.sol";
@@ -141,7 +142,29 @@ contract VestingWallet is Context, Ownable {
      * @dev Calculates the amount of tokens that has already vested. Default implementation is a linear vesting curve.
      */
     function vestedAmount(address token, uint64 timestamp) public view virtual returns (uint256) {
-        return _vestingSchedule(IERC20(token).balanceOf(address(this)) + released(token), timestamp);
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        uint256 releasedAmount = released(token);
+
+        if (balance <= type(uint256).max - releasedAmount) {
+            return _vestingSchedule(balance + releasedAmount, timestamp);
+        }
+
+        if (timestamp < start()) {
+            return 0;
+        } else if (timestamp >= end()) {
+            return type(uint256).max;
+        }
+
+        uint256 elapsed = timestamp - start();
+        uint256 vestingDuration = duration();
+
+        uint256 vestedBalance = Math.mulDiv(balance, elapsed, vestingDuration);
+        uint256 vestedReleased = Math.mulDiv(releasedAmount, elapsed, vestingDuration);
+
+        uint256 remainderBalance = mulmod(balance, elapsed, vestingDuration);
+        uint256 remainderReleased = mulmod(releasedAmount, elapsed, vestingDuration);
+
+        return vestedBalance + vestedReleased + (remainderBalance + remainderReleased >= vestingDuration ? 1 : 0);
     }
 
     /**
@@ -154,7 +177,7 @@ contract VestingWallet is Context, Ownable {
         } else if (timestamp >= end()) {
             return totalAllocation;
         } else {
-            return (totalAllocation * (timestamp - start())) / duration();
+            return Math.mulDiv(totalAllocation, timestamp - start(), duration());
         }
     }
 }

--- a/contracts/finance/VestingWallet.sol
+++ b/contracts/finance/VestingWallet.sol
@@ -164,7 +164,20 @@ contract VestingWallet is Context, Ownable {
         uint256 remainderBalance = mulmod(balance, elapsed, vestingDuration);
         uint256 remainderReleased = mulmod(releasedAmount, elapsed, vestingDuration);
 
-        return vestedBalance + vestedReleased + (remainderBalance + remainderReleased >= vestingDuration ? 1 : 0);
+        if (vestedBalance > type(uint256).max - vestedReleased) {
+            return type(uint256).max;
+        }
+
+        uint256 vested = vestedBalance + vestedReleased;
+
+        if (remainderBalance + remainderReleased >= vestingDuration) {
+            if (vested == type(uint256).max) {
+                return type(uint256).max;
+            }
+            ++vested;
+        }
+
+        return vested;
     }
 
     /**

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -38,6 +38,24 @@ describe('VestingWallet', function () {
       .withArgs(ethers.ZeroAddress);
   });
 
+  it('does not overflow when released tokens are transferred back', async function () {
+    const token = await ethers.deployContract('$ERC20', ['Name', 'Symbol']);
+
+    await token.$_mint(this.mock, ethers.MaxUint256);
+
+    const timestamp = this.start + this.duration / 2n;
+    await time.increaseTo.timestamp(timestamp);
+
+    const releasable = await this.mock['releasable(address)'](token);
+    expect(releasable).to.be.gt(0n);
+
+    await this.mock.connect(this.beneficiary)['release(address)'](token);
+
+    await token.connect(this.beneficiary).transfer(this.mock, releasable);
+
+    await expect(this.mock['vestedAmount(address,uint64)'](token, timestamp)).not.to.be.reverted;
+  });
+
   it('check vesting contract', async function () {
     expect(await this.mock.owner()).to.equal(this.beneficiary);
     expect(await this.mock.start()).to.equal(this.start);

--- a/test/finance/VestingWallet.test.js
+++ b/test/finance/VestingWallet.test.js
@@ -54,6 +54,11 @@ describe('VestingWallet', function () {
     await token.connect(this.beneficiary).transfer(this.mock, releasable);
 
     await expect(this.mock['vestedAmount(address,uint64)'](token, timestamp)).not.to.be.reverted;
+
+    const laterTimestamp = this.start + (this.duration * 3n) / 4n;
+    await expect(this.mock['vestedAmount(address,uint64)'](token, laterTimestamp)).to.not.be.reverted;
+
+    expect(await this.mock['vestedAmount(address,uint64)'](token, laterTimestamp)).to.equal(ethers.MaxUint256);
   });
 
   it('check vesting contract', async function () {


### PR DESCRIPTION
## Description

Fixes an integer overflow in `VestingWallet.vestedAmount(address,uint64)`
when the current token balance and previously released amount together
exceed `uint256.max`.

The existing vesting calculation is preserved when the total allocation
can be safely computed without overflowing. When the addition would
overflow, the vesting calculation is performed using overflow-safe
arithmetic.

## Tests

- Added a regression test covering released tokens being transferred back
  to the VestingWallet.
- Full test suite: 8047 passing, 1 pending.
- VestingWallet tests: 9 passing.
- ESLint passed.
- Solhint passed.
- Prettier check passed.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
