### PR TITLE
Hardhat3: Checkout submodules when packing a release

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -136,6 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
       - id: pack

--- a/.github/workflows/release-upgradeable.yml
+++ b/.github/workflows/release-upgradeable.yml
@@ -42,10 +42,12 @@ jobs:
         with:
           repository: ${{ github.repository }}-upgradeable
           ref: ${{ github.ref }}
+          submodules: recursive
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           path: lib/openzeppelin-contracts
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
       - id: pack


### PR DESCRIPTION
## Summary

#6542's `hardhat compile` also builds `test/**/*.t.sol`, which import `forge-std`. Release `npm pack` runs that compile. `checks.yml` already checks out submodules; the publish jobs in `release-cycle.yml` and `release-upgradeable.yml` did not.

## Test plan

- [ ] Hide `lib/forge-std`, run `npm run compile`, confirm it fails looking for `Test.sol`
- [ ] Restore the submodule, compile succeeds


Made with [Cursor](https://cursor.com)