### PR TITLE
skills(add-changeset): state the change, don't justify it

### DIFF
--- a/.claude/skills/add-changeset/SKILL.md
+++ b/.claude/skills/add-changeset/SKILL.md
@@ -47,6 +47,7 @@ The resulting file in `.changeset/` looks like:
 - **Then a colon, then one sentence** describing the user-visible change.
 - **Imperative mood** (matching PR titles: "Add", "Fix", not "Added", "Fixed"). Trailing period optional.
 - **No bullet points**, no headings, no multi-paragraph prose. The release workflow concatenates these verbatim.
+- **State the change, don't justify it.** Skip "This mirrors ...", "so that ...", "closes a gap where ...", parallels to other functions, or motivation. If the user needs to take action (migration step, breaking rename, tighter requirement they might now hit), state that instead — otherwise the changelog line is just the fact of the change. Rationale belongs in the PR body and commit message, not the changelog.
 
 Good examples (taken from existing entries):
 


### PR DESCRIPTION
## Summary

Add a format rule to the `add-changeset` skill saying changeset lines should state the fact of the change only — no "This mirrors …", "so that …", parallels to other functions, or motivation. User actionables (migration steps, breaking renames, tighter requirements callers may now hit) are the exception. Rationale belongs in the PR body and commit message, which are the artefacts a curious reader clicks through to.

The existing skill covered *when* to add a changeset and mechanical format rules (one sentence, imperative mood, backtick prefix), but had no rule about *what to leave out*.

## Test plan

- [x] Skill file renders as expected under the "Format rules" section
- [x] Existing example changesets in `.changeset/` still conform to the tightened rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)