### PR TITLE
Skip exposed contracts generation for tasks that don't need it

### DIFF
--- a/hardhat/hardhat-exposed/hook-handlers/config.ts
+++ b/hardhat/hardhat-exposed/hook-handlers/config.ts
@@ -38,22 +38,16 @@ export default async (): Promise<Partial<ConfigHooks>> => ({
     const makeAbsolutePath = (p: string) =>
       path.isAbsolute(p) ? p : path.resolve(partiallyResolvedConfig.paths.root, p);
 
-    const outDir = makeAbsolutePath(userConfig.exposed?.outDir ?? 'contracts-exposed');
-
+    // Note: the output directory is deliberately NOT added to `paths.sources.solidity` here. The `build` task adds it,
+    // in place, right after generating its content. That way tasks that don't generate the exposed contracts (docgen,
+    // transpile, `build --noExpose`, ...) neither compile them nor see them as one of the project source directories.
     return {
       ...partiallyResolvedConfig,
-      paths: {
-        ...partiallyResolvedConfig.paths,
-        sources: {
-          ...partiallyResolvedConfig.paths.sources,
-          solidity: [...partiallyResolvedConfig.paths.sources.solidity, outDir],
-        },
-      },
       exposed: {
         prefix: userConfig.exposed?.prefix ?? '$',
         exclude: (userConfig.exposed?.exclude ?? []).map(makeAbsolutePath),
         include: (userConfig.exposed?.include ?? ['**/*']).map(makeAbsolutePath),
-        outDir,
+        outDir: makeAbsolutePath(userConfig.exposed?.outDir ?? 'contracts-exposed'),
         initializers: userConfig.exposed?.initializers ?? false,
       },
     };

--- a/hardhat/hardhat-exposed/tasks/build.ts
+++ b/hardhat/hardhat-exposed/tasks/build.ts
@@ -1,8 +1,13 @@
+import path from 'node:path';
+
 import type { HardhatRuntimeEnvironment } from 'hardhat/types/hre';
 import type { TaskArguments } from 'hardhat/types/tasks';
 
 export interface BuildOverrideArguments {
+  files: string[];
+  noContracts: boolean;
   noExpose: boolean;
+  noTests: boolean;
 }
 
 export default async function build(
@@ -12,6 +17,29 @@ export default async function build(
 ) {
   if (args.noExpose !== true) {
     await hre.tasks.getTask('generate-exposed-contracts').run({ force: 'force' in args ? args.force : false });
+    return await runSuper(args);
+  }
+
+  // The `config` hook unconditionally adds the exposed contracts output directory to the compilation scope. Drop it
+  // here, so that `--noExpose` doesn't compile the (possibly stale) exposed contracts left over by a previous build.
+  // This has to be an in-place mutation: the solidity build system captures this array by reference when the HRE is
+  // created.
+  const sources = hre.config.paths.sources.solidity;
+  const index = sources.findIndex(source => path.resolve(source) === hre.config.exposed.outDir);
+  if (index !== -1) sources.splice(index, 1);
+
+  // Hardhat only cleans up "stale" artifacts on a full build (no file, and no `--no-contracts`/`--no-tests` flag).
+  // Since the exposed contracts are no longer part of the compilation scope, that cleanup would remove their
+  // artifacts, forcing the next regular build to recompile all of them. Listing the (now filtered) root files
+  // explicitly turns the full build into a partial one, which leaves the existing artifacts alone.
+  if (args.files.length === 0 && !args.noContracts && !args.noTests) {
+    args = {
+      ...args,
+      files: [
+        ...(await hre.solidity.getRootFilePaths({ scope: 'contracts' })),
+        ...(hre.config.solidity.splitTestsCompilation ? await hre.solidity.getRootFilePaths({ scope: 'tests' }) : []),
+      ],
+    };
   }
 
   return await runSuper(args);

--- a/hardhat/hardhat-exposed/tasks/build.ts
+++ b/hardhat/hardhat-exposed/tasks/build.ts
@@ -33,5 +33,5 @@ export default async function build(
     ];
   }
 
-  return await runSuper(args);
+  return runSuper(args);
 }

--- a/hardhat/hardhat-exposed/tasks/build.ts
+++ b/hardhat/hardhat-exposed/tasks/build.ts
@@ -23,10 +23,7 @@ export default async function build(
       hre.config.paths.sources.solidity.push(hre.config.exposed.outDir);
     }
   } else if (args.files.length === 0 && !args.noContracts && !args.noTests) {
-    // Hardhat only cleans up "stale" artifacts on a full build (no file, and no `--no-contracts`/`--no-tests` flag).
-    // Since the exposed contracts are not in the compilation scope here, that cleanup would remove their artifacts,
-    // forcing the next regular build to recompile all of them. Listing the root files explicitly turns the full build
-    // into a partial one, which leaves the existing artifacts alone.
+    // List roots explicitly to keep this a partial build; a full build's stale-artifact sweep would delete exposed artifacts.
     args.files = [
       ...(await hre.solidity.getRootFilePaths({ scope: 'contracts' })),
       ...(hre.config.solidity.splitTestsCompilation ? await hre.solidity.getRootFilePaths({ scope: 'tests' }) : []),

--- a/hardhat/hardhat-exposed/tasks/build.ts
+++ b/hardhat/hardhat-exposed/tasks/build.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import type { HardhatRuntimeEnvironment } from 'hardhat/types/hre';
 import type { TaskArguments } from 'hardhat/types/tasks';
 
@@ -15,31 +13,24 @@ export default async function build(
   hre: HardhatRuntimeEnvironment,
   runSuper: (taskArguments: TaskArguments) => Promise<any>,
 ) {
-  if (args.noExpose !== true) {
+  if (!args.noExpose) {
     await hre.tasks.getTask('generate-exposed-contracts').run({ force: 'force' in args ? args.force : false });
-    return await runSuper(args);
-  }
 
-  // The `config` hook unconditionally adds the exposed contracts output directory to the compilation scope. Drop it
-  // here, so that `--noExpose` doesn't compile the (possibly stale) exposed contracts left over by a previous build.
-  // This has to be an in-place mutation: the solidity build system captures this array by reference when the HRE is
-  // created.
-  const sources = hre.config.paths.sources.solidity;
-  const index = sources.findIndex(source => path.resolve(source) === hre.config.exposed.outDir);
-  if (index !== -1) sources.splice(index, 1);
-
-  // Hardhat only cleans up "stale" artifacts on a full build (no file, and no `--no-contracts`/`--no-tests` flag).
-  // Since the exposed contracts are no longer part of the compilation scope, that cleanup would remove their
-  // artifacts, forcing the next regular build to recompile all of them. Listing the (now filtered) root files
-  // explicitly turns the full build into a partial one, which leaves the existing artifacts alone.
-  if (args.files.length === 0 && !args.noContracts && !args.noTests) {
-    args = {
-      ...args,
-      files: [
-        ...(await hre.solidity.getRootFilePaths({ scope: 'contracts' })),
-        ...(hre.config.solidity.splitTestsCompilation ? await hre.solidity.getRootFilePaths({ scope: 'tests' }) : []),
-      ],
-    };
+    // The exposed contracts output directory is not part of the project sources (see the `config` hook). Add it now
+    // that its content is up to date, so that it gets compiled. This has to be an in-place mutation: the solidity
+    // build system captures this array by reference when the HRE is created.
+    if (!hre.config.paths.sources.solidity.includes(hre.config.exposed.outDir)) {
+      hre.config.paths.sources.solidity.push(hre.config.exposed.outDir);
+    }
+  } else if (args.files.length === 0 && !args.noContracts && !args.noTests) {
+    // Hardhat only cleans up "stale" artifacts on a full build (no file, and no `--no-contracts`/`--no-tests` flag).
+    // Since the exposed contracts are not in the compilation scope here, that cleanup would remove their artifacts,
+    // forcing the next regular build to recompile all of them. Listing the root files explicitly turns the full build
+    // into a partial one, which leaves the existing artifacts alone.
+    args.files = [
+      ...(await hre.solidity.getRootFilePaths({ scope: 'contracts' })),
+      ...(hre.config.solidity.splitTestsCompilation ? await hre.solidity.getRootFilePaths({ scope: 'tests' }) : []),
+    ];
   }
 
   return await runSuper(args);

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "!/contracts/mocks/**/*"
   ],
   "scripts": {
-    "compile": "hardhat compile",
-    "compile:harnesses": "env SRC=./fv/harnesses hardhat compile",
+    "compile": "hardhat build",
+    "compile:harnesses": "env SRC=./fv/harnesses hardhat build --noExpose",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.mjs",
     "prepare": "husky",
@@ -23,12 +23,12 @@
     "clean": "hardhat clean && rimraf build contracts/build",
     "prepack": "scripts/prepack.sh",
     "generate": "scripts/generate/run.js",
-    "pragma": "npm run compile && scripts/minimize-pragma.js artifacts/build-info/*",
+    "pragma": "hardhat build --noExpose && scripts/minimize-pragma.js artifacts/build-info/*",
     "version": "scripts/release/version.sh",
     "test": "hardhat test",
     "test:generation": "scripts/checks/generation.sh",
-    "test:inheritance": "npm run compile && scripts/checks/inheritance-ordering.js artifacts/build-info/*.output.json",
-    "test:pragma": "npm run compile && scripts/checks/pragma-validity.js artifacts/build-info/*.output.json",
+    "test:inheritance": "hardhat build --noExpose && scripts/checks/inheritance-ordering.js artifacts/build-info/*.output.json",
+    "test:pragma": "hardhat build --noExpose && scripts/checks/pragma-validity.js artifacts/build-info/*.output.json",
     "coverage": "hardhat test --coverage",
     "gas-report": "hardhat test --gas-stats",
     "slither": "npm run clean && slither ."

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -13,7 +13,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 npm run clean
 
-env COMPILE_MODE=production npm run compile
+env COMPILE_MODE=production npx hardhat build --noExpose
 
 mkdirp contracts/build/contracts
 cp artifacts/contracts/**/*.json contracts/build/contracts


### PR DESCRIPTION
Generating and compiling the exposed contracts (`contracts-exposed/`) is a significant part of our build time, and several npm scripts don't need them at all.

Two things were in the way:

- `hardhat compile` is only an *alias* of `build` in Hardhat 3, so the `hardhat-exposed` task override — and therefore its `--noExpose` flag — never applied to it. Scripts now call `hardhat build` explicitly.
- `--noExpose` only skipped the *generation* step: the output directory was added to `paths.sources.solidity` by the `config` hook, so the (possibly stale) exposed contracts left over by a previous build were still compiled — and could even make the build fail.

The output directory doesn't have to be a project source directory: only the build that just generated its content needs it in the compilation scope. It is therefore no longer added by the `config` hook, but by the `build` task, right after generation. Tasks that don't generate the exposed contracts — `docgen` and `transpile` (both already run `build --noExpose`), `build --noExpose`, `hardhat compile` — neither compile them nor see them in `paths.sources.solidity`.

One subtlety: hardhat cleans up "stale" artifacts on full builds only, so a `--noExpose` full build would delete the exposed artifacts, and the next regular build would have to recompile all of them (~1 min locally). The override therefore lists the root files explicitly, which makes it a partial build and leaves existing artifacts alone. As a side effect, `npm run compile:harnesses` no longer wipes the `contracts/` artifacts either.

The scripts that only consume the regular build info now pass `--noExpose`:

- `pragma` (`scripts/minimize-pragma.js`)
- `test:pragma` (`scripts/checks/pragma-validity.js`)
- `test:inheritance` (`scripts/checks/inheritance-ordering.js`)
- `compile:harnesses` (Certora harnesses, `SRC=./fv/harnesses`)
- `scripts/prepack.sh` (only `artifacts/contracts/**` is packed)

`npm run compile` keeps generating the exposed contracts, since that is what `npm test` and local development rely on.

No changeset: repository plumbing only, no contract change.