### PR TITLE
hardhat-exposed: resolve npm imports in generated contracts

### DIFF
--- a/hardhat/hardhat-exposed/internal/expose.ts
+++ b/hardhat/hardhat-exposed/internal/expose.ts
@@ -65,18 +65,19 @@ function getImportPathFromExposedContract(
   ).replaceAll(/\\/g, '/'); // Normalize windows paths to unix paths
 }
 
-const remappingRegex = /^(?<context>[^:]*):(?<prefix>[^=]*)=(?<target>.*)$/;
+const remappingRegex = /^(?:(?<context>[^:]*):)?(?<prefix>[^=]*)=(?<target>.*)$/;
 
 // Files that come from an npm package have an input source name of the form `npm/<name>@<version>/<path>`, which is
 // neither a valid import path nor a usable output path. Exposed contracts live in the project, so they refer to these
 // files the way the project does, using the name the package is installed under. Hardhat records that mapping in the
-// solc input remappings, as `<context>:<prefix>=<target>` entries (e.g. `project/:hardhat/=npm/hardhat@3.9.1/`); we
-// invert the ones that apply to the project sources, and fall back to dropping the version if none matches.
+// solc input remappings, as `[<context>:]<prefix>=<target>` entries (e.g. `project/:hardhat/=npm/hardhat@3.9.1/`); we
+// invert the ones that apply to the project sources, and fall back to dropping the version if none matches. A missing
+// context is an empty one: the remapping applies to every file, project sources included.
 function getNpmImportPath(inputSourceName: string, remappings: string[]): string {
   // Longest target first: multiple remappings may apply, the most specific one is the right one.
   const item = remappings
     .flatMap(remapping => (remappingRegex.exec(remapping)?.groups ?? []) as { [key: string]: string }[])
-    .filter(({ context, target }) => ['', 'project/'].includes(context) && inputSourceName.startsWith(target))
+    .filter(({ context, target }) => ['', 'project/'].includes(context ?? '') && inputSourceName.startsWith(target))
     .sort((a, b) => b.target.length - a.target.length)
     .at(0);
 

--- a/hardhat/hardhat-exposed/internal/expose.ts
+++ b/hardhat/hardhat-exposed/internal/expose.ts
@@ -77,7 +77,7 @@ function getNpmImportPath(inputSourceName: string, remappings: string[]): string
   // Longest target first: multiple remappings may apply, the most specific one is the right one.
   const item = remappings
     .map(remapping => remappingRegex.exec(remapping)?.groups ?? {})
-    .filter(({ context, target }) => ['', 'project/'].includes(context ?? '') && inputSourceName.startsWith(target))
+    .filter(({ context, target }) => [undefined, '', 'project/'].includes(context) && inputSourceName.startsWith(target))
     .sort((a, b) => b.target.length - a.target.length)
     .at(0);
 

--- a/hardhat/hardhat-exposed/internal/expose.ts
+++ b/hardhat/hardhat-exposed/internal/expose.ts
@@ -35,11 +35,12 @@ export function getExposed(
 ): Map<string, string> {
   const res = new Map<string, string>();
   const deref = astDereferencer(solcOutput);
+  const remappings = solidityBuildInfo.input.settings.remappings ?? [];
 
   for (const [sourceName, inputSourceName] of Object.entries(solidityBuildInfo.userSourceNameMap)) {
     const ast = solcOutput.sources[inputSourceName].ast;
 
-    const exposedFile = getExposedFile(sourceName, inputSourceName, ast, deref, config);
+    const exposedFile = getExposedFile(sourceName, inputSourceName, ast, deref, config, remappings);
     if (exposedFile !== undefined) {
       res.set(exposedFile.absolutePath, exposedFile.content);
     }
@@ -52,6 +53,7 @@ function getImportPathFromExposedContract(
   exposedFileAbsolutePath: string,
   importedFileInputSourceName: string,
   projectRoot: string,
+  remappings: string[],
 ): string {
   return (
     importedFileInputSourceName.startsWith('project/')
@@ -59,8 +61,28 @@ function getImportPathFromExposedContract(
           path.dirname(exposedFileAbsolutePath),
           path.resolve(projectRoot, importedFileInputSourceName.replace(/^project\//, '')),
         )
-      : importedFileInputSourceName
+      : getNpmImportPath(importedFileInputSourceName, remappings)
   ).replaceAll(/\\/g, '/'); // Normalize windows paths to unix paths
+}
+
+const remappingRegex = /^(?<context>[^:]*):(?<prefix>[^=]*)=(?<target>.*)$/;
+
+// Files that come from an npm package have an input source name of the form `npm/<name>@<version>/<path>`, which is
+// neither a valid import path nor a usable output path. Exposed contracts live in the project, so they refer to these
+// files the way the project does, using the name the package is installed under. Hardhat records that mapping in the
+// solc input remappings, as `<context>:<prefix>=<target>` entries (e.g. `project/:hardhat/=npm/hardhat@3.9.1/`); we
+// invert the ones that apply to the project sources, and fall back to dropping the version if none matches.
+function getNpmImportPath(inputSourceName: string, remappings: string[]): string {
+  // Longest target first: multiple remappings may apply, the most specific one is the right one.
+  const item = remappings
+    .flatMap(remapping => (remappingRegex.exec(remapping)?.groups ?? []) as { [key: string]: string }[])
+    .filter(({ context, target }) => ['', 'project/'].includes(context) && inputSourceName.startsWith(target))
+    .sort((a, b) => b.target.length - a.target.length)
+    .at(0);
+
+  return item
+    ? item.prefix + inputSourceName.slice(item.target.length)
+    : inputSourceName.replace(/^npm\/(@[^/]+\/[^@/]+|[^@/]+)@[^/]+\//, '$1/');
 }
 
 function getExposedFile(
@@ -69,10 +91,11 @@ function getExposedFile(
   ast: SourceUnit,
   deref: ASTDereferencer,
   config: HardhatConfig,
+  remappings: string[],
 ): ExposedFile | undefined {
   const exposedFileAbsolutePath = path.join(
     config.exposed.outDir,
-    inputSourceName.startsWith('project/') ? sourceName : inputSourceName.replace('npm:', ''),
+    inputSourceName.startsWith('project/') ? sourceName : getNpmImportPath(inputSourceName, remappings),
   );
 
   const content = getExposedContent(
@@ -82,6 +105,7 @@ function getExposedFile(
     config.exposed.prefix,
     config.exposed.initializers,
     config.paths.root,
+    remappings,
   );
 
   return content === undefined ? undefined : { absolutePath: exposedFileAbsolutePath, content };
@@ -94,6 +118,7 @@ function getExposedContent(
   prefix: string,
   initializers: boolean,
   projectRoot: string,
+  remappings: string[],
 ): string | undefined {
   if (prefix === '' || /^\d|[^0-9a-z_$]/i.test(prefix)) {
     throw new Error(`Prefix '${prefix}' is not valid`);
@@ -102,7 +127,7 @@ function getExposedContent(
   const contractPrefix = prefix.replace(/^./, c => c.toUpperCase());
 
   const imports = Array.from(getNeededImports(ast, deref), u =>
-    getImportPathFromExposedContract(exposedFileAbsolutePath, u.absolutePath, projectRoot),
+    getImportPathFromExposedContract(exposedFileAbsolutePath, u.absolutePath, projectRoot, remappings),
   );
 
   const contracts = [...findAll('ContractDefinition', ast)].filter(c => c.contractKind !== 'interface');

--- a/hardhat/hardhat-exposed/internal/expose.ts
+++ b/hardhat/hardhat-exposed/internal/expose.ts
@@ -76,7 +76,7 @@ const remappingRegex = /^(?:(?<context>[^:]*):)?(?<prefix>[^=]*)=(?<target>.*)$/
 function getNpmImportPath(inputSourceName: string, remappings: string[]): string {
   // Longest target first: multiple remappings may apply, the most specific one is the right one.
   const item = remappings
-    .flatMap(remapping => (remappingRegex.exec(remapping)?.groups ?? []) as { [key: string]: string }[])
+    .map(remapping => remappingRegex.exec(remapping)?.groups ?? {})
     .filter(({ context, target }) => ['', 'project/'].includes(context ?? '') && inputSourceName.startsWith(target))
     .sort((a, b) => b.target.length - a.target.length)
     .at(0);

--- a/hardhat/hardhat-exposed/internal/expose.ts
+++ b/hardhat/hardhat-exposed/internal/expose.ts
@@ -77,7 +77,9 @@ function getNpmImportPath(inputSourceName: string, remappings: string[]): string
   // Longest target first: multiple remappings may apply, the most specific one is the right one.
   const item = remappings
     .map(remapping => remappingRegex.exec(remapping)?.groups ?? {})
-    .filter(({ context, target }) => [undefined, '', 'project/'].includes(context) && inputSourceName.startsWith(target))
+    .filter(
+      ({ context, target }) => [undefined, '', 'project/'].includes(context) && inputSourceName.startsWith(target),
+    )
     .sort((a, b) => b.target.length - a.target.length)
     .at(0);
 


### PR DESCRIPTION
Importing a file from an npm package in a contract breaks `hardhat compile`. For example, adding

```solidity
import {console} from "hardhat/console.sol";
```

to `ERC20.sol` fails with:

```
Error HHE902: There was an error while resolving the import "npm/hardhat@3.9.1/console.sol" from "./contracts-exposed/contracts/token/ERC20/extensions/draft-ERC3009.sol":
The file "hardhat@3.9.1/console.sol" is not exported by the package.
```

Files that come from an npm package have a solc input source name of the form `npm/<name>@<version>/<path>`, which the exposed-contract generation emitted verbatim as an import path. Hardhat then reads that as package `npm` with subpath `hardhat@3.9.1/console.sol`. It affects every exposed file deriving from the contract, not just the one holding the import, since `getNeededImports` re-emits the symbol-aliased imports of each base contract.

Exposed contracts live in the project, so they must refer to those files the way the project does, by the name the package is installed under. Hardhat already records that mapping in the solc input remappings it generates (`project/:hardhat/=npm/hardhat@3.9.1/`), so `getNpmImportPath` inverts the remappings whose context applies to the project sources, longest target first, and falls back to dropping the `npm/` prefix and the `@<version>` (scoped packages included) when none matches.

Remappings are `[<context>:]<prefix>=<target>`, so the context is optional and an absent one applies to every file; both forms are accepted.

The same helper now builds the output path, replacing an `inputSourceName.replace('npm:', '')` that used a prefix Hardhat 3 never emits — an npm root would have landed in `contracts-exposed/npm/hardhat@3.9.1/console.sol`.

No changeset: this only touches repo tooling, no contract behavior changes.

<details>
<summary>Verification</summary>

- With the `hardhat/console.sol` import in `ERC20.sol`, `hardhat compile` succeeds and the only npm import emitted across the 302 generated files is `import "hardhat/console.sol";`.
- Forced regeneration from an empty `contracts-exposed/`, with and without that import: 302 files generated, 700 compiled, no errors — the project-relative path is unchanged.
- The output path branch is unreachable as configured (npm files are never compilation roots), so it was checked by temporarily injecting the npm source into `userSourceNameMap`: the file lands at `contracts-exposed/hardhat/console.sol`, with no `npm/` prefix and no version, and compiles.

</details>

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)

