### PR TITLE
ERC4337Utils: align block-range validity decoding with canonical EntryPoint

### DIFF
--- a/.changeset/erc4337utils-block-range-validuntil-parse.md
+++ b/.changeset/erc4337utils-block-range-validuntil-parse.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC4337Utils`: fix `parseValidationData`, `packValidationData` and `PaymasterSigner` handling of `validUntil == 0` under `ValidationRange.BLOCK`.
+`ERC4337Utils`: align `parseValidationData`, `packValidationData`, `getValidationData` and `combineValidationData` with how the EntryPoint reads a validity range. A zero `validUntil` ("indefinitely") is now resolved before the block-range flags are tested, and the flag is only stripped once a block range is detected, so a timestamp range with a residual flag is no longer silently turned into a plausible window. Also fixes `PaymasterSigner` handling of `validUntil == 0` under `ValidationRange.BLOCK`.

--- a/.changeset/erc4337utils-block-range-validuntil-parse.md
+++ b/.changeset/erc4337utils-block-range-validuntil-parse.md
@@ -2,4 +2,4 @@
 'openzeppelin-solidity': patch
 ---
 
-`ERC4337Utils`: align `parseValidationData`, `packValidationData`, `getValidationData` and `combineValidationData` with how the EntryPoint reads a validity range. A zero `validUntil` ("indefinitely") is now resolved before the block-range flags are tested, and the flag is only stripped once a block range is detected, so a timestamp range with a residual flag is no longer silently turned into a plausible window. Also fixes `PaymasterSigner` handling of `validUntil == 0` under `ValidationRange.BLOCK`.
+`ERC4337Utils`: in `parseValidationData`, resolve `validUntil == 0` to `type(uint48).max` and only strip `BLOCK_RANGE_FLAG` when a block range is detected. Propagates to `packValidationData`, `getValidationData`, `combineValidationData` and `PaymasterSigner`, matching the EntryPoint's behavior.

--- a/.changeset/erc4337utils-block-range-validuntil-parse.md
+++ b/.changeset/erc4337utils-block-range-validuntil-parse.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC4337Utils`: fix `parseValidationData`, `packValidationData` and `PaymasterSigner` handling of `validUntil == 0` under `ValidationRange.BLOCK`.

--- a/contracts/account/paymaster/extensions/PaymasterSigner.sol
+++ b/contracts/account/paymaster/extensions/PaymasterSigner.sol
@@ -100,15 +100,20 @@ abstract contract PaymasterSigner is AbstractSigner, EIP712, Paymaster {
     ) internal virtual override returns (bytes memory context, uint256 validationData) {
         (uint48 validAfter, uint48 validUntil, bytes calldata signature) = _decodePaymasterUserOp(userOp);
 
-        // Mixed `BLOCK_RANGE_FLAG` bits between `validAfter` and `validUntil` are rejected
-        bool rangeFlagsCompatible = (validAfter ^ validUntil) & ERC4337Utils.BLOCK_RANGE_FLAG == 0;
+        // Mixed `BLOCK_RANGE_FLAG` bits are rejected, unless `validUntil == 0` (no-expiry sentinel).
+        if (validUntil != 0 && (validAfter ^ validUntil) & ERC4337Utils.BLOCK_RANGE_FLAG != 0) {
+            return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
+        }
 
         return (
             bytes(""),
-            rangeFlagsCompatible
-                ? _rawSignatureValidation(_signableUserOpHash(userOp, validAfter, validUntil), signature)
-                    .packValidationData(validAfter, validUntil)
-                : ERC4337Utils.SIG_VALIDATION_FAILED
+            _rawSignatureValidation(_signableUserOpHash(userOp, validAfter, validUntil), signature).packValidationData(
+                validAfter,
+                validUntil,
+                validAfter & ERC4337Utils.BLOCK_RANGE_FLAG == 0
+                    ? ERC4337Utils.ValidationRange.TIMESTAMP
+                    : ERC4337Utils.ValidationRange.BLOCK
+            )
         );
     }
 

--- a/contracts/account/paymaster/extensions/PaymasterSigner.sol
+++ b/contracts/account/paymaster/extensions/PaymasterSigner.sol
@@ -100,20 +100,15 @@ abstract contract PaymasterSigner is AbstractSigner, EIP712, Paymaster {
     ) internal virtual override returns (bytes memory context, uint256 validationData) {
         (uint48 validAfter, uint48 validUntil, bytes calldata signature) = _decodePaymasterUserOp(userOp);
 
-        // Mixed `BLOCK_RANGE_FLAG` bits are rejected, unless `validUntil == 0` (no-expiry sentinel).
-        if (validUntil != 0 && (validAfter ^ validUntil) & ERC4337Utils.BLOCK_RANGE_FLAG != 0) {
-            return (bytes(""), ERC4337Utils.SIG_VALIDATION_FAILED);
-        }
+        // If validUntil is non-zero, mixed `BLOCK_RANGE_FLAG` bits between `validAfter` and `validUntil` are rejected
+        bool rangeFlagsCompatible = validUntil == 0 || ((validAfter ^ validUntil) & ERC4337Utils.BLOCK_RANGE_FLAG == 0);
 
         return (
             bytes(""),
-            _rawSignatureValidation(_signableUserOpHash(userOp, validAfter, validUntil), signature).packValidationData(
-                validAfter,
-                validUntil,
-                validAfter & ERC4337Utils.BLOCK_RANGE_FLAG == 0
-                    ? ERC4337Utils.ValidationRange.TIMESTAMP
-                    : ERC4337Utils.ValidationRange.BLOCK
-            )
+            rangeFlagsCompatible
+                ? _rawSignatureValidation(_signableUserOpHash(userOp, validAfter, validUntil), signature)
+                    .packValidationData(validAfter, validUntil)
+                : ERC4337Utils.SIG_VALIDATION_FAILED
         );
     }
 

--- a/contracts/account/utils/ERC4337Utils.sol
+++ b/contracts/account/utils/ERC4337Utils.sol
@@ -61,12 +61,12 @@ library ERC4337Utils {
         validAfter = uint48(bytes32(validationData).extract_32_6(0));
         validUntil = uint48(bytes32(validationData).extract_32_6(6));
         aggregator = address(bytes32(validationData).extract_32_20(12));
+
+        if (validUntil == 0) validUntil = type(uint48).max;
         range = ((validAfter & validUntil & BLOCK_RANGE_FLAG) == 0) ? ValidationRange.TIMESTAMP : ValidationRange.BLOCK;
 
         validAfter &= BLOCK_RANGE_MASK;
         validUntil &= BLOCK_RANGE_MASK;
-
-        if (validUntil == 0) validUntil = BLOCK_RANGE_MASK;
     }
 
     /// @dev Packs the validation data into a single uint256. See {parseValidationData}.
@@ -99,7 +99,7 @@ library ERC4337Utils {
             validUntil &= BLOCK_RANGE_MASK;
         } else if (range == ValidationRange.BLOCK) {
             validAfter |= BLOCK_RANGE_FLAG;
-            validUntil |= BLOCK_RANGE_FLAG;
+            if (validUntil != 0) validUntil |= BLOCK_RANGE_FLAG;
         }
         return uint256(bytes6(validAfter).pack_6_6(bytes6(validUntil)).pack_12_20(bytes20(aggregator)));
     }

--- a/contracts/account/utils/ERC4337Utils.sol
+++ b/contracts/account/utils/ERC4337Utils.sol
@@ -181,10 +181,14 @@ library ERC4337Utils {
                             )
                         )
                     ),
-                    uint48(Math.max(validAfter1, validAfter2)) |
-                        (BLOCK_RANGE_FLAG * uint48(SafeCast.toUint(range1 == ValidationRange.BLOCK))),
-                    uint48(Math.min(validUntil1, validUntil2)) |
-                        (BLOCK_RANGE_FLAG * uint48(SafeCast.toUint(range1 == ValidationRange.BLOCK)))
+                    uint48(
+                        Math.max(validAfter1, validAfter2) |
+                            (BLOCK_RANGE_FLAG * SafeCast.toUint(range1 == ValidationRange.BLOCK))
+                    ),
+                    uint48(
+                        Math.min(validUntil1, validUntil2) |
+                            (BLOCK_RANGE_FLAG * SafeCast.toUint(range1 == ValidationRange.BLOCK))
+                    )
                 )
                 : SIG_VALIDATION_FAILED;
     }

--- a/contracts/account/utils/ERC4337Utils.sol
+++ b/contracts/account/utils/ERC4337Utils.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 
 import {IEntryPoint, PackedUserOperation} from "../../interfaces/IERC4337.sol";
 import {Math} from "../../utils/math/Math.sol";
+import {SafeCast} from "../../utils/math/SafeCast.sol";
 import {Calldata} from "../../utils/Calldata.sol";
 import {Packing} from "../../utils/Packing.sol";
 
@@ -62,7 +63,8 @@ library ERC4337Utils {
         validUntil = uint48(bytes32(validationData).extract_32_6(6));
         aggregator = address(bytes32(validationData).extract_32_20(12));
 
-        if (validUntil == 0) validUntil = type(uint48).max;
+        validUntil |= type(uint48).max * uint48(SafeCast.toUint(validUntil == 0));
+
         range = ((validAfter & validUntil & BLOCK_RANGE_FLAG) == 0) ? ValidationRange.TIMESTAMP : ValidationRange.BLOCK;
 
         validAfter &= BLOCK_RANGE_MASK;
@@ -80,7 +82,9 @@ library ERC4337Utils {
                 aggregator,
                 validAfter,
                 validUntil,
-                (validAfter & validUntil & BLOCK_RANGE_FLAG) == 0 ? ValidationRange.TIMESTAMP : ValidationRange.BLOCK
+                (validAfter & BLOCK_RANGE_FLAG != 0) && (validUntil & BLOCK_RANGE_FLAG != 0 || validUntil == 0)
+                    ? ValidationRange.BLOCK
+                    : ValidationRange.TIMESTAMP
             );
     }
 
@@ -99,7 +103,7 @@ library ERC4337Utils {
             validUntil &= BLOCK_RANGE_MASK;
         } else if (range == ValidationRange.BLOCK) {
             validAfter |= BLOCK_RANGE_FLAG;
-            if (validUntil != 0) validUntil |= BLOCK_RANGE_FLAG;
+            validUntil |= BLOCK_RANGE_FLAG * uint48(SafeCast.toUint(validUntil > 0));
         }
         return uint256(bytes6(validAfter).pack_6_6(bytes6(validUntil)).pack_12_20(bytes20(aggregator)));
     }

--- a/contracts/account/utils/ERC4337Utils.sol
+++ b/contracts/account/utils/ERC4337Utils.sol
@@ -54,7 +54,19 @@ library ERC4337Utils {
 
     /**
      * @dev Parses the validation data into its components and the validity range. See {packValidationData}.
-     * Strips away the highest bit flag from the `validAfter` and `validUntil` fields.
+     *
+     * This mirrors, step for step, how the EntryPoint reads a validation data word:
+     *
+     * * a zero `validUntil` means "indefinitely" and is replaced with `type(uint48).max`, *before* the validity
+     *   range is detected;
+     * * the range is a block range if and only if both `validAfter` and `validUntil` carry {BLOCK_RANGE_FLAG};
+     * * {BLOCK_RANGE_FLAG} is stripped from both fields for a block range, and left untouched otherwise.
+     *
+     * NOTE: For a timestamp range, `validAfter` or `validUntil` may still carry {BLOCK_RANGE_FLAG}, in which case
+     * the corresponding bound is out of reach of `block.timestamp` (never valid, resp. never expiring). This is
+     * deliberate: the EntryPoint compares `block.timestamp` against the raw fields, so stripping the flag here
+     * would silently turn such a bound into a plausible timestamp and make {getValidationData} disagree with the
+     * EntryPoint. Encoders should not produce such a mismatch in the first place; {packValidationData} never does.
      */
     function parseValidationData(
         uint256 validationData
@@ -65,10 +77,13 @@ library ERC4337Utils {
 
         validUntil |= type(uint48).max * uint48(SafeCast.toUint(validUntil == 0));
 
-        range = ((validAfter & validUntil & BLOCK_RANGE_FLAG) == 0) ? ValidationRange.TIMESTAMP : ValidationRange.BLOCK;
-
-        validAfter &= BLOCK_RANGE_MASK;
-        validUntil &= BLOCK_RANGE_MASK;
+        if ((validAfter & validUntil & BLOCK_RANGE_FLAG) == 0) {
+            range = ValidationRange.TIMESTAMP;
+        } else {
+            range = ValidationRange.BLOCK;
+            validAfter &= BLOCK_RANGE_MASK;
+            validUntil &= BLOCK_RANGE_MASK;
+        }
     }
 
     /// @dev Packs the validation data into a single uint256. See {parseValidationData}.
@@ -105,7 +120,7 @@ library ERC4337Utils {
             validAfter |= BLOCK_RANGE_FLAG;
             validUntil |= BLOCK_RANGE_FLAG * uint48(SafeCast.toUint(validUntil > 0));
         }
-        return uint256(bytes6(validAfter).pack_6_6(bytes6(validUntil)).pack_12_20(bytes20(aggregator)));
+        return _packRaw(aggregator, validAfter, validUntil);
     }
 
     /// @dev Variant of {packValidationData} that uses a boolean success flag instead of an aggregator address.
@@ -153,15 +168,30 @@ library ERC4337Utils {
             validationData2
         );
 
-        if (range1 == range2) {
-            bool success = aggregator1 == address(uint160(SIG_VALIDATION_SUCCESS)) &&
-                aggregator2 == address(uint160(SIG_VALIDATION_SUCCESS));
-            uint48 validAfter = uint48(Math.max(validAfter1, validAfter2));
-            uint48 validUntil = uint48(Math.min(validUntil1, validUntil2));
-            return packValidationData(success, validAfter, validUntil, range1);
-        } else {
-            return SIG_VALIDATION_FAILED;
-        }
+        return
+            range1 == range2
+                ? _packRaw(
+                    address(
+                        uint160(
+                            Math.ternary(
+                                aggregator1 == address(uint160(SIG_VALIDATION_SUCCESS)) &&
+                                    aggregator2 == address(uint160(SIG_VALIDATION_SUCCESS)),
+                                SIG_VALIDATION_SUCCESS,
+                                SIG_VALIDATION_FAILED
+                            )
+                        )
+                    ),
+                    uint48(Math.max(validAfter1, validAfter2)) |
+                        (BLOCK_RANGE_FLAG * uint48(SafeCast.toUint(range1 == ValidationRange.BLOCK))),
+                    uint48(Math.min(validUntil1, validUntil2)) |
+                        (BLOCK_RANGE_FLAG * uint48(SafeCast.toUint(range1 == ValidationRange.BLOCK)))
+                )
+                : SIG_VALIDATION_FAILED;
+    }
+
+    /// @dev Encodes the fields of a validation data word verbatim, without normalizing {BLOCK_RANGE_FLAG}.
+    function _packRaw(address aggregator, uint48 validAfter, uint48 validUntil) private pure returns (uint256) {
+        return uint256(bytes6(validAfter).pack_6_6(bytes6(validUntil)).pack_12_20(bytes20(aggregator)));
     }
 
     /// @dev Returns the aggregator of the `validationData` and whether it is out of time range.

--- a/test/account/paymaster/PaymasterSigner.test.js
+++ b/test/account/paymaster/PaymasterSigner.test.js
@@ -88,14 +88,14 @@ for (const [name, opts] of Object.entries({
       Object.assign(this, connection, await loadFixture(fixture));
     });
 
-    it('rejects validAfter with the flag set when validUntil has no flag', async function () {
+    it('rejects validAfter with the flag set when validUntil has no flag (and is non-zero)', async function () {
       await this.paymaster.deposit({ value: ethers.parseEther('1') });
 
       const signedUserOp = await this.account
         .createUserOp({
           paymaster: this.paymaster,
         })
-        .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG | 1n, validUntil: 0n }))
+        .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG | 1n, validUntil: 2n }))
         .then(op => this.signUserOp(op));
 
       await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
@@ -116,6 +116,18 @@ for (const [name, opts] of Object.entries({
       await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
         .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
         .withArgs(0n, 'AA34 signature error');
+    });
+
+    it('accepts a block-range sponsorship with `validUntil = 0` (no expiry)', async function () {
+      await this.paymaster.deposit({ value: ethers.parseEther('1') });
+
+      const validAfter = BLOCK_RANGE_FLAG | (BigInt(await ethers.provider.getBlockNumber()) - 1n);
+      const signedUserOp = await this.account
+        .createUserOp({ paymaster: this.paymaster })
+        .then(op => this.paymasterSignUserOp(op, { validAfter, validUntil: 0n }))
+        .then(op => this.signUserOp(op));
+
+      await ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver).then(op => op.wait());
     });
 
     it('returns SIG_VALIDATION_FAILED for paymasterData shorter than 12 bytes', async function () {

--- a/test/account/paymaster/PaymasterSigner.test.js
+++ b/test/account/paymaster/PaymasterSigner.test.js
@@ -10,6 +10,7 @@ const BLOCK_RANGE_FLAG = 0x800000000000n;
 const connection = await network.create();
 const {
   ethers,
+  helpers: { time },
   networkHelpers: { loadFixture },
 } = connection;
 
@@ -88,63 +89,103 @@ for (const [name, opts] of Object.entries({
       Object.assign(this, connection, await loadFixture(fixture));
     });
 
-    it('rejects validAfter with the flag set when validUntil has no flag (and is non-zero)', async function () {
-      await this.paymaster.deposit({ value: ethers.parseEther('1') });
+    describe('with deposit', function () {
+      beforeEach(async function () {
+        await this.paymaster.deposit({ value: ethers.parseEther('1') });
+      });
 
-      const signedUserOp = await this.account
-        .createUserOp({
-          paymaster: this.paymaster,
-        })
-        .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG | 1n, validUntil: 2n }))
-        .then(op => this.signUserOp(op));
+      for (const { name, flag, reason } of [
+        { name: 'timestamp', flag: 0n, reason: 'AA32 paymaster expired or not due' },
+        { name: 'blockNumber', flag: BLOCK_RANGE_FLAG, reason: 'AA37 paymaster inval block range' },
+      ]) {
+        describe(`${name}-range sponsorship`, function () {
+          it(`accepts a valid ${name}-range sponsorship`, async function () {
+            const now = await time.clock[name]();
+            const signedUserOp = await this.account
+              .createUserOp({
+                paymaster: this.paymaster,
+              })
+              .then(op => this.paymasterSignUserOp(op, { validAfter: flag | 0n, validUntil: flag | (now + 100n) }))
+              .then(op => this.signUserOp(op));
 
-      await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
-        .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
-        .withArgs(0n, 'AA34 signature error');
-    });
+            await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver)).to.not.revert(
+              ethers,
+            );
+          });
 
-    it('rejects validUntil with the flag set when validAfter has no flag', async function () {
-      await this.paymaster.deposit({ value: ethers.parseEther('1') });
+          it(`rejects expired ${name}-range sponsorships (validUntil in the past)`, async function () {
+            const now = await time.clock[name]();
+            const signedUserOp = await this.account
+              .createUserOp({
+                paymaster: this.paymaster,
+              })
+              .then(op => this.paymasterSignUserOp(op, { validAfter: flag | 1n, validUntil: flag | (now - 1n) }))
+              .then(op => this.signUserOp(op));
 
-      const signedUserOp = await this.account
-        .createUserOp({
-          paymaster: this.paymaster,
-        })
-        .then(op => this.paymasterSignUserOp(op, { validAfter: 0n, validUntil: BLOCK_RANGE_FLAG | 1n }))
-        .then(op => this.signUserOp(op));
+            await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
+              .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
+              .withArgs(0n, reason);
+          });
 
-      await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
-        .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
-        .withArgs(0n, 'AA34 signature error');
-    });
+          it(`accepts a ${name}-range sponsorship with validUntil = 0 (no expiry)`, async function () {
+            const signedUserOp = await this.account
+              .createUserOp({ paymaster: this.paymaster })
+              .then(op => this.paymasterSignUserOp(op, { validAfter: flag | 1n, validUntil: 0n }))
+              .then(op => this.signUserOp(op));
 
-    it('accepts a block-range sponsorship with `validUntil = 0` (no expiry)', async function () {
-      await this.paymaster.deposit({ value: ethers.parseEther('1') });
+            await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver)).to.not.revert(
+              ethers,
+            );
+          });
 
-      const signedUserOp = await this.account
-        .createUserOp({ paymaster: this.paymaster })
-        .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG | 1n, validUntil: 0n }))
-        .then(op => this.signUserOp(op));
+          if (flag !== 0n) {
+            it(`rejects a ${name}-range sponsorship with validUntil = BLOCK_RANGE_FLAG (expired at genesis)`, async function () {
+              const signedUserOp = await this.account
+                .createUserOp({ paymaster: this.paymaster })
+                .then(op => this.paymasterSignUserOp(op, { validAfter: flag | 1n, validUntil: flag | 0n }))
+                .then(op => this.signUserOp(op));
 
-      await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver)).to.not.revert(
-        ethers,
-      );
-    });
+              await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
+                .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
+                .withArgs(0n, reason);
+            });
+          }
+        });
+      }
 
-    it('returns SIG_VALIDATION_FAILED for paymasterData shorter than 12 bytes', async function () {
-      await this.paymaster.deposit({ value: ethers.parseEther('1') });
+      it('rejects when range uses mixed values', async function () {
+        const signedUserOp1 = await this.account
+          .createUserOp({ paymaster: this.paymaster })
+          .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG, validUntil: BLOCK_RANGE_FLAG - 1n }))
+          .then(op => this.signUserOp(op));
 
-      const signedUserOp = await this.account
-        .createUserOp({ paymaster: this.paymaster })
-        .then(op => {
-          op.paymasterData = '0x'; // empty (0 bytes < 12)
-          return op;
-        })
-        .then(op => this.signUserOp(op));
+        await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp1.packed], this.receiver))
+          .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
+          .withArgs(0n, 'AA34 signature error');
 
-      await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
-        .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
-        .withArgs(0n, 'AA34 signature error');
+        const signedUserOp2 = await this.account
+          .createUserOp({ paymaster: this.paymaster })
+          .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG - 1n, validUntil: BLOCK_RANGE_FLAG }))
+          .then(op => this.signUserOp(op));
+
+        await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp2.packed], this.receiver))
+          .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
+          .withArgs(0n, 'AA34 signature error');
+      });
+
+      it('returns SIG_VALIDATION_FAILED for paymasterData shorter than 12 bytes', async function () {
+        const signedUserOp = await this.account
+          .createUserOp({ paymaster: this.paymaster })
+          .then(op => {
+            op.paymasterData = '0x'; // empty (0 bytes < 12)
+            return op;
+          })
+          .then(op => this.signUserOp(op));
+
+        await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver))
+          .to.be.revertedWithCustomError(ethers.predeploy.entrypoint.v09, 'FailedOp')
+          .withArgs(0n, 'AA34 signature error');
+      });
     });
 
     shouldBehaveLikePaymaster(opts);

--- a/test/account/paymaster/PaymasterSigner.test.js
+++ b/test/account/paymaster/PaymasterSigner.test.js
@@ -121,13 +121,14 @@ for (const [name, opts] of Object.entries({
     it('accepts a block-range sponsorship with `validUntil = 0` (no expiry)', async function () {
       await this.paymaster.deposit({ value: ethers.parseEther('1') });
 
-      const validAfter = BLOCK_RANGE_FLAG | (BigInt(await ethers.provider.getBlockNumber()) - 1n);
       const signedUserOp = await this.account
         .createUserOp({ paymaster: this.paymaster })
-        .then(op => this.paymasterSignUserOp(op, { validAfter, validUntil: 0n }))
+        .then(op => this.paymasterSignUserOp(op, { validAfter: BLOCK_RANGE_FLAG | 1n, validUntil: 0n }))
         .then(op => this.signUserOp(op));
 
-      await ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver).then(op => op.wait());
+      await expect(ethers.predeploy.entrypoint.v09.handleOps([signedUserOp.packed], this.receiver)).to.not.revert(
+        ethers,
+      );
     });
 
     it('returns SIG_VALIDATION_FAILED for paymasterData shorter than 12 bytes', async function () {

--- a/test/account/utils/ERC4337Utils.test.js
+++ b/test/account/utils/ERC4337Utils.test.js
@@ -11,8 +11,8 @@ const {
 } = await network.create();
 
 const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
-const BLOCK_RANGE_FLAG = 0x800000000000n; // 1n << 48n
-const MAX_UINT47 = 0x7fffffffffffn; // (1n << 48n) - 1n
+const BLOCK_RANGE_FLAG = 0x800000000000n; // 1n << 47n
+const MAX_UINT47 = 0x7fffffffffffn; // (1n << 47n) - 1n
 
 async function fixture() {
   const [authorizer, sender, factory, paymaster] = await ethers.getSigners();

--- a/test/account/utils/ERC4337Utils.test.js
+++ b/test/account/utils/ERC4337Utils.test.js
@@ -55,7 +55,7 @@ describe('ERC4337Utils', function () {
       ]);
     });
 
-    it('strips away the highest bit flag from the `validAfter` and `validUntil` fields', async function () {
+    it('strips away the highest bit flag from the `validAfter` and `validUntil` fields (block range)', async function () {
       const authorizer = this.authorizer;
       const validAfter = 0x12345678n | 0x800000000000n;
       const validUntil = 0x23456789n | 0x800000000000n;
@@ -89,10 +89,12 @@ describe('ERC4337Utils', function () {
       const validUntil = 0n;
       const validationData = packValidationData(validAfter, validUntil, authorizer);
 
+      // no flag to strip in a timestamp range: the sentinel expands to type(uint48).max, like the EntryPoint's
+      // `_parseValidationData` does
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
         validAfter,
-        0x7fffffffffffn,
+        MAX_UINT48,
         ValidationRange.Timestamp,
       ]);
     });
@@ -114,10 +116,7 @@ describe('ERC4337Utils', function () {
     it('classifies (flag | validAfter, 0) as block range (matches EntryPoint substitution order)', async function () {
       const authorizer = this.authorizer;
       const validAfter = 0x12345678n;
-      const validationData = ethers.solidityPacked(
-        ['uint48', 'uint48', 'address'],
-        [0x800000000000n | validAfter, 0n, authorizer.address],
-      );
+      const validationData = packValidationData(0x800000000000n | validAfter, 0n, authorizer.address);
 
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
@@ -131,14 +130,40 @@ describe('ERC4337Utils', function () {
       await expect(this.utils.$parseValidationData(this.SIG_VALIDATION_SUCCESS)).to.eventually.deep.equal([
         ethers.ZeroAddress,
         0n,
-        0x7fffffffffffn,
+        MAX_UINT48,
         ValidationRange.Timestamp,
       ]);
 
       await expect(this.utils.$parseValidationData(this.SIG_VALIDATION_FAILED)).to.eventually.deep.equal([
         ADDRESS_ONE,
         0n,
-        0x7fffffffffffn,
+        MAX_UINT48,
+        ValidationRange.Timestamp,
+      ]);
+    });
+
+    // The EntryPoint only strips BLOCK_RANGE_FLAG once it has detected a block range; in a timestamp range it
+    // compares `block.timestamp` against the raw fields. A residual flag must therefore survive parsing.
+    it('keeps the block-range flag on `validUntil` in a timestamp range', async function () {
+      const authorizer = this.authorizer;
+      const validationData = packValidationData(0n, 0x800000000000n | 100n, authorizer.address);
+
+      await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
+        authorizer.address,
+        0n,
+        0x800000000000n | 100n,
+        ValidationRange.Timestamp,
+      ]);
+    });
+
+    it('keeps the block-range flag on `validAfter` in a timestamp range', async function () {
+      const authorizer = this.authorizer;
+      const validationData = packValidationData(0x800000000000n | 1000n, 2000n, authorizer.address);
+
+      await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
+        authorizer.address,
+        0x800000000000n | 1000n,
+        2000n,
         ValidationRange.Timestamp,
       ]);
     });
@@ -332,14 +357,34 @@ describe('ERC4337Utils', function () {
     });
 
     it('preserves the block-range flag when combining a `(flag | validAfter, 0)` operand', async function () {
-      const blockValidationData = ethers.solidityPacked(
-        ['uint48', 'uint48', 'address'],
-        [0x800000000000n | 0x00abcdefn, 0n, ethers.ZeroAddress],
-      );
+      const blockValidationData = packValidationData(0x800000000000n | 0x00abcdefn, 0n, ethers.ZeroAddress);
 
       const combined = await this.utils.$combineValidationData(blockValidationData, blockValidationData);
       const [, , , range] = await this.utils.$parseValidationData(combined);
       expect(range).to.equal(ValidationRange.Block);
+    });
+
+    it('does not turn a never-valid timestamp operand into a valid range', async function () {
+      const now = await time.clock.timestamp();
+
+      // `validAfter` carries the block-range flag but `validUntil` does not, so the EntryPoint reads this as a
+      // timestamp range whose `validAfter` (2**47) `block.timestamp` will never reach: it is never valid.
+      const neverValid = packValidationData(0x800000000000n, now + 2000n, ethers.ZeroAddress);
+      const valid = packValidationData(now - 1000n, now + 1000n, ethers.ZeroAddress);
+
+      // check symmetry
+      for (const combined of [
+        await this.utils.$combineValidationData(neverValid, valid),
+        await this.utils.$combineValidationData(valid, neverValid),
+      ]) {
+        await expect(this.utils.$parseValidationData(combined)).to.eventually.deep.equal([
+          ethers.ZeroAddress,
+          0x800000000000n,
+          now + 1000n,
+          ValidationRange.Timestamp,
+        ]);
+        await expect(this.utils.$getValidationData(combined)).to.eventually.deep.equal([ethers.ZeroAddress, true]);
+      }
     });
 
     it('returns SIG_VALIDATION_FAILURE if the validation ranges differ', async function () {
@@ -473,12 +518,28 @@ describe('ERC4337Utils', function () {
     it('reports not-yet-valid for a future block range with `validUntil == 0`', async function () {
       const aggregator = this.authorizer;
       const validAfter = (await time.clock.blockNumber()) + 100n;
-      const validationData = ethers.solidityPacked(
-        ['uint48', 'uint48', 'address'],
-        [0x800000000000n | validAfter, 0n, aggregator.address],
-      );
+      const validationData = packValidationData(0x800000000000n | validAfter, 0n, aggregator.address);
 
       await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, true]);
+    });
+
+    // `EntryPoint._getValidationData` falls back to comparing `block.timestamp` against the raw fields whenever the
+    // two flags do not agree, so a flagged bound is out of reach: `validAfter` is never reached and `validUntil` is
+    // never exceeded.
+    it('never enters the range when only `validAfter` carries the block-range flag', async function () {
+      const aggregator = this.authorizer;
+      const validationData = packValidationData(0x800000000000n, 0x7fffffffffffn, aggregator.address);
+
+      // `block.timestamp <= 2**47` holds
+      await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, true]);
+    });
+
+    it('never leaves the range when only `validUntil` carries the block-range flag', async function () {
+      const aggregator = this.authorizer;
+      const validationData = packValidationData(0n, 0x800000000000n | 100n, aggregator.address);
+
+      // neither `block.timestamp > 2**47 + 100` nor `block.timestamp <= 0` holds
+      await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, false]);
     });
   });
 

--- a/test/account/utils/ERC4337Utils.test.js
+++ b/test/account/utils/ERC4337Utils.test.js
@@ -11,6 +11,8 @@ const {
 } = await network.create();
 
 const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
+const BLOCK_RANGE_FLAG = 0x800000000000n; // 1n << 48n
+const MAX_UINT47 = 0x7fffffffffffn; // (1n << 48n) - 1n
 
 async function fixture() {
   const [authorizer, sender, factory, paymaster] = await ethers.getSigners();
@@ -57,14 +59,14 @@ describe('ERC4337Utils', function () {
 
     it('strips away the highest bit flag from the `validAfter` and `validUntil` fields (block range)', async function () {
       const authorizer = this.authorizer;
-      const validAfter = 0x12345678n | 0x800000000000n;
-      const validUntil = 0x23456789n | 0x800000000000n;
+      const validAfter = 0x12345678n | BLOCK_RANGE_FLAG;
+      const validUntil = 0x23456789n | BLOCK_RANGE_FLAG;
       const validationData = packValidationData(validAfter, validUntil, authorizer);
 
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
-        validAfter & ~0x800000000000n,
-        validUntil & ~0x800000000000n,
+        validAfter & ~BLOCK_RANGE_FLAG,
+        validUntil & ~BLOCK_RANGE_FLAG,
         ValidationRange.Block,
       ]);
     });
@@ -108,7 +110,7 @@ describe('ERC4337Utils', function () {
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
         validAfter,
-        0x7fffffffffffn,
+        MAX_UINT47,
         ValidationRange.Block,
       ]);
     });
@@ -116,12 +118,12 @@ describe('ERC4337Utils', function () {
     it('classifies (flag | validAfter, 0) as block range (matches EntryPoint substitution order)', async function () {
       const authorizer = this.authorizer;
       const validAfter = 0x12345678n;
-      const validationData = packValidationData(0x800000000000n | validAfter, 0n, authorizer.address);
+      const validationData = packValidationData(BLOCK_RANGE_FLAG | validAfter, 0n, authorizer.address);
 
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
         validAfter,
-        0x7fffffffffffn,
+        MAX_UINT47,
         ValidationRange.Block,
       ]);
     });
@@ -146,23 +148,23 @@ describe('ERC4337Utils', function () {
     // compares `block.timestamp` against the raw fields. A residual flag must therefore survive parsing.
     it('keeps the block-range flag on `validUntil` in a timestamp range', async function () {
       const authorizer = this.authorizer;
-      const validationData = packValidationData(0n, 0x800000000000n | 100n, authorizer.address);
+      const validationData = packValidationData(0n, BLOCK_RANGE_FLAG | 100n, authorizer.address);
 
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
         0n,
-        0x800000000000n | 100n,
+        BLOCK_RANGE_FLAG | 100n,
         ValidationRange.Timestamp,
       ]);
     });
 
     it('keeps the block-range flag on `validAfter` in a timestamp range', async function () {
       const authorizer = this.authorizer;
-      const validationData = packValidationData(0x800000000000n | 1000n, 2000n, authorizer.address);
+      const validationData = packValidationData(BLOCK_RANGE_FLAG | 1000n, 2000n, authorizer.address);
 
       await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
         authorizer.address,
-        0x800000000000n | 1000n,
+        BLOCK_RANGE_FLAG | 1000n,
         2000n,
         ValidationRange.Timestamp,
       ]);
@@ -181,18 +183,18 @@ describe('ERC4337Utils', function () {
       ).to.eventually.equal(validationData);
 
       await expect(
-        this.utils.$packValidationData(ethers.Typed.address(authorizer), validAfter | 0x800000000000n, validUntil),
+        this.utils.$packValidationData(ethers.Typed.address(authorizer), validAfter | BLOCK_RANGE_FLAG, validUntil),
       ).to.eventually.equal(validationData);
 
       await expect(
-        this.utils.$packValidationData(ethers.Typed.address(authorizer), validAfter, validUntil | 0x800000000000n),
+        this.utils.$packValidationData(ethers.Typed.address(authorizer), validAfter, validUntil | BLOCK_RANGE_FLAG),
       ).to.eventually.equal(validationData);
     });
 
     it('packs the validation data with implicit block number', async function () {
       const authorizer = this.authorizer;
-      const validAfter = 0x12345678n | 0x800000000000n;
-      const validUntil = 0x23456789n | 0x800000000000n;
+      const validAfter = 0x12345678n | BLOCK_RANGE_FLAG;
+      const validUntil = 0x23456789n | BLOCK_RANGE_FLAG;
       const validationData = packValidationData(validAfter, validUntil, authorizer);
 
       await expect(
@@ -202,8 +204,8 @@ describe('ERC4337Utils', function () {
 
     it('packs the validation data with explicit timestamp', async function () {
       const authorizer = this.authorizer;
-      const validAfter = 0x12345678n | 0x800000000000n; // extra flag will be cleaned up
-      const validUntil = 0x23456789n | 0x800000000000n; // extra flag will be cleaned up
+      const validAfter = 0x12345678n | BLOCK_RANGE_FLAG; // extra flag will be cleaned up
+      const validUntil = 0x23456789n | BLOCK_RANGE_FLAG; // extra flag will be cleaned up
       const validationData = packValidationData(validAfter, validUntil, authorizer, ValidationRange.Timestamp);
 
       await expect(
@@ -243,18 +245,18 @@ describe('ERC4337Utils', function () {
       ).to.eventually.equal(validationData);
 
       await expect(
-        this.utils.$packValidationData(ethers.Typed.bool(success), validAfter | 0x800000000000n, validUntil),
+        this.utils.$packValidationData(ethers.Typed.bool(success), validAfter | BLOCK_RANGE_FLAG, validUntil),
       ).to.eventually.equal(validationData);
 
       await expect(
-        this.utils.$packValidationData(ethers.Typed.bool(success), validAfter, validUntil | 0x800000000000n),
+        this.utils.$packValidationData(ethers.Typed.bool(success), validAfter, validUntil | BLOCK_RANGE_FLAG),
       ).to.eventually.equal(validationData);
     });
 
     it('packs the validation data (bool) with implicit block number', async function () {
       const success = false;
-      const validAfter = 0x12345678n | 0x800000000000n;
-      const validUntil = 0x23456789n | 0x800000000000n;
+      const validAfter = 0x12345678n | BLOCK_RANGE_FLAG;
+      const validUntil = 0x23456789n | BLOCK_RANGE_FLAG;
       const validationData = packValidationData(validAfter, validUntil, false);
 
       await expect(
@@ -264,8 +266,8 @@ describe('ERC4337Utils', function () {
 
     it('packs the validation data (bool) with explicit timestamp', async function () {
       const success = false;
-      const validAfter = 0x12345678n | 0x800000000000n; // extra flag will be cleaned up
-      const validUntil = 0x23456789n | 0x800000000000n; // extra flag will be cleaned up
+      const validAfter = 0x12345678n | BLOCK_RANGE_FLAG; // extra flag will be cleaned up
+      const validUntil = 0x23456789n | BLOCK_RANGE_FLAG; // extra flag will be cleaned up
       const validationData = packValidationData(validAfter, validUntil, false, ValidationRange.Timestamp);
 
       await expect(
@@ -357,7 +359,7 @@ describe('ERC4337Utils', function () {
     });
 
     it('preserves the block-range flag when combining a `(flag | validAfter, 0)` operand', async function () {
-      const blockValidationData = packValidationData(0x800000000000n | 0x00abcdefn, 0n, ethers.ZeroAddress);
+      const blockValidationData = packValidationData(BLOCK_RANGE_FLAG | 0x00abcdefn, 0n, ethers.ZeroAddress);
 
       const combined = await this.utils.$combineValidationData(blockValidationData, blockValidationData);
       const [, , , range] = await this.utils.$parseValidationData(combined);
@@ -369,7 +371,7 @@ describe('ERC4337Utils', function () {
 
       // `validAfter` carries the block-range flag but `validUntil` does not, so the EntryPoint reads this as a
       // timestamp range whose `validAfter` (2**47) `block.timestamp` will never reach: it is never valid.
-      const neverValid = packValidationData(0x800000000000n, now + 2000n, ethers.ZeroAddress);
+      const neverValid = packValidationData(BLOCK_RANGE_FLAG, now + 2000n, ethers.ZeroAddress);
       const valid = packValidationData(now - 1000n, now + 1000n, ethers.ZeroAddress);
 
       // check symmetry
@@ -379,12 +381,36 @@ describe('ERC4337Utils', function () {
       ]) {
         await expect(this.utils.$parseValidationData(combined)).to.eventually.deep.equal([
           ethers.ZeroAddress,
-          0x800000000000n,
+          BLOCK_RANGE_FLAG,
           now + 1000n,
           ValidationRange.Timestamp,
         ]);
         await expect(this.utils.$getValidationData(combined)).to.eventually.deep.equal([ethers.ZeroAddress, true]);
       }
+    });
+
+    it('accepts a block range that is valid from the first block, forever', async function () {
+      const valid = packValidationData(BLOCK_RANGE_FLAG, 0n, ethers.ZeroAddress);
+
+      await expect(this.utils.$parseValidationData(valid)).to.eventually.deep.equal([
+        ethers.ZeroAddress,
+        0n,
+        MAX_UINT47,
+        ValidationRange.Block,
+      ]);
+
+      await expect(this.utils.$getValidationData(valid)).to.eventually.deep.equal([ethers.ZeroAddress, false]);
+
+      const combined = await this.utils.$combineValidationData(valid, valid);
+
+      await expect(this.utils.$parseValidationData(combined)).to.eventually.deep.equal([
+        ethers.ZeroAddress,
+        0n,
+        MAX_UINT47,
+        ValidationRange.Block,
+      ]);
+
+      await expect(this.utils.$getValidationData(combined)).to.eventually.deep.equal([ethers.ZeroAddress, false]);
     });
 
     it('returns SIG_VALIDATION_FAILURE if the validation ranges differ', async function () {
@@ -518,7 +544,7 @@ describe('ERC4337Utils', function () {
     it('reports not-yet-valid for a future block range with `validUntil == 0`', async function () {
       const aggregator = this.authorizer;
       const validAfter = (await time.clock.blockNumber()) + 100n;
-      const validationData = packValidationData(0x800000000000n | validAfter, 0n, aggregator.address);
+      const validationData = packValidationData(BLOCK_RANGE_FLAG | validAfter, 0n, aggregator.address);
 
       await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, true]);
     });
@@ -528,7 +554,7 @@ describe('ERC4337Utils', function () {
     // never exceeded.
     it('never enters the range when only `validAfter` carries the block-range flag', async function () {
       const aggregator = this.authorizer;
-      const validationData = packValidationData(0x800000000000n, 0x7fffffffffffn, aggregator.address);
+      const validationData = packValidationData(BLOCK_RANGE_FLAG, MAX_UINT47, aggregator.address);
 
       // `block.timestamp <= 2**47` holds
       await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, true]);
@@ -536,7 +562,7 @@ describe('ERC4337Utils', function () {
 
     it('never leaves the range when only `validUntil` carries the block-range flag', async function () {
       const aggregator = this.authorizer;
-      const validationData = packValidationData(0n, 0x800000000000n | 100n, aggregator.address);
+      const validationData = packValidationData(0n, BLOCK_RANGE_FLAG | 100n, aggregator.address);
 
       // neither `block.timestamp > 2**47 + 100` nor `block.timestamp <= 0` holds
       await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, false]);

--- a/test/account/utils/ERC4337Utils.test.js
+++ b/test/account/utils/ERC4337Utils.test.js
@@ -111,6 +111,22 @@ describe('ERC4337Utils', function () {
       ]);
     });
 
+    it('classifies (flag | validAfter, 0) as block range (matches EntryPoint substitution order)', async function () {
+      const authorizer = this.authorizer;
+      const validAfter = 0x12345678n;
+      const validationData = ethers.solidityPacked(
+        ['uint48', 'uint48', 'address'],
+        [0x800000000000n | validAfter, 0n, authorizer.address],
+      );
+
+      await expect(this.utils.$parseValidationData(validationData)).to.eventually.deep.equal([
+        authorizer.address,
+        validAfter,
+        0x7fffffffffffn,
+        ValidationRange.Block,
+      ]);
+    });
+
     it('parse canonical values', async function () {
       await expect(this.utils.$parseValidationData(this.SIG_VALIDATION_SUCCESS)).to.eventually.deep.equal([
         ethers.ZeroAddress,
@@ -315,6 +331,17 @@ describe('ERC4337Utils', function () {
       await expect(this.utils.$combineValidationData(validationData2, validationData1)).to.eventually.equal(expected);
     });
 
+    it('preserves the block-range flag when combining a `(flag | validAfter, 0)` operand', async function () {
+      const blockValidationData = ethers.solidityPacked(
+        ['uint48', 'uint48', 'address'],
+        [0x800000000000n | 0x00abcdefn, 0n, ethers.ZeroAddress],
+      );
+
+      const combined = await this.utils.$combineValidationData(blockValidationData, blockValidationData);
+      const [, , , range] = await this.utils.$parseValidationData(combined);
+      expect(range).to.equal(ValidationRange.Block);
+    });
+
     it('returns SIG_VALIDATION_FAILURE if the validation ranges differ', async function () {
       const validationData1 = packValidationData(
         validAfter1,
@@ -441,6 +468,17 @@ describe('ERC4337Utils', function () {
 
     it('returns address(0) and false for validationData = 0', async function () {
       await expect(this.utils.$getValidationData(0n)).to.eventually.deep.equal([ethers.ZeroAddress, false]);
+    });
+
+    it('reports not-yet-valid for a future block range with `validUntil == 0`', async function () {
+      const aggregator = this.authorizer;
+      const validAfter = (await time.clock.blockNumber()) + 100n;
+      const validationData = ethers.solidityPacked(
+        ['uint48', 'uint48', 'address'],
+        [0x800000000000n | validAfter, 0n, aggregator.address],
+      );
+
+      await expect(this.utils.$getValidationData(validationData)).to.eventually.deep.equal([aggregator.address, true]);
     });
   });
 

--- a/test/helpers/erc4337.js
+++ b/test/helpers/erc4337.js
@@ -20,6 +20,7 @@ function pack(left, right) {
 export function packValidationData(validAfter, validUntil, authorizer, range = undefined) {
   // if range is not specified, use the value as provided,
   // otherwise, clean the values (& BLOCK_RANGE_MASK) and set the flag if corresponding to the range.
+  // in Block range, `validUntil == 0` is left as 0 so the decoder's `validUntil == 0 -> max` rule applies.
   return ethers.solidityPacked(
     ['uint48', 'uint48', 'address'],
     [
@@ -28,7 +29,9 @@ export function packValidationData(validAfter, validUntil, authorizer, range = u
         : (BigInt(validAfter) & BLOCK_RANGE_MASK) | (range == ValidationRange.Block ? BLOCK_RANGE_FLAG : 0n),
       range === undefined
         ? BigInt(validUntil)
-        : (BigInt(validUntil) & BLOCK_RANGE_MASK) | (range == ValidationRange.Block ? BLOCK_RANGE_FLAG : 0n),
+        : range == ValidationRange.Block && (BigInt(validUntil) & BLOCK_RANGE_MASK) == 0n
+          ? 0n
+          : (BigInt(validUntil) & BLOCK_RANGE_MASK) | (range == ValidationRange.Block ? BLOCK_RANGE_FLAG : 0n),
       typeof authorizer == 'boolean'
         ? authorizer
           ? SIG_VALIDATION_SUCCESS


### PR DESCRIPTION
## Summary

Fixes a divergence between `ERC4337Utils` and canonical EntryPoint v0.9 parsing of the ERC-4337 `validationData` field. Reported privately via Immunefi; the same primitive was flagged as **M-11 (Medium, still open)** on a prior audit scan (2026-03) and was not actioned in the v5.7 cycle.

### The bug

Introduced in #6215 (v5.7). In `parseValidationData`:

- The validity range is decided from `(validAfter & validUntil & BLOCK_RANGE_FLAG)` **before** the `validUntil == 0 -> max` substitution. When the caller encodes "from block N, no expiry" as `(BLOCK_RANGE_FLAG | N, 0)`, the AND against the literal-zero `validUntil` wipes the flag and the range is misclassified as timestamp.
- The substituted constant is `BLOCK_RANGE_MASK` (`0x7f…`, flag bit off) instead of `type(uint48).max` (`0xff…`, flag bit on) — the flag can't survive the substitution even if the ordering were fixed.

Canonical EntryPoint v0.9 (`core/Helpers.sol:_parseValidationData`) does the opposite: substitutes first with `type(uint48).max`, then tests the flag.

Downstream divergences off the same root cause:

- `getValidationData` reports `outOfTimeRange = false` for a future block-range window that the EntryPoint would reject with `AA37 paymaster inval block range` (fail-open on the decode).
- `combineValidationData` re-packs through the timestamp branch and strips the block-range restriction; the EntryPoint then accepts the result.
- `packValidationData(...,BLOCK)` ORed `BLOCK_RANGE_FLAG` onto `validUntil == 0`, producing a value the EntryPoint rejected forever, so `PaymasterSigner` could not express "block range, no expiry" via the natural encoding.

### The fix

- `parseValidationData`: substitute `validUntil == 0 -> type(uint48).max` first, then decide range, then mask. Mirrors EntryPoint's ordering exactly. Removes the fail-open, unblocks `combineValidationData`, and closes M-11.
- `packValidationData(...,BLOCK)`: preserve `validUntil == 0` (do not OR the flag onto it). The zero passes through to the EntryPoint, which substitutes it to `type(uint48).max` via the canonical no-expiry rule.
- `PaymasterSigner._validatePaymasterUserOp`: allow the mixed-flag case when `validUntil == 0` (the no-expiry sentinel), and route to the explicit-range `packValidationData` overload so block-mode intent is carried from `validAfter`'s flag bit.

### Backward compatibility

- `parseValidationData` return value changes only for the specific class of inputs that was previously misdecoded (`(FLAG | validAfter, 0)`). No storage layout impact. Public function signatures unchanged.
- `PaymasterSigner`: previously rejected `(FLAG | validAfter, 0)` now succeeds when validly signed. This is an expansion of the accepted domain, not a restriction — no existing valid sponsorship becomes invalid.

## Test plan

- [x] Existing `ERC4337Utils` and `PaymasterSigner` tests pass (94/94 in the two files, 921/921 across `test/account/**/*.test.js`)
- [x] New regression tests:
  - `parseValidationData` classifies `(FLAG | validAfter, 0)` as block range
  - `getValidationData` reports not-yet-valid for a future block range with `validUntil == 0`
  - `combineValidationData` preserves the block-range flag when both operands use the no-expiry sentinel
  - `PaymasterSigner` accepts a block-range sponsorship with `validUntil = 0` end-to-end against canonical EntryPoint v0.9 bytecode
  - Existing `PaymasterSigner` "reject mixed flags" test tightened to a non-zero `validUntil` case
- [x] Lint, prettier, solhint

#### PR Checklist

- [x] Tests
- [x] Documentation (existing NatSpec still accurate; behavior now matches canonical EntryPoint)
- [x] Changeset entry