### PR TITLE
Arrays: fix `sort(address[])` ordering with dirty values

### DIFF
--- a/.changeset/arrays-sort-address-dirty-bits.md
+++ b/.changeset/arrays-sort-address-dirty-bits.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`Arrays`: `sort(address[])` now compares entries on their lower 160 bits. Previously the array was reinterpreted as `uint256[]` and compared word-for-word, so entries whose upper 96 bits were dirty were ordered incorrectly.

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -57,6 +57,10 @@ library Arrays {
      * consume more gas than is available in a block, leading to potential DoS.
      *
      * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.
+     *
+     * NOTE: `comp` receives the array entries verbatim, including any dirty (non-zero) upper bits. Solidity assumes
+     * `address` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
+     * A comparator that may be given dirty entries should mask them, as in `uint160(a) < uint160(b)`.
      */
     function sort(
         address[] memory array,
@@ -70,7 +74,7 @@ library Arrays {
      * @dev Variant of {sort} that sorts an array of address in increasing order.
      */
     function sort(address[] memory array) internal pure returns (address[] memory) {
-        sort(_castToUint256Array(array), Comparators.lt);
+        sort(_castToUint256Array(array), _addressLt);
         return array;
     }
 
@@ -182,6 +186,11 @@ library Arrays {
             mstore(ptr1, value2)
             mstore(ptr2, value1)
         }
+    }
+
+    /// @dev Helper: strict comparison of two address values held in (potentially dirty) uint256 words
+    function _addressLt(uint256 a, uint256 b) private pure returns (bool) {
+        return uint160(a) < uint160(b);
     }
 
     /// @dev Helper: low level cast address memory array to uint256 memory array

--- a/scripts/generate/templates/Arrays.js
+++ b/scripts/generate/templates/Arrays.js
@@ -15,6 +15,16 @@ import {Math} from "./math/Math.sol";
  */
 `;
 
+// Comparators for types narrower than a word receive (potentially) dirty inputs. See {_addressLt}.
+const dirtyNote = type =>
+  type.size && type.size < 32
+    ? `
+ *
+ * NOTE: \`comp\` receives the array entries verbatim, including any dirty (non-zero) upper bits. Solidity assumes
+ * \`${type.name}\` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
+ * A comparator that may be given dirty entries should mask them, as in \`uint${type.size * 8}(a) < uint${type.size * 8}(b)\`.`
+    : '';
+
 const sort = type => `\
 /**
  * @dev Sort an array of ${type.name} (in memory) following the provided comparator function.
@@ -27,7 +37,9 @@ const sort = type => `\
  * when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
  * consume more gas than is available in a block, leading to potential DoS.
  *
- * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.
+ * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.${dirtyNote(
+   type,
+ )}
  */
 function sort(
     ${type.name}[] memory array,
@@ -45,7 +57,7 @@ function sort(
  * @dev Variant of {sort} that sorts an array of ${type.name} in increasing order.
  */
 function sort(${type.name}[] memory array) internal pure returns (${type.name}[] memory) {
-    ${type.name === 'uint256' ? 'sort(array, Comparators.lt);' : 'sort(_castToUint256Array(array), Comparators.lt);'}
+    ${type.name === 'uint256' ? 'sort(array, Comparators.lt);' : `sort(_castToUint256Array(array), ${type.size == 32 ? 'Comparators.lt' : `_${type.name}Lt`});`}
     return array;
 }
 `;
@@ -130,6 +142,13 @@ function _swap(uint256 ptr1, uint256 ptr2) private pure {
         mstore(ptr1, value2)
         mstore(ptr2, value1)
     }
+}
+`;
+
+const comparator = type => `\
+/// @dev Helper: strict comparison of two ${type.name} values held in (potentially dirty) uint256 words
+function _${type.name}Lt(uint256 a, uint256 b) private pure returns (bool) {
+    return uint${type.size * 8}(a) < uint${type.size * 8}(b);
 }
 `;
 
@@ -346,7 +365,7 @@ const unsafeAccessMemory = type => `\
  * WARNING: Only use if you are certain \`pos\` is lower than the array length.
  */
 function unsafeMemoryAccess(${type.name}[] memory arr, uint256 pos) internal pure returns (${type.name}${
-  type.isValueType ? '' : ' memory'
+  type.size ? '' : ' memory'
 } res) {
     assembly {
         res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
@@ -494,15 +513,16 @@ export default format(
       '',
       // sorting, comparator, helpers and internal
       sort({ name: 'uint256' }),
-      TYPES.filter(type => type.isValueType && type.name !== 'uint256').map(sort),
+      TYPES.filter(type => type.size && type.name !== 'uint256').map(sort),
       quickSort,
-      TYPES.filter(type => type.isValueType && type.name !== 'uint256').map(castArray),
-      TYPES.filter(type => type.isValueType && type.name !== 'uint256').map(castComparator),
+      TYPES.filter(type => type.size && type.size < 32).map(comparator),
+      TYPES.filter(type => type.size && type.name !== 'uint256').map(castArray),
+      TYPES.filter(type => type.size && type.name !== 'uint256').map(castComparator),
       // lookup
       search,
       // slice and splice for value types only
-      TYPES.filter(type => type.isValueType).map(slice),
-      TYPES.filter(type => type.isValueType).map(splice),
+      TYPES.filter(type => type.size).map(slice),
+      TYPES.filter(type => type.size).map(splice),
       // unsafe (direct) storage and memory access
       TYPES.map(unsafeAccessStorage),
       TYPES.map(unsafeAccessMemory),

--- a/scripts/generate/templates/Arrays.opts.js
+++ b/scripts/generate/templates/Arrays.opts.js
@@ -1,7 +1,7 @@
 export const TYPES = [
-  { name: 'address', isValueType: true },
-  { name: 'bytes32', isValueType: true },
-  { name: 'uint256', isValueType: true },
-  { name: 'bytes', isValueType: false },
-  { name: 'string', isValueType: false },
+  { name: 'address', size: 20 },
+  { name: 'bytes32', size: 32 },
+  { name: 'uint256', size: 32 },
+  { name: 'bytes' }, // non value type don't have a size
+  { name: 'string' }, // non value type don't have a size
 ];

--- a/test/utils/Arrays.t.sol
+++ b/test/utils/Arrays.t.sol
@@ -22,6 +22,12 @@ contract ArraysTest is Test, SymTest {
         _assertSort(values);
     }
 
+    function testSortAddressDirty(address[] memory values, uint256 seed) public pure {
+        _dirty(values, seed);
+        Arrays.sort(values);
+        _assertSort(values);
+    }
+
     /// Slice
 
     function testSliceAddressWithStartOnly(address[] memory values, uint256 start) public pure {
@@ -358,6 +364,12 @@ contract ArraysTest is Test, SymTest {
         }
     }
 
+    function _assertSort(address[] memory values) internal pure {
+        for (uint256 i = 1; i < values.length; ++i) {
+            assertLe(uint160(values[i - 1]), uint160(values[i]));
+        }
+    }
+
     function _assertSliceOf(
         address[] memory result,
         address[] memory original,
@@ -395,6 +407,17 @@ contract ArraysTest is Test, SymTest {
     }
 
     /// Helpers
+
+    /// @dev Sets the unused upper 96 bits of each entry to a (per-entry) non-zero value.
+    function _dirty(address[] memory values, uint256 seed) internal pure {
+        for (uint256 i = 0; i < values.length; ++i) {
+            uint256 mask = uint256(keccak256(abi.encode(seed, i))) << 160;
+            assembly ("memory-safe") {
+                let ptr := add(add(values, 0x20), mul(i, 0x20))
+                mstore(ptr, or(mload(ptr), mask))
+            }
+        }
+    }
 
     function _copyArray(uint256[] memory values) internal pure returns (uint256[] memory) {
         uint256[] memory copy = new uint256[](values.length);

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -125,7 +125,7 @@ describe('Arrays', function () {
     }
   });
 
-  for (const { name, isValueType } of TYPES) {
+  for (const { name, size } of TYPES) {
     const elements = Array.from({ length: 10 }, randomOf(name));
 
     describe(name, function () {
@@ -137,7 +137,7 @@ describe('Arrays', function () {
         Object.assign(this, await loadFixture(fixture));
       });
 
-      if (isValueType) {
+      if (size) {
         describe('sort', function () {
           // When coverage is enabled, only consider length up to 32 (to avoid CI timeouts)
           for (const length of [0, 1, 2, 8, 32, 128, 384].filter(l => !globalOptions.coverage || l <= 32)) {
@@ -278,7 +278,7 @@ describe('Arrays', function () {
           it('unsafeMemoryAccess loop around', async function () {
             for (let i = 251n; i < 256n; ++i) {
               await expect(this.mock[fragment](elements, 2n ** i - 1n)).to.eventually.equal(
-                isValueType ? BigInt(elements.length) : randomOf(name).zero,
+                size ? BigInt(elements.length) : randomOf(name).zero,
               );
               await expect(this.mock[fragment](elements, 2n ** i + 0n)).to.eventually.equal(elements[0]);
               await expect(this.mock[fragment](elements, 2n ** i + 1n)).to.eventually.equal(elements[1]);


### PR DESCRIPTION
Following a report that `Arrays.sort(address[])` mis-orders "dirty" addresses (entries whose upper 96 bits are not zero).

`sort(address[])` reinterprets the array as `uint256[]` — a free cast, since both are one word per entry — and then sorted it with `Comparators.lt`, which compares the full 256-bit word. Entries carrying dirty upper bits were therefore ordered by that garbage rather than by the address itself.

The array cast stays; only the comparator changes. `sort(address[])` now uses a dedicated `_addressLt` that truncates to `uint160` before comparing. `bytes32` and `uint256` fill a whole word and cannot be dirty, so they keep using `Comparators.lt`.

In the generator, `TYPES` entries carry a `size` (in bytes) instead of `isValueType` — non-value types have none — and the masking comparator is emitted only for types with `size < 32`.

The overload taking a user-supplied comparator is unchanged: it casts `function(address, address)` to `function(uint256, uint256)`, so entries reach the comparator verbatim. There is no way to wrap a comparator without a closure, so this is documented with a NOTE telling callers to mask their inputs if dirty entries are possible.

Note that sorting still does not *clean* the array — only the ordering is fixed. Entries that go in dirty come out dirty.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)