### PR TITLE
Memory: add ConstSlice type and align slice() with Bytes.slice

### DIFF
--- a/.changeset/memory-const-slice.md
+++ b/.changeset/memory-const-slice.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`Memory`: Add a `ConstSlice` type, obtained from `asConstSlice(bytes)` or `asConst(Slice)`, that marks a memory region as read-only at the type level. All read-only slice operations (`length`, `load`, `isReserved`, `equal`, `slice`, `toBytes`) accept both `Slice` and `ConstSlice`. Also add `write(Slice|ConstSlice,bytes)` to copy a slice into a caller-provided buffer instead of allocating a new one.

--- a/.changeset/memory-slice-start-end.md
+++ b/.changeset/memory-slice-start-end.md
@@ -1,5 +1,5 @@
 ---
-'openzeppelin-solidity': minor
+'openzeppelin-solidity': major
 ---
 
 [BREAKING] `Memory`: `slice(Slice,uint256,uint256)` now takes `(start, end)` bounds instead of `(offset, length)`, and both `slice` overloads truncate out-of-range bounds instead of reverting with `Panic.ARRAY_OUT_OF_BOUNDS`. This aligns `Memory.slice` with `Bytes.slice` and `Arrays.slice`. The signature is unchanged, so existing calls keep compiling with a different meaning: `s.slice(a, b)` must be rewritten as `s.slice(a, a + b)`.

--- a/.changeset/memory-slice-start-end.md
+++ b/.changeset/memory-slice-start-end.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+[BREAKING] `Memory`: `slice(Slice,uint256,uint256)` now takes `(start, end)` bounds instead of `(offset, length)`, and truncates out-of-range bounds instead of reverting with `Panic.ARRAY_OUT_OF_BOUNDS`. This aligns `Memory.slice` with `Bytes.slice` and `Arrays.slice`. The signature is unchanged, so existing calls keep compiling with a different meaning: `s.slice(a, b)` must be rewritten as `s.slice(a, a + b)`.

--- a/.changeset/memory-slice-start-end.md
+++ b/.changeset/memory-slice-start-end.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-[BREAKING] `Memory`: `slice(Slice,uint256,uint256)` now takes `(start, end)` bounds instead of `(offset, length)`, and truncates out-of-range bounds instead of reverting with `Panic.ARRAY_OUT_OF_BOUNDS`. This aligns `Memory.slice` with `Bytes.slice` and `Arrays.slice`. The signature is unchanged, so existing calls keep compiling with a different meaning: `s.slice(a, b)` must be rewritten as `s.slice(a, a + b)`.
+[BREAKING] `Memory`: `slice(Slice,uint256,uint256)` now takes `(start, end)` bounds instead of `(offset, length)`, and both `slice` overloads truncate out-of-range bounds instead of reverting with `Panic.ARRAY_OUT_OF_BOUNDS`. This aligns `Memory.slice` with `Bytes.slice` and `Arrays.slice`. The signature is unchanged, so existing calls keep compiling with a different meaning: `s.slice(a, b)` must be rewritten as `s.slice(a, a + b)`.

--- a/contracts/utils/Memory.sol
+++ b/contracts/utils/Memory.sol
@@ -53,6 +53,7 @@ library Memory {
     }
 
     type Slice is bytes32;
+    type ConstSlice is bytes32;
 
     /// @dev Get a slice representation of a bytes object in memory
     function asSlice(bytes memory self) internal pure returns (Slice result) {
@@ -61,41 +62,26 @@ library Memory {
         }
     }
 
-    /// @dev Returns the length of a given slice (equiv to self.length for calldata slices)
-    function length(Slice self) internal pure returns (uint256 result) {
-        assembly ("memory-safe") {
-            result := shr(128, self)
-        }
+    /// @dev Get a constant slice representation of a bytes object in memory
+    function asConstSlice(bytes memory self) internal pure returns (ConstSlice result) {
+        return asConst(asSlice(self));
     }
 
-    /// @dev Offset a memory slice (equivalent to self[offset:] for calldata slices)
-    function slice(Slice self, uint256 offset) internal pure returns (Slice) {
-        if (offset > length(self)) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
-        return _asSlice(length(self) - offset, forward(_pointer(self), offset));
+    // @dev Get a constant slice representation of a non-constant slice
+    function asConst(Slice self) internal pure returns (ConstSlice result) {
+        return ConstSlice.wrap(Slice.unwrap(self));
     }
 
-    /// @dev Offset and cut a Slice (equivalent to self[offset:offset+len] for calldata slices)
-    function slice(Slice self, uint256 offset, uint256 len) internal pure returns (Slice) {
-        if (offset + len > length(self)) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
-        return _asSlice(len, forward(_pointer(self), offset));
-    }
+    // ===============================================================================================================
+    // Export
+    // ===============================================================================================================
 
-    /**
-     * @dev Read a bytes32 buffer from a given Slice at a specific offset
-     *
-     * NOTE: If offset > length(slice) - 0x20, part of the return value will be out of bound of the slice. These bytes are zeroed.
-     */
-    function load(Slice self, uint256 offset) internal pure returns (bytes32 value) {
-        uint256 outOfBoundBytes = Math.saturatingSub(0x20 + offset, length(self));
-        if (outOfBoundBytes > 0x1f) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
-
-        assembly ("memory-safe") {
-            value := and(mload(add(and(self, shr(128, not(0))), offset)), shl(mul(8, outOfBoundBytes), not(0)))
-        }
+    function toBytes(Slice self) internal pure returns (bytes memory result) {
+        return toBytes(asConst(self));
     }
 
     /// @dev Extract the data corresponding to a Slice (allocate new memory)
-    function toBytes(Slice self) internal pure returns (bytes memory result) {
+    function toBytes(ConstSlice self) internal pure returns (bytes memory result) {
         uint256 len = length(self);
         Pointer ptr = _pointer(self);
         assembly ("memory-safe") {
@@ -106,8 +92,85 @@ library Memory {
         }
     }
 
-    /// @dev Returns true if the two slices contain the same data.
+    function write(Slice self, bytes memory buffer) internal pure returns (bytes memory result) {
+        return write(asConst(self), buffer);
+    }
+
+    function write(ConstSlice self, bytes memory buffer) internal pure returns (bytes memory result) {
+        uint256 len = length(self);
+        if (buffer.length < len) Panic.panic(Panic.RESOURCE_ERROR);
+        Pointer ptr = _pointer(self);
+        assembly ("memory-safe") {
+            mstore(buffer, len)
+            mcopy(add(buffer, 0x20), ptr, len)
+        }
+        return buffer;
+    }
+
+    // ===============================================================================================================
+    // Getters
+    // ===============================================================================================================
+
+    /// @dev Returns the length of a given slice (equiv to self.length for calldata slices)
+    function length(Slice self) internal pure returns (uint256 result) {
+        return length(asConst(self));
+    }
+
+    function length(ConstSlice self) internal pure returns (uint256 result) {
+        assembly ("memory-safe") {
+            result := shr(128, self)
+        }
+    }
+
+    /**
+     * @dev Read a bytes32 buffer from a given Slice at a specific offset
+     *
+     * NOTE: If offset > length(slice) - 0x20, part of the return value will be out of bound of the slice. These bytes are zeroed.
+     */
+    function load(Slice self, uint256 offset) internal pure returns (bytes32 value) {
+        return load(asConst(self), offset);
+    }
+
+    function load(ConstSlice self, uint256 offset) internal pure returns (bytes32 value) {
+        uint256 outOfBoundBytes = Math.saturatingSub(0x20 + offset, length(self));
+        if (outOfBoundBytes > 0x1f) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
+
+        assembly ("memory-safe") {
+            value := and(mload(add(and(self, shr(128, not(0))), offset)), shl(mul(8, outOfBoundBytes), not(0)))
+        }
+    }
+
+    /// @dev Returns true if the memory occupied by the slice is reserved (i.e. before the free memory pointer)
+    function isReserved(Slice self) internal pure returns (bool result) {
+        return isReserved(asConst(self));
+    }
+
+    function isReserved(ConstSlice self) internal pure returns (bool result) {
+        Memory.Pointer fmp = getFreeMemoryPointer();
+        Memory.Pointer end = forward(_pointer(self), length(self));
+        assembly ("memory-safe") {
+            result := iszero(lt(fmp, end)) // end <= fmp
+        }
+    }
+
+    // ===============================================================================================================
+    // Comparators
+    // ===============================================================================================================
+
     function equal(Slice a, Slice b) internal pure returns (bool result) {
+        return equal(asConst(a), asConst(b));
+    }
+
+    function equal(ConstSlice a, Slice b) internal pure returns (bool result) {
+        return equal(a, asConst(b));
+    }
+
+    function equal(Slice a, ConstSlice b) internal pure returns (bool result) {
+        return equal(asConst(a), b);
+    }
+
+    /// @dev Returns true if the two slices contain the same data.
+    function equal(ConstSlice a, ConstSlice b) internal pure returns (bool result) {
         uint256 len = length(a);
         if (len == length(b)) {
             Memory.Pointer ptrA = _pointer(a);
@@ -119,14 +182,41 @@ library Memory {
         // else returns false (default value)
     }
 
-    /// @dev Returns true if the memory occupied by the slice is reserved (i.e. before the free memory pointer)
-    function isReserved(Slice self) internal pure returns (bool result) {
-        Memory.Pointer fmp = getFreeMemoryPointer();
-        Memory.Pointer end = forward(_pointer(self), length(self));
-        assembly ("memory-safe") {
-            result := iszero(lt(fmp, end)) // end <= fmp
+    // ===============================================================================================================
+    // Slice
+    // ===============================================================================================================
+
+    /// @dev Offset a memory slice (equivalent to self[start:] for calldata slices)
+    function slice(Slice self, uint256 start) internal pure returns (Slice) {
+        return slice(self, start, length(self));
+    }
+
+    /// @dev Offset and cut a Slice (equivalent to self[start:end] for calldata slices)
+    function slice(Slice self, uint256 start, uint256 end) internal pure returns (Slice) {
+        unchecked {
+            end = Math.min(end, length(self));
+            start = Math.min(start, end);
+            return _asSlice(forward(_pointer(self), start), end - start);
         }
     }
+
+    /// @dev Offset a memory slice (equivalent to self[start:] for calldata slices)
+    function slice(ConstSlice self, uint256 start) internal pure returns (ConstSlice) {
+        return slice(self, start, length(self));
+    }
+
+    /// @dev Offset and cut a Slice (equivalent to self[start:end] for calldata slices)
+    function slice(ConstSlice self, uint256 start, uint256 end) internal pure returns (ConstSlice) {
+        unchecked {
+            end = Math.min(end, length(self));
+            start = Math.min(start, end);
+            return _asConstSlice(forward(_pointer(self), start), end - start);
+        }
+    }
+
+    // ===============================================================================================================
+    // Private helpers
+    // ===============================================================================================================
 
     /**
      * @dev Private helper: create a slice from raw values (length and pointer)
@@ -136,14 +226,22 @@ library Memory {
      * (`slice(Slice,uint256)` and `slice(Slice,uint256, uint256)`) should not cause this issue if the parent slice is
      * correct.
      */
-    function _asSlice(uint256 len, Pointer ptr) private pure returns (Slice result) {
+    function _asSlice(Pointer ptr, uint256 len) private pure returns (Slice result) {
         assembly ("memory-safe") {
             result := or(shl(128, len), ptr)
         }
     }
 
+    function _asConstSlice(Pointer ptr, uint256 len) private pure returns (ConstSlice result) {
+        return asConst(_asSlice(ptr, len));
+    }
+
     /// @dev Returns the memory location of a given slice (equiv to self.offset for calldata slices)
     function _pointer(Slice self) private pure returns (Pointer result) {
+        return _pointer(asConst(self));
+    }
+
+    function _pointer(ConstSlice self) private pure returns (Pointer result) {
         assembly ("memory-safe") {
             result := and(self, shr(128, not(0)))
         }

--- a/contracts/utils/Memory.sol
+++ b/contracts/utils/Memory.sol
@@ -52,7 +52,16 @@ library Memory {
         return Pointer.unwrap(ptr1) == Pointer.unwrap(ptr2);
     }
 
+    /// @dev A view into a region of memory: a pointer and a length packed into a single word.
     type Slice is bytes32;
+
+    /**
+     * @dev A {Slice} that is not meant to be written to.
+     *
+     * This type carries no enforcement of its own. It documents intent at the type level and, because there is no
+     * conversion back to {Slice}, it keeps a read-only slice from being passed where a writable one is expected. The
+     * underlying memory stays reachable, and mutable, through any other pointer to the same region.
+     */
     type ConstSlice is bytes32;
 
     /// @dev Get a slice representation of a bytes object in memory
@@ -67,7 +76,7 @@ library Memory {
         return asConst(asSlice(self));
     }
 
-    // @dev Get a constant slice representation of a non-constant slice
+    /// @dev Get a constant slice representation of a non-constant slice. This conversion is one-way.
     function asConst(Slice self) internal pure returns (ConstSlice result) {
         return ConstSlice.wrap(Slice.unwrap(self));
     }
@@ -76,11 +85,12 @@ library Memory {
     // Export
     // ===============================================================================================================
 
+    /// @dev Extract the data corresponding to a Slice (allocate new memory)
     function toBytes(Slice self) internal pure returns (bytes memory result) {
         return toBytes(asConst(self));
     }
 
-    /// @dev Extract the data corresponding to a Slice (allocate new memory)
+    /// @dev Extract the data corresponding to a ConstSlice (allocate new memory)
     function toBytes(ConstSlice self) internal pure returns (bytes memory result) {
         uint256 len = length(self);
         Pointer ptr = _pointer(self);
@@ -92,13 +102,32 @@ library Memory {
         }
     }
 
+    /**
+     * @dev Extract the data corresponding to a Slice into an existing `buffer` (does not allocate memory).
+     *
+     * NOTE: This modifies `buffer` in place and shrinks it to the length of the slice. See the `ConstSlice` variant
+     * of this function for the full requirements and semantics.
+     */
     function write(Slice self, bytes memory buffer) internal pure returns (bytes memory result) {
         return write(asConst(self), buffer);
     }
 
+    /**
+     * @dev Extract the data corresponding to a ConstSlice into an existing `buffer` (does not allocate memory), and
+     * return that buffer shrunk to the length of the slice. Use {toBytes} instead if a freshly allocated result is
+     * needed.
+     *
+     * NOTE: This function modifies the provided buffer in place, and the returned value is that same buffer. Its
+     * length is reduced to the length of the slice, so any space it held past that point becomes unreachable while
+     * remaining reserved. A buffer's length can only ever shrink this way, never grow back.
+     *
+     * Requirements:
+     *
+     * * `buffer` must be at least as long as the slice, otherwise this panics with {ARRAY_OUT_OF_BOUNDS}.
+     */
     function write(ConstSlice self, bytes memory buffer) internal pure returns (bytes memory result) {
         uint256 len = length(self);
-        if (buffer.length < len) Panic.panic(Panic.RESOURCE_ERROR);
+        if (buffer.length < len) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
         Pointer ptr = _pointer(self);
         assembly ("memory-safe") {
             mstore(buffer, len)
@@ -116,6 +145,7 @@ library Memory {
         return length(asConst(self));
     }
 
+    /// @dev Returns the length of a given constant slice (equiv to self.length for calldata slices)
     function length(ConstSlice self) internal pure returns (uint256 result) {
         assembly ("memory-safe") {
             result := shr(128, self)
@@ -131,6 +161,11 @@ library Memory {
         return load(asConst(self), offset);
     }
 
+    /**
+     * @dev Read a bytes32 buffer from a given ConstSlice at a specific offset
+     *
+     * NOTE: If offset > length(slice) - 0x20, part of the return value will be out of bound of the slice. These bytes are zeroed.
+     */
     function load(ConstSlice self, uint256 offset) internal pure returns (bytes32 value) {
         uint256 outOfBoundBytes = Math.saturatingSub(0x20 + offset, length(self));
         if (outOfBoundBytes > 0x1f) Panic.panic(Panic.ARRAY_OUT_OF_BOUNDS);
@@ -145,6 +180,7 @@ library Memory {
         return isReserved(asConst(self));
     }
 
+    /// @dev Returns true if the memory occupied by the constant slice is reserved (i.e. before the free memory pointer)
     function isReserved(ConstSlice self) internal pure returns (bool result) {
         Memory.Pointer fmp = getFreeMemoryPointer();
         Memory.Pointer end = forward(_pointer(self), length(self));
@@ -157,14 +193,17 @@ library Memory {
     // Comparators
     // ===============================================================================================================
 
+    /// @dev Returns true if the two slices contain the same data.
     function equal(Slice a, Slice b) internal pure returns (bool result) {
         return equal(asConst(a), asConst(b));
     }
 
+    /// @dev Returns true if the two slices contain the same data.
     function equal(ConstSlice a, Slice b) internal pure returns (bool result) {
         return equal(a, asConst(b));
     }
 
+    /// @dev Returns true if the two slices contain the same data.
     function equal(Slice a, ConstSlice b) internal pure returns (bool result) {
         return equal(asConst(a), b);
     }
@@ -186,30 +225,56 @@ library Memory {
     // Slice
     // ===============================================================================================================
 
-    /// @dev Offset a memory slice (equivalent to self[start:] for calldata slices)
+    /**
+     * @dev Returns a Slice covering `self`, from `start` (included) to the end of `self`. Unlike
+     * {xref-Bytes-slice-bytes-uint256-uint256-}[`Bytes.slice`], this is a view into the same memory: no data is copied.
+     *
+     * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
+     */
     function slice(Slice self, uint256 start) internal pure returns (Slice) {
         return slice(self, start, length(self));
     }
 
-    /// @dev Offset and cut a Slice (equivalent to self[start:end] for calldata slices)
+    /**
+     * @dev Returns a Slice covering `self`, from `start` (included) to `end` (excluded). The `end` argument is
+     * truncated to the length of `self`, and `start` is truncated to `end`. Unlike a calldata slice expression
+     * (`self[start:end]`), out-of-range bounds do not revert: they produce a shorter, possibly empty, slice. Unlike
+     * {xref-Bytes-slice-bytes-uint256-uint256-}[`Bytes.slice`], this is a view into the same memory: no data is copied.
+     *
+     * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
+     */
     function slice(Slice self, uint256 start, uint256 end) internal pure returns (Slice) {
         unchecked {
             end = Math.min(end, length(self));
             start = Math.min(start, end);
+            // Overflow not possible: start <= end, both truncated to length(self).
             return _asSlice(forward(_pointer(self), start), end - start);
         }
     }
 
-    /// @dev Offset a memory slice (equivalent to self[start:] for calldata slices)
+    /**
+     * @dev Returns a ConstSlice covering `self`, from `start` (included) to the end of `self`. Unlike {Bytes-slice},
+     * this is a view into the same memory: no data is copied.
+     *
+     * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
+     */
     function slice(ConstSlice self, uint256 start) internal pure returns (ConstSlice) {
         return slice(self, start, length(self));
     }
 
-    /// @dev Offset and cut a Slice (equivalent to self[start:end] for calldata slices)
+    /**
+     * @dev Returns a ConstSlice covering `self`, from `start` (included) to `end` (excluded). The `end` argument is
+     * truncated to the length of `self`, and `start` is truncated to `end`. Unlike a calldata slice expression
+     * (`self[start:end]`), out-of-range bounds do not revert: they produce a shorter, possibly empty, slice. Unlike
+     * {xref-Bytes-slice-bytes-uint256-uint256-}[`Bytes.slice`], this is a view into the same memory: no data is copied.
+     *
+     * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
+     */
     function slice(ConstSlice self, uint256 start, uint256 end) internal pure returns (ConstSlice) {
         unchecked {
             end = Math.min(end, length(self));
             start = Math.min(start, end);
+            // Overflow not possible: start <= end, both truncated to length(self).
             return _asConstSlice(forward(_pointer(self), start), end - start);
         }
     }
@@ -219,12 +284,11 @@ library Memory {
     // ===============================================================================================================
 
     /**
-     * @dev Private helper: create a slice from raw values (length and pointer)
+     * @dev Private helper: create a slice from raw values (pointer and length)
      *
-     * NOTE: this function MUST NOT be called with `len` or `ptr` that exceed `2**128-1`. This should never be
-     * the case of slices produced by `asSlice(bytes)`, and function that reduce the scope of slices
-     * (`slice(Slice,uint256)` and `slice(Slice,uint256, uint256)`) should not cause this issue if the parent slice is
-     * correct.
+     * NOTE: this function MUST NOT be called with `ptr` or `len` that exceed `2**128-1`. This should never be
+     * the case of slices produced by `asSlice(bytes)`, and functions that reduce the scope of slices
+     * (the `slice` overloads) should not cause this issue if the parent slice is correct.
      */
     function _asSlice(Pointer ptr, uint256 len) private pure returns (Slice result) {
         assembly ("memory-safe") {
@@ -232,6 +296,7 @@ library Memory {
         }
     }
 
+    /// @dev Private helper: create a constant slice from raw values (pointer and length). See {_asSlice}.
     function _asConstSlice(Pointer ptr, uint256 len) private pure returns (ConstSlice result) {
         return asConst(_asSlice(ptr, len));
     }
@@ -241,6 +306,7 @@ library Memory {
         return _pointer(asConst(self));
     }
 
+    /// @dev Returns the memory location of a given constant slice (equiv to self.offset for calldata slices)
     function _pointer(ConstSlice self) private pure returns (Pointer result) {
         assembly ("memory-safe") {
             result := and(self, shr(128, not(0)))

--- a/contracts/utils/RLP.sol
+++ b/contracts/utils/RLP.sol
@@ -338,7 +338,7 @@ library RLP {
         require(itemType == ItemType.Data, RLPInvalidEncoding());
 
         // Length is checked by {slice}
-        return item.slice(offset, length).toBytes();
+        return item.slice(offset, offset + length).toBytes();
     }
 
     /// @dev Decodes an RLP encoded string. See {encode-string}
@@ -368,7 +368,7 @@ library RLP {
         // Get all items in order, and push them to the buffer
         for (uint256 currentOffset = listOffset; currentOffset < itemLength; ptr += 0x20) {
             (uint256 elementOffset, uint256 elementLength, ) = _decodeLength(item.slice(currentOffset));
-            Memory.Slice element = item.slice(currentOffset, elementLength + elementOffset);
+            Memory.Slice element = item.slice(currentOffset, currentOffset + elementLength + elementOffset);
             currentOffset += elementOffset + elementLength;
 
             // Write item to the buffer

--- a/contracts/utils/RLP.sol
+++ b/contracts/utils/RLP.sol
@@ -337,7 +337,7 @@ library RLP {
         (uint256 offset, uint256 length, ItemType itemType) = _decodeLength(item);
         require(itemType == ItemType.Data, RLPInvalidEncoding());
 
-        // Length is checked by {slice}
+        // {slice} truncates rather than reverting, but {_decodeLength} guarantees offset + length <= item.length()
         return item.slice(offset, offset + length).toBytes();
     }
 

--- a/test/utils/Memory.t.sol
+++ b/test/utils/Memory.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.20;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, stdError} from "forge-std/Test.sol";
 import {Bytes} from "@openzeppelin/contracts/utils/Bytes.sol";
 import {Memory} from "@openzeppelin/contracts/utils/Memory.sol";
 
@@ -41,6 +41,50 @@ contract MemoryTest is Test {
         assertTrue(slice.isReserved());
     }
 
+    function testAsConstSliceToBytes(bytes memory input) public pure {
+        Memory.ConstSlice slice = input.asConstSlice();
+        assertEq(slice.length(), input.length);
+        assertEq(slice.toBytes(), input);
+        assertTrue(slice.isReserved());
+    }
+
+    function testAsConstMatchesAsConstSlice(bytes memory input) public pure {
+        assertEq(Memory.ConstSlice.unwrap(input.asSlice().asConst()), Memory.ConstSlice.unwrap(input.asConstSlice()));
+    }
+
+    function testConstSlice(bytes memory input, uint256 start, uint256 end) public pure {
+        assertEq(input.asConstSlice().slice(start).toBytes(), input.slice(start));
+        assertEq(input.asConstSlice().slice(start, end).toBytes(), input.slice(start, end));
+    }
+
+    function testWrite(bytes memory input, uint256 extra) public pure {
+        bytes memory buffer = new bytes(input.length + bound(extra, 0, 256));
+
+        bytes memory result = input.asSlice().write(buffer);
+        assertEq(result, input);
+        // the buffer is modified in place and shrunk to the length of the slice
+        assertEq(buffer, input);
+        assertEq(buffer.length, input.length);
+    }
+
+    function testWriteConst(bytes memory input, uint256 extra) public pure {
+        bytes memory buffer = new bytes(input.length + bound(extra, 0, 256));
+        assertEq(input.asConstSlice().write(buffer), input);
+    }
+
+    function testWriteBufferTooSmall(bytes memory input, uint256 bufferLength) public {
+        vm.assume(input.length > 0);
+        bytes memory buffer = new bytes(bound(bufferLength, 0, input.length - 1));
+
+        vm.expectRevert(stdError.indexOOBError);
+        this.writeExternal(input, buffer);
+    }
+
+    /// @dev External wrapper: {vm-expectRevert} only observes reverts across a call boundary.
+    function writeExternal(bytes memory input, bytes memory buffer) external pure {
+        input.asSlice().write(buffer);
+    }
+
     function testInvalidSliceOutOfBound() public pure {
         bytes memory input = new bytes(256);
 
@@ -65,6 +109,15 @@ contract MemoryTest is Test {
         Memory.Slice sliceB = b.asSlice();
         bool expected = keccak256(a) == keccak256(b);
         assertEq(Memory.equal(sliceA, sliceB), expected);
+    }
+
+    /// @dev Covers the four `equal` overloads (Slice/ConstSlice in either position).
+    function testEqualConstOverloads(bytes memory a, bytes memory b) public pure {
+        bool expected = keccak256(a) == keccak256(b);
+        assertEq(a.asSlice().equal(b.asSlice()), expected);
+        assertEq(a.asConstSlice().equal(b.asSlice()), expected);
+        assertEq(a.asSlice().equal(b.asConstSlice()), expected);
+        assertEq(a.asConstSlice().equal(b.asConstSlice()), expected);
     }
 
     function testEqual(

--- a/test/utils/Memory.t.sol
+++ b/test/utils/Memory.t.sol
@@ -27,20 +27,17 @@ contract MemoryTest is Test {
         assertTrue(slice.isReserved());
     }
 
-    function testSlice(bytes memory input, uint256 offset) public pure {
-        offset = bound(offset, 0, input.length);
+    function testSlice(bytes memory input, uint256 start) public pure {
+        start = bound(start, 0, input.length);
 
-        Memory.Slice slice = input.asSlice().slice(offset);
-        assertEq(slice.toBytes(), input.slice(offset));
+        Memory.Slice slice = input.asSlice().slice(start);
+        assertEq(slice.toBytes(), input.slice(start));
         assertTrue(slice.isReserved());
     }
 
-    function testSlice(bytes memory input, uint256 offset, uint256 length) public pure {
-        offset = bound(offset, 0, input.length);
-        length = bound(length, 0, input.length - offset);
-
-        Memory.Slice slice = input.asSlice().slice(offset, length);
-        assertEq(slice.toBytes(), input.slice(offset, offset + length));
+    function testSlice(bytes memory input, uint256 start, uint256 end) public pure {
+        Memory.Slice slice = input.asSlice().slice(start, end);
+        assertEq(slice.toBytes(), input.slice(start, end));
         assertTrue(slice.isReserved());
     }
 
@@ -72,19 +69,15 @@ contract MemoryTest is Test {
 
     function testEqual(
         bytes memory a,
-        uint256 offsetA,
-        uint256 lengthA,
+        uint256 startA,
+        uint256 endA,
         bytes memory b,
-        uint256 offsetB,
-        uint256 lengthB
+        uint256 startB,
+        uint256 endB
     ) public pure {
-        offsetA = bound(offsetA, 0, a.length);
-        offsetB = bound(offsetB, 0, b.length);
-        lengthA = bound(lengthA, 0, a.length - offsetA);
-        lengthB = bound(lengthB, 0, b.length - offsetB);
         assertEq(
-            a.asSlice().slice(offsetA, lengthA).equal(b.asSlice().slice(offsetB, lengthB)),
-            keccak256(a.slice(offsetA, offsetA + lengthA)) == keccak256(b.slice(offsetB, offsetB + lengthB))
+            a.asSlice().slice(startA, endA).equal(b.asSlice().slice(startB, endB)),
+            keccak256(a.slice(startA, endA)) == keccak256(b.slice(startB, endB))
         );
     }
 }

--- a/test/utils/Memory.test.js
+++ b/test/utils/Memory.test.js
@@ -1,6 +1,5 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
-import { PANIC_CODES } from '@nomicfoundation/hardhat-ethers-chai-matchers/panic';
 import * as random from '../helpers/random';
 
 const {
@@ -8,7 +7,7 @@ const {
   networkHelpers: { loadFixture },
 } = await network.create();
 
-const formatSlice = ({ length, ptr = 0xa0 }) =>
+const formatSlice = ({ ptr = 0xa0, length = 0n }) =>
   ethers.toBeHex((ethers.toBigInt(length) << 128n) | ethers.toBigInt(ptr), 32);
 
 async function fixture() {
@@ -46,51 +45,48 @@ describe('Memory', function () {
     it('length', async function () {
       for (const ptr of ['0x00', '0xa0', '0x42a0']) {
         for (const length of [0, 20, 32, 256]) {
-          await expect(this.mock.$length(formatSlice({ length, ptr }))).to.eventually.equal(length);
+          await expect(this.mock.$length_Memory_Slice(formatSlice({ length, ptr }))).to.eventually.equal(length);
+          await expect(this.mock.$length_Memory_ConstSlice(formatSlice({ length, ptr }))).to.eventually.equal(length);
         }
       }
     });
 
-    it('slice(Slice,uint256)', async function () {
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256)')(formatSlice({ length: 0n, ptr: 256n }), 0n),
-      ).to.eventually.equal(formatSlice({ length: 0n, ptr: 256n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 0n),
-      ).to.eventually.equal(formatSlice({ length: 10n, ptr: 256n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 8n),
-      ).to.eventually.equal(formatSlice({ length: 2n, ptr: 264n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 10n),
-      ).to.eventually.equal(formatSlice({ length: 0n, ptr: 266n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256)')(formatSlice({ length: 0n, ptr: 256n }), 1n),
-      ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 11n),
-      ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
-    });
+    for (const [descr, fn] of Object.entries({
+      'slice(Slice,uint256)': '$slice_Memory_Slice(bytes32,uint256)',
+      'slice(ConstSlice,uint256)': '$slice_Memory_ConstSlice(bytes32,uint256)',
+    })) {
+      it(descr, async function () {
+        for (const { input, start, output } of [
+          { input: { ptr: 256n, length: 0n }, start: 0n, output: { ptr: 256n, length: 0n } }, // empty + everything => empty
+          { input: { ptr: 256n, length: 10n }, start: 0n, output: { ptr: 256n, length: 10n } }, // non empty + everything => identical
+          { input: { ptr: 256n, length: 10n }, start: 8n, output: { ptr: 264n, length: 2n } }, // non empty + offset => moved slice
+          { input: { ptr: 256n, length: 10n }, start: 10n, output: { ptr: 266n, length: 0n } }, // non empty + start at end => empty
+          { input: { ptr: 256n, length: 0n }, start: 1n, output: { ptr: 256n, length: 0n } }, // empty + offset => empty
+          { input: { ptr: 256n, length: 10n }, start: 11n, output: { ptr: 266n, length: 0n } }, // non empty + start after end => empty
+        ]) {
+          await expect(this.mock.getFunction(fn)(formatSlice(input), start)).to.eventually.equal(formatSlice(output));
+        }
+      });
+    }
 
-    it('slice(Slice,uint256,uint256)', async function () {
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256,uint256)')(formatSlice({ length: 0n, ptr: 256n }), 0n, 0n),
-      ).to.eventually.equal(formatSlice({ length: 0n, ptr: 256n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 0n, 10n),
-      ).to.eventually.equal(formatSlice({ length: 10n, ptr: 256n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 0n, 4n),
-      ).to.eventually.equal(formatSlice({ length: 4n, ptr: 256n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 4n, 4n),
-      ).to.eventually.equal(formatSlice({ length: 4n, ptr: 260n }));
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256,uint256)')(formatSlice({ length: 0n, ptr: 256n }), 0n, 1n),
-      ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
-      await expect(
-        this.mock.getFunction('$slice(bytes32,uint256,uint256)')(formatSlice({ length: 10n, ptr: 256n }), 6n, 6n),
-      ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
-    });
+    for (const [descr, fn] of Object.entries({
+      'slice(Slice,uint256,uint256)': '$slice_Memory_Slice(bytes32,uint256,uint256)',
+      'slice(ConstSlice,uint256,uint256)': '$slice_Memory_ConstSlice(bytes32,uint256,uint256)',
+    })) {
+      it(descr, async function () {
+        for (const { input, start, end, output } of [
+          { input: { ptr: 256n, length: 0n }, start: 0n, end: 0n, output: { ptr: 256n, length: 0n } }, // empty + empty => empty
+          { input: { ptr: 256n, length: 10n }, start: 0n, end: 10n, output: { ptr: 256n, length: 10n } }, // non empty + everything => identical
+          { input: { ptr: 256n, length: 10n }, start: 0n, end: 4n, output: { ptr: 256n, length: 4n } }, // non empty + section at beginning => slice
+          { input: { ptr: 256n, length: 10n }, start: 4n, end: 8n, output: { ptr: 260n, length: 4n } }, // non empty + section in the middle => slice
+          { input: { ptr: 256n, length: 0n }, start: 0n, end: 1n, output: { ptr: 256n, length: 0n } }, // empty + section past the end => empty
+          { input: { ptr: 256n, length: 10n }, start: 6n, end: 12n, output: { ptr: 262n, length: 4n } }, // non empty + section past the end => slice
+        ]) {
+          await expect(this.mock.getFunction(fn)(formatSlice(input), start, end)).to.eventually.equal(
+            formatSlice(output),
+          );
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
> [!NOTE]
> Targeting **6.0**: this contains a source-breaking change to a released `Memory` API (see the first item below). Opening against `master` for review — the `major` changeset gates the actual release.

## What

Two changes to `Memory`, plus the two `RLP` call sites they touch.

### 1. `slice` takes `(start, end)` and truncates — **breaking**

`slice(Slice,uint256,uint256)` shipped in v5.7.0 as `(offset, length)`. It now takes `(start, end)` bounds, and both `slice` overloads truncate out-of-range bounds instead of reverting with `Panic.ARRAY_OUT_OF_BOUNDS`. This aligns `Memory.slice` with `Bytes.slice` and `Arrays.slice`, which already had exactly these semantics (`end` truncated to the length, `start` truncated to `end`, JS `Array.slice` behavior).

The signature is unchanged, so **existing calls keep compiling with a different meaning**: `s.slice(a, b)` must be rewritten as `s.slice(a, a + b)`. There is no compiler error to catch this, which is the main reason this is flagged for a major.

The two in-repo call sites in `RLP` are updated. I checked that this does not weaken RLP or `TrieProof`, which previously relied on the panic:

- Every branch of `RLP._decodeLength` guarantees `offset + length <= itemLength`, so `readBytes` and the `readList` loop never reach the new truncation path.
- In `TrieProof`, `keyIndex <= keyExpanded.length` is invariant, `path.length >= 2` is checked before use, and the `keyRemainder.slice(0, pathRemainderLength)` call is short-circuit-guarded by the preceding length comparison. `slice(s, 0, len)` also means the same thing under both old and new semantics, which is why nothing there needed editing.

### 2. New `ConstSlice` type

A `ConstSlice`, obtained from `asConstSlice(bytes)` or `asConst(Slice)`, marks a memory region as not meant to be written to. All read-only operations (`length`, `load`, `isReserved`, `equal`, `slice`, `toBytes`) accept both `Slice` and `ConstSlice`. There is deliberately no conversion back to `Slice`.

The type carries no enforcement of its own, and the NatSpec says so plainly: it documents intent, and the absence of a reverse conversion keeps a read-only slice from being passed where a writable one is expected. The underlying memory stays reachable and mutable through any other pointer to the same region.

**Open question for review:** no operation in the library mutates a `Slice` today, so `ConstSlice` currently guards against something that cannot yet happen. If mutating operations are planned, it may be worth landing them together so the type's purpose is legible to users.

### 3. `write(Slice|ConstSlice,bytes)`

Copies a slice into a caller-provided buffer instead of allocating, returning that buffer shrunk to the slice length. It modifies the buffer in place — the return value *is* the argument — and the NatSpec documents that, along with the fact that a buffer's length can only shrink this way. Panics with `ARRAY_OUT_OF_BOUNDS` if the buffer is too small.

## Documentation fixes

- The old `slice` NatSpec claimed equivalence to `self[start:end]` for calldata slices. That no longer holds: calldata slice expressions revert on out-of-range bounds, these truncate. Replaced with the `Bytes.slice` wording, plus a note that the result is a *view* rather than a copy — the one way `Memory.slice` still differs from `Bytes.slice`.
- `RLP`'s `// Length is checked by {slice}` comment was left describing a check that no longer exists. It now attributes the bound to `_decodeLength`, where it actually comes from.
- NatSpec added for the `Slice` and `ConstSlice` types and every previously undocumented overload. Two `// @dev` that were plain comments (and so invisible to the docs site) are now `///`.
- `_asSlice`'s doc said "(length and pointer)" after its arguments were swapped.
- Named the overflow bound on the two `unchecked` blocks in `slice`.

## Tests

The `Memory` Foundry suite goes from 7 to 14 tests, covering what was previously untested: `write` (including that it shrinks the caller's buffer in place, and the undersized-buffer panic), `asConst`/`asConstSlice` agreement, `ConstSlice` slicing, and all four `equal` overloads. The JS suite exercises both `Slice` and `ConstSlice` for `length` and both `slice` overloads.

Verified locally: `npm run lint`, `npm run test:pragma`, 32 Foundry tests across `Memory.t.sol` and `RLP.t.sol`, and 89 JS tests across the `Memory`, `RLP`, `BlockHeader`, and `TrieProof` suites.
