### PR TITLE
PaymasterERC20: exclude the billed postOp gas from the penalty base

### DIFF
--- a/.changeset/olive-tigers-repeat.md
+++ b/.changeset/olive-tigers-repeat.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`PaymasterERC20`: Charge the EntryPoint unused-gas penalty only on the part of `paymasterPostOpGasLimit` that exceeds the new `_postOpGasBudget` virtual, instead of on the whole limit. Gas the paymaster already bills through `_postOpCost` (widened by `_guaranteedPostOpCost` in `PaymasterERC20Guarantor`) is no longer billed a second time as a penalty. `_postOpGasPenalty` now takes an upper bound on the unused gas rather than the limit, and no longer claims the EntryPoint's 40_000 gas threshold relief.

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -290,6 +290,10 @@ abstract contract PaymasterERC20 is Paymaster {
      *
      * NOTE: The default assumes a standard ERC-20. Override with a higher value for gas-heavier tokens; a persistent
      * underestimate drains the paymaster's deposit.
+     *
+     * NOTE: Extensions that bill extra postOp gas through a separate cost (rather than by widening this virtual)
+     * must also widen {_postOpGasBudget} by the same amount, otherwise the extra gas is billed twice: once as cost
+     * and once as unused-gas penalty.
      */
     function _postOpCost() internal view virtual returns (uint256) {
         return 30_000;

--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -107,7 +107,13 @@ abstract contract PaymasterERC20 is Paymaster {
         // only after `postOp` returns, so it is absent from the `actualGasCost` reported to {_postOp}. We price it
         // into the charge here and retain it in {_postOp}, so a user cannot inflate `paymasterPostOpGasLimit` to
         // drain the paymaster's deposit.
-        uint256 penaltyGas = _postOpGasPenalty(userOp.paymasterPostOpGasLimit());
+        //
+        // Only the part of the limit above {_postOpGasBudget} can go unused: the paymaster bills the budget in full
+        // through {_postOpCost}, so charging a penalty on it would bill the sender twice for gas the paymaster
+        // itself demanded.
+        uint256 penaltyGas = _postOpGasPenalty(
+            userOp.paymasterPostOpGasLimit().saturatingSub(_postOpGasBudget(userOp))
+        );
 
         // If the _erc20Cost math fails, the returned value will be type(uint256).max, which we will never be able
         // to charge as a prefund. The `trySafeTransferFrom` in the `_prefund` will fail, causing success to be false.
@@ -290,20 +296,39 @@ abstract contract PaymasterERC20 is Paymaster {
     }
 
     /**
-     * @dev Worst-case unused-gas penalty (in gas units) that the EntryPoint charges the paymaster's deposit for an
-     * over-provisioned, user-controlled `paymasterPostOpGasLimit`. This penalty is excluded from the `actualGasCost`
-     * reported to {_postOp} (the EntryPoint computes it only after `postOp` returns), so it is priced into the charge
-     * during validation and retained in {_postOp}. Without it, a user could inflate `paymasterPostOpGasLimit` and
-     * have the paymaster absorb the resulting penalty on every operation, draining its deposit.
+     * @dev Portion of the user-controlled `paymasterPostOpGasLimit` that this paymaster already bills through
+     * {_postOpCost}, and on which no unused-gas penalty is therefore charged (see {_postOpGasPenalty}).
      *
-     * The default mirrors the EntryPoint (v0.7-v0.9): a 10% penalty on unused postOp gas, applied only once the
-     * unused amount reaches 40_000 gas. The worst case is a `postOp` that consumes ~0 gas (e.g. it reverts and the
-     * maximum penalty is charged), leaving the whole limit unused.
+     * Extensions that bill extra postOp gas must widen this by the same amount, otherwise the gas they require the
+     * sender to provision is billed twice: once as cost, once as penalty.
      *
-     * NOTE: Override to return 0 when targeting an EntryPoint that has no unused-gas penalty.
+     * IMPORTANT: The value returned here MUST NOT exceed the total postOp gas the paymaster bills. Combined with
+     * {_postOpCost} over-estimating the gas `postOp` actually consumes, that keeps the charge computed in
+     * {_validatePaymasterUserOp} above what the EntryPoint debits. A budget larger than what is billed under-prices
+     * the penalty and settles operations at a loss.
      */
-    function _postOpGasPenalty(uint256 postOpGasLimit) internal view virtual returns (uint256) {
-        return Math.ternary(postOpGasLimit > 40_000, postOpGasLimit / 10, 0);
+    function _postOpGasBudget(PackedUserOperation calldata /* userOp */) internal view virtual returns (uint256) {
+        return _postOpCost();
+    }
+
+    /**
+     * @dev Unused-gas penalty (in gas units) that the EntryPoint charges the paymaster's deposit, given
+     * `unusedPostOpGas`: an upper bound on the part of `paymasterPostOpGasLimit` that `postOp` will leave unspent
+     * (see {_postOpGasBudget}). This penalty is excluded from the `actualGasCost` reported to {_postOp} (the
+     * EntryPoint computes it only after `postOp` returns), so it is priced into the charge during validation and
+     * retained in {_postOp}. Without it, a user could inflate `paymasterPostOpGasLimit` and have the paymaster
+     * absorb the resulting penalty on every operation, draining its deposit.
+     *
+     * The default mirrors the 10% penalty the EntryPoint (v0.7-v0.9) applies to unused postOp gas. It deliberately
+     * does not reproduce the EntryPoint's 40_000 gas threshold below which no penalty applies: `unusedPostOpGas` is
+     * an upper bound on the real unused amount, so claiming that relief here can price the charge below the penalty
+     * the EntryPoint actually debits.
+     *
+     * NOTE: Overrides MUST return an upper bound on the real penalty, otherwise the paymaster settles operations at
+     * a loss. Override to return 0 when targeting an EntryPoint that has no unused-gas penalty.
+     */
+    function _postOpGasPenalty(uint256 unusedPostOpGas) internal view virtual returns (uint256) {
+        return unusedPostOpGas / 10;
     }
 
     /// @dev Denominator used for interpreting the `tokenPerNative` returned by {_fetchDetails} as "fixed point" in {_erc20Cost}.

--- a/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20Guarantor.sol
@@ -50,6 +50,9 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
      * the actual token-specific cost reintroduces the strand-the-prefund failure mode described in
      * {PaymasterERC20-_postOp}. Size {PaymasterERC20-_postOpCost} and {_guaranteedPostOpCost} for the
      * specific ERC-20 accepted by the paymaster.
+     *
+     * Provisioning exactly the floor carries no unused-gas penalty: {_postOpGasBudget} covers it, so
+     * {PaymasterERC20-_postOpGasPenalty} only prices the limit provisioned on top of it.
      */
     function _prefund(
         PackedUserOperation calldata userOp,
@@ -155,6 +158,16 @@ abstract contract PaymasterERC20Guarantor is PaymasterERC20 {
             forwardedContext
         );
         return (refunded, Math.ternary(prefunder != userOpSender, effectiveAmount, returnedEffectiveAmount));
+    }
+
+    /**
+     * @dev See {PaymasterERC20-_postOpGasBudget}. Widened by {_guaranteedPostOpCost} for guaranteed operations:
+     * that is the extra postOp gas they are billed, and which {_prefund} requires them to provision.
+     */
+    function _postOpGasBudget(PackedUserOperation calldata userOp) internal view virtual override returns (uint256) {
+        return
+            super._postOpGasBudget(userOp) +
+            Math.ternary(_fetchGuarantor(userOp) == address(0), 0, _guaranteedPostOpCost());
     }
 
     /**

--- a/contracts/mocks/account/paymaster/PaymasterERC20Mock.sol
+++ b/contracts/mocks/account/paymaster/PaymasterERC20Mock.sol
@@ -124,6 +124,12 @@ abstract contract PaymasterERC20GuarantorMock is PaymasterERC20Mock, PaymasterER
                 : address(0);
     }
 
+    function _postOpGasBudget(
+        PackedUserOperation calldata userOp
+    ) internal view virtual override(PaymasterERC20, PaymasterERC20Guarantor) returns (uint256) {
+        return super._postOpGasBudget(userOp);
+    }
+
     function _refund(
         IERC20 token,
         uint256 actualAmount,
@@ -247,6 +253,12 @@ contract PaymasterERC20GuarantorReducingMock is PaymasterERC20ReducingMock, Paym
 
     function _guaranteedPostOpCost() internal pure override returns (uint256) {
         return 0;
+    }
+
+    function _postOpGasBudget(
+        PackedUserOperation calldata userOp
+    ) internal view virtual override(PaymasterERC20, PaymasterERC20Guarantor) returns (uint256) {
+        return super._postOpGasBudget(userOp);
     }
 
     function _prefund(

--- a/test/account/paymaster/PaymasterERC20.test.js
+++ b/test/account/paymaster/PaymasterERC20.test.js
@@ -360,11 +360,23 @@ describe('PaymasterERC20', function () {
   });
 
   describe('edge cases', function () {
-    it('_postOpGasPenalty prices the worst-case unused-gas penalty only above the threshold', async function () {
+    it('_postOpGasPenalty prices the whole unused gas, without the EntryPoint threshold relief', async function () {
+      // The argument is an upper bound on the unused gas, so claiming the EntryPoint's 40_000 gas relief here
+      // could price the charge below what the EntryPoint actually debits.
       await expect(this.paymaster.$_postOpGasPenalty(0n)).to.eventually.equal(0n);
-      await expect(this.paymaster.$_postOpGasPenalty(40_000n)).to.eventually.equal(0n); // threshold is exclusive
-      await expect(this.paymaster.$_postOpGasPenalty(40_001n)).to.eventually.equal(4_000n); // 10% of the limit
+      await expect(this.paymaster.$_postOpGasPenalty(40_000n)).to.eventually.equal(4_000n);
       await expect(this.paymaster.$_postOpGasPenalty(1_000_000n)).to.eventually.equal(100_000n);
+    });
+
+    it('_postOpGasBudget defaults to _postOpCost', async function () {
+      const signedUserOp = await this.account
+        .createUserOp({ ...this.userOp, paymaster: this.paymaster })
+        .then(op => this.paymasterSignUserOp(op))
+        .then(op => this.signUserOp(op));
+
+      await expect(this.paymaster.$_postOpGasBudget(signedUserOp.packed)).to.eventually.equal(
+        await this.paymaster.$_postOpCost(),
+      );
     });
 
     it('_erc20Cost returns max uint256 without reverting when muldiv overflows', async function () {

--- a/test/account/paymaster/PaymasterERC20Guarantor.test.js
+++ b/test/account/paymaster/PaymasterERC20Guarantor.test.js
@@ -410,6 +410,64 @@ describe('PaymasterERC20Guarantor', function () {
         .withArgs(true, anyValue, anyValue, anyValue);
     });
 
+    it('_postOpGasBudget covers the guaranteed postOp cost only for guaranteed ops', async function () {
+      const [postOpCost, guaranteedPostOpCost] = await Promise.all([
+        this.paymaster.$_postOpCost(),
+        this.paymaster.$_guaranteedPostOpCost(),
+      ]);
+
+      const guaranteed = await this.account
+        .createUserOp(this.userOp)
+        .then(op => this.paymasterSignUserOp(op, { guarantor: this.guarantor }))
+        .then(op => this.signUserOp(op));
+      const plain = await this.account
+        .createUserOp(this.userOp)
+        .then(op => this.paymasterSignUserOp(op))
+        .then(op => this.signUserOp(op));
+
+      await expect(this.paymaster.$_postOpGasBudget(guaranteed.packed)).to.eventually.equal(
+        postOpCost + guaranteedPostOpCost,
+      );
+      await expect(this.paymaster.$_postOpGasBudget(plain.packed)).to.eventually.equal(postOpCost);
+    });
+
+    it('charges no unused-gas penalty for a guaranteed op provisioned at the floor', async function () {
+      await this.token.$_mint(this.guarantor, value);
+      await this.token.$_approve(this.guarantor, this.paymaster, ethers.MaxUint256);
+
+      // The floor is exactly _postOpGasBudget for a guaranteed op, so the penalty base saturates to zero.
+      const floor = await this.paymaster.$_postOpGasBudget(
+        await this.account
+          .createUserOp(this.userOp)
+          .then(op => this.paymasterSignUserOp(op, { guarantor: this.guarantor }))
+          .then(op => this.signUserOp(op))
+          .then(op => op.packed),
+      );
+
+      for (const [paymasterPostOpGasLimit, expectedPenaltyGas] of [
+        [floor, 0n],
+        [floor + 50_000n, 5_000n], // only the gas provisioned above the budget is penalized
+      ]) {
+        const signedUserOp = await this.account
+          .createUserOp({ ...this.userOp, paymasterPostOpGasLimit })
+          .then(op => this.paymasterSignUserOp(op, { guarantor: this.guarantor }))
+          .then(op => this.signUserOp(op));
+
+        // context layout: userOpHash(32) | token(20) | tokenPerNative(32) | prefundAmount(32) | prefunder(20) |
+        //                 penaltyGas(32) | prefundContext
+        const { logs } = await this.paymaster
+          .$_validatePaymasterUserOp(signedUserOp.packed, ethers.ZeroHash, 0n)
+          .then(tx => tx.wait());
+        const { context } = this.paymaster.interface.parseLog(
+          logs.find(
+            log => log.topics[0] === this.paymaster.interface.getEvent('return$_validatePaymasterUserOp').topicHash,
+          ),
+        ).args;
+
+        expect(ethers.toBigInt(ethers.dataSlice(context, 0x88, 0xa8))).to.equal(expectedPenaltyGas);
+      }
+    });
+
     it('reverts with invalid guarantor signature', async function () {
       await this.token.$_mint(this.guarantor, value);
       await this.token.$_approve(this.guarantor, this.paymaster, ethers.MaxUint256);


### PR DESCRIPTION
Targets #6680 rather than `master`, since it builds on the `paymasterPostOpGasLimit` floor introduced there.

## Problem

`penaltyGas` is priced on the whole user-controlled `paymasterPostOpGasLimit`:

```solidity
uint256 penaltyGas = _postOpGasPenalty(userOp.paymasterPostOpGasLimit());
```

But part of that limit is not "over-provisioning the user chose" — it is gas the paymaster itself demands and already bills through `_postOpCost()`. Charging a penalty on it bills the sender twice for the same gas: once as cost, once as penalty.

#6680 makes this concrete. Its floor is `_postOpCost() + _guaranteedPostOpCost()` = 45_000 by default, which is above the EntryPoint's 40_000 penalty threshold. So a guaranteed op provisioned at exactly the floor is charged 4_500 gas of penalty while the EntryPoint debits **zero** — the real penalty would need `postOp` to consume under 5_000 gas, and it does two ERC-20 transfers. The surcharge is unavoidable for a user who provisions exactly what the paymaster asked for, and it grows with any integrator override of `_postOpCost()`.

## Change

Introduce `_postOpGasBudget(PackedUserOperation calldata)`, defaulting to `_postOpCost()`, and penalize only the limit provisioned above it:

```solidity
uint256 penaltyGas = _postOpGasPenalty(
    userOp.paymasterPostOpGasLimit().saturatingSub(_postOpGasBudget(userOp))
);
```

`PaymasterERC20Guarantor` widens the budget by `_guaranteedPostOpCost()` for guaranteed ops, so an op at the floor now carries no penalty at all.

`_postOpGasPenalty` also changes: it takes an upper bound on the unused gas rather than the limit, and returns `unusedPostOpGas / 10` without reproducing the EntryPoint's 40_000 gas threshold relief.

## Why drop the threshold

Keeping it reintroduces an under-charge. With `C = _postOpCost()`, `U` = real postOp gas, `L` = the limit, and `g(x) = x > 40_000 ? x/10 : 0`, the paymaster bills `C + g(L - C)` and owes `U + g(L - U)`. Since `C >= U`, the real penalty can fire while the charged one does not:

```
U = 30_000, C = 34_000, L = 74_000
  charged = 34_000 + g(40_000) = 34_000 + 0     = 34_000
  owed    = 30_000 + g(44_000) = 30_000 + 4_400 = 34_400
  -> paymaster short 400 gas
```

The argument is an upper bound on the unused gas, so claiming relief meant for the real amount can price the charge below the debit. Charging `(L - C)/10` unconditionally gives `charged - owed >= 0.9 * (C - U) >= 0` for every `L`, so solvency reduces to `_postOpCost()` over-estimating real postOp consumption — the invariant its NatSpec already states.

Net effect on users is a reduction almost everywhere (`L = 100_000, C = 30_000`: 10_000 -> 7_000). The exception is small limits just under the threshold, where a bounded charge under 4_000 gas replaces zero — the direction the library already takes elsewhere, since an under-estimate drains the paymaster's deposit.

## Compatibility

`_postOpGasPenalty` shipped in v5.7.0. Its signature is unchanged but its argument now means something different, so an override that faithfully re-implements a specific EntryPoint's formula would start under-charging. A `return 0` override (documented for penalty-free EntryPoints) is unaffected.

Adding an overridden virtual to `PaymasterERC20Guarantor` is source-breaking for downstream contracts that combine it with another `PaymasterERC20` extension: they must add an explicit `override(PaymasterERC20, PaymasterERC20Guarantor)`, as the two mocks here now do. Changeset is marked `minor` for both reasons.

## Verification

`npm run compile`, `npm run lint`, `npm run test:inheritance`, 565 account tests, and `forge test --match-path "test/account/**"` all pass.

New tests cover `_postOpGasBudget` defaulting to `_postOpCost`, the guarantor widening it only for guaranteed ops, and `penaltyGas` decoded from the validation context being `0` at the floor and `5_000` at floor + 50_000.