### PR TITLE
GovernorPreventLateQuorum: document first-quorum-only behavior

### DIFF
--- a/contracts/governance/extensions/GovernorPreventLateQuorum.sol
+++ b/contracts/governance/extensions/GovernorPreventLateQuorum.sol
@@ -14,6 +14,9 @@ import {Math} from "../../utils/math/Math.sol";
  * If a vote causes quorum to be reached, the proposal's voting period may be extended so that it does not end before at
  * least a specified time has passed (the "vote extension" parameter). This parameter can be set through a governance
  * proposal.
+ *
+ * NOTE: This module only reacts to the first time a proposal reaches quorum. If quorum can later be lost, for example
+ * when combined with {GovernorCountingOverridable}, reaching quorum again will not trigger another vote extension.
  */
 abstract contract GovernorPreventLateQuorum is Governor {
     uint48 private _voteExtension;


### PR DESCRIPTION
Clarifies that `GovernorPreventLateQuorum` only reacts to the first time a proposal reaches quorum.

When composed with counting modules where quorum can later be lost, such as `GovernorCountingOverridable`, restoring quorum does not trigger another vote extension.

This documents the existing intended behavior and does not introduce any functional changes.

#### PR Checklist

* [ ] Tests — documentation-only change
* [x] Documentation
* [ ] Changeset entry — NatSpec-only change
