### PR TITLE
Fix CI by turning setting `lint_on_build` to false in `foundry.toml`

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,5 +9,6 @@ libs = ['node_modules', 'lib']
 cache_path  = 'cache_forge'
 
 [lint]
+lint_on_build = false
 exclude_lints = ["mixed-case-function", "asm-keccak256", "screaming-snake-case-immutable", "incorrect-shift", "mixed-case-variable"]
 ignore = ["./contracts/interfaces/**/*.sol"]


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

CI broke due to the release of foundry v1.8.0 changing a default setting in the `foundry.toml`. This PR reverts `lint_on_build` back to false and fixes CI.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
