### PR TITLE
GovernorCrosschain: forward value to the gateway and surface the `sendId`

### DIFF
--- a/.changeset/governor-crosschain-relay-value.md
+++ b/.changeset/governor-crosschain-relay-value.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+[BREAKING] `GovernorCrosschain`: `relayCrosschain` is now `payable` and forwards its value to the ERC-7786 gateway, which some gateways charge as a message fee. It returns the gateway's `sendId`, which is also emitted in a new `CrosschainInstructionRelayed` event, so that messages needing further gateway processing can be tracked. `_crosschainExecute` takes an additional `value` argument and returns the `sendId`.

--- a/contracts/governance/extensions/GovernorCrosschain.sol
+++ b/contracts/governance/extensions/GovernorCrosschain.sol
@@ -9,23 +9,42 @@ import {IERC7786GatewaySource} from "../../interfaces/draft-IERC7786.sol";
 
 /// @dev Extension of {Governor} for cross-chain governance through ERC-7786 gateways and {CrosschainRemoteExecutor}.
 abstract contract GovernorCrosschain is Governor {
-    /// @dev Send crosschain instruction to an arbitrary remote executor via an arbitrary ERC-7786 gateway.
+    /// @dev Emitted when a crosschain instruction is relayed to a remote executor.
+    event CrosschainInstructionRelayed(bytes32 indexed sendId, address indexed gateway, bytes executor);
+
+    /**
+     * @dev Send crosschain instruction to an arbitrary remote executor via an arbitrary ERC-7786 gateway.
+     *
+     * Any value sent with this call is forwarded to the gateway. Some gateways require it as a message fee.
+     *
+     * Returns the `sendId` reported by the gateway. A non-zero value means the message requires further,
+     * gateway specific, processing before it is delivered to the destination chain.
+     */
     function relayCrosschain(
         address gateway,
         bytes memory executor,
         Mode mode,
         bytes memory executionCalldata
-    ) public virtual onlyGovernance {
-        _crosschainExecute(gateway, executor, mode, executionCalldata);
+    ) public payable virtual onlyGovernance returns (bytes32) {
+        return _crosschainExecute(gateway, executor, mode, executionCalldata, msg.value);
     }
 
-    /// @dev Send crosschain instruction to an arbitrary remote executor via an arbitrary ERC-7786 gateway.
+    /**
+     * @dev Send crosschain instruction to an arbitrary remote executor via an arbitrary ERC-7786 gateway, forwarding
+     * `value` to the gateway. Emits a {CrosschainInstructionRelayed} event and returns the gateway's `sendId`.
+     */
     function _crosschainExecute(
         address gateway,
         bytes memory executor,
         Mode mode,
-        bytes memory executionCalldata
-    ) internal virtual {
-        IERC7786GatewaySource(gateway).sendMessage(executor, abi.encodePacked(mode, executionCalldata), new bytes[](0));
+        bytes memory executionCalldata,
+        uint256 value
+    ) internal virtual returns (bytes32 sendId) {
+        sendId = IERC7786GatewaySource(gateway).sendMessage{value: value}(
+            executor,
+            abi.encodePacked(mode, executionCalldata),
+            new bytes[](0)
+        );
+        emit CrosschainInstructionRelayed(sendId, gateway, executor);
     }
 }

--- a/test/governance/extensions/GovernorCrosschain.test.js
+++ b/test/governance/extensions/GovernorCrosschain.test.js
@@ -96,6 +96,39 @@ describe('GovernorCrosschain', function () {
     await expect(this.helper.execute()).to.emit(this.receiver, 'MockFunctionCalledExtra').withArgs(this.executor, 0n);
   });
 
+  it('forwards value to the gateway as a message fee', async function () {
+    const fee = ethers.parseEther('0.5');
+
+    this.helper.setProposal(
+      [
+        {
+          target: this.governor.target,
+          value: fee,
+          data: this.governor.interface.encodeFunctionData('relayCrosschain(address,bytes,bytes32,bytes)', [
+            this.gateway.target,
+            chain.toErc7930(this.executor),
+            encodeMode({ callType: CALL_TYPE_CALL }),
+            encodeSingle(this.receiver, 0n, this.receiver.interface.encodeFunctionData('mockFunctionExtra')),
+          ]),
+        },
+      ],
+      '<proposal description>',
+    );
+
+    await this.helper.propose();
+    await this.helper.waitForSnapshot();
+    await this.helper.connect(this.voter1).vote({ support: VoteType.For });
+    await this.helper.connect(this.voter2).vote({ support: VoteType.For });
+    await this.helper.waitForDeadline();
+
+    await expect(this.helper.execute())
+      .to.emit(this.governor, 'CrosschainInstructionRelayed')
+      .withArgs(ethers.ZeroHash, this.gateway, chain.toErc7930(this.executor));
+
+    // the gateway mock forwards the fee to the recipient, so it lands on the executor
+    await expect(ethers.provider.getBalance(this.executor)).to.eventually.equal(fee);
+  });
+
   it('relayCrosschain is onlyGovernance', async function () {
     await expect(
       this.governor.getFunction('relayCrosschain(address,bytes,bytes32,bytes)')(


### PR DESCRIPTION
relayCrosschain is nonpayable while IERC7786GatewaySource.sendMessage is payable, and _crosschainExecute calls it with no value. A gateway charging a message fee therefore cannot be paid. Governor._executeOperations dispatches with target.call{value: values[i]}, so a proposal that attaches the fee reverts with FailedCall() on reaching the governor, and one that omits it reverts inside the gateway. Either way the extension is unusable with any fee-charging ERC-7786 gateway.

Separately, the sendId returned by sendMessage was discarded. ERC-7786 uses a non-zero sendId to signal that a message requires further, gateway-specific processing before it is delivered, so the one bit distinguishing a sent message from an accepted-but-pending one was not observable on chain.

relayCrosschain is now payable and passes its value through. _crosschainExecute takes the value as an explicit argument and returns the sendId, which is also emitted as CrosschainInstructionRelayed. Returning and emitting matches BridgeFungible._crosschainTransfer, which already does both around the same gateway call.

This changes the signature of _crosschainExecute and the return type of relayCrosschain, so it breaks contracts overriding either; the changeset is marked [BREAKING]. The non-breaking variant – reading msg.value inside _crosschainExecute and leaving both signatures alone – was rejected because _crosschainExecute is internal and virtual: a derived contract relaying two messages in one transaction would forward the same msg.value twice and spend the contract's own balance on the second. An explicit argument forces the caller to split it. Nothing outside this file overrides or calls either function.

The new case in the existing suite runs a full proposal carrying a fee, asserts CrosschainInstructionRelayed, and checks the value reaches the recipient through the gateway mock. It was verified to be a real regression test: with the contract reverted to master and the test kept, it fails with FailedCall() from Governor._executeOperations while the three pre-existing cases still pass. Full suite green.