### PR TITLE
Fix paymaster tests under coverage

### DIFF
--- a/test/account/paymaster/Paymaster.behavior.js
+++ b/test/account/paymaster/Paymaster.behavior.js
@@ -1,3 +1,4 @@
+import { globalOptions } from 'hardhat';
 import { ethers } from 'ethers';
 import { expect } from 'chai';
 import { encodeBatch, encodeMode, CALL_TYPE_BATCH } from '../../helpers/erc7579';
@@ -21,6 +22,7 @@ export function shouldBehaveLikePaymaster({ postOp, timeRange }) {
 
       this.userOp ??= {};
       this.userOp.paymaster = this.paymaster;
+      if (globalOptions.coverage) this.userOp.paymasterVerificationGasLimit ??= 200_000n;
     });
 
     describe('validation (signature/token ownership/allowance)', function () {


### PR DESCRIPTION
Follow-up to #6680.

Running the paymaster test suite with `--coverage` fails in the shared `shouldBehaveLikePaymaster` behavior:

```
PaymasterERC20Guarantor
  core paymaster behavior
    validatePaymasterUserOp
      time range
        revert if validation data is too early
        revert if validation data is too late
```

Both expect `FailedOp(0, 'AA32 paymaster expired or not due')` but get `AA36 over pmVerificationGasLimit`. Coverage instrumentation makes `validatePaymasterUserOp` (oracle signature recovery + prefund transfer, plus the extra layer in the guarantor variant) exceed the `paymasterVerificationGasLimit` default of `100_000` that `test/helpers/erc4337.js` applies to sponsored user operations, so the EntryPoint aborts on the gas check before it ever reaches the time-range check.

This raises the limit to `200_000` in the behavior's `validatePaymasterUserOp` setup, gated on `globalOptions.coverage` — the same pattern already used for the guarantor functionality tests in `PaymasterERC20Guarantor.test.js`. The `??=` leaves per-file overrides in charge, and nothing changes outside coverage runs.

Tests only, no changeset.