### PR TITLE
Derive the transpiler public initializer list automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nomicfoundation/hardhat-network-helpers": "^3.0.11",
         "@openzeppelin/docs-utils": "^0.1.6",
         "@openzeppelin/merkle-tree": "^1.0.7",
-        "@openzeppelin/upgrade-safe-transpiler": "^0.4.1",
+        "@openzeppelin/upgrade-safe-transpiler": "^0.4.2",
         "@openzeppelin/upgrades-core": "^1.20.6",
         "@types/node": "^25.9.4",
         "@types/yargs": "^17.0.35",
@@ -2176,7 +2176,9 @@
       }
     },
     "node_modules/@openzeppelin/upgrade-safe-transpiler": {
-      "version": "0.4.1",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrade-safe-transpiler/-/upgrade-safe-transpiler-0.4.2.tgz",
+      "integrity": "sha512-Rct4coEubwKpUIcFv41DUHQiOMMTH1EZ23oYBESFqN79TZ7qiUMdfgQKsokwozkqqPD7WR4dvZpzdFl46wrZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@nomicfoundation/hardhat-network-helpers": "^3.0.11",
     "@openzeppelin/docs-utils": "^0.1.6",
     "@openzeppelin/merkle-tree": "^1.0.7",
-    "@openzeppelin/upgrade-safe-transpiler": "^0.4.1",
+    "@openzeppelin/upgrade-safe-transpiler": "^0.4.2",
     "@openzeppelin/upgrades-core": "^1.20.6",
     "@types/node": "^25.9.4",
     "@types/yargs": "^17.0.35",

--- a/scripts/upgradeable/transpile.config.json
+++ b/scripts/upgradeable/transpile.config.json
@@ -7,13 +7,7 @@
     "contracts/proxy/**/*Proxy*.sol",
     "contracts/proxy/beacon/UpgradeableBeacon.sol"
   ],
-  "publicInitializers": [
-    "contracts/access/manager/AccessManager.sol",
-    "contracts/crosschain/CrosschainRemoteExecutor.sol",
-    "contracts/finance/VestingWallet.sol",
-    "contracts/governance/TimelockController.sol",
-    "contracts/metatx/ERC2771Forwarder.sol"
-  ],
+  "publicInitializers": ["!contracts/mocks/**/*"],
   "namespaced": true,
   "namespaceExclude": ["contracts/mocks/**/*"],
   "peerProject": "@openzeppelin/"


### PR DESCRIPTION
Follow up to #6702.

Bumps `@openzeppelin/upgrade-safe-transpiler` to `^0.4.2`, which no longer adds a public initializer to abstract contracts.

With that fix, the hand-maintained `publicInitializers` list in `scripts/upgradeable/transpile.config.json` can be replaced by a single `!contracts/mocks/**/*` pattern: every non-excluded, non-stateless, concrete contract outside of mocks gets a public initializer, which resolves to exactly the list we were maintaining by hand. Adding a new contract no longer requires a config update.