### PR TITLE
Document delegateBySig EIP-712 message format

### DIFF
--- a/.changeset/delegate-by-sig-docs.md
+++ b/.changeset/delegate-by-sig-docs.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`Votes`: Document delegateBySig EIP-712 Delegation message format.

--- a/contracts/governance/README.adoc
+++ b/contracts/governance/README.adoc
@@ -120,6 +120,17 @@ NOTE: Functions of the `Governor` contract do not include access control. If you
 
 {{VotesExtended}}
 
+[[votes-delegate-by-sig]]
+==== Delegating by signature
+
+{Votes} (and tokens that use it, such as {ERC20Votes} and {ERC721Votes}) accept off-chain delegations through {IVotes-delegateBySig}. The signer produces an EIP-712 signature over this primary type, using the voting contract's EIP-712 domain:
+
+```
+Delegation(address delegatee,uint256 nonce,uint256 expiry)
+```
+
+`nonce` is the signer's current {Nonces-nonces} value. `expiry` is a UNIX timestamp; after that time the contract reverts with {IVotes-VotesExpiredSignature}. Anyone can submit the resulting `(v, r, s)` signature.
+
 == Timelock
 
 In a governance system, the {TimelockController} contract is in charge of introducing a delay between a proposal and its execution. It can be used with or without a {Governor}.

--- a/contracts/governance/utils/IVotes.sol
+++ b/contracts/governance/utils/IVotes.sol
@@ -54,7 +54,23 @@ interface IVotes {
     function delegate(address delegatee) external;
 
     /**
-     * @dev Delegates votes from signer to `delegatee`.
+     * @dev Delegates votes from signer to `delegatee` using an EIP-712 signature.
+     *
+     * The signed message is an EIP-712 typed structured data payload whose primary type is:
+     *
+     * ```
+     * Delegation(address delegatee,uint256 nonce,uint256 expiry)
+     * ```
+     *
+     * The EIP-712 domain is the signing contract's domain as defined by {EIP712} (typically `name`, `version`,
+     * `chainId`, and `verifyingContract`). `nonce` must be the signer's current nonce (see {Nonces-nonces}). `expiry`
+     * is a UNIX timestamp after which the signature is no longer valid.
+     *
+     * Requirements:
+     *
+     * - `expiry` must be a timestamp in the future.
+     * - `v`, `r` and `s` must be a valid `secp256k1` signature from the delegator over that typed data.
+     * - the signature must use the signer's current nonce (see {Nonces-nonces}).
      */
     function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external;
 }

--- a/contracts/governance/utils/Votes.sol
+++ b/contracts/governance/utils/Votes.sol
@@ -132,6 +132,18 @@ abstract contract Votes is Context, EIP712, Nonces, IERC5805 {
 
     /**
      * @dev Delegates votes from signer to `delegatee`.
+     *
+     * See {IVotes-delegateBySig}.
+     *
+     * The signed payload is EIP-712 typed data with primary type
+     * `Delegation(address delegatee,uint256 nonce,uint256 expiry)` and this contract's {EIP712} domain. `nonce` is
+     * consumed through {Nonces-_useCheckedNonce}.
+     *
+     * Requirements:
+     *
+     * - `expiry` must be a timestamp in the future.
+     * - `v`, `r` and `s` must be a valid `secp256k1` signature from the delegator over that typed data.
+     * - the signature must use the signer's current nonce (see {Nonces-nonces}).
      */
     function delegateBySig(
         address delegatee,

--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -139,6 +139,41 @@ Votes are cast by interacting with the Governor contract through the `castVote` 
 
 image::tally-vote.png[Voting in Tally]
 
+=== Delegate by signature
+
+Voting power only counts after it is delegated (including self-delegation). Holders who do not want to send a transaction can sign an EIP-712 message and have anyone submit it with `delegateBySig`.
+
+The signed payload uses this primary type, together with the token's EIP-712 domain (`name`, `version`, `chainId`, `verifyingContract`):
+
+```
+Delegation(address delegatee,uint256 nonce,uint256 expiry)
+```
+
+`nonce` is the signer's current value from `nonces(signer)`. `expiry` is a UNIX timestamp after which the signature is rejected.
+
+```javascript
+const domain = await getDomain(token); // { name, version, chainId, verifyingContract }
+const types = {
+  Delegation: [
+    { name: "delegatee", type: "address" },
+    { name: "nonce", type: "uint256" },
+    { name: "expiry", type: "uint256" },
+  ],
+};
+const expiry = ethers.MaxUint256;
+const nonce = await token.nonces(holder.address);
+const signature = await holder.signTypedData(domain, types, {
+  delegatee: delegatee.address,
+  nonce,
+  expiry,
+});
+const { v, r, s } = ethers.Signature.from(signature);
+
+await token.delegateBySig(delegatee.address, nonce, expiry, v, r, s);
+```
+
+NOTE: `getDomain` can be replaced by reading `eip712Domain()` on the token (ERC-5267) or by assembling the four fields above from the token's constructor arguments and deployment address.
+
 === Execute the Proposal
 
 Once the voting period is over, if quorum was reached (enough voting power participated) and the majority voted in favor, the proposal is considered successful and can proceed to be executed. Once a proposal passes, it can be queued and executed from the same place you voted.

--- a/test/governance/utils/Votes.behavior.js
+++ b/test/governance/utils/Votes.behavior.js
@@ -88,6 +88,12 @@ export function shouldBehaveLikeVotes(tokens, { mode = 'blockNumber', fungible =
       describe('with signature', function () {
         const nonce = 0n;
 
+        it('uses the documented Delegation EIP-712 type', function () {
+          expect(ethers.TypedDataEncoder.from({ Delegation }).encodeType('Delegation')).to.equal(
+            'Delegation(address delegatee,uint256 nonce,uint256 expiry)',
+          );
+        });
+
         it('accept signed delegation', async function () {
           await this.votes.$_mint(this.delegator, token);
           const weight = getWeight(token);


### PR DESCRIPTION
Fixes #2927

`delegateBySig` already recovers an EIP-712 `Delegation` signature, and the Hardhat tests already build that payload, but the signed message format was not documented. This makes the typehash, domain, nonce, and expiry part of the public API docs.

## Changes

- Document the `Delegation(address delegatee,uint256 nonce,uint256 expiry)` typed data on `IVotes.delegateBySig` and `Votes.delegateBySig` (domain, nonce via `Nonces`, UNIX `expiry`).
- Add a short "Delegating by signature" note to the governance README and an ethers.js example to the on-chain governance guide.
- Assert the documented primary type string in `Votes.behavior.js` so the NatSpec cannot drift from the payload the contract accepts.

No contract behavior change. No changeset (NatSpec and docs only).

## Tests

```
npx hardhat test test/governance/utils/Votes.test.js test/token/ERC20/extensions/ERC20Votes.test.js test/token/ERC721/extensions/ERC721Votes.test.js --grep 'with signature'
```

46 + 9 mocha tests passing, including `uses the documented Delegation EIP-712 type`.