### PR TITLE
hardhat-exposed: fail gracefully when the sources don't compile

### DIFF
--- a/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
+++ b/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
@@ -107,7 +107,6 @@ export default async function generateExposedContracts(
     console.log(`Generated ${exposedPaths.size} exposed contract files`);
     return successfulResult();
   } else {
-    console.error('Failed to generate exposed contracts: the sources do not compile');
     return errorResult();
   }
 }

--- a/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
+++ b/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
@@ -69,6 +69,7 @@ export default async function generateExposedContracts(
   const spinner = createSpinner({ text: `Generating exposed contracts...` });
   spinner.start();
 
+  let compilationSuccess = true;
   try {
     for (const buildInfo of astOnlyBuildInfos) {
       // Sanity check: No exposed contract should be included as part of the
@@ -82,6 +83,14 @@ export default async function generateExposedContracts(
 
       const buildOutput = await hre.solidity.compileBuildInfo(buildInfo);
 
+      // A failed compilation produces no sources at all, which would make the AST processing below fail with a
+      // confusing error. The errors are not printed here: this build info is a subset of what the build task
+      // compiles right after, so the build reports them itself, with the proper exit code.
+      if (buildOutput.errors?.some(error => error.severity === 'error')) {
+        compilationSuccess = false;
+        break;
+      }
+
       const exposed = getExposed(buildInfo, buildOutput, hre.config);
 
       for (const [exposedPath, exposedContent] of exposed) {
@@ -94,6 +103,11 @@ export default async function generateExposedContracts(
     spinner.stop();
   }
 
-  console.log(`Generated ${exposedPaths.size} exposed contract files`);
-  return successfulResult();
+  if (compilationSuccess) {
+    console.log(`Generated ${exposedPaths.size} exposed contract files`);
+    return successfulResult();
+  } else {
+    console.error('Failed to generate exposed contracts: the sources do not compile');
+    return errorResult();
+  }
 }

--- a/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
+++ b/hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts
@@ -69,7 +69,6 @@ export default async function generateExposedContracts(
   const spinner = createSpinner({ text: `Generating exposed contracts...` });
   spinner.start();
 
-  let compilationSuccess = true;
   try {
     for (const buildInfo of astOnlyBuildInfos) {
       // Sanity check: No exposed contract should be included as part of the
@@ -87,8 +86,8 @@ export default async function generateExposedContracts(
       // confusing error. The errors are not printed here: this build info is a subset of what the build task
       // compiles right after, so the build reports them itself, with the proper exit code.
       if (buildOutput.errors?.some(error => error.severity === 'error')) {
-        compilationSuccess = false;
-        break;
+        spinner.stop();
+        return errorResult();
       }
 
       const exposed = getExposed(buildInfo, buildOutput, hre.config);
@@ -103,10 +102,6 @@ export default async function generateExposedContracts(
     spinner.stop();
   }
 
-  if (compilationSuccess) {
-    console.log(`Generated ${exposedPaths.size} exposed contract files`);
-    return successfulResult();
-  } else {
-    return errorResult();
-  }
+  console.log(`Generated ${exposedPaths.size} exposed contract files`);
+  return successfulResult();
 }


### PR DESCRIPTION
When the sources don't compile, `hardhat compile` currently dies inside the exposed-contracts generation with an opaque error, hiding the actual compilation errors:

```
TypeError: Cannot read properties of undefined (reading 'ast')
    at getExposed (hardhat/hardhat-exposed/internal/expose.ts:40:53)
    at generateExposedContracts (hardhat/hardhat-exposed/tasks/generate-exposed-contracts.ts:85:23)
```

`compileBuildInfo` returns an output with no `sources` when the compilation fails, so `getExposed` dereferences `undefined` while walking `userSourceNameMap`. The solc errors themselves are never shown, which makes any syntax or type error in `contracts/` look like a Hardhat/plugin bug.

This checks the compiler output for fatal errors before touching the ASTs, and returns an `errorResult` instead.

The errors are deliberately not printed by the task: the ast-only build info is a subset of what the `build` task compiles immediately after (same sources, same solc, only `outputSelection` narrowed to `ast`), so every error the generation can hit is reported by the build itself — with warnings, colors and remapped source names. Printing them here as well would only duplicate the output. `build` therefore keeps calling `runSuper` after a failed generation, which also preserves the exit code and the `{ contractRootPaths, testRootPaths }` return value its callers rely on.

Verified, with a deliberate type error in `contracts/utils/Memory.sol`:

- `npm run compile` → `Failed to generate exposed contracts: the sources do not compile`, followed by the real solc diagnostics and `Error HHE910`, exit code 1
- `npx hardhat generate-exposed-contracts` → same message, exit code 1
- on a clean tree → `Generated 302 exposed contract files` / `Compiled 699 Solidity files`, exit code 0, and `--force` / incremental runs unchanged

No changeset: repo plumbing, no user-visible contract change.