### PR TITLE
Clarify ERC20 permit deadline boundary

### DIFF
--- a/.changeset/permit-deadline-boundary.md
+++ b/.changeset/permit-deadline-boundary.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`IERC20Permit`: Clarify that a permit deadline equal to the current block timestamp is valid, as specified by ERC-2612.

--- a/contracts/token/ERC20/extensions/IERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/IERC20Permit.sol
@@ -52,7 +52,7 @@ interface IERC20Permit {
      * Requirements:
      *
      * - `spender` cannot be the zero address.
-     * - `deadline` must be a timestamp in the future.
+     * - `deadline` must be greater than or equal to the current block timestamp.
      * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
      * over the EIP712-formatted function arguments.
      * - the signature must use ``owner``'s current nonce (see {nonces}).

--- a/test/token/ERC20/extensions/ERC20Permit.test.js
+++ b/test/token/ERC20/extensions/ERC20Permit.test.js
@@ -71,6 +71,19 @@ describe('ERC20Permit', function () {
       expect(await this.token.allowance(this.owner, this.spender)).to.equal(value);
     });
 
+    it('accepts deadline equal to the block timestamp', async function () {
+      const deadline = (await time.clock.timestamp()) + 1n;
+      const { v, r, s } = await this.buildData(this.token, deadline)
+        .then(({ domain, types, message }) => this.owner.signTypedData(domain, types, message))
+        .then(ethers.Signature.from);
+
+      await time.increaseTo.timestamp(deadline, false);
+      await this.token.permit(this.owner, this.spender, value, deadline, v, r, s);
+
+      expect(await this.token.nonces(this.owner)).to.equal(1n);
+      expect(await this.token.allowance(this.owner, this.spender)).to.equal(value);
+    });
+
     it('rejects reused signature', async function () {
       const { v, r, s, serialized } = await this.buildData(this.token)
         .then(({ domain, types, message }) => this.owner.signTypedData(domain, types, message))


### PR DESCRIPTION
## Summary

- Clarify that an ERC-2612 permit deadline may equal the current block timestamp.
- Add a regression test for the exact `block.timestamp == deadline` boundary.
- Add a patch changeset for the documentation correction.

ERC-2612 requires the current block time to be less than or equal to `deadline`. `ERC20Permit` already implements this correctly by reverting only when `block.timestamp > deadline`, but `IERC20Permit` currently describes the deadline as necessarily being “in the future.”

## Background

The ERC-2612 specification defines a permit as valid when the current block time is less than or equal to its signed deadline. Equality is therefore an intentional part of the standard's validity interval rather than an implementation-specific relaxation.

The current `IERC20Permit` NatSpec says that `deadline` “must be a timestamp in the future.” Read literally, that wording excludes a deadline equal to the executing block's timestamp. This differs from both the normative ERC-2612 condition and the existing `ERC20Permit` implementation:

```solidity
if (block.timestamp > deadline) {
    revert ERC2612ExpiredSignature(deadline);
}
```

This PR aligns the public interface documentation with the standard and with the behavior users already receive.

## Existing coverage and boundary gap

The existing permit tests cover:

- a normally valid signature using `type(uint256).max` as its deadline; and
- an expired signature whose deadline is one week in the past.

Those cases establish the broad valid and invalid regions, but they do not pin the transition point between them. The new test schedules the permit transaction at the exact signed deadline and asserts that it succeeds, consumes the nonce, and sets the requested allowance. This guards the ERC-2612 inequality against an accidental future change from `>` to `>=`.

## Why no implementation change is needed

The runtime implementation is already standards-compliant. Changing contract logic would be unnecessary and could introduce compatibility risk. The focused fix is therefore limited to:

1. replacing the stricter NatSpec wording with the exact inclusive condition;
2. adding deterministic regression coverage for equality; and
3. recording the documentation correction in a patch changeset.

## Tests

- `npx hardhat test test/token/ERC20/extensions/ERC20Permit.test.js` — 7 passing
- `npm test` — 8440 passing, 1 pending
- Focused Prettier, ESLint, Solhint, and `git diff --check` — passing

## Impact

No runtime, ABI, storage, gas, or compatibility impact. This changes NatSpec and pins existing standards-compliant behavior with a regression test.

Specification: https://eips.ethereum.org/EIPS/eip-2612#specification
