### PR TITLE
IAccessManager: document that a role admin can cancel scheduled grant and revoke operations

### DIFF
--- a/contracts/access/manager/IAccessManager.sol
+++ b/contracts/access/manager/IAccessManager.sol
@@ -377,7 +377,9 @@ interface IAccessManager {
      *
      * Requirements:
      *
-     * - the caller must be the proposer, a guardian of the targeted function, or a global admin
+     * - the caller must be the proposer, a guardian of the targeted function, or a global admin. A {grantRole} or
+     *   {revokeRole} operation targeting this manager can also be cancelled by an admin of the role being granted
+     *   or revoked (see {getRoleAdmin}).
      *
      * Emits a {OperationCanceled} event.
      */


### PR DESCRIPTION
`IAccessManager.cancel` documents three accepted callers. Since #6573 there are four.

[`IAccessManager.sol#L374-L384`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fddac901ccdbdb06be90536822936ea765dd9218/contracts/access/manager/IAccessManager.sol#L374-L384):

```solidity
/**
 * @dev Cancel a scheduled (delayed) operation. Returns the nonce that identifies the previously scheduled
 * operation that is cancelled.
 *
 * Requirements:
 *
 * - the caller must be the proposer, a guardian of the targeted function, or a global admin
 *
 * Emits a {OperationCanceled} event.
 */
function cancel(address caller, address target, bytes calldata data) external returns (uint32);
```

#6573 moved the authorization out of `cancel` into `_canCancel` and added a fourth path ([`AccessManager.sol#L737-L745`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fddac901ccdbdb06be90536822936ea765dd9218/contracts/access/manager/AccessManager.sol#L737-L745)):

```solidity
// if the target is this AccessManager and the call matches an admin-restricted function, allow members
// of the admin role returned by _getAdminRestrictions to cancel. ADMIN_ROLE was already checked above.
if (target == address(this)) {
    (bool adminRestricted, uint64 roleId, ) = _getAdminRestrictions(data);
    if (adminRestricted && roleId != ADMIN_ROLE) {
        (bool inRole, ) = hasRole(roleId, msgsender);
        return inRole;
    }
}
```

`_getAdminRestrictions` returns `(true, getRoleAdmin(roleId), 0)` for `grantRole` and `revokeRole` ([L658-L661](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fddac901ccdbdb06be90536822936ea765dd9218/contracts/access/manager/AccessManager.sol#L658-L661)) and `ADMIN_ROLE` for every other admin-restricted selector, so the `roleId != ADMIN_ROLE` guard confines the new path to those two functions. When a role's admin is left at its `ADMIN_ROLE` default the branch is skipped, and global admins are already covered by the preceding clause, so "an admin of the role being granted or revoked" describes the behavior in both cases.

That change shipped in 5.7.0 and is in the changelog ("`AccessManager`: Allow a role admin to cancel operations that grant or revoke roles."), but the interface requirements were not updated with it. `AccessManager.cancel` carries `/// @inheritdoc IAccessManager`, so the stale list renders for the implementation as well as the interface.

Checked rather than assumed, with a scratch Foundry test: with `setRoleAdmin(X, Y)`, `y1` (member of `Y`, 10 day execution delay) schedules `grantRole(X, bob, 0)` against the manager, and `y2` (member of `Y`, no delay) cancels it. `y2` is not the proposer, `hasRole(ADMIN_ROLE, y2)` is false, and `hasRole(getRoleGuardian(getTargetFunctionRole(manager, grantRole.selector)), y2)` is false (that target function role is `0`, whose guardian is `ADMIN_ROLE`). None of the three documented conditions holds and the cancel succeeds.

This PR rewrites that one requirements bullet. No other NatSpec and no code is touched.

#### Verification

Comment-only, and checked rather than assumed: compiled `master` and this branch with `bytecode_hash = none` and compared every artifact under `out/`. Creation and runtime bytecode are byte-identical for all 522 contracts, `AccessManager` included.

`npm run lint:sol` clean, `npm test` green (8438 passing: 361 solidity, 8077 mocha, 1 pending, 0 failing).

#### Changeset

None. NatSpec only, no user-visible behavior change. Recent documentation-only PRs (#6681, #6648, #6636, #6633, #6623, #6607, #6422) all merged with no changeset and the `ignore-changeset` label. Happy to add one instead if you prefer.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
