### PR TITLE
Simplify Checkpoints codegen templates

### DIFF
--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -23,16 +23,7 @@ export const ARRAYS_SORT_TYPES = ARRAYS_VALUE_TYPES.toSorted((a, b) => (b.type =
 export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.size < 32);
 
 // ─── Checkpoints (Checkpoints + Checkpoints.t) ───
-export const CHECKPOINTS_OPTS = [256, 224, 208, 160].map(size => ({
-  historyTypeName: `Trace${size}`,
-  checkpointTypeName: `Checkpoint${size}`,
-  checkpointFieldName: '_checkpoints',
-  checkpointSize: size < 256 ? 1 : 2,
-  keyTypeName: size < 256 ? `uint${256 - size}` : 'uint256',
-  keyFieldName: '_key',
-  valueTypeName: `uint${size}`,
-  valueFieldName: '_value',
-}));
+export const CHECKPOINTS_LENGTH = [256, 224, 208, 160];
 
 // ─── Enumerable (EnumerableSet, EnumerableMap) ───
 export const typeDescr = ({ type, size = 0, memory }) => {

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -23,7 +23,7 @@ export const ARRAYS_SORT_TYPES = ARRAYS_VALUE_TYPES.toSorted((a, b) => (b.type =
 export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.size < 32);
 
 // ─── Checkpoints (Checkpoints + Checkpoints.t) ───
-export const CHECKPOINTS_LENGTH = [256, 224, 208, 160];
+export const CHECKPOINTS_LENGTH = [256, 224, 208, 160].map(size => ({ size, keySize: size < 256 ? 256 - size : 256 }));
 
 // ─── Enumerable (EnumerableSet, EnumerableMap) ───
 export const typeDescr = ({ type, size = 0, memory }) => {

--- a/scripts/generate/templates/Checkpoints.sol.eta
+++ b/scripts/generate/templates/Checkpoints.sol.eta
@@ -14,51 +14,52 @@ library Checkpoints {
      * @dev A value was attempted to be inserted on a past checkpoint.
      */
     error CheckpointUnorderedInsertion();
-<% for (const opts of it.CHECKPOINTS_OPTS) { %>
 
-    struct <%= opts.historyTypeName %> {
-        <%= opts.checkpointTypeName %>[] <%= opts.checkpointFieldName %>;
+<% for (const size of it.CHECKPOINTS_LENGTH) { %>
+<% const keySize = size < 256 ? (256 - size) : 256; %>
+    struct Trace<%= size %> {
+        Checkpoint<%= size %>[] _checkpoints;
     }
 
-    struct <%= opts.checkpointTypeName %> {
-        <%= opts.keyTypeName %> <%= opts.keyFieldName %>;
-        <%= opts.valueTypeName %> <%= opts.valueFieldName %>;
+    struct Checkpoint<%= size %> {
+        uint<%= keySize %> _key;
+        uint<%= size %> _value;
     }
 
     /**
-     * @dev Pushes a (`key`, `value`) pair into a <%= opts.historyTypeName %> so that it is stored as the checkpoint.
+     * @dev Pushes a (`key`, `value`) pair into a Trace<%= size %> so that it is stored as the checkpoint.
      *
      * Returns previous value and new value.
      *
-     * IMPORTANT: Never accept `key` as a user input, since an arbitrary `type(<%= opts.keyTypeName %>).max` key set will disable the
+     * IMPORTANT: Never accept `key` as a user input, since an arbitrary `type(uint<%= keySize %>).max` key set will disable the
      * library.
      */
     function push(
-        <%= opts.historyTypeName %> storage self,
-        <%= opts.keyTypeName %> key,
-        <%= opts.valueTypeName %> value
-    ) internal returns (<%= opts.valueTypeName %> oldValue, <%= opts.valueTypeName %> newValue) {
-        return _insert(self.<%= opts.checkpointFieldName %>, key, value);
+        Trace<%= size %> storage self,
+        uint<%= keySize %> key,
+        uint<%= size %> value
+    ) internal returns (uint<%= size %> oldValue, uint<%= size %> newValue) {
+        return _insert(self._checkpoints, key, value);
     }
 
     /**
      * @dev Returns the value in the first (oldest) checkpoint with key greater or equal than the search key, or zero if
      * there is none.
      */
-    function lowerLookup(<%= opts.historyTypeName %> storage self, <%= opts.keyTypeName %> key) internal view returns (<%= opts.valueTypeName %>) {
-        uint256 len = self.<%= opts.checkpointFieldName %>.length;
-        uint256 index = _lowerBinaryLookup(self.<%= opts.checkpointFieldName %>, key, 0, len);
-        return index == len ? 0 : _unsafeAccess(self.<%= opts.checkpointFieldName %>, index).<%= opts.valueFieldName %>;
+    function lowerLookup(Trace<%= size %> storage self, uint<%= keySize %> key) internal view returns (uint<%= size %>) {
+        uint256 len = self._checkpoints.length;
+        uint256 index = _lowerBinaryLookup(self._checkpoints, key, 0, len);
+        return index == len ? 0 : _unsafeAccess(self._checkpoints, index)._value;
     }
 
     /**
      * @dev Returns the value in the last (most recent) checkpoint with key lower or equal than the search key, or zero
      * if there is none.
      */
-    function upperLookup(<%= opts.historyTypeName %> storage self, <%= opts.keyTypeName %> key) internal view returns (<%= opts.valueTypeName %>) {
-        uint256 len = self.<%= opts.checkpointFieldName %>.length;
-        uint256 index = _upperBinaryLookup(self.<%= opts.checkpointFieldName %>, key, 0, len);
-        return index == 0 ? 0 : _unsafeAccess(self.<%= opts.checkpointFieldName %>, index - 1).<%= opts.valueFieldName %>;
+    function upperLookup(Trace<%= size %> storage self, uint<%= keySize %> key) internal view returns (uint<%= size %>) {
+        uint256 len = self._checkpoints.length;
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, 0, len);
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
@@ -68,53 +69,53 @@ library Checkpoints {
      * NOTE: This is a variant of {upperLookup} that is optimized to find "recent" checkpoint (checkpoints with high
      * keys).
      */
-    function upperLookupRecent(<%= opts.historyTypeName %> storage self, <%= opts.keyTypeName %> key) internal view returns (<%= opts.valueTypeName %>) {
-        uint256 len = self.<%= opts.checkpointFieldName %>.length;
+    function upperLookupRecent(Trace<%= size %> storage self, uint<%= keySize %> key) internal view returns (uint<%= size %>) {
+        uint256 len = self._checkpoints.length;
 
         uint256 low = 0;
         uint256 high = len;
 
         if (len > 5) {
             uint256 mid = len - Math.sqrt(len);
-            if (key < _unsafeAccess(self.<%= opts.checkpointFieldName %>, mid)._key) {
+            if (key < _unsafeAccess(self._checkpoints, mid)._key) {
                 high = mid;
             } else {
                 low = mid + 1;
             }
         }
 
-        uint256 index = _upperBinaryLookup(self.<%= opts.checkpointFieldName %>, key, low, high);
+        uint256 index = _upperBinaryLookup(self._checkpoints, key, low, high);
 
-        return index == 0 ? 0 : _unsafeAccess(self.<%= opts.checkpointFieldName %>, index - 1).<%= opts.valueFieldName %>;
+        return index == 0 ? 0 : _unsafeAccess(self._checkpoints, index - 1)._value;
     }
 
     /**
      * @dev Returns the value in the most recent checkpoint, or zero if there are no checkpoints.
      */
-    function latest(<%= opts.historyTypeName %> storage self) internal view returns (<%= opts.valueTypeName %>) {
-        uint256 len = self.<%= opts.checkpointFieldName %>.length;
-        return len == 0 ? 0 : _unsafeAccess(self.<%= opts.checkpointFieldName %>, len - 1).<%= opts.valueFieldName %>;
+    function latest(Trace<%= size %> storage self) internal view returns (uint<%= size %>) {
+        uint256 len = self._checkpoints.length;
+        return len == 0 ? 0 : _unsafeAccess(self._checkpoints, len - 1)._value;
     }
 
     /**
      * @dev Returns whether there is a checkpoint in the structure (i.e. it is not empty), and if so the key and value
      * in the most recent checkpoint.
      */
-    function latestCheckpoint(<%= opts.historyTypeName %> storage self) internal view returns (bool exists, <%= opts.keyTypeName %> <%= opts.keyFieldName %>, <%= opts.valueTypeName %> <%= opts.valueFieldName %>) {
-        uint256 len = self.<%= opts.checkpointFieldName %>.length;
+    function latestCheckpoint(Trace<%= size %> storage self) internal view returns (bool exists, uint<%= keySize %> _key, uint<%= size %> _value) {
+        uint256 len = self._checkpoints.length;
         if (len == 0) {
             return (false, 0, 0);
         } else {
-            <%= opts.checkpointTypeName %> storage ckpt = _unsafeAccess(self.<%= opts.checkpointFieldName %>, len - 1);
-            return (true, ckpt.<%= opts.keyFieldName %>, ckpt.<%= opts.valueFieldName %>);
+            Checkpoint<%= size %> storage ckpt = _unsafeAccess(self._checkpoints, len - 1);
+            return (true, ckpt._key, ckpt._value);
         }
     }
 
     /**
      * @dev Returns the number of checkpoints.
      */
-    function length(<%= opts.historyTypeName %> storage self) internal view returns (uint256) {
-        return self.<%= opts.checkpointFieldName %>.length;
+    function length(Trace<%= size %> storage self) internal view returns (uint256) {
+        return self._checkpoints.length;
     }
 
     /**
@@ -123,7 +124,7 @@ library Checkpoints {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= opts.historyTypeName %> storage self, uint32 index) internal view returns (<%= opts.checkpointTypeName %> memory) {
+    function at(Trace<%= size %> storage self, uint32 index) internal view returns (Checkpoint<%= size %> memory) {
         return pos(self, index);
     }
 
@@ -132,8 +133,8 @@ library Checkpoints {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= opts.historyTypeName %> storage self, uint32 index) internal view returns (<%= opts.checkpointTypeName %> memory) {
-        return self.<%= opts.checkpointFieldName %>[index];
+    function pos(Trace<%= size %> storage self, uint32 index) internal view returns (Checkpoint<%= size %> memory) {
+        return self._checkpoints[index];
     }
 
     /**
@@ -141,16 +142,16 @@ library Checkpoints {
      * or by updating the last one.
      */
     function _insert(
-        <%= opts.checkpointTypeName %>[] storage self,
-        <%= opts.keyTypeName %> key,
-        <%= opts.valueTypeName %> value
-    ) private returns (<%= opts.valueTypeName %> oldValue, <%= opts.valueTypeName %> newValue) {
+        Checkpoint<%= size %>[] storage self,
+        uint<%= keySize %> key,
+        uint<%= size %> value
+    ) private returns (uint<%= size %> oldValue, uint<%= size %> newValue) {
         uint256 len = self.length;
 
         if (len > 0) {
-            <%= opts.checkpointTypeName %> storage last = _unsafeAccess(self, len - 1);
-            <%= opts.keyTypeName %> lastKey = last.<%= opts.keyFieldName %>;
-            <%= opts.valueTypeName %> lastValue = last.<%= opts.valueFieldName %>;
+            Checkpoint<%= size %> storage last = _unsafeAccess(self, len - 1);
+            uint<%= keySize %> lastKey = last._key;
+            uint<%= size %> lastValue = last._value;
 
             // Checkpoint keys must be non-decreasing.
             if (lastKey > key) {
@@ -159,13 +160,13 @@ library Checkpoints {
 
             // Update or push new checkpoint
             if (lastKey == key) {
-                last.<%= opts.valueFieldName %> = value;
+                last._value = value;
             } else {
-                self.push(<%= opts.checkpointTypeName %>({<%= opts.keyFieldName %>: key, <%= opts.valueFieldName %>: value}));
+                self.push(Checkpoint<%= size %>({_key: key, _value: value}));
             }
             return (lastValue, value);
         } else {
-            self.push(<%= opts.checkpointTypeName %>({<%= opts.keyFieldName %>: key, <%= opts.valueFieldName %>: value}));
+            self.push(Checkpoint<%= size %>({_key: key, _value: value}));
             return (0, value);
         }
     }
@@ -178,14 +179,14 @@ library Checkpoints {
      * WARNING: `high` should not be greater than the array's length.
      */
     function _upperBinaryLookup(
-        <%= opts.checkpointTypeName %>[] storage self,
-        <%= opts.keyTypeName %> key,
+        Checkpoint<%= size %>[] storage self,
+        uint<%= keySize %> key,
         uint256 low,
         uint256 high
     ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
-            if (_unsafeAccess(self, mid).<%= opts.keyFieldName %> > key) {
+            if (_unsafeAccess(self, mid)._key > key) {
                 high = mid;
             } else {
                 low = mid + 1;
@@ -202,14 +203,14 @@ library Checkpoints {
      * WARNING: `high` should not be greater than the array's length.
      */
     function _lowerBinaryLookup(
-        <%= opts.checkpointTypeName %>[] storage self,
-        <%= opts.keyTypeName %> key,
+        Checkpoint<%= size %>[] storage self,
+        uint<%= keySize %> key,
         uint256 low,
         uint256 high
     ) private view returns (uint256) {
         while (low < high) {
             uint256 mid = Math.average(low, high);
-            if (_unsafeAccess(self, mid).<%= opts.keyFieldName %> < key) {
+            if (_unsafeAccess(self, mid)._key < key) {
                 low = mid + 1;
             } else {
                 high = mid;
@@ -222,12 +223,12 @@ library Checkpoints {
      * @dev Access an element of the array without performing bounds check. The position is assumed to be within bounds.
      */
     function _unsafeAccess(
-        <%= opts.checkpointTypeName %>[] storage self,
+        Checkpoint<%= size %>[] storage self,
         uint256 index
-    ) private pure returns (<%= opts.checkpointTypeName %> storage result) {
+    ) private pure returns (Checkpoint<%= size %> storage result) {
         assembly {
             mstore(0x00, self.slot)
-            result.slot := add(keccak256(0x00, 0x20), <%= opts.checkpointSize === 1 ? 'index' : `mul(index, ${opts.checkpointSize})` %>)
+            result.slot := add(keccak256(0x00, 0x20), <%= size < 256 ? 'index' : `mul(index, 2)` %>)
         }
     }
 <% } %>

--- a/scripts/generate/templates/Checkpoints.sol.eta
+++ b/scripts/generate/templates/Checkpoints.sol.eta
@@ -15,8 +15,7 @@ library Checkpoints {
      */
     error CheckpointUnorderedInsertion();
 
-<% for (const size of it.CHECKPOINTS_LENGTH) { %>
-<% const keySize = size < 256 ? (256 - size) : 256; %>
+<% for (const { size, keySize } of it.CHECKPOINTS_LENGTH) { %>
     struct Trace<%= size %> {
         Checkpoint<%= size %>[] _checkpoints;
     }

--- a/scripts/generate/templates/Checkpoints.t.sol.eta
+++ b/scripts/generate/templates/Checkpoints.t.sol.eta
@@ -3,40 +3,41 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
-<% for (const opts of it.CHECKPOINTS_OPTS) { %>
 
-contract Checkpoints<%= opts.historyTypeName %>Test is Test {
-    using Checkpoints for Checkpoints.<%= opts.historyTypeName %>;
+<% for (const size of it.CHECKPOINTS_LENGTH) { %>
+<% const keySize = size < 256 ? (256 - size) : 256; %>
+contract CheckpointsTrace<%= size %>Test is Test {
+    using Checkpoints for Checkpoints.Trace<%= size %>;
 
     // Maximum gap between keys used during the fuzzing tests: the `_prepareKeys` function will make sure that
     // key#n+1 is in the [key#n, key#n + _KEY_MAX_GAP] range.
     uint8 internal constant _KEY_MAX_GAP = 64;
 
-    Checkpoints.<%= opts.historyTypeName %> internal _ckpts;
+    Checkpoints.Trace<%= size %> internal _ckpts;
 
     // helpers
-    function _bound<%= it.capitalize(opts.keyTypeName) %>(<%= opts.keyTypeName %> x, <%= opts.keyTypeName %> min, <%= opts.keyTypeName %> max) internal pure returns (<%= opts.keyTypeName %>) {
-        return <%= opts.keyTypeName === 'uint256' ? 'bound(x, min, max)' : `SafeCast.to${it.capitalize(opts.keyTypeName)}(bound(uint256(x), uint256(min), uint256(max)))` %>;
+    function _boundUint<%= keySize %>(uint<%= keySize %> x, uint<%= keySize %> min, uint<%= keySize %> max) internal pure returns (uint<%= keySize %>) {
+        return <%= size === 256 ? 'bound(x, min, max)' : `SafeCast.toUint${keySize}(bound(uint256(x), uint256(min), uint256(max)))` %>;
     }
 
-    function _prepareKeys(<%= opts.keyTypeName %>[] memory keys, <%= opts.keyTypeName %> maxSpread) internal pure {
-        <%= opts.keyTypeName %> lastKey = 0;
+    function _prepareKeys(uint<%= keySize %>[] memory keys, uint<%= keySize %> maxSpread) internal pure {
+        uint<%= keySize %> lastKey = 0;
         for (uint256 i = 0; i < keys.length; ++i) {
-            <%= opts.keyTypeName %> key = _bound<%= it.capitalize(opts.keyTypeName) %>(keys[i], lastKey, lastKey + maxSpread);
+            uint<%= keySize %> key = _boundUint<%= keySize %>(keys[i], lastKey, lastKey + maxSpread);
             keys[i] = key;
             lastKey = key;
         }
     }
 
-    function _assertLatestCheckpoint(bool exist, <%= opts.keyTypeName %> key, <%= opts.valueTypeName %> value) internal view {
-        (bool _exist, <%= opts.keyTypeName %> _key, <%= opts.valueTypeName %> _value) = _ckpts.latestCheckpoint();
+    function _assertLatestCheckpoint(bool exist, uint<%= keySize %> key, uint<%= size %> value) internal view {
+        (bool _exist, uint<%= keySize %> _key, uint<%= size %> _value) = _ckpts.latestCheckpoint();
         assertEq(_exist, exist);
         assertEq(_key, key);
         assertEq(_value, value);
     }
 
     // tests
-    function testPush(<%= opts.keyTypeName %>[] memory keys, <%= opts.valueTypeName %>[] memory values, <%= opts.keyTypeName %> pastKey) public {
+    function testPush(uint<%= keySize %>[] memory keys, uint<%= size %>[] memory values, uint<%= keySize %> pastKey) public {
         vm.assume(values.length > 0 && values.length <= keys.length);
         _prepareKeys(keys, _KEY_MAX_GAP);
 
@@ -47,8 +48,8 @@ contract Checkpoints<%= opts.historyTypeName %>Test is Test {
 
         uint256 duplicates = 0;
         for (uint256 i = 0; i < keys.length; ++i) {
-            <%= opts.keyTypeName %> key = keys[i];
-            <%= opts.valueTypeName %> value = values[i % values.length];
+            uint<%= keySize %> key = keys[i];
+            uint<%= size %> value = values[i % values.length];
             if (i > 0 && key == keys[i - 1]) ++duplicates;
 
             // push
@@ -61,9 +62,9 @@ contract Checkpoints<%= opts.historyTypeName %>Test is Test {
         }
 
         if (keys.length > 0) {
-            <%= opts.keyTypeName %> lastKey = keys[keys.length - 1];
+            uint<%= keySize %> lastKey = keys[keys.length - 1];
             if (lastKey > 0) {
-                pastKey = _bound<%= it.capitalize(opts.keyTypeName) %>(pastKey, 0, lastKey - 1);
+                pastKey = _boundUint<%= keySize %>(pastKey, 0, lastKey - 1);
 
                 vm.expectRevert();
                 this.push(pastKey, values[keys.length % values.length]);
@@ -72,23 +73,23 @@ contract Checkpoints<%= opts.historyTypeName %>Test is Test {
     }
 
     // used to test reverts
-    function push(<%= opts.keyTypeName %> key, <%= opts.valueTypeName %> value) external {
+    function push(uint<%= keySize %> key, uint<%= size %> value) external {
         _ckpts.push(key, value);
     }
 
-    function testLookup(<%= opts.keyTypeName %>[] memory keys, <%= opts.valueTypeName %>[] memory values, <%= opts.keyTypeName %> lookup) public {
+    function testLookup(uint<%= keySize %>[] memory keys, uint<%= size %>[] memory values, uint<%= keySize %> lookup) public {
         vm.assume(values.length > 0 && values.length <= keys.length);
         _prepareKeys(keys, _KEY_MAX_GAP);
 
-        <%= opts.keyTypeName %> lastKey = keys.length == 0 ? 0 : keys[keys.length - 1];
-        lookup = _bound<%= it.capitalize(opts.keyTypeName) %>(lookup, 0, lastKey + _KEY_MAX_GAP);
+        uint<%= keySize %> lastKey = keys.length == 0 ? 0 : keys[keys.length - 1];
+        lookup = _boundUint<%= keySize %>(lookup, 0, lastKey + _KEY_MAX_GAP);
 
-        <%= opts.valueTypeName %> upper = 0;
-        <%= opts.valueTypeName %> lower = 0;
-        <%= opts.keyTypeName %> lowerKey = type(<%= opts.keyTypeName %>).max;
+        uint<%= size %> upper = 0;
+        uint<%= size %> lower = 0;
+        uint<%= keySize %> lowerKey = type(uint<%= keySize %>).max;
         for (uint256 i = 0; i < keys.length; ++i) {
-            <%= opts.keyTypeName %> key = keys[i];
-            <%= opts.valueTypeName %> value = values[i % values.length];
+            uint<%= keySize %> key = keys[i];
+            uint<%= size %> value = values[i % values.length];
 
             // push
             _ckpts.push(key, value);

--- a/scripts/generate/templates/Checkpoints.t.sol.eta
+++ b/scripts/generate/templates/Checkpoints.t.sol.eta
@@ -4,8 +4,7 @@ import {Test} from "forge-std/Test.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 
-<% for (const size of it.CHECKPOINTS_LENGTH) { %>
-<% const keySize = size < 256 ? (256 - size) : 256; %>
+<% for (const { size, keySize } of it.CHECKPOINTS_LENGTH) { %>
 contract CheckpointsTrace<%= size %>Test is Test {
     using Checkpoints for Checkpoints.Trace<%= size %>;
 

--- a/test/utils/structs/Checkpoints.test.js
+++ b/test/utils/structs/Checkpoints.test.js
@@ -8,9 +8,7 @@ const {
 } = await network.create();
 
 describe('Checkpoints', function () {
-  for (const size of CHECKPOINTS_LENGTH) {
-    const keySize = size < 256 ? 256 - size : 256;
-
+  for (const { size, keySize } of CHECKPOINTS_LENGTH) {
     describe(`Trace${size}`, function () {
       const fixture = async () => {
         const mock = await ethers.deployContract('$Checkpoints');

--- a/test/utils/structs/Checkpoints.test.js
+++ b/test/utils/structs/Checkpoints.test.js
@@ -1,6 +1,6 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
-import { CHECKPOINTS_OPTS as OPTS } from '../../../scripts/generate/data.js';
+import { CHECKPOINTS_LENGTH } from '../../../scripts/generate/data.js';
 
 const {
   ethers,
@@ -8,21 +8,21 @@ const {
 } = await network.create();
 
 describe('Checkpoints', function () {
-  for (const opt of OPTS) {
-    describe(opt.historyTypeName, function () {
+  for (const size of CHECKPOINTS_LENGTH) {
+    const keySize = size < 256 ? 256 - size : 256;
+
+    describe(`Trace${size}`, function () {
       const fixture = async () => {
         const mock = await ethers.deployContract('$Checkpoints');
         const methods = {
-          at: (...args) => mock.getFunction(`$at_Checkpoints_${opt.historyTypeName}`)(0, ...args),
-          latest: (...args) => mock.getFunction(`$latest_Checkpoints_${opt.historyTypeName}`)(0, ...args),
-          latestCheckpoint: (...args) =>
-            mock.getFunction(`$latestCheckpoint_Checkpoints_${opt.historyTypeName}`)(0, ...args),
-          length: (...args) => mock.getFunction(`$length_Checkpoints_${opt.historyTypeName}`)(0, ...args),
-          push: (...args) => mock.getFunction(`$push(uint256,${opt.keyTypeName},${opt.valueTypeName})`)(0, ...args),
-          lowerLookup: (...args) => mock.getFunction(`$lowerLookup(uint256,${opt.keyTypeName})`)(0, ...args),
-          upperLookup: (...args) => mock.getFunction(`$upperLookup(uint256,${opt.keyTypeName})`)(0, ...args),
-          upperLookupRecent: (...args) =>
-            mock.getFunction(`$upperLookupRecent(uint256,${opt.keyTypeName})`)(0, ...args),
+          at: (...args) => mock.getFunction(`$at_Checkpoints_Trace${size}`)(0, ...args),
+          latest: (...args) => mock.getFunction(`$latest_Checkpoints_Trace${size}`)(0, ...args),
+          latestCheckpoint: (...args) => mock.getFunction(`$latestCheckpoint_Checkpoints_Trace${size}`)(0, ...args),
+          length: (...args) => mock.getFunction(`$length_Checkpoints_Trace${size}`)(0, ...args),
+          push: (...args) => mock.getFunction(`$push(uint256,uint${keySize},uint${size})`)(0, ...args),
+          lowerLookup: (...args) => mock.getFunction(`$lowerLookup(uint256,uint${keySize})`)(0, ...args),
+          upperLookup: (...args) => mock.getFunction(`$upperLookup(uint256,uint${keySize})`)(0, ...args),
+          upperLookupRecent: (...args) => mock.getFunction(`$upperLookupRecent(uint256,uint${keySize})`)(0, ...args),
         };
 
         return { mock, methods };


### PR DESCRIPTION
Follow-up to #6720.

The `CHECKPOINTS_OPTS` entries in `scripts/generate/data.js` carried a lot of names (`historyTypeName`, `checkpointTypeName`, `checkpointFieldName`, `keyFieldName`, `valueFieldName`, …) that were never actually variable — they were all mechanical functions of the value size, or plain constants. Threading them through the templates made the templates harder to read than the Solidity they produce.

This inlines them:

- `data.js` exports `CHECKPOINTS_LENGTH = [256, 224, 208, 160]` instead of `CHECKPOINTS_OPTS`.
- `Checkpoints.sol.eta` and `Checkpoints.t.sol.eta` derive `keySize` locally and write `Trace<size>` / `Checkpoint<size>` / `_key` / `_value` literally.
- `test/utils/structs/Checkpoints.test.js` follows the same shape.

No behavior change: `npm run test:generation` confirms the generated `contracts/utils/structs/Checkpoints.sol` and `test/utils/structs/Checkpoints.t.sol` are byte-identical.

### Checks

- `npm run test:generation` — clean (no diff in generated files)
- `npx hardhat test --grep Checkpoints` — 48 passing
- `forge test --match-path test/utils/structs/Checkpoints.t.sol` — 8 passing

No changeset: templates and tests only, no user-visible contract change.