### PR TITLE
CI: opt in to the fork checkout in the Certora workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,6 +21,13 @@ inputs:
     description: Path to Python requirements file (if python is true)
     required: false
     default: 'requirements.txt'
+  cache:
+    description: How this job may use the shared dependency cache
+    required: false
+    # 'restore' reads the cache but never writes it back. A job that runs untrusted code MUST use it:
+    # the cache scope is keyed on the branch, so a write from such a job lands where every other
+    # workflow reads from.
+    default: 'on' # 'off' | 'restore' | 'on'
   solc:
     description: Whether to set up solc
     required: false
@@ -64,13 +71,20 @@ runs:
         node-version: ${{ steps.versions.outputs.node }}
     - name: Try fetch node modules from cache
       id: cache
-      if: inputs.node != 'off'
+      if: inputs.node != 'off' && inputs.cache == 'on'
       uses: actions/cache@v6
       with:
         path: '**/node_modules'
         key: npm-${{ steps.versions.outputs.node }}-${{ hashFiles('**/package-lock.json') }}
+    - name: Try fetch node modules from cache (read only)
+      id: cache-restore
+      if: inputs.node != 'off' && inputs.cache == 'restore'
+      uses: actions/cache/restore@v6
+      with:
+        path: '**/node_modules'
+        key: npm-${{ steps.versions.outputs.node }}-${{ hashFiles('**/package-lock.json') }}
     - name: Install dependencies
-      if: inputs.node != 'off' && steps.cache.outputs.cache-hit != 'true'
+      if: inputs.node != 'off' && steps.cache.outputs.cache-hit != 'true' && steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
       run: npm ci
     # Foundry setup
@@ -92,7 +106,8 @@ runs:
       uses: actions/setup-python@v7
       with:
         python-version: ${{ steps.versions.outputs.python }}
-        cache: 'pip'
+        # `setup-python` has no read-only mode, so any caller that cannot write the cache goes without
+        cache: ${{ inputs.cache == 'on' && 'pip' || '' }}
         cache-dependency-path: ${{ inputs.python-requirements }}
     - name: Install python packages
       if: inputs.python != 'off'

--- a/.github/workflows/fv-certora.yml
+++ b/.github/workflows/fv-certora.yml
@@ -28,8 +28,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           # `pull_request_target` checks out the base by default. This runs the contributor's code,
-          # which is why the environment approval above is required.
+          # which is why the environment approval above is required. actions/checkout refuses a fork
+          # checkout in this context unless that risk is explicitly acknowledged.
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0 # Include history so the diff against the PR base resolves
           persist-credentials: false
       - name: Set up environment

--- a/.github/workflows/fv-certora.yml
+++ b/.github/workflows/fv-certora.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup
         with:
+          # Read the cache, never write it. The scope is the base branch here, so a cache saved after
+          # the contributor's code has run would be restored by every other workflow.
+          cache: 'restore'
           solc: 'on'
           java: 'on'
           python: 'on'


### PR DESCRIPTION
Fixes the Certora workflow, which currently fails at the checkout step with:

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. [...] To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

`actions/checkout` v7 refuses to check out fork PR code from a `pull_request_target` workflow unless the risk is explicitly acknowledged. Running the contributor's code is the whole point of this workflow (see #6699), and it is gated by the `formal-verification` label plus a manual approval on the `certora` environment, with `persist-credentials: false` and no write permissions. So we opt in.

### Also here: the dependency cache

The error message also flags the default-branch cache scope, and that turned out to be the half the environment approval does *not* cover, so it is fixed here too.

`.github/actions/setup` ran `actions/cache` over `**/node_modules` with key `npm-<node>-<hash(package-lock.json)>`; under `pull_request_target` that write lands in the base branch's cache scope, so a fork PR that doesn't touch `package-lock.json` shares its key with `master`. GitHub won't overwrite an existing key, so the window is narrow (a PR that bumps the lockfile poisons the new key, then gets merged), but it is real — and unlike the `CERTORAKEY` exposure, it isn't something a reviewer approving the `certora` environment can catch, because the payload is a post-job cache upload rather than anything visible in the diff.

The setup action now takes a `cache` input (`'off' | 'restore' | 'on'`, default `'on'`, so every other caller is unchanged):

- `'on'` keeps `actions/cache` as before.
- `'restore'` swaps in `actions/cache/restore`, which reads the same key and never writes it back.
- `npm ci` gates on both steps' `cache-hit`; a skipped step yields an empty output, so the condition collapses correctly in all three modes.
- `actions/setup-python` has no read-only mode, so its `pip` cache is enabled only under `'on'`.

The Certora job passes `cache: 'restore'`. It still gets the `node_modules` restore, but nothing it produces after the contributor's code has run can reach a scope another workflow reads from. The `fv-requirements.txt` install is now uncached there, which costs a few seconds on a job that runs for minutes.
