### PR TITLE
CrosschainRemoteExecutor: validate the controller in `_setup`

### DIFF
--- a/.changeset/crosschain-executor-controller-validation.md
+++ b/.changeset/crosschain-executor-controller-validation.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`CrosschainRemoteExecutor`: Validate that the controller is a full interoperable address (chain reference and address) in `_setup`. A controller that the gateway can never report as `sender` would permanently lock the executor and the assets it holds.
+`CrosschainRemoteExecutor`: Validate that the controller is a full interoperable address (chain reference and address, with no trailing bytes) in `_setup`. A controller that the gateway can never report as `sender` would permanently lock the executor and the assets it holds.

--- a/.changeset/crosschain-executor-controller-validation.md
+++ b/.changeset/crosschain-executor-controller-validation.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`CrosschainRemoteExecutor`: Validate that the controller is a full interoperable address (chain reference and address) in `_setup`. A controller that the gateway can never report as `sender` would permanently lock the executor and the assets it holds.

--- a/contracts/crosschain/CrosschainRemoteExecutor.sol
+++ b/contracts/crosschain/CrosschainRemoteExecutor.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.27;
 import {IERC7786GatewaySource} from "../interfaces/draft-IERC7786.sol";
 import {ERC7786Recipient} from "./ERC7786Recipient.sol";
 import {ERC7579Utils, Mode, CallType, ExecType} from "../account/utils/draft-ERC7579Utils.sol";
+import {InteroperableAddress} from "../utils/draft-InteroperableAddress.sol";
 import {Bytes} from "../utils/Bytes.sol";
 
 /**
@@ -30,6 +31,9 @@ contract CrosschainRemoteExecutor is ERC7786Recipient {
 
     /// @dev Reverted when a non-controller tries to relay instructions to this executor.
     error AccessRestricted();
+
+    /// @dev Reverted when the controller is not a full interoperable address (chain reference and address).
+    error InvalidController(bytes controller);
 
     constructor(address initialGateway, bytes memory initialController) {
         _setup(initialGateway, initialController);
@@ -62,6 +66,13 @@ contract CrosschainRemoteExecutor is ERC7786Recipient {
         // Sanity check, this should revert if gateway is not an ERC-7786 implementation. Note that since
         // supportsAttribute returns data, accounts without code would fail that test (nothing returned).
         IERC7786GatewaySource(gateway_).supportsAttribute(bytes4(0));
+
+        // Sanity check, authorization in {_isAuthorizedGateway} is a strict byte comparison between the controller
+        // and the sender reported by the gateway, which is always a full interoperable address. A controller that
+        // is not one can never match, which would permanently lock this executor: {reconfigure} is only reachable
+        // through a message from the controller, so neither the executor nor the assets it holds could be recovered.
+        (, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(controller_);
+        require(chainReference.length > 0 && addr.length > 0, InvalidController(controller_));
 
         _gateway = gateway_;
         _controller = controller_;

--- a/contracts/crosschain/CrosschainRemoteExecutor.sol
+++ b/contracts/crosschain/CrosschainRemoteExecutor.sol
@@ -71,8 +71,17 @@ contract CrosschainRemoteExecutor is ERC7786Recipient {
         // and the sender reported by the gateway, which is always a full interoperable address. A controller that
         // is not one can never match, which would permanently lock this executor: {reconfigure} is only reachable
         // through a message from the controller, so neither the executor nor the assets it holds could be recovered.
+        //
+        // {InteroperableAddress-parseV1} ignores trailing bytes, so the encoding must also be checked for length:
+        // a padded controller decodes to the right address but is not equal, byte for byte, to what a gateway
+        // reports. This is a length check, not a canonicalization of the components themselves.
         (, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(controller_);
-        require(chainReference.length > 0 && addr.length > 0, InvalidController(controller_));
+        require(
+            chainReference.length > 0 &&
+                addr.length > 0 &&
+                controller_.length == 6 + chainReference.length + addr.length,
+            InvalidController(controller_)
+        );
 
         _gateway = gateway_;
         _controller = controller_;

--- a/contracts/crosschain/CrosschainRemoteExecutor.sol
+++ b/contracts/crosschain/CrosschainRemoteExecutor.sol
@@ -67,14 +67,29 @@ contract CrosschainRemoteExecutor is ERC7786Recipient {
         // supportsAttribute returns data, accounts without code would fail that test (nothing returned).
         IERC7786GatewaySource(gateway_).supportsAttribute(bytes4(0));
 
-        // Sanity check, authorization in {_isAuthorizedGateway} is a strict byte comparison between the controller
-        // and the sender reported by the gateway, which is always a full interoperable address. A controller that
-        // is not one can never match, which would permanently lock this executor: {reconfigure} is only reachable
-        // through a message from the controller, so neither the executor nor the assets it holds could be recovered.
-        //
-        // {InteroperableAddress-parseV1} ignores trailing bytes, so the encoding must also be checked for length:
-        // a padded controller decodes to the right address but is not equal, byte for byte, to what a gateway
-        // reports. This is a length check, not a canonicalization of the components themselves.
+        _validateController(controller_);
+
+        _gateway = gateway_;
+        _controller = controller_;
+
+        emit CrosschainControllerSet(gateway_, controller_);
+    }
+
+    /**
+     * @dev Checks that `controller_` is a full interoperable address, and reverts with {InvalidController}
+     * otherwise. Every configuration path goes through {_setup}, so this holds for the stored controller at all
+     * times.
+     *
+     * Authorization in {_isAuthorizedGateway} is a strict byte comparison between the controller and the sender
+     * reported by the gateway, which is always a full interoperable address. A controller that is not one can never
+     * match, which would permanently lock this executor: {reconfigure} is only reachable through a message from the
+     * controller, so neither the executor nor the assets it holds could be recovered.
+     *
+     * {InteroperableAddress-parseV1} ignores trailing bytes, so the encoding must also be checked for length: a
+     * padded controller decodes to the right address but is not equal, byte for byte, to what a gateway reports.
+     * This is a length check, not a canonicalization of the components themselves.
+     */
+    function _validateController(bytes memory controller_) private pure {
         (, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(controller_);
         require(
             chainReference.length > 0 &&
@@ -82,11 +97,6 @@ contract CrosschainRemoteExecutor is ERC7786Recipient {
                 controller_.length == 6 + chainReference.length + addr.length,
             InvalidController(controller_)
         );
-
-        _gateway = gateway_;
-        _controller = controller_;
-
-        emit CrosschainControllerSet(gateway_, controller_);
     }
 
     /// @inheritdoc ERC7786Recipient

--- a/test/crosschain/CrosschainRemoteExecutor.t.sol
+++ b/test/crosschain/CrosschainRemoteExecutor.t.sol
@@ -52,6 +52,18 @@ contract CrosschainRemoteExecutorTest is Test {
         new CrosschainRemoteExecutor(address(_gateway), chainOnly);
     }
 
+    /// @dev {InteroperableAddress-parseV1} ignores trailing bytes, so a padded controller decodes to the right
+    /// address while not being equal, byte for byte, to the sender a gateway reports.
+    function testConstructorRejectsControllerWithTrailingBytes() public {
+        bytes memory padded = bytes.concat(_controller(), hex"00");
+
+        (, bytes memory chainReference, bytes memory addr) = InteroperableAddress.parseV1(padded);
+        assertEq(padded.length, chainReference.length + addr.length + 7);
+
+        vm.expectRevert(abi.encodeWithSelector(CrosschainRemoteExecutor.InvalidController.selector, padded));
+        new CrosschainRemoteExecutor(address(_gateway), padded);
+    }
+
     function testConstructorAcceptsValidController() public {
         CrosschainRemoteExecutor executor = new CrosschainRemoteExecutor(address(_gateway), _controller());
         assertEq(executor.gateway(), address(_gateway));
@@ -73,6 +85,34 @@ contract CrosschainRemoteExecutorTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, hex"deadbeef")
         );
+        IERC7786Recipient(address(executor)).receiveMessage(bytes32(uint256(1)), _controller(), payload);
+
+        // the controller is unchanged and still able to drive the executor
+        assertEq(executor.controller(), _controller());
+
+        vm.prank(address(_gateway));
+        IERC7786Recipient(address(executor)).receiveMessage(
+            bytes32(uint256(2)),
+            _controller(),
+            _singleCallPayload(address(0xBEEF), 1 ether, "")
+        );
+        assertEq(address(0xBEEF).balance, 1 ether);
+        assertEq(address(executor).balance, 0);
+    }
+
+    function testReconfigureRejectsControllerWithTrailingBytes() public {
+        CrosschainRemoteExecutor executor = new CrosschainRemoteExecutor(address(_gateway), _controller());
+        vm.deal(address(executor), 1 ether);
+
+        bytes memory padded = bytes.concat(_controller(), hex"00");
+        bytes memory payload = _singleCallPayload(
+            address(executor),
+            0,
+            abi.encodeCall(CrosschainRemoteExecutor.reconfigure, (address(_gateway), padded))
+        );
+
+        vm.prank(address(_gateway));
+        vm.expectRevert(abi.encodeWithSelector(CrosschainRemoteExecutor.InvalidController.selector, padded));
         IERC7786Recipient(address(executor)).receiveMessage(bytes32(uint256(1)), _controller(), payload);
 
         // the controller is unchanged and still able to drive the executor

--- a/test/crosschain/CrosschainRemoteExecutor.t.sol
+++ b/test/crosschain/CrosschainRemoteExecutor.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {CrosschainRemoteExecutor} from "@openzeppelin/contracts/crosschain/CrosschainRemoteExecutor.sol";
+import {ERC7786Recipient} from "@openzeppelin/contracts/crosschain/ERC7786Recipient.sol";
+import {IERC7786GatewaySource, IERC7786Recipient} from "@openzeppelin/contracts/interfaces/draft-IERC7786.sol";
+import {InteroperableAddress} from "@openzeppelin/contracts/utils/draft-InteroperableAddress.sol";
+import {
+    ERC7579Utils,
+    Mode,
+    ModeSelector,
+    ModePayload
+} from "@openzeppelin/contracts/account/utils/draft-ERC7579Utils.sol";
+
+contract CrosschainRemoteExecutorGatewayMock is IERC7786GatewaySource {
+    function supportsAttribute(bytes4) public view virtual returns (bool) {
+        return false;
+    }
+
+    function sendMessage(bytes calldata, bytes calldata, bytes[] calldata) public payable virtual returns (bytes32) {
+        return bytes32(0);
+    }
+}
+
+contract CrosschainRemoteExecutorTest is Test {
+    CrosschainRemoteExecutorGatewayMock private _gateway;
+
+    address private constant CONTROLLER = address(0xC0FFEE);
+    uint256 private constant REMOTE_CHAIN = 10;
+
+    function setUp() public {
+        _gateway = new CrosschainRemoteExecutorGatewayMock();
+    }
+
+    function testConstructorRejectsEmptyController() public {
+        vm.expectRevert(abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, ""));
+        new CrosschainRemoteExecutor(address(_gateway), "");
+    }
+
+    function testConstructorRejectsUnparseableController() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, hex"deadbeef")
+        );
+        new CrosschainRemoteExecutor(address(_gateway), hex"deadbeef");
+    }
+
+    function testConstructorRejectsControllerWithoutAddress() public {
+        bytes memory chainOnly = InteroperableAddress.formatEvmV1(REMOTE_CHAIN);
+        vm.expectRevert(abi.encodeWithSelector(CrosschainRemoteExecutor.InvalidController.selector, chainOnly));
+        new CrosschainRemoteExecutor(address(_gateway), chainOnly);
+    }
+
+    function testConstructorAcceptsValidController() public {
+        CrosschainRemoteExecutor executor = new CrosschainRemoteExecutor(address(_gateway), _controller());
+        assertEq(executor.gateway(), address(_gateway));
+        assertEq(executor.controller(), _controller());
+    }
+
+    /// @dev A controller the gateway can never emit as `sender` would lock the executor and the assets it holds.
+    function testReconfigureRejectsInvalidController() public {
+        CrosschainRemoteExecutor executor = new CrosschainRemoteExecutor(address(_gateway), _controller());
+        vm.deal(address(executor), 1 ether);
+
+        bytes memory payload = _singleCallPayload(
+            address(executor),
+            0,
+            abi.encodeCall(CrosschainRemoteExecutor.reconfigure, (address(_gateway), hex"deadbeef"))
+        );
+
+        vm.prank(address(_gateway));
+        vm.expectRevert(
+            abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, hex"deadbeef")
+        );
+        IERC7786Recipient(address(executor)).receiveMessage(bytes32(uint256(1)), _controller(), payload);
+
+        // the controller is unchanged and still able to drive the executor
+        assertEq(executor.controller(), _controller());
+
+        vm.prank(address(_gateway));
+        IERC7786Recipient(address(executor)).receiveMessage(
+            bytes32(uint256(2)),
+            _controller(),
+            _singleCallPayload(address(0xBEEF), 1 ether, "")
+        );
+        assertEq(address(0xBEEF).balance, 1 ether);
+        assertEq(address(executor).balance, 0);
+    }
+
+    function testReconfigureToValidControllerRotatesAuthorization() public {
+        CrosschainRemoteExecutor executor = new CrosschainRemoteExecutor(address(_gateway), _controller());
+
+        address newController = address(0xDECAF);
+        bytes memory newControllerAddr = InteroperableAddress.formatEvmV1(REMOTE_CHAIN, newController);
+
+        vm.prank(address(_gateway));
+        IERC7786Recipient(address(executor)).receiveMessage(
+            bytes32(uint256(1)),
+            _controller(),
+            _singleCallPayload(
+                address(executor),
+                0,
+                abi.encodeCall(CrosschainRemoteExecutor.reconfigure, (address(_gateway), newControllerAddr))
+            )
+        );
+        assertEq(executor.controller(), newControllerAddr);
+
+        // the previous controller is no longer authorized
+        vm.prank(address(_gateway));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC7786Recipient.ERC7786RecipientUnauthorizedGateway.selector,
+                address(_gateway),
+                _controller()
+            )
+        );
+        IERC7786Recipient(address(executor)).receiveMessage(
+            bytes32(uint256(2)),
+            _controller(),
+            _singleCallPayload(address(0xBEEF), 0, "")
+        );
+    }
+
+    function _controller() private pure returns (bytes memory) {
+        return InteroperableAddress.formatEvmV1(REMOTE_CHAIN, CONTROLLER);
+    }
+
+    /// @dev Builds an ERC-7579 single-call payload: mode (32 bytes) followed by target, value and calldata.
+    function _singleCallPayload(
+        address target,
+        uint256 value,
+        bytes memory callData
+    ) private pure returns (bytes memory) {
+        Mode mode = ERC7579Utils.encodeMode(
+            ERC7579Utils.CALLTYPE_SINGLE,
+            ERC7579Utils.EXECTYPE_DEFAULT,
+            ModeSelector.wrap(0),
+            ModePayload.wrap(0)
+        );
+        return abi.encodePacked(mode, bytes20(target), bytes32(value), callData);
+    }
+}


### PR DESCRIPTION
_setup stores controller_ without inspecting it. Authorization in _isAuthorizedGateway is strict byte equality between that stored value and the sender the gateway reports, so any controller the gateway can never emit – empty bytes, or bytes that are not a valid ERC-7930 interoperable address – is accepted at construction and through reconfigure, and then matches nothing.

The resulting state is terminal. reconfigure is guarded by msg.sender == address(this) and is therefore reachable only through a message the executor accepted from its controller. The full external surface is gateway(), controller(), receiveMessage and reconfigure: there is no owner and no rescue path. Since the executor holds assets and permissions on behalf of its controller, both go with it.

_setup now parses the controller and requires a non-empty chain reference and a non-empty address. parseV1 rejects anything that is not v1 ERC-7930, and the length requirement rejects the chain-only and address-only forms, neither of which a gateway reports as sender. This cannot reject a working configuration: a controller that fails the check could never have matched an inbound message. It mirrors CrosschainLinked._setLink, which already parses its counterpart through _extractChain.

#6674 documents the neighbouring trap on _setLink rather than enforcing it, reasoning that requiring a canonical encoding would make our encoding authoritative over the gateway's. That holds for canonicalisation and I am not proposing it – the check here is only well-formedness with both components present, which _setLink performs today. The asymmetry is that a CrosschainLinked misconfiguration is recoverable, since _setLink can be called again with allowOverride, while the executor's is not.

Six tests in test/crosschain/CrosschainRemoteExecutor.t.sol cover rejection of empty, unparseable and address-less controllers at construction; rejection through reconfigure, with the existing controller left intact and still able to drive the executor afterwards; and a valid rotation moving authorization to a new controller. Full suite green.