### PR TITLE
docs: add self-contained ERC20 method notices

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -89,6 +89,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     }
 
     /**
+     * @notice Moves a `value` amount of tokens from the caller's account to `to`.
      * @dev See {IERC20-transfer}.
      *
      * Requirements:
@@ -108,6 +109,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     }
 
     /**
+     * @notice Sets a `value` amount of tokens as the allowance of `spender` over the caller's tokens.
      * @dev See {IERC20-approve}.
      *
      * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on
@@ -124,6 +126,7 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
     }
 
     /**
+     * @notice Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism.
      * @dev See {IERC20-transferFrom}.
      *
      * Skips emitting an {Approval} event indicating an allowance update. This is not


### PR DESCRIPTION
Fixes #6595

## Summary

Add self-contained `@notice` descriptions to the public ERC20 `transfer`, `approve`, and `transferFrom` methods. Keep the existing `{IERC20-...}` references in `@dev` for technical cross-references.

This improves generated ABI user documentation for explorers and contract interfaces that do not resolve NatSpec references. Users will see the method behavior directly instead of an unresolved `See {IERC20-...}` string.

## Validation

- `git diff --check` passes.
- - The change is documentation-only and does not alter contract behavior or storage.
- - The commit is GPG verified.
## PR Checklist

- [x] Documentation
- [ ] - [ ] Tests, not applicable to NatSpec-only changes
- [ ] - [ ] Changeset entry, not applicable to documentation-only changes
- [ ] 