### PR TITLE
Hardhat3: fix `test:inheritance` no-op

### DIFF
--- a/scripts/checks/inheritance-ordering.js
+++ b/scripts/checks/inheritance-ordering.js
@@ -11,9 +11,11 @@ import { hideBin } from 'yargs/helpers';
 const { _: artifacts } = yargs(hideBin(process.argv)).argv;
 
 // only consider files in the package: take pattern from package.json
-const { files: patterns } = JSON.parse(
+// npm `files` entries are rooted (`/contracts/**/*.sol`); solc source keys are not
+const { files: pkgFiles } = JSON.parse(
   fs.readFileSync(path.resolve(import.meta.dirname, '../../', 'package.json'), 'utf-8'),
 );
+const patterns = pkgFiles.map(p => p.replace(/^\//, '').replace(/^!\//, '!'));
 
 for (const artifact of artifacts) {
   const { output: solcOutput } = JSON.parse(


### PR DESCRIPTION
## Summary

After #6542, `npm run test:inheritance` is not running correctly anymore because it matches `/contracts/**/*.sol` against solc paths like `contracts/token/ERC20/ERC20.sol`. micromatch matches nothing, so the C3 check always prints "consistent" without looking at a contract.

Strip the leading `/` from those patterns.

## Test plan

- [x] Existing build-info: 0 files matched before, 449 after
- [x] Checker still exits 0 (no real C3 conflict)