### PR TITLE
docs: note duplicate-action limitation on GovernorTimelockCompound

### DIFF
--- a/.changeset/gtc-duplicate-actions-note.md
+++ b/.changeset/gtc-duplicate-actions-note.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`GovernorTimelockCompound`: Document that a proposal with duplicate actions reverts at queue time and cannot be executed, and the calldata-suffix workaround.

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -17,6 +17,12 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * Using this model means the proposal will be operated by the {TimelockController} and not by the {Governor}. Thus,
  * the assets and permissions must be attached to the {TimelockController}. Any asset sent to the {Governor} will be
  * inaccessible from a proposal, unless executed via {Governor-relay}.
+ *
+ * NOTE: The Compound Timelock keys each queued action by the hash of its (target, value, signature, data, eta)
+ * tuple, and every action in a proposal shares the same eta. A proposal that repeats an action with identical
+ * target, value, and calldata therefore reverts with {GovernorAlreadyQueuedProposal} when queued, after the vote
+ * has succeeded, and can never be executed. To repeat an otherwise-identical call, make each action unique, e.g.
+ * by appending distinct trailing bytes to its calldata.
  */
 abstract contract GovernorTimelockCompound is Governor {
     ICompoundTimelock private _timelock;

--- a/contracts/governance/extensions/GovernorTimelockCompound.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompound.sol
@@ -22,7 +22,7 @@ import {SafeCast} from "../../utils/math/SafeCast.sol";
  * tuple, and every action in a proposal shares the same eta. A proposal that repeats an action with identical
  * target, value, and calldata therefore reverts with {GovernorAlreadyQueuedProposal} when queued, after the vote
  * has succeeded, and can never be executed. To repeat an otherwise-identical call, make each action unique, e.g.
- * by appending distinct trailing bytes to its calldata.
+ * by appending distinct trailing bytes to the calldata of targets that ignore them.
  */
 abstract contract GovernorTimelockCompound is Governor {
     ICompoundTimelock private _timelock;


### PR DESCRIPTION
Documents the known Compound-timelock behavior that a proposal with duplicate actions (same target, value, and calldata) reverts at queue time and becomes unexecutable after a successful vote, with the calldata-suffix workaround.

Closes #6431 as answered, following #6457 where enforcing uniqueness at propose time was declined in favor of documenting the limitation (the workaround is costless and the failure is already loud via `GovernorAlreadyQueuedProposal`, just late). Docs-only, no code change; happy to add a changeset if you prefer.