### PR TITLE
Make ERC6909 abstract and complete the publicInitializers list

### DIFF
--- a/.changeset/crosschain-remote-executor-public-initializer.md
+++ b/.changeset/crosschain-remote-executor-public-initializer.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`CrosschainRemoteExecutorUpgradeable`: Add a public `initialize` function to the upgradeable variant, which was previously transpiled with an internal initializer only.

--- a/contracts/token/ERC6909/ERC6909.sol
+++ b/contracts/token/ERC6909/ERC6909.sol
@@ -11,7 +11,7 @@ import {IERC165, ERC165} from "../../utils/introspection/ERC165.sol";
  * @dev Implementation of ERC-6909.
  * See https://eips.ethereum.org/EIPS/eip-6909
  */
-contract ERC6909 is Context, ERC165, IERC6909 {
+abstract contract ERC6909 is Context, ERC165, IERC6909 {
     mapping(address owner => mapping(uint256 id => uint256)) private _balances;
 
     mapping(address owner => mapping(address operator => bool)) private _operatorApprovals;

--- a/contracts/token/ERC6909/extensions/ERC6909ContentURI.sol
+++ b/contracts/token/ERC6909/extensions/ERC6909ContentURI.sol
@@ -10,7 +10,7 @@ import {IERC165} from "../../../utils/introspection/IERC165.sol";
 /**
  * @dev Implementation of the Content URI extension defined in ERC6909.
  */
-contract ERC6909ContentURI is ERC6909, IERC6909ContentURI {
+abstract contract ERC6909ContentURI is ERC6909, IERC6909ContentURI {
     string private _contractURI;
     mapping(uint256 id => string) private _tokenURIs;
 

--- a/contracts/token/ERC6909/extensions/ERC6909Metadata.sol
+++ b/contracts/token/ERC6909/extensions/ERC6909Metadata.sol
@@ -10,7 +10,7 @@ import {IERC165} from "../../../utils/introspection/IERC165.sol";
 /**
  * @dev Implementation of the Metadata extension defined in ERC6909. Exposes the name, symbol, and decimals of each token id.
  */
-contract ERC6909Metadata is ERC6909, IERC6909Metadata {
+abstract contract ERC6909Metadata is ERC6909, IERC6909Metadata {
     struct TokenMetadata {
         string name;
         string symbol;

--- a/contracts/token/ERC6909/extensions/ERC6909TokenSupply.sol
+++ b/contracts/token/ERC6909/extensions/ERC6909TokenSupply.sol
@@ -11,7 +11,7 @@ import {IERC165} from "../../../utils/introspection/IERC165.sol";
  * @dev Implementation of the Token Supply extension defined in ERC6909.
  * Tracks the total supply of each token id individually.
  */
-contract ERC6909TokenSupply is ERC6909, IERC6909TokenSupply {
+abstract contract ERC6909TokenSupply is ERC6909, IERC6909TokenSupply {
     mapping(uint256 id => uint256) private _totalSupplies;
 
     /// @inheritdoc IERC6909TokenSupply

--- a/scripts/upgradeable/transpile.config.json
+++ b/scripts/upgradeable/transpile.config.json
@@ -9,6 +9,7 @@
   ],
   "publicInitializers": [
     "contracts/access/manager/AccessManager.sol",
+    "contracts/crosschain/CrosschainRemoteExecutor.sol",
     "contracts/finance/VestingWallet.sol",
     "contracts/governance/TimelockController.sol",
     "contracts/metatx/ERC2771Forwarder.sol"


### PR DESCRIPTION
## Goal

Enforce a consistent rule across `contracts/` (mocks excluded):

1. Contracts that are **not usable out-of-the-box** should be `abstract`.
2. Contracts that **are** usable out-of-the-box and are **not stateless** should have a public initializer in the upgradeable variant.

## Changes

**1. `ERC6909` and its extensions become `abstract`**

`ERC6909`, `ERC6909ContentURI`, `ERC6909Metadata` and `ERC6909TokenSupply` were the only concrete token contracts in the library. None of them exposes a minting entrypoint (`_mint` is `internal`), so deploying one directly gives a token whose supply is permanently zero — a dead contract. They are now `abstract`, consistent with `ERC20`, `ERC721`, `ERC1155` and every extension thereof.

**2. `CrosschainRemoteExecutor` added to `publicInitializers`**

Applying rule 2 to the remaining concrete contracts: after excluding the `exclude` globs in `scripts/upgradeable/transpile.config.json` (which drop the whole `contracts/proxy/` group) and the three `@custom:stateless` ERC-7913 verifiers, the transpiled concrete contracts are:

| Contract | in `publicInitializers` |
| --- | --- |
| `AccessManager` | yes |
| `TimelockController` | yes |
| `ERC2771Forwarder` | yes |
| `VestingWallet` | yes |
| `CrosschainRemoteExecutor` | **no → added** |

`CrosschainRemoteExecutor` shipped in v5.7.0 as a concrete, stateful, transpiled contract but was never listed, so the upgradeable variant has no public initializer. With this change the two sets match exactly.

## Notes

- The changeset covers only the new public initializer on `CrosschainRemoteExecutorUpgradeable`. The `abstract` change is deliberately not called out: a directly-deployed `ERC6909` was a dead contract with no way to mint, so nothing usable is being taken away.
- No source changes were needed elsewhere: the tests deploy through `hardhat-exposed` `$` wrappers, and the docs mock `ERC6909GameItems` is concrete already.

## Checks

- `npm run compile` — passes
- ERC6909 test suites (`ERC6909`, `ERC6909ContentURI`, `ERC6909Metadata`, `ERC6909TokenSupply`) — 86 passing