### PR TITLE
AccountERC7579: document that isValidSignature has no native validation fallback

### DIFF
--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -183,8 +183,14 @@ abstract contract AccountERC7579 is Account, IERC1271, IERC7579Execution, IERC75
     }
 
     /**
-     * @dev Implement ERC-1271 through IERC7579Validator modules. If module based validation fails, fallback to
-     * "native" validation by the abstract signer.
+     * @dev Implement ERC-1271 through IERC7579Validator modules. The validator module is extracted from the first
+     * 20 bytes of the signature (see {_extractSignatureValidator}) and its return value is forwarded as-is.
+     * Returns `0xffffffff` if the signature is too short to extract a module, if that module is not installed as
+     * a validator, or if the call to it reverts.
+     *
+     * NOTE: Unlike {_validateUserOp}, this function does not fall back to "native" validation by the abstract
+     * signer. Signature validation is delegated to the modules only, matching {_rawSignatureValidation} being
+     * disabled in this contract.
      *
      * NOTE: when combined with {ERC7739}, resolution ordering may have an impact ({ERC7739} does not call super).
      * Manual resolution might be necessary.


### PR DESCRIPTION
`AccountERC7579.isValidSignature` is documented as falling back to "native" validation by the abstract signer. It does not, and it never has.

[`draft-AccountERC7579.sol#L185-L191`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7e4d00653fc05da26a8c160a90179cc0d6cdb54b/contracts/account/extensions/draft-AccountERC7579.sol#L185-L191):

```solidity
/**
 * @dev Implement ERC-1271 through IERC7579Validator modules. If module based validation fails, fallback to
 * "native" validation by the abstract signer.
 * ...
```

The body ([L192-L207](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7e4d00653fc05da26a8c160a90179cc0d6cdb54b/contracts/account/extensions/draft-AccountERC7579.sol#L192-L207)) returns `bytes4(0xffffffff)` on every path that does not reach an installed validator. It calls neither `super` nor `_rawSignatureValidation`, and this same contract overrides `_rawSignatureValidation` at [L423-L429](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7e4d00653fc05da26a8c160a90179cc0d6cdb54b/contracts/account/extensions/draft-AccountERC7579.sol#L423-L429) to return `false`, under the comment "By default, only use the modules for validation of userOp and signature. Disable raw signatures."

So the file states both that native validation is a fallback and that it is disabled. The code agrees with the second.

`_validateUserOp` ([L209-L226](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7e4d00653fc05da26a8c160a90179cc0d6cdb54b/contracts/account/extensions/draft-AccountERC7579.sol#L209-L226)) is the function that does have the fallback:

```solidity
return
    isModuleInstalled(MODULE_TYPE_VALIDATOR, module, Calldata.emptyBytes())
        ? IERC7579Validator(module).validateUserOp(userOp, _signableUserOpHash(userOp, userOpHash))
        : super._validateUserOp(userOp, userOpHash, signature);
```

`super._validateUserOp` resolves to `Account._validateUserOp`, which is exactly `_rawSignatureValidation(...) ? SIG_VALIDATION_SUCCESS : SIG_VALIDATION_FAILED`. That makes the fallback meaningful for a derived contract that re-overrides `_rawSignatureValidation` (as `AccountMock` does), and its NatSpec ("Falls back to `{Account-_validateUserOp}` otherwise") is accurate.

The asymmetry between the two functions looks deliberate: the `_rawSignatureValidation` override states the same decision a second way. Only the description of `isValidSignature` is wrong, and it has been since #5657 introduced the function: that `@dev` block and the body have both been unchanged since, so this is a stale description rather than a behavior change that the docs missed. This PR rewrites that one `@dev` block to say how the validator is selected, that the module's return value is forwarded as-is, and which three paths produce `0xffffffff`. `_validateUserOp` and the `_rawSignatureValidation` override are untouched.

#### Verification

Comment-only, and checked rather than assumed: compiled `master` and this branch, stripped the trailing CBOR metadata from `deployedBytecode`, and the runtime code of `$AccountERC7579Mock`, `$AccountERC7579HookedMock` and `$AccountMock` is byte-identical across the two.

`npm run lint:sol` clean, `npm test` green (8417 passing: 361 solidity, 8056 mocha, 0 failing).

#### Changeset

None. NatSpec only, no user-visible behavior change. Recent documentation-only PRs (#6681, #6648, #6636, #6633, #6623, #6607, #6422) all merged with no changeset and the `ignore-changeset` label. Happy to add one instead if you prefer.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
