### PR TITLE
Share one solidity type registry across codegen generators

### DIFF
--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -10,35 +10,38 @@ export const args = (...parts) => parts.filter(Boolean).join(', ');
 // ─── All solidity types ───
 export const ALL_TYPES = Object.fromEntries(
   [
-    { type: 'bool', name: 'Boolean', size: 1 },
     { type: 'address', size: 160 },
+    { type: 'bool', name: 'boolean', size: 1 },
     ...range(1, 33).map(size => ({
       type: `bytes${size}`,
       size: 8 * size,
-      upcastTo: 'bytes32',
+      upcastTo: size < 32 ? 'bytes32' : undefined,
     })),
     ...range(8, 257, 8).map(size => ({
       type: `uint${size}`,
       size,
-      upcastTo: 'uint256',
+      upcastTo: size < 256 ? 'uint256' : undefined,
     })),
     ...range(8, 257, 8).map(size => ({
       type: `int${size}`,
       size,
-      upcastTo: 'int256',
+      upcastTo: size < 256 ? 'int256' : undefined,
       signed: true,
     })),
     { type: 'string' },
     { type: 'bytes' },
-  ].map(entry => [
-    entry.type,
-    {
+  ]
+    .map(entry => ({
       ...entry,
       name: entry.name ?? entry.type,
       capitalized: capitalize(entry.name ?? entry.type),
       location: entry.size ? '' : 'memory',
-    },
-  ]),
+    }))
+    .map((entry, _, all) => ({
+      ...entry,
+      upcastOf: all.filter(type => type.upcastTo === entry.type),
+    }))
+    .map(entry => [entry.type, entry]),
 );
 
 // ─── Arrays ───
@@ -106,12 +109,4 @@ export const PACKING_SIZES = [1, 2, 4, 6, 8, 10, 12, 16, 20, 22, 24, 28, 32];
 export const SAFECAST_LENGTHS = Array.from({ length: 31 }, (_, i) => 248 - i * 8);
 
 // ─── Slot family (StorageSlot, TransientSlot, SlotDerivation, and their mocks/tests) ───
-export const SLOT_TYPES = [
-  ALL_TYPES.address,
-  ALL_TYPES.bool,
-  { ...ALL_TYPES.bytes32, variants: [ALL_TYPES.bytes4] },
-  { ...ALL_TYPES.uint256, variants: [ALL_TYPES.uint32] },
-  { ...ALL_TYPES.int256, variants: [ALL_TYPES.int32] },
-  ALL_TYPES.string,
-  ALL_TYPES.bytes,
-];
+export const SLOT_TYPES = Object.values(ALL_TYPES).filter(type => !type.upcastTo);

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -56,9 +56,11 @@ export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.si
 export const CHECKPOINTS_LENGTH = [256, 224, 208, 160].map(size => ({ size, keySize: size < 256 ? 256 - size : 256 }));
 
 // ─── Enumerable (EnumerableSet, EnumerableMap) ───
+const enumerableName = ({ type, name }) => (type === 'uint256' ? 'Uint' : name);
+
 export const SET_TYPES = [TYPES.bytes32, TYPES.bytes4, TYPES.address, TYPES.uint256, TYPES.string, TYPES.bytes].map(
   value => ({
-    name: `${value.type == 'uint256' ? 'Uint' : value.name}Set`,
+    name: `${enumerableName(value)}Set`,
     value,
   }),
 );
@@ -75,7 +77,7 @@ export const MAP_TYPES = []
     { key: TYPES.bytes, value: TYPES.bytes },
   )
   .map(({ key, value }) => ({
-    name: `${key.type === 'uint256' ? 'Uint' : key.name}To${value.type === 'uint256' ? 'Uint' : value.name}Map`,
+    name: `${enumerableName(key)}To${enumerableName(value)}Map`,
     key,
     value,
   }));

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -54,8 +54,8 @@ export const ARRAYS_TYPES = [
 ];
 
 export const ARRAYS_VALUE_TYPES = ARRAYS_TYPES.filter(type => type.size);
-export const ARRAYS_CAST_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.name !== 'uint256');
-export const ARRAYS_SORT_TYPES = ARRAYS_VALUE_TYPES.toSorted((a, b) => (b.name == 'uint256') - (a.name == 'uint256'));
+export const ARRAYS_CAST_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.type !== 'uint256');
+export const ARRAYS_SORT_TYPES = ARRAYS_VALUE_TYPES.toSorted((a, b) => (b.type == 'uint256') - (a.type == 'uint256'));
 export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.size < 256);
 
 // ─── Checkpoints (Checkpoints + Checkpoints.t) ───
@@ -70,7 +70,7 @@ export const SET_TYPES = [
   ALL_TYPES.string,
   ALL_TYPES.bytes,
 ].map(value => ({
-  name: `${value.name == 'uint256' ? 'Uint' : value.capitalized}Set`,
+  name: `${value.type == 'uint256' ? 'Uint' : value.capitalized}Set`,
   value,
 }));
 
@@ -86,7 +86,7 @@ export const MAP_TYPES = []
     { key: ALL_TYPES.bytes, value: ALL_TYPES.bytes },
   )
   .map(({ key, value }) => ({
-    name: `${key.name === 'uint256' ? 'Uint' : key.capitalized}To${value.name === 'uint256' ? 'Uint' : value.capitalized}Map`,
+    name: `${key.type === 'uint256' ? 'Uint' : key.capitalized}To${value.type === 'uint256' ? 'Uint' : value.capitalized}Map`,
     key,
     value,
   }));

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -8,7 +8,7 @@ export * from '../helpers.js';
 export const args = (...parts) => parts.filter(Boolean).join(', ');
 
 // ─── All solidity types ───
-export const ALL_TYPES = Object.fromEntries(
+export const TYPES = Object.fromEntries(
   [
     { type: 'address', size: 160 },
     { type: 'bool', name: 'Boolean', size: 1 },
@@ -45,13 +45,7 @@ export const ALL_TYPES = Object.fromEntries(
 );
 
 // ─── Arrays ───
-export const ARRAYS_TYPES = [
-  ALL_TYPES.address,
-  ALL_TYPES.bytes32,
-  ALL_TYPES.uint256,
-  ALL_TYPES.bytes,
-  ALL_TYPES.string,
-];
+export const ARRAYS_TYPES = [TYPES.address, TYPES.bytes32, TYPES.uint256, TYPES.bytes, TYPES.string];
 
 export const ARRAYS_VALUE_TYPES = ARRAYS_TYPES.filter(type => type.size);
 export const ARRAYS_CAST_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.type !== 'uint256');
@@ -62,28 +56,23 @@ export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.si
 export const CHECKPOINTS_LENGTH = [256, 224, 208, 160].map(size => ({ size, keySize: size < 256 ? 256 - size : 256 }));
 
 // ─── Enumerable (EnumerableSet, EnumerableMap) ───
-export const SET_TYPES = [
-  ALL_TYPES.bytes32,
-  ALL_TYPES.bytes4,
-  ALL_TYPES.address,
-  ALL_TYPES.uint256,
-  ALL_TYPES.string,
-  ALL_TYPES.bytes,
-].map(value => ({
-  name: `${value.type == 'uint256' ? 'Uint' : value.name}Set`,
-  value,
-}));
+export const SET_TYPES = [TYPES.bytes32, TYPES.bytes4, TYPES.address, TYPES.uint256, TYPES.string, TYPES.bytes].map(
+  value => ({
+    name: `${value.type == 'uint256' ? 'Uint' : value.name}Set`,
+    value,
+  }),
+);
 
 export const MAP_TYPES = []
   .concat(
     // value type maps
-    [ALL_TYPES.uint256, ALL_TYPES.address, ALL_TYPES.bytes32]
+    [TYPES.uint256, TYPES.address, TYPES.bytes32]
       .flatMap((key, _, array) => array.map(value => ({ key, value })))
       .slice(0, -1), // remove bytes32 → bytes32 (last one) that is already defined
     // other value type maps
-    { key: ALL_TYPES.bytes4, value: ALL_TYPES.address },
+    { key: TYPES.bytes4, value: TYPES.address },
     // non-value type maps
-    { key: ALL_TYPES.bytes, value: ALL_TYPES.bytes },
+    { key: TYPES.bytes, value: TYPES.bytes },
   )
   .map(({ key, value }) => ({
     name: `${key.type === 'uint256' ? 'Uint' : key.name}To${value.type === 'uint256' ? 'Uint' : value.name}Map`,
@@ -109,4 +98,4 @@ export const PACKING_SIZES = [1, 2, 4, 6, 8, 10, 12, 16, 20, 22, 24, 28, 32];
 export const SAFECAST_LENGTHS = Array.from({ length: 31 }, (_, i) => 248 - i * 8);
 
 // ─── Slot family (StorageSlot, TransientSlot, SlotDerivation, and their mocks/tests) ───
-export const SLOT_TYPES = Object.values(ALL_TYPES).filter(type => !type.upcastTo);
+export const SLOT_TYPES = Object.values(TYPES).filter(type => !type.upcastTo);

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -1,4 +1,4 @@
-import { capitalize, mapValues, product } from '../helpers.js';
+import { capitalize, range, product } from '../helpers.js';
 
 // ─── Shared helpers ───
 export const isReferenceType = type => ['string', 'bytes'].includes(type);
@@ -8,63 +8,86 @@ export * from '../helpers.js';
 
 export const args = (...parts) => parts.filter(Boolean).join(', ');
 
+// ─── All solidity types ───
+export const ALL_TYPES = Object.fromEntries(
+  [
+    { type: 'bool', name: 'Boolean', size: 1 },
+    { type: 'address', size: 160 },
+    ...range(1, 33).map(size => ({
+      type: `bytes${size}`,
+      size: 8 * size,
+      upcastTo: 'bytes32',
+    })),
+    ...range(8, 257, 8).map(size => ({
+      type: `uint${size}`,
+      size,
+      upcastTo: 'uint256',
+    })),
+    ...range(8, 257, 8).map(size => ({
+      type: `int${size}`,
+      size,
+      upcastTo: 'int256',
+      signed: true,
+    })),
+    { type: 'string' },
+    { type: 'bytes' },
+  ].map(entry => [
+    entry.type,
+    {
+      ...entry,
+      name: entry.name ?? entry.type,
+      capitalized: capitalize(entry.name ?? entry.type),
+      location: entry.size ? '' : 'memory',
+    },
+  ]),
+);
+
 // ─── Arrays ───
 export const ARRAYS_TYPES = [
-  { type: 'address', size: 20 },
-  { type: 'bytes32', size: 32 },
-  { type: 'uint256', size: 32 },
-  { type: 'bytes' }, // reference types have no size
-  { type: 'string' },
-].map(type => ({ ...type, isValueType: !isReferenceType(type.type) }));
+  ALL_TYPES.address,
+  ALL_TYPES.bytes32,
+  ALL_TYPES.uint256,
+  ALL_TYPES.bytes,
+  ALL_TYPES.string,
+];
 
-export const ARRAYS_VALUE_TYPES = ARRAYS_TYPES.filter(type => type.isValueType);
-export const ARRAYS_CAST_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.type !== 'uint256');
-export const ARRAYS_SORT_TYPES = ARRAYS_VALUE_TYPES.toSorted((a, b) => (b.type == 'uint256') - (a.type == 'uint256'));
-export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.size < 32);
+export const ARRAYS_VALUE_TYPES = ARRAYS_TYPES.filter(type => type.size);
+export const ARRAYS_CAST_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.name !== 'uint256');
+export const ARRAYS_SORT_TYPES = ARRAYS_VALUE_TYPES.toSorted((a, b) => (b.name == 'uint256') - (a.name == 'uint256'));
+export const ARRAYS_COMPARATOR_TYPES = ARRAYS_VALUE_TYPES.filter(type => type.size < 256);
 
 // ─── Checkpoints (Checkpoints + Checkpoints.t) ───
 export const CHECKPOINTS_LENGTH = [256, 224, 208, 160].map(size => ({ size, keySize: size < 256 ? 256 - size : 256 }));
 
 // ─── Enumerable (EnumerableSet, EnumerableMap) ───
-export const typeDescr = ({ type, size = 0, memory }) => {
-  memory = (memory ?? isReferenceType(type)) || size > 0;
-
-  const name = [type == 'uint256' ? 'Uint' : capitalize(type), size].filter(Boolean).join('x');
-  const base = size ? type : undefined;
-  const typeFull = size ? `${type}[${size}]` : type;
-  const typeLoc = memory ? `${typeFull} memory` : typeFull;
-  return { name, type: typeFull, typeLoc, base, size, memory };
-};
-
-const toSetTypeDescr = value => ({
-  name: value.name + 'Set',
+export const SET_TYPES = [
+  ALL_TYPES.bytes32,
+  ALL_TYPES.bytes4,
+  ALL_TYPES.address,
+  ALL_TYPES.uint256,
+  ALL_TYPES.string,
+  ALL_TYPES.bytes,
+].map(value => ({
+  name: `${value.name == 'uint256' ? 'Uint' : value.capitalized}Set`,
   value,
-});
-
-export const toMapTypeDescr = ({ key, value }) => ({
-  name: `${key.name}To${value.name}Map`,
-  keySet: toSetTypeDescr(key),
-  key,
-  value,
-});
-
-export const SET_TYPES = ['bytes32', 'bytes4', 'address', 'uint256', 'string', 'bytes']
-  .map(type => typeDescr({ type }))
-  .map(toSetTypeDescr);
+}));
 
 export const MAP_TYPES = []
   .concat(
     // value type maps
-    ['uint256', 'address', 'bytes32']
-      .flatMap((keyType, _, array) => array.map(valueType => ({ key: { type: keyType }, value: { type: valueType } })))
+    [ALL_TYPES.uint256, ALL_TYPES.address, ALL_TYPES.bytes32]
+      .flatMap((key, _, array) => array.map(value => ({ key, value })))
       .slice(0, -1), // remove bytes32 → bytes32 (last one) that is already defined
     // other value type maps
-    { key: { type: 'bytes4' }, value: { type: 'address' } },
+    { key: ALL_TYPES.bytes4, value: ALL_TYPES.address },
     // non-value type maps
-    { key: { type: 'bytes' }, value: { type: 'bytes' } },
+    { key: ALL_TYPES.bytes, value: ALL_TYPES.bytes },
   )
-  .map(entry => mapValues(entry, typeDescr))
-  .map(toMapTypeDescr);
+  .map(({ key, value }) => ({
+    name: `${key.name === 'uint256' ? 'Uint' : key.capitalized}To${value.name === 'uint256' ? 'Uint' : value.capitalized}Map`,
+    key,
+    value,
+  }));
 
 // ─── MerkleProof ───
 export const MERKLEPROOF_DEFAULT_HASH = 'Hashes.commutativeKeccak256';
@@ -85,14 +108,11 @@ export const SAFECAST_LENGTHS = Array.from({ length: 31 }, (_, i) => 248 - i * 8
 
 // ─── Slot family (StorageSlot, TransientSlot, SlotDerivation, and their mocks/tests) ───
 export const SLOT_TYPES = [
-  { type: 'address' },
-  { type: 'bool', name: 'Boolean' },
-  { type: 'bytes32', variants: ['bytes4'] },
-  { type: 'uint256', variants: ['uint32'] },
-  { type: 'int256', variants: ['int32'] },
-  { type: 'string' },
-  { type: 'bytes' },
-].map(type => ({ ...type, name: type.name ?? capitalize(type.type), isValueType: !isReferenceType(type.type) }));
-// allow keyed access (e.g. SLOT_TYPES.bool, SLOT_TYPES.address)
-Object.assign(SLOT_TYPES, Object.fromEntries(SLOT_TYPES.map(entry => [entry.type, entry])));
-export const SLOT_VALUE_TYPES = SLOT_TYPES.filter(type => type.isValueType);
+  ALL_TYPES.address,
+  ALL_TYPES.bool,
+  { ...ALL_TYPES.bytes32, variants: [ALL_TYPES.bytes4] },
+  { ...ALL_TYPES.uint256, variants: [ALL_TYPES.uint32] },
+  { ...ALL_TYPES.int256, variants: [ALL_TYPES.int32] },
+  ALL_TYPES.string,
+  ALL_TYPES.bytes,
+];

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -38,6 +38,7 @@ export const ALL_TYPES = Object.fromEntries(
     }))
     .map((entry, _, all) => ({
       ...entry,
+      upcastTo: all.find(type => type.type === entry.upcastTo),
       upcastOf: all.filter(type => type.upcastTo === entry.type),
     }))
     .map(entry => [entry.type, entry]),

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -11,7 +11,7 @@ export const args = (...parts) => parts.filter(Boolean).join(', ');
 export const ALL_TYPES = Object.fromEntries(
   [
     { type: 'address', size: 160 },
-    { type: 'bool', name: 'boolean', size: 1 },
+    { type: 'bool', name: 'Boolean', size: 1 },
     ...range(1, 33).map(size => ({
       type: `bytes${size}`,
       size: 8 * size,
@@ -33,8 +33,7 @@ export const ALL_TYPES = Object.fromEntries(
   ]
     .map(entry => ({
       ...entry,
-      name: entry.name ?? entry.type,
-      capitalized: capitalize(entry.name ?? entry.type),
+      name: entry.name ?? capitalize(entry.type),
       location: entry.size ? '' : 'memory',
     }))
     .map((entry, _, all) => ({
@@ -70,7 +69,7 @@ export const SET_TYPES = [
   ALL_TYPES.string,
   ALL_TYPES.bytes,
 ].map(value => ({
-  name: `${value.type == 'uint256' ? 'Uint' : value.capitalized}Set`,
+  name: `${value.type == 'uint256' ? 'Uint' : value.name}Set`,
   value,
 }));
 
@@ -86,7 +85,7 @@ export const MAP_TYPES = []
     { key: ALL_TYPES.bytes, value: ALL_TYPES.bytes },
   )
   .map(({ key, value }) => ({
-    name: `${key.type === 'uint256' ? 'Uint' : key.capitalized}To${value.type === 'uint256' ? 'Uint' : value.capitalized}Map`,
+    name: `${key.type === 'uint256' ? 'Uint' : key.name}To${value.type === 'uint256' ? 'Uint' : value.name}Map`,
     key,
     value,
   }));

--- a/scripts/generate/data.js
+++ b/scripts/generate/data.js
@@ -1,7 +1,6 @@
 import { capitalize, range, product } from '../helpers.js';
 
 // ─── Shared helpers ───
-export const isReferenceType = type => ['string', 'bytes'].includes(type);
 export * as sanitize from './helpers/sanitize.js';
 export * from './helpers/conversion.js';
 export * from '../helpers.js';

--- a/scripts/generate/templates/Arrays.sol.eta
+++ b/scripts/generate/templates/Arrays.sol.eta
@@ -14,7 +14,7 @@ library Arrays {
 
 <% for (const type of it.ARRAYS_SORT_TYPES) { %>
     /**
-     * @dev Sort an array of <%= type.type %> (in memory) following the provided comparator function.
+     * @dev Sort an array of <%= type.name %> (in memory) following the provided comparator function.
      *
      * This function does the sorting "in place", meaning that it overrides the input. The object is returned for
      * convenience, but that returned value can be discarded safely if the caller has a memory pointer to the array.
@@ -24,25 +24,25 @@ library Arrays {
      * when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
      * consume more gas than is available in a block, leading to potential DoS.
      *
-     * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (type.size && type.size < 32) { %>
+     * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (type.size && type.size < 256) { %>
      *
      * NOTE: `comp` receives the array entries verbatim, including any dirty (non-zero) upper bits. Solidity assumes
-     * `<%= type.type %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
-     * A comparator that may be given dirty entries should mask them, as in `uint<%= type.size * 8 %>(a) < uint<%= type.size * 8 %>(b)`.<% } %>
+     * `<%= type.name %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
+     * A comparator that may be given dirty entries should mask them, as in `uint<%= type.size %>(a) < uint<%= type.size %>(b)`.<% } %>
      */
     function sort(
-        <%= type.type %>[] memory array,
-        function(<%= type.type %>, <%= type.type %>) pure returns (bool) comp
-    ) internal pure returns (<%= type.type %>[] memory) {
-        <% if (type.type === 'uint256') { %>_quickSort(_begin(array), _end(array), comp);<% } else { %>sort(_castToUint256Array(array), _castToUint256Comp(comp));<% } %>
+        <%= type.name %>[] memory array,
+        function(<%= type.name %>, <%= type.name %>) pure returns (bool) comp
+    ) internal pure returns (<%= type.name %>[] memory) {
+        <% if (type.name === 'uint256') { %>_quickSort(_begin(array), _end(array), comp);<% } else { %>sort(_castToUint256Array(array), _castToUint256Comp(comp));<% } %>
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of <%= type.type %> in increasing order.
+     * @dev Variant of {sort} that sorts an array of <%= type.name %> in increasing order.
      */
-    function sort(<%= type.type %>[] memory array) internal pure returns (<%= type.type %>[] memory) {
-        <% if (type.type === 'uint256') { %>sort(array, Comparators.lt);<% } else { %>sort(_castToUint256Array(array), <%= type.size == 32 ? 'Comparators.lt' : `_${type.type}Lt` %>);<% } %>
+    function sort(<%= type.name %>[] memory array) internal pure returns (<%= type.name %>[] memory) {
+        <% if (type.name === 'uint256') { %>sort(array, Comparators.lt);<% } else { %>sort(_castToUint256Array(array), <%= type.size == 256 ? 'Comparators.lt' : `_${type.name}Lt` %>);<% } %>
         return array;
     }
 
@@ -129,15 +129,15 @@ library Arrays {
     }
 
 <% for (const type of it.ARRAYS_COMPARATOR_TYPES) { %>
-    /// @dev Helper: strict comparison of two <%= type.type %> values held in (potentially dirty) uint256 words
-    function _<%= type.type %>Lt(uint256 a, uint256 b) private pure returns (bool) {
-        return uint<%= type.size * 8 %>(a) < uint<%= type.size * 8 %>(b);
+    /// @dev Helper: strict comparison of two <%= type.name %> values held in (potentially dirty) uint256 words
+    function _<%= type.name %>Lt(uint256 a, uint256 b) private pure returns (bool) {
+        return uint<%= type.size %>(a) < uint<%= type.size %>(b);
     }
 
 <% } %>
 <% for (const type of it.ARRAYS_CAST_TYPES) { %>
-    /// @dev Helper: low level cast <%= type.type %> memory array to uint256 memory array
-    function _castToUint256Array(<%= type.type %>[] memory input) private pure returns (uint256[] memory output) {
+    /// @dev Helper: low level cast <%= type.name %> memory array to uint256 memory array
+    function _castToUint256Array(<%= type.name %>[] memory input) private pure returns (uint256[] memory output) {
         assembly {
             output := input
         }
@@ -145,9 +145,9 @@ library Arrays {
 
 <% } %>
 <% for (const type of it.ARRAYS_CAST_TYPES) { %>
-    /// @dev Helper: low level cast <%= type.type %> comp function to uint256 comp function
+    /// @dev Helper: low level cast <%= type.name %> comp function to uint256 comp function
     function _castToUint256Comp(
-        function(<%= type.type %>, <%= type.type %>) pure returns (bool) input
+        function(<%= type.name %>, <%= type.name %>) pure returns (bool) input
     ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
         assembly {
             output := input
@@ -324,28 +324,28 @@ library Arrays {
 
 <% for (const type of it.ARRAYS_VALUE_TYPES) { %>
     /**
-     * @dev Copies the content of `array`, from `start` (included) to the end of `array` into a new <%= type.type %> array in
+     * @dev Copies the content of `array`, from `start` (included) to the end of `array` into a new <%= type.name %> array in
      * memory.
      *
      * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
      */
-    function slice(<%= type.type %>[] memory array, uint256 start) internal pure returns (<%= type.type %>[] memory) {
+    function slice(<%= type.name %>[] memory array, uint256 start) internal pure returns (<%= type.name %>[] memory) {
         return slice(array, start, array.length);
     }
 
     /**
-     * @dev Copies the content of `array`, from `start` (included) to `end` (excluded) into a new <%= type.type %> array in
+     * @dev Copies the content of `array`, from `start` (included) to `end` (excluded) into a new <%= type.name %> array in
      * memory. The `end` argument is truncated to the length of the `array`.
      *
      * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
      */
-    function slice(<%= type.type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.type %>[] memory) {
+    function slice(<%= type.name %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.name %>[] memory) {
         // sanitize
         end = Math.min(end, array.length);
         start = Math.min(start, end);
 
         // allocate and copy
-        <%= type.type %>[] memory result = new <%= type.type %>[](end - start);
+        <%= type.name %>[] memory result = new <%= type.name %>[](end - start);
         assembly ("memory-safe") {
             mcopy(add(result, 0x20), add(add(array, 0x20), mul(start, 0x20)), mul(sub(end, start), 0x20))
         }
@@ -361,7 +361,7 @@ library Arrays {
      *
      * NOTE: This function modifies the provided array in place. If you need to preserve the original array, use {slice} instead.
      */
-    function splice(<%= type.type %>[] memory array, uint256 start) internal pure returns (<%= type.type %>[] memory) {
+    function splice(<%= type.name %>[] memory array, uint256 start) internal pure returns (<%= type.name %>[] memory) {
         return splice(array, start, array.length);
     }
 
@@ -372,7 +372,7 @@ library Arrays {
      *
      * NOTE: This function modifies the provided array in place. If you need to preserve the original array, use {slice} instead.
      */
-    function splice(<%= type.type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.type %>[] memory) {
+    function splice(<%= type.name %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.name %>[] memory) {
         // sanitize
         end = Math.min(end, array.length);
         start = Math.min(start, end);
@@ -395,10 +395,10 @@ library Arrays {
      * NOTE: This function modifies the provided array in place.
      */
     function replace(
-        <%= type.type %>[] memory array,
+        <%= type.name %>[] memory array,
         uint256 pos,
-        <%= type.type %>[] memory replacement
-    ) internal pure returns (<%= type.type %>[] memory) {
+        <%= type.name %>[] memory replacement
+    ) internal pure returns (<%= type.name %>[] memory) {
         return replace(array, pos, replacement, 0, replacement.length);
     }
 
@@ -414,12 +414,12 @@ library Arrays {
      * NOTE: This function modifies the provided array in place.
      */
     function replace(
-        <%= type.type %>[] memory array,
+        <%= type.name %>[] memory array,
         uint256 pos,
-        <%= type.type %>[] memory replacement,
+        <%= type.name %>[] memory replacement,
         uint256 offset,
         uint256 length
-    ) internal pure returns (<%= type.type %>[] memory) {
+    ) internal pure returns (<%= type.name %>[] memory) {
         // sanitize
         pos = Math.min(pos, array.length);
         offset = Math.min(offset, replacement.length);
@@ -444,12 +444,12 @@ library Arrays {
      *
      * WARNING: Only use if you are certain `pos` is lower than the array length.
      */
-    function unsafeAccess(<%= type.type %>[] storage arr, uint256 pos) internal pure returns (StorageSlot.<%= it.capitalize(type.type) %>Slot storage) {
+    function unsafeAccess(<%= type.name %>[] storage arr, uint256 pos) internal pure returns (StorageSlot.<%= type.capitalized %>Slot storage) {
         bytes32 slot;
         assembly ("memory-safe") {
             slot := arr.slot
         }
-        return slot.deriveArray().offset(pos).get<%= it.capitalize(type.type) %>Slot();
+        return slot.deriveArray().offset(pos).get<%= type.capitalized %>Slot();
     }
 
 <% } %>
@@ -459,7 +459,7 @@ library Arrays {
      *
      * WARNING: Only use if you are certain `pos` is lower than the array length.
      */
-    function unsafeMemoryAccess(<%= type.type %>[] memory arr, uint256 pos) internal pure returns (<%= type.type %><%= type.isValueType ? '' : ' memory' %> res) {
+    function unsafeMemoryAccess(<%= type.name %>[] memory arr, uint256 pos) internal pure returns (<%= type.name %><%= type.size ? '' : ' memory' %> res) {
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
         }
@@ -472,7 +472,7 @@ library Arrays {
      *
      * WARNING: this does not clear elements if length is reduced, or initialize elements if length is increased.
      */
-    function unsafeSetLength(<%= type.type %>[] storage array, uint256 len) internal {
+    function unsafeSetLength(<%= type.name %>[] storage array, uint256 len) internal {
         assembly ("memory-safe") {
             sstore(array.slot, len)
         }

--- a/scripts/generate/templates/Arrays.sol.eta
+++ b/scripts/generate/templates/Arrays.sol.eta
@@ -24,7 +24,7 @@ library Arrays {
      * when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
      * consume more gas than is available in a block, leading to potential DoS.
      *
-     * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (size && size < 256) { %>
+     * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (size < 256) { %>
      *
      * NOTE: `comp` receives the array entries verbatim, including any dirty (non-zero) upper bits. Solidity assumes
      * `<%= type %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.

--- a/scripts/generate/templates/Arrays.sol.eta
+++ b/scripts/generate/templates/Arrays.sol.eta
@@ -14,7 +14,7 @@ library Arrays {
 
 <% for (const type of it.ARRAYS_SORT_TYPES) { %>
     /**
-     * @dev Sort an array of <%= type.name %> (in memory) following the provided comparator function.
+     * @dev Sort an array of <%= type.type %> (in memory) following the provided comparator function.
      *
      * This function does the sorting "in place", meaning that it overrides the input. The object is returned for
      * convenience, but that returned value can be discarded safely if the caller has a memory pointer to the array.
@@ -27,22 +27,22 @@ library Arrays {
      * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (type.size && type.size < 256) { %>
      *
      * NOTE: `comp` receives the array entries verbatim, including any dirty (non-zero) upper bits. Solidity assumes
-     * `<%= type.name %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
+     * `<%= type.type %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
      * A comparator that may be given dirty entries should mask them, as in `uint<%= type.size %>(a) < uint<%= type.size %>(b)`.<% } %>
      */
     function sort(
-        <%= type.name %>[] memory array,
-        function(<%= type.name %>, <%= type.name %>) pure returns (bool) comp
-    ) internal pure returns (<%= type.name %>[] memory) {
-        <% if (type.name === 'uint256') { %>_quickSort(_begin(array), _end(array), comp);<% } else { %>sort(_castToUint256Array(array), _castToUint256Comp(comp));<% } %>
+        <%= type.type %>[] memory array,
+        function(<%= type.type %>, <%= type.type %>) pure returns (bool) comp
+    ) internal pure returns (<%= type.type %>[] memory) {
+        <% if (type.type === 'uint256') { %>_quickSort(_begin(array), _end(array), comp);<% } else { %>sort(_castToUint256Array(array), _castToUint256Comp(comp));<% } %>
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of <%= type.name %> in increasing order.
+     * @dev Variant of {sort} that sorts an array of <%= type.type %> in increasing order.
      */
-    function sort(<%= type.name %>[] memory array) internal pure returns (<%= type.name %>[] memory) {
-        <% if (type.name === 'uint256') { %>sort(array, Comparators.lt);<% } else { %>sort(_castToUint256Array(array), <%= type.size == 256 ? 'Comparators.lt' : `_${type.name}Lt` %>);<% } %>
+    function sort(<%= type.type %>[] memory array) internal pure returns (<%= type.type %>[] memory) {
+        <% if (type.type === 'uint256') { %>sort(array, Comparators.lt);<% } else { %>sort(_castToUint256Array(array), <%= type.size == 256 ? 'Comparators.lt' : `_${type.type}Lt` %>);<% } %>
         return array;
     }
 
@@ -129,15 +129,15 @@ library Arrays {
     }
 
 <% for (const type of it.ARRAYS_COMPARATOR_TYPES) { %>
-    /// @dev Helper: strict comparison of two <%= type.name %> values held in (potentially dirty) uint256 words
-    function _<%= type.name %>Lt(uint256 a, uint256 b) private pure returns (bool) {
+    /// @dev Helper: strict comparison of two <%= type.type %> values held in (potentially dirty) uint256 words
+    function _<%= type.type %>Lt(uint256 a, uint256 b) private pure returns (bool) {
         return uint<%= type.size %>(a) < uint<%= type.size %>(b);
     }
 
 <% } %>
 <% for (const type of it.ARRAYS_CAST_TYPES) { %>
-    /// @dev Helper: low level cast <%= type.name %> memory array to uint256 memory array
-    function _castToUint256Array(<%= type.name %>[] memory input) private pure returns (uint256[] memory output) {
+    /// @dev Helper: low level cast <%= type.type %> memory array to uint256 memory array
+    function _castToUint256Array(<%= type.type %>[] memory input) private pure returns (uint256[] memory output) {
         assembly {
             output := input
         }
@@ -145,9 +145,9 @@ library Arrays {
 
 <% } %>
 <% for (const type of it.ARRAYS_CAST_TYPES) { %>
-    /// @dev Helper: low level cast <%= type.name %> comp function to uint256 comp function
+    /// @dev Helper: low level cast <%= type.type %> comp function to uint256 comp function
     function _castToUint256Comp(
-        function(<%= type.name %>, <%= type.name %>) pure returns (bool) input
+        function(<%= type.type %>, <%= type.type %>) pure returns (bool) input
     ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
         assembly {
             output := input
@@ -324,28 +324,28 @@ library Arrays {
 
 <% for (const type of it.ARRAYS_VALUE_TYPES) { %>
     /**
-     * @dev Copies the content of `array`, from `start` (included) to the end of `array` into a new <%= type.name %> array in
+     * @dev Copies the content of `array`, from `start` (included) to the end of `array` into a new <%= type.type %> array in
      * memory.
      *
      * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
      */
-    function slice(<%= type.name %>[] memory array, uint256 start) internal pure returns (<%= type.name %>[] memory) {
+    function slice(<%= type.type %>[] memory array, uint256 start) internal pure returns (<%= type.type %>[] memory) {
         return slice(array, start, array.length);
     }
 
     /**
-     * @dev Copies the content of `array`, from `start` (included) to `end` (excluded) into a new <%= type.name %> array in
+     * @dev Copies the content of `array`, from `start` (included) to `end` (excluded) into a new <%= type.type %> array in
      * memory. The `end` argument is truncated to the length of the `array`.
      *
      * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
      */
-    function slice(<%= type.name %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.name %>[] memory) {
+    function slice(<%= type.type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.type %>[] memory) {
         // sanitize
         end = Math.min(end, array.length);
         start = Math.min(start, end);
 
         // allocate and copy
-        <%= type.name %>[] memory result = new <%= type.name %>[](end - start);
+        <%= type.type %>[] memory result = new <%= type.type %>[](end - start);
         assembly ("memory-safe") {
             mcopy(add(result, 0x20), add(add(array, 0x20), mul(start, 0x20)), mul(sub(end, start), 0x20))
         }
@@ -361,7 +361,7 @@ library Arrays {
      *
      * NOTE: This function modifies the provided array in place. If you need to preserve the original array, use {slice} instead.
      */
-    function splice(<%= type.name %>[] memory array, uint256 start) internal pure returns (<%= type.name %>[] memory) {
+    function splice(<%= type.type %>[] memory array, uint256 start) internal pure returns (<%= type.type %>[] memory) {
         return splice(array, start, array.length);
     }
 
@@ -372,7 +372,7 @@ library Arrays {
      *
      * NOTE: This function modifies the provided array in place. If you need to preserve the original array, use {slice} instead.
      */
-    function splice(<%= type.name %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.name %>[] memory) {
+    function splice(<%= type.type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.type %>[] memory) {
         // sanitize
         end = Math.min(end, array.length);
         start = Math.min(start, end);
@@ -395,10 +395,10 @@ library Arrays {
      * NOTE: This function modifies the provided array in place.
      */
     function replace(
-        <%= type.name %>[] memory array,
+        <%= type.type %>[] memory array,
         uint256 pos,
-        <%= type.name %>[] memory replacement
-    ) internal pure returns (<%= type.name %>[] memory) {
+        <%= type.type %>[] memory replacement
+    ) internal pure returns (<%= type.type %>[] memory) {
         return replace(array, pos, replacement, 0, replacement.length);
     }
 
@@ -414,12 +414,12 @@ library Arrays {
      * NOTE: This function modifies the provided array in place.
      */
     function replace(
-        <%= type.name %>[] memory array,
+        <%= type.type %>[] memory array,
         uint256 pos,
-        <%= type.name %>[] memory replacement,
+        <%= type.type %>[] memory replacement,
         uint256 offset,
         uint256 length
-    ) internal pure returns (<%= type.name %>[] memory) {
+    ) internal pure returns (<%= type.type %>[] memory) {
         // sanitize
         pos = Math.min(pos, array.length);
         offset = Math.min(offset, replacement.length);
@@ -444,7 +444,7 @@ library Arrays {
      *
      * WARNING: Only use if you are certain `pos` is lower than the array length.
      */
-    function unsafeAccess(<%= type.name %>[] storage arr, uint256 pos) internal pure returns (StorageSlot.<%= type.capitalized %>Slot storage) {
+    function unsafeAccess(<%= type.type %>[] storage arr, uint256 pos) internal pure returns (StorageSlot.<%= type.capitalized %>Slot storage) {
         bytes32 slot;
         assembly ("memory-safe") {
             slot := arr.slot
@@ -459,7 +459,7 @@ library Arrays {
      *
      * WARNING: Only use if you are certain `pos` is lower than the array length.
      */
-    function unsafeMemoryAccess(<%= type.name %>[] memory arr, uint256 pos) internal pure returns (<%= type.name %><%= type.size ? '' : ' memory' %> res) {
+    function unsafeMemoryAccess(<%= type.type %>[] memory arr, uint256 pos) internal pure returns (<%= type.type %><%= type.size ? '' : ' memory' %> res) {
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
         }
@@ -472,7 +472,7 @@ library Arrays {
      *
      * WARNING: this does not clear elements if length is reduced, or initialize elements if length is increased.
      */
-    function unsafeSetLength(<%= type.name %>[] storage array, uint256 len) internal {
+    function unsafeSetLength(<%= type.type %>[] storage array, uint256 len) internal {
         assembly ("memory-safe") {
             sstore(array.slot, len)
         }

--- a/scripts/generate/templates/Arrays.sol.eta
+++ b/scripts/generate/templates/Arrays.sol.eta
@@ -12,9 +12,9 @@ library Arrays {
     using SlotDerivation for bytes32;
     using StorageSlot for bytes32;
 
-<% for (const type of it.ARRAYS_SORT_TYPES) { %>
+<% for (const { type, size } of it.ARRAYS_SORT_TYPES) { %>
     /**
-     * @dev Sort an array of <%= type.type %> (in memory) following the provided comparator function.
+     * @dev Sort an array of <%= type %> (in memory) following the provided comparator function.
      *
      * This function does the sorting "in place", meaning that it overrides the input. The object is returned for
      * convenience, but that returned value can be discarded safely if the caller has a memory pointer to the array.
@@ -24,29 +24,29 @@ library Arrays {
      * when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
      * consume more gas than is available in a block, leading to potential DoS.
      *
-     * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (type.size && type.size < 256) { %>
+     * IMPORTANT: Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.<% if (size && size < 256) { %>
      *
      * NOTE: `comp` receives the array entries verbatim, including any dirty (non-zero) upper bits. Solidity assumes
-     * `<%= type.type %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
-     * A comparator that may be given dirty entries should mask them, as in `uint<%= type.size %>(a) < uint<%= type.size %>(b)`.<% } %>
+     * `<%= type %>` values are clean, so a comparator that compares its arguments directly may order them incorrectly.
+     * A comparator that may be given dirty entries should mask them, as in `uint<%= size %>(a) < uint<%= size %>(b)`.<% } %>
      */
     function sort(
-        <%= type.type %>[] memory array,
-        function(<%= type.type %>, <%= type.type %>) pure returns (bool) comp
-    ) internal pure returns (<%= type.type %>[] memory) {
-        <% if (type.type === 'uint256') { %>_quickSort(_begin(array), _end(array), comp);<% } else { %>sort(_castToUint256Array(array), _castToUint256Comp(comp));<% } %>
+        <%= type %>[] memory array,
+        function(<%= type %>, <%= type %>) pure returns (bool) comp
+    ) internal pure returns (<%= type %>[] memory) {
+        <% if (type === 'uint256') { %>_quickSort(_begin(array), _end(array), comp);<% } else { %>sort(_castToUint256Array(array), _castToUint256Comp(comp));<% } %>
         return array;
     }
 
     /**
-     * @dev Variant of {sort} that sorts an array of <%= type.type %> in increasing order.
+     * @dev Variant of {sort} that sorts an array of <%= type %> in increasing order.
      */
-    function sort(<%= type.type %>[] memory array) internal pure returns (<%= type.type %>[] memory) {
-        <% if (type.type === 'uint256') { %>sort(array, Comparators.lt);<% } else { %>sort(_castToUint256Array(array), <%= type.size == 256 ? 'Comparators.lt' : `_${type.type}Lt` %>);<% } %>
+    function sort(<%= type %>[] memory array) internal pure returns (<%= type %>[] memory) {
+        <% if (type === 'uint256') { %>sort(array, Comparators.lt);<% } else { %>sort(_castToUint256Array(array), <%= size == 256 ? 'Comparators.lt' : `_${type}Lt` %>);<% } %>
         return array;
     }
-
 <% } %>
+
     /**
      * @dev Performs a quick sort of a segment of memory. The segment sorted starts at `begin` (inclusive), and stops
      * at end (exclusive). Sorting follows the `comp` comparator.
@@ -128,33 +128,33 @@ library Arrays {
         }
     }
 
-<% for (const type of it.ARRAYS_COMPARATOR_TYPES) { %>
-    /// @dev Helper: strict comparison of two <%= type.type %> values held in (potentially dirty) uint256 words
-    function _<%= type.type %>Lt(uint256 a, uint256 b) private pure returns (bool) {
-        return uint<%= type.size %>(a) < uint<%= type.size %>(b);
+<% for (const { type, size } of it.ARRAYS_COMPARATOR_TYPES) { %>
+    /// @dev Helper: strict comparison of two <%= type %> values held in (potentially dirty) uint256 words
+    function _<%= type %>Lt(uint256 a, uint256 b) private pure returns (bool) {
+        return uint<%= size %>(a) < uint<%= size %>(b);
     }
-
 <% } %>
-<% for (const type of it.ARRAYS_CAST_TYPES) { %>
-    /// @dev Helper: low level cast <%= type.type %> memory array to uint256 memory array
-    function _castToUint256Array(<%= type.type %>[] memory input) private pure returns (uint256[] memory output) {
+
+<% for (const { type } of it.ARRAYS_CAST_TYPES) { %>
+    /// @dev Helper: low level cast <%= type %> memory array to uint256 memory array
+    function _castToUint256Array(<%= type %>[] memory input) private pure returns (uint256[] memory output) {
         assembly {
             output := input
         }
     }
-
 <% } %>
-<% for (const type of it.ARRAYS_CAST_TYPES) { %>
-    /// @dev Helper: low level cast <%= type.type %> comp function to uint256 comp function
+
+<% for (const { type } of it.ARRAYS_CAST_TYPES) { %>
+    /// @dev Helper: low level cast <%= type %> comp function to uint256 comp function
     function _castToUint256Comp(
-        function(<%= type.type %>, <%= type.type %>) pure returns (bool) input
+        function(<%= type %>, <%= type %>) pure returns (bool) input
     ) private pure returns (function(uint256, uint256) pure returns (bool) output) {
         assembly {
             output := input
         }
     }
-
 <% } %>
+
     /**
      * @dev Searches a sorted `array` and returns the first index that contains
      * a value greater or equal to `element`. If no such index exists (i.e. all
@@ -322,46 +322,46 @@ library Arrays {
         return low;
     }
 
-<% for (const type of it.ARRAYS_VALUE_TYPES) { %>
+<% for (const { type } of it.ARRAYS_VALUE_TYPES) { %>
     /**
-     * @dev Copies the content of `array`, from `start` (included) to the end of `array` into a new <%= type.type %> array in
+     * @dev Copies the content of `array`, from `start` (included) to the end of `array` into a new <%= type %> array in
      * memory.
      *
      * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
      */
-    function slice(<%= type.type %>[] memory array, uint256 start) internal pure returns (<%= type.type %>[] memory) {
+    function slice(<%= type %>[] memory array, uint256 start) internal pure returns (<%= type %>[] memory) {
         return slice(array, start, array.length);
     }
 
     /**
-     * @dev Copies the content of `array`, from `start` (included) to `end` (excluded) into a new <%= type.type %> array in
+     * @dev Copies the content of `array`, from `start` (included) to `end` (excluded) into a new <%= type %> array in
      * memory. The `end` argument is truncated to the length of the `array`.
      *
      * NOTE: replicates the behavior of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Javascript's `Array.slice`]
      */
-    function slice(<%= type.type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.type %>[] memory) {
+    function slice(<%= type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type %>[] memory) {
         // sanitize
         end = Math.min(end, array.length);
         start = Math.min(start, end);
 
         // allocate and copy
-        <%= type.type %>[] memory result = new <%= type.type %>[](end - start);
+        <%= type %>[] memory result = new <%= type %>[](end - start);
         assembly ("memory-safe") {
             mcopy(add(result, 0x20), add(add(array, 0x20), mul(start, 0x20)), mul(sub(end, start), 0x20))
         }
 
         return result;
     }
-
 <% } %>
-<% for (const type of it.ARRAYS_VALUE_TYPES) { %>
+
+<% for (const { type } of it.ARRAYS_VALUE_TYPES) { %>
     /**
      * @dev Moves the content of `array`, from `start` (included) to the end of `array` to the start of that array,
      * and shrinks the array length accordingly, effectively overwriting the array with array[start:].
      *
      * NOTE: This function modifies the provided array in place. If you need to preserve the original array, use {slice} instead.
      */
-    function splice(<%= type.type %>[] memory array, uint256 start) internal pure returns (<%= type.type %>[] memory) {
+    function splice(<%= type %>[] memory array, uint256 start) internal pure returns (<%= type %>[] memory) {
         return splice(array, start, array.length);
     }
 
@@ -372,7 +372,7 @@ library Arrays {
      *
      * NOTE: This function modifies the provided array in place. If you need to preserve the original array, use {slice} instead.
      */
-    function splice(<%= type.type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type.type %>[] memory) {
+    function splice(<%= type %>[] memory array, uint256 start, uint256 end) internal pure returns (<%= type %>[] memory) {
         // sanitize
         end = Math.min(end, array.length);
         start = Math.min(start, end);
@@ -395,10 +395,10 @@ library Arrays {
      * NOTE: This function modifies the provided array in place.
      */
     function replace(
-        <%= type.type %>[] memory array,
+        <%= type %>[] memory array,
         uint256 pos,
-        <%= type.type %>[] memory replacement
-    ) internal pure returns (<%= type.type %>[] memory) {
+        <%= type %>[] memory replacement
+    ) internal pure returns (<%= type %>[] memory) {
         return replace(array, pos, replacement, 0, replacement.length);
     }
 
@@ -414,12 +414,12 @@ library Arrays {
      * NOTE: This function modifies the provided array in place.
      */
     function replace(
-        <%= type.type %>[] memory array,
+        <%= type %>[] memory array,
         uint256 pos,
-        <%= type.type %>[] memory replacement,
+        <%= type %>[] memory replacement,
         uint256 offset,
         uint256 length
-    ) internal pure returns (<%= type.type %>[] memory) {
+    ) internal pure returns (<%= type %>[] memory) {
         // sanitize
         pos = Math.min(pos, array.length);
         offset = Math.min(offset, replacement.length);
@@ -436,47 +436,46 @@ library Arrays {
 
         return array;
     }
-
 <% } %>
-<% for (const type of it.ARRAYS_TYPES) { %>
+
+<% for (const { name, type } of it.ARRAYS_TYPES) { %>
     /**
      * @dev Access an array in an "unsafe" way. Skips solidity "index-out-of-range" check.
      *
      * WARNING: Only use if you are certain `pos` is lower than the array length.
      */
-    function unsafeAccess(<%= type.type %>[] storage arr, uint256 pos) internal pure returns (StorageSlot.<%= type.capitalized %>Slot storage) {
+    function unsafeAccess(<%= type %>[] storage arr, uint256 pos) internal pure returns (StorageSlot.<%= name %>Slot storage) {
         bytes32 slot;
         assembly ("memory-safe") {
             slot := arr.slot
         }
-        return slot.deriveArray().offset(pos).get<%= type.capitalized %>Slot();
+        return slot.deriveArray().offset(pos).get<%= name %>Slot();
     }
-
 <% } %>
-<% for (const type of it.ARRAYS_TYPES) { %>
+
+<% for (const { type, size } of it.ARRAYS_TYPES) { %>
     /**
      * @dev Access an array in an "unsafe" way. Skips solidity "index-out-of-range" check.
      *
      * WARNING: Only use if you are certain `pos` is lower than the array length.
      */
-    function unsafeMemoryAccess(<%= type.type %>[] memory arr, uint256 pos) internal pure returns (<%= type.type %><%= type.size ? '' : ' memory' %> res) {
+    function unsafeMemoryAccess(<%= type %>[] memory arr, uint256 pos) internal pure returns (<%= type %><%= size ? '' : ' memory' %> res) {
         assembly {
             res := mload(add(add(arr, 0x20), mul(pos, 0x20)))
         }
     }
-
 <% } %>
-<% for (const type of it.ARRAYS_TYPES) { %>
+
+<% for (const { type } of it.ARRAYS_TYPES) { %>
     /**
      * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
      *
      * WARNING: this does not clear elements if length is reduced, or initialize elements if length is increased.
      */
-    function unsafeSetLength(<%= type.type %>[] storage array, uint256 len) internal {
+    function unsafeSetLength(<%= type %>[] storage array, uint256 len) internal {
         assembly ("memory-safe") {
             sstore(array.slot, len)
         }
     }
-
 <% } %>
 }

--- a/scripts/generate/templates/EnumerableMap.sol.eta
+++ b/scripts/generate/templates/EnumerableMap.sol.eta
@@ -348,11 +348,11 @@ library EnumerableMap {
     /**
      * @dev Query for a nonexistent map key.
      */
-    error EnumerableMapNonexistent<%= key.capitalized %>Key(<%= key.type %> key);
+    error EnumerableMapNonexistent<%= key.name %>Key(<%= key.type %> key);
 
     struct <%= name %> {
         // Storage of keys
-        EnumerableSet.<%= key.capitalized %>Set _keys;
+        EnumerableSet.<%= key.name %>Set _keys;
         mapping(<%= key.type %> key => <%= value.type %>) _values;
     }
 
@@ -468,7 +468,7 @@ library EnumerableMap {
         bool exists;
         (exists, value) = tryGet(map, key);
         if (!exists) {
-            revert EnumerableMapNonexistent<%= key.capitalized %>Key(key);
+            revert EnumerableMapNonexistent<%= key.name %>Key(key);
         }
     }
 

--- a/scripts/generate/templates/EnumerableMap.sol.eta
+++ b/scripts/generate/templates/EnumerableMap.sol.eta
@@ -202,7 +202,7 @@ library EnumerableMap {
     function keys(Bytes32ToBytes32Map storage map, uint256 start, uint256 end) internal view returns (bytes32[] memory) {
         return map._keys.values(start, end);
     }
-<% for (const { name, key, value } of it.MAP_TYPES.filter(({ key, value }) => !(key.memory || value.memory))) { %>
+<% for (const { name, key, value } of it.MAP_TYPES.filter(({ key, value }) => key.size && value.size)) { %>
     // <%= name %>
 
     struct <%= name %> {
@@ -216,8 +216,8 @@ library EnumerableMap {
      * Returns true if the key was added to the map, that is if it was not
      * already present.
      */
-    function set(<%= name %> storage map, <%= key.type %> key, <%= value.type %> value) internal returns (bool) {
-        return set(map._inner, <%= it.toBytes32(key.type, 'key') %>, <%= it.toBytes32(value.type, 'value') %>);
+    function set(<%= name %> storage map, <%= key.name %> key, <%= value.name %> value) internal returns (bool) {
+        return set(map._inner, <%= it.toBytes32(key.name, 'key') %>, <%= it.toBytes32(value.name, 'value') %>);
     }
 
     /**
@@ -225,8 +225,8 @@ library EnumerableMap {
      *
      * Returns true if the key was removed from the map, that is if it was present.
      */
-    function remove(<%= name %> storage map, <%= key.type %> key) internal returns (bool) {
-        return remove(map._inner, <%= it.toBytes32(key.type, 'key') %>);
+    function remove(<%= name %> storage map, <%= key.name %> key) internal returns (bool) {
+        return remove(map._inner, <%= it.toBytes32(key.name, 'key') %>);
     }
 
     /**
@@ -243,8 +243,8 @@ library EnumerableMap {
     /**
      * @dev Returns true if the key is in the map. O(1).
      */
-    function contains(<%= name %> storage map, <%= key.type %> key) internal view returns (bool) {
-        return contains(map._inner, <%= it.toBytes32(key.type, 'key') %>);
+    function contains(<%= name %> storage map, <%= key.name %> key) internal view returns (bool) {
+        return contains(map._inner, <%= it.toBytes32(key.name, 'key') %>);
     }
 
     /**
@@ -266,7 +266,7 @@ library EnumerableMap {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= name %> storage map, uint256 index) internal view returns (<%= key.type %> key, <%= value.type %> value) {
+    function at(<%= name %> storage map, uint256 index) internal view returns (<%= key.name %> key, <%= value.name %> value) {
         return pos(map, index);
     }
 
@@ -281,18 +281,18 @@ library EnumerableMap {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= name %> storage map, uint256 index) internal view returns (<%= key.type %> key, <%= value.type %> value) {
+    function pos(<%= name %> storage map, uint256 index) internal view returns (<%= key.name %> key, <%= value.name %> value) {
         (bytes32 atKey, bytes32 val) = pos(map._inner, index);
-        return (<%= it.fromBytes32(key.type, 'atKey') %>, <%= it.fromBytes32(value.type, 'val') %>);
+        return (<%= it.fromBytes32(key.name, 'atKey') %>, <%= it.fromBytes32(value.name, 'val') %>);
     }
 
     /**
      * @dev Tries to return the value associated with `key`. O(1).
      * Does not revert if `key` is not in the map.
      */
-    function tryGet(<%= name %> storage map, <%= key.type %> key) internal view returns (bool exists, <%= value.type %> value) {
-        (bool success, bytes32 val) = tryGet(map._inner, <%= it.toBytes32(key.type, 'key') %>);
-        return (success, <%= it.fromBytes32(value.type, 'val') %>);
+    function tryGet(<%= name %> storage map, <%= key.name %> key) internal view returns (bool exists, <%= value.name %> value) {
+        (bool success, bytes32 val) = tryGet(map._inner, <%= it.toBytes32(key.name, 'key') %>);
+        return (success, <%= it.fromBytes32(value.name, 'val') %>);
     }
 
     /**
@@ -302,8 +302,8 @@ library EnumerableMap {
      *
      * - `key` must be in the map.
      */
-    function get(<%= name %> storage map, <%= key.type %> key) internal view returns (<%= value.type %>) {
-        return <%= it.fromBytes32(value.type, `get(map._inner, ${it.toBytes32(key.type, 'key')})`) %>;
+    function get(<%= name %> storage map, <%= key.name %> key) internal view returns (<%= value.name %>) {
+        return <%= it.fromBytes32(value.name, `get(map._inner, ${it.toBytes32(key.name, 'key')})`) %>;
     }
 
     /**
@@ -314,9 +314,9 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map) internal view returns (<%= key.type %>[] memory) {
+    function keys(<%= name %> storage map) internal view returns (<%= key.name %>[] memory) {
         bytes32[] memory store = keys(map._inner);
-        <%= key.type %>[] memory result;
+        <%= key.name %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -333,9 +333,9 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.type %>[] memory) {
+    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.name %>[] memory) {
         bytes32[] memory store = keys(map._inner, start, end);
-        <%= key.type %>[] memory result;
+        <%= key.name %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -344,16 +344,16 @@ library EnumerableMap {
         return result;
     }
 <% } %>
-<% for (const { name, keySet, key, value } of it.MAP_TYPES.filter(({ key, value }) => key.memory || value.memory)) { %>
+<% for (const { name, key, value } of it.MAP_TYPES.filter(({ key, value }) => !key.size || !value.size)) { %>
     /**
      * @dev Query for a nonexistent map key.
      */
-    error EnumerableMapNonexistent<%= key.name %>Key(<%= key.type %> key);
+    error EnumerableMapNonexistent<%= key.capitalized %>Key(<%= key.name %> key);
 
     struct <%= name %> {
         // Storage of keys
-        EnumerableSet.<%= keySet.name %> _keys;
-        mapping(<%= key.type %> key => <%= value.type %>) _values;
+        EnumerableSet.<%= key.capitalized %>Set _keys;
+        mapping(<%= key.name %> key => <%= value.name %>) _values;
     }
 
     /**
@@ -363,7 +363,7 @@ library EnumerableMap {
      * Returns true if the key was added to the map, that is if it was not
      * already present.
      */
-    function set(<%= name %> storage map, <%= key.typeLoc %> key, <%= value.typeLoc %> value) internal returns (bool) {
+    function set(<%= name %> storage map, <%= key.name %> <%= key.location %> key, <%= value.name %> <%= value.location %> value) internal returns (bool) {
         map._values[key] = value;
         return map._keys.add(key);
     }
@@ -373,7 +373,7 @@ library EnumerableMap {
      *
      * Returns true if the key was removed from the map, that is if it was present.
      */
-    function remove(<%= name %> storage map, <%= key.typeLoc %> key) internal returns (bool) {
+    function remove(<%= name %> storage map, <%= key.name %> <%= key.location %> key) internal returns (bool) {
         delete map._values[key];
         return map._keys.remove(key);
     }
@@ -395,7 +395,7 @@ library EnumerableMap {
     /**
      * @dev Returns true if the key is in the map. O(1).
      */
-    function contains(<%= name %> storage map, <%= key.typeLoc %> key) internal view returns (bool) {
+    function contains(<%= name %> storage map, <%= key.name %> <%= key.location %> key) internal view returns (bool) {
         return map._keys.contains(key);
     }
 
@@ -422,7 +422,7 @@ library EnumerableMap {
     function at(
         <%= name %> storage map,
         uint256 index
-    ) internal view returns (<%= key.typeLoc %> key, <%= value.typeLoc %> value) {
+    ) internal view returns (<%= key.name %> <%= key.location %> key, <%= value.name %> <%= value.location %> value) {
         return pos(map, index);
     }
 
@@ -440,7 +440,7 @@ library EnumerableMap {
     function pos(
         <%= name %> storage map,
         uint256 index
-    ) internal view returns (<%= key.typeLoc %> key, <%= value.typeLoc %> value) {
+    ) internal view returns (<%= key.name %> <%= key.location %> key, <%= value.name %> <%= value.location %> value) {
         key = map._keys.pos(index);
         value = map._values[key];
     }
@@ -451,10 +451,10 @@ library EnumerableMap {
      */
     function tryGet(
         <%= name %> storage map,
-        <%= key.typeLoc %> key
-    ) internal view returns (bool exists, <%= value.typeLoc %> value) {
+        <%= key.name %> <%= key.location %> key
+    ) internal view returns (bool exists, <%= value.name %> <%= value.location %> value) {
         value = map._values[key];
-        exists = <%= value.memory ? 'bytes(value).length != 0' : `value != ${value.type}(0)` %> || contains(map, key);
+        exists = <%= value.size ? `value != ${value.name}(0)` : 'bytes(value).length != 0' %> || contains(map, key);
     }
 
     /**
@@ -464,11 +464,11 @@ library EnumerableMap {
      *
      * - `key` must be in the map.
      */
-    function get(<%= name %> storage map, <%= key.typeLoc %> key) internal view returns (<%= value.typeLoc %> value) {
+    function get(<%= name %> storage map, <%= key.name %> <%= key.location %> key) internal view returns (<%= value.name %> <%= value.location %> value) {
         bool exists;
         (exists, value) = tryGet(map, key);
         if (!exists) {
-            revert EnumerableMapNonexistent<%= key.name %>Key(key);
+            revert EnumerableMapNonexistent<%= key.capitalized %>Key(key);
         }
     }
 
@@ -480,7 +480,7 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map) internal view returns (<%= key.type %>[] memory) {
+    function keys(<%= name %> storage map) internal view returns (<%= key.name %>[] memory) {
         return map._keys.values();
     }
 
@@ -492,7 +492,7 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.type %>[] memory) {
+    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.name %>[] memory) {
         return map._keys.values(start, end);
     }
 <% } %>

--- a/scripts/generate/templates/EnumerableMap.sol.eta
+++ b/scripts/generate/templates/EnumerableMap.sol.eta
@@ -216,8 +216,8 @@ library EnumerableMap {
      * Returns true if the key was added to the map, that is if it was not
      * already present.
      */
-    function set(<%= name %> storage map, <%= key.name %> key, <%= value.name %> value) internal returns (bool) {
-        return set(map._inner, <%= it.toBytes32(key.name, 'key') %>, <%= it.toBytes32(value.name, 'value') %>);
+    function set(<%= name %> storage map, <%= key.type %> key, <%= value.type %> value) internal returns (bool) {
+        return set(map._inner, <%= it.toBytes32(key.type, 'key') %>, <%= it.toBytes32(value.type, 'value') %>);
     }
 
     /**
@@ -225,8 +225,8 @@ library EnumerableMap {
      *
      * Returns true if the key was removed from the map, that is if it was present.
      */
-    function remove(<%= name %> storage map, <%= key.name %> key) internal returns (bool) {
-        return remove(map._inner, <%= it.toBytes32(key.name, 'key') %>);
+    function remove(<%= name %> storage map, <%= key.type %> key) internal returns (bool) {
+        return remove(map._inner, <%= it.toBytes32(key.type, 'key') %>);
     }
 
     /**
@@ -243,8 +243,8 @@ library EnumerableMap {
     /**
      * @dev Returns true if the key is in the map. O(1).
      */
-    function contains(<%= name %> storage map, <%= key.name %> key) internal view returns (bool) {
-        return contains(map._inner, <%= it.toBytes32(key.name, 'key') %>);
+    function contains(<%= name %> storage map, <%= key.type %> key) internal view returns (bool) {
+        return contains(map._inner, <%= it.toBytes32(key.type, 'key') %>);
     }
 
     /**
@@ -266,7 +266,7 @@ library EnumerableMap {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= name %> storage map, uint256 index) internal view returns (<%= key.name %> key, <%= value.name %> value) {
+    function at(<%= name %> storage map, uint256 index) internal view returns (<%= key.type %> key, <%= value.type %> value) {
         return pos(map, index);
     }
 
@@ -281,18 +281,18 @@ library EnumerableMap {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= name %> storage map, uint256 index) internal view returns (<%= key.name %> key, <%= value.name %> value) {
+    function pos(<%= name %> storage map, uint256 index) internal view returns (<%= key.type %> key, <%= value.type %> value) {
         (bytes32 atKey, bytes32 val) = pos(map._inner, index);
-        return (<%= it.fromBytes32(key.name, 'atKey') %>, <%= it.fromBytes32(value.name, 'val') %>);
+        return (<%= it.fromBytes32(key.type, 'atKey') %>, <%= it.fromBytes32(value.type, 'val') %>);
     }
 
     /**
      * @dev Tries to return the value associated with `key`. O(1).
      * Does not revert if `key` is not in the map.
      */
-    function tryGet(<%= name %> storage map, <%= key.name %> key) internal view returns (bool exists, <%= value.name %> value) {
-        (bool success, bytes32 val) = tryGet(map._inner, <%= it.toBytes32(key.name, 'key') %>);
-        return (success, <%= it.fromBytes32(value.name, 'val') %>);
+    function tryGet(<%= name %> storage map, <%= key.type %> key) internal view returns (bool exists, <%= value.type %> value) {
+        (bool success, bytes32 val) = tryGet(map._inner, <%= it.toBytes32(key.type, 'key') %>);
+        return (success, <%= it.fromBytes32(value.type, 'val') %>);
     }
 
     /**
@@ -302,8 +302,8 @@ library EnumerableMap {
      *
      * - `key` must be in the map.
      */
-    function get(<%= name %> storage map, <%= key.name %> key) internal view returns (<%= value.name %>) {
-        return <%= it.fromBytes32(value.name, `get(map._inner, ${it.toBytes32(key.name, 'key')})`) %>;
+    function get(<%= name %> storage map, <%= key.type %> key) internal view returns (<%= value.type %>) {
+        return <%= it.fromBytes32(value.type, `get(map._inner, ${it.toBytes32(key.type, 'key')})`) %>;
     }
 
     /**
@@ -314,9 +314,9 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map) internal view returns (<%= key.name %>[] memory) {
+    function keys(<%= name %> storage map) internal view returns (<%= key.type %>[] memory) {
         bytes32[] memory store = keys(map._inner);
-        <%= key.name %>[] memory result;
+        <%= key.type %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -333,9 +333,9 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.name %>[] memory) {
+    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.type %>[] memory) {
         bytes32[] memory store = keys(map._inner, start, end);
-        <%= key.name %>[] memory result;
+        <%= key.type %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -348,12 +348,12 @@ library EnumerableMap {
     /**
      * @dev Query for a nonexistent map key.
      */
-    error EnumerableMapNonexistent<%= key.capitalized %>Key(<%= key.name %> key);
+    error EnumerableMapNonexistent<%= key.capitalized %>Key(<%= key.type %> key);
 
     struct <%= name %> {
         // Storage of keys
         EnumerableSet.<%= key.capitalized %>Set _keys;
-        mapping(<%= key.name %> key => <%= value.name %>) _values;
+        mapping(<%= key.type %> key => <%= value.type %>) _values;
     }
 
     /**
@@ -363,7 +363,7 @@ library EnumerableMap {
      * Returns true if the key was added to the map, that is if it was not
      * already present.
      */
-    function set(<%= name %> storage map, <%= key.name %> <%= key.location %> key, <%= value.name %> <%= value.location %> value) internal returns (bool) {
+    function set(<%= name %> storage map, <%= key.type %> <%= key.location %> key, <%= value.type %> <%= value.location %> value) internal returns (bool) {
         map._values[key] = value;
         return map._keys.add(key);
     }
@@ -373,7 +373,7 @@ library EnumerableMap {
      *
      * Returns true if the key was removed from the map, that is if it was present.
      */
-    function remove(<%= name %> storage map, <%= key.name %> <%= key.location %> key) internal returns (bool) {
+    function remove(<%= name %> storage map, <%= key.type %> <%= key.location %> key) internal returns (bool) {
         delete map._values[key];
         return map._keys.remove(key);
     }
@@ -395,7 +395,7 @@ library EnumerableMap {
     /**
      * @dev Returns true if the key is in the map. O(1).
      */
-    function contains(<%= name %> storage map, <%= key.name %> <%= key.location %> key) internal view returns (bool) {
+    function contains(<%= name %> storage map, <%= key.type %> <%= key.location %> key) internal view returns (bool) {
         return map._keys.contains(key);
     }
 
@@ -422,7 +422,7 @@ library EnumerableMap {
     function at(
         <%= name %> storage map,
         uint256 index
-    ) internal view returns (<%= key.name %> <%= key.location %> key, <%= value.name %> <%= value.location %> value) {
+    ) internal view returns (<%= key.type %> <%= key.location %> key, <%= value.type %> <%= value.location %> value) {
         return pos(map, index);
     }
 
@@ -440,7 +440,7 @@ library EnumerableMap {
     function pos(
         <%= name %> storage map,
         uint256 index
-    ) internal view returns (<%= key.name %> <%= key.location %> key, <%= value.name %> <%= value.location %> value) {
+    ) internal view returns (<%= key.type %> <%= key.location %> key, <%= value.type %> <%= value.location %> value) {
         key = map._keys.pos(index);
         value = map._values[key];
     }
@@ -451,10 +451,10 @@ library EnumerableMap {
      */
     function tryGet(
         <%= name %> storage map,
-        <%= key.name %> <%= key.location %> key
-    ) internal view returns (bool exists, <%= value.name %> <%= value.location %> value) {
+        <%= key.type %> <%= key.location %> key
+    ) internal view returns (bool exists, <%= value.type %> <%= value.location %> value) {
         value = map._values[key];
-        exists = <%= value.size ? `value != ${value.name}(0)` : 'bytes(value).length != 0' %> || contains(map, key);
+        exists = <%= value.size ? `value != ${value.type}(0)` : 'bytes(value).length != 0' %> || contains(map, key);
     }
 
     /**
@@ -464,7 +464,7 @@ library EnumerableMap {
      *
      * - `key` must be in the map.
      */
-    function get(<%= name %> storage map, <%= key.name %> <%= key.location %> key) internal view returns (<%= value.name %> <%= value.location %> value) {
+    function get(<%= name %> storage map, <%= key.type %> <%= key.location %> key) internal view returns (<%= value.type %> <%= value.location %> value) {
         bool exists;
         (exists, value) = tryGet(map, key);
         if (!exists) {
@@ -480,7 +480,7 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map) internal view returns (<%= key.name %>[] memory) {
+    function keys(<%= name %> storage map) internal view returns (<%= key.type %>[] memory) {
         return map._keys.values();
     }
 
@@ -492,7 +492,7 @@ library EnumerableMap {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.name %>[] memory) {
+    function keys(<%= name %> storage map, uint256 start, uint256 end) internal view returns (<%= key.type %>[] memory) {
         return map._keys.values(start, end);
     }
 <% } %>

--- a/scripts/generate/templates/EnumerableSet.sol.eta
+++ b/scripts/generate/templates/EnumerableSet.sol.eta
@@ -209,8 +209,8 @@ library EnumerableSet {
      * Returns true if the value was added to the set, that is if it was not
      * already present.
      */
-    function add(<%= name %> storage set, <%= value.name %> value) internal returns (bool) {
-        return _add(set._inner, <%= it.toBytes32(value.name, 'value') %>);
+    function add(<%= name %> storage set, <%= value.type %> value) internal returns (bool) {
+        return _add(set._inner, <%= it.toBytes32(value.type, 'value') %>);
     }
 
     /**
@@ -219,8 +219,8 @@ library EnumerableSet {
      * Returns true if the value was removed from the set, that is if it was
      * present.
      */
-    function remove(<%= name %> storage set, <%= value.name %> value) internal returns (bool) {
-        return _remove(set._inner, <%= it.toBytes32(value.name, 'value') %>);
+    function remove(<%= name %> storage set, <%= value.type %> value) internal returns (bool) {
+        return _remove(set._inner, <%= it.toBytes32(value.type, 'value') %>);
     }
 
     /**
@@ -236,8 +236,8 @@ library EnumerableSet {
     /**
      * @dev Returns true if the value is in the set. O(1).
      */
-    function contains(<%= name %> storage set, <%= value.name %> value) internal view returns (bool) {
-        return _contains(set._inner, <%= it.toBytes32(value.name, 'value') %>);
+    function contains(<%= name %> storage set, <%= value.type %> value) internal view returns (bool) {
+        return _contains(set._inner, <%= it.toBytes32(value.type, 'value') %>);
     }
 
     /**
@@ -260,7 +260,7 @@ library EnumerableSet {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %>) {
+    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %>) {
         return pos(set, index);
     }
 
@@ -276,8 +276,8 @@ library EnumerableSet {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %>) {
-        return <%= it.fromBytes32(value.name, '_pos(set._inner, index)') %>;
+    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %>) {
+        return <%= it.fromBytes32(value.type, '_pos(set._inner, index)') %>;
     }
 
     /**
@@ -288,9 +288,9 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set) internal view returns (<%= value.name %>[] memory) {
+    function values(<%= name %> storage set) internal view returns (<%= value.type %>[] memory) {
         bytes32[] memory store = _values(set._inner);
-        <%= value.name %>[] memory result;
+        <%= value.type %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -307,9 +307,9 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.name %>[] memory) {
+    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.type %>[] memory) {
         bytes32[] memory store = _values(set._inner, start, end);
-        <%= value.name %>[] memory result;
+        <%= value.type %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -321,10 +321,10 @@ library EnumerableSet {
 <% for (const { name, value } of it.SET_TYPES.filter(({ value }) => !value.size)) { %>
     struct <%= name %> {
         // Storage of set values
-        <%= value.name %>[] _values;
+        <%= value.type %>[] _values;
         // Position is the index of the value in the `values` array plus 1.
         // Position 0 is used to mean a value is not in the set.
-        mapping(<%= value.name %> value => uint256) _positions;
+        mapping(<%= value.type %> value => uint256) _positions;
     }
 
     /**
@@ -333,7 +333,7 @@ library EnumerableSet {
      * Returns true if the value was added to the set, that is if it was not
      * already present.
      */
-    function add(<%= name %> storage set, <%= value.name %> memory value) internal returns (bool) {
+    function add(<%= name %> storage set, <%= value.type %> memory value) internal returns (bool) {
         if (!contains(set, value)) {
             set._values.push(value);
             // The value is stored at length-1, but we add 1 to all indexes
@@ -351,7 +351,7 @@ library EnumerableSet {
      * Returns true if the value was removed from the set, that is if it was
      * present.
      */
-    function remove(<%= name %> storage set, <%= value.name %> memory value) internal returns (bool) {
+    function remove(<%= name %> storage set, <%= value.type %> memory value) internal returns (bool) {
         // We cache the value's position to prevent multiple reads from the same storage slot
         uint256 position = set._positions[value];
 
@@ -365,7 +365,7 @@ library EnumerableSet {
             uint256 lastIndex = set._values.length - 1;
 
             if (valueIndex != lastIndex) {
-                <%= value.name %> memory lastValue = set._values[lastIndex];
+                <%= value.type %> memory lastValue = set._values[lastIndex];
 
                 // Move the lastValue to the index where the value to delete is
                 set._values[valueIndex] = lastValue;
@@ -402,7 +402,7 @@ library EnumerableSet {
     /**
      * @dev Returns true if the value is in the set. O(1).
      */
-    function contains(<%= name %> storage set, <%= value.name %> memory value) internal view returns (bool) {
+    function contains(<%= name %> storage set, <%= value.type %> memory value) internal view returns (bool) {
         return set._positions[value] != 0;
     }
 
@@ -426,7 +426,7 @@ library EnumerableSet {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %> memory) {
+    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %> memory) {
         return pos(set, index);
     }
 
@@ -442,7 +442,7 @@ library EnumerableSet {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %> memory) {
+    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %> memory) {
         return set._values[index];
     }
 
@@ -454,7 +454,7 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set) internal view returns (<%= value.name %>[] memory) {
+    function values(<%= name %> storage set) internal view returns (<%= value.type %>[] memory) {
         return set._values;
     }
 
@@ -466,13 +466,13 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.name %>[] memory) {
+    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.type %>[] memory) {
         unchecked {
             end = Math.min(end, length(set));
             start = Math.min(start, end);
 
             uint256 len = end - start;
-            <%= value.name %>[] memory result = new <%= value.name %>[](len);
+            <%= value.type %>[] memory result = new <%= value.type %>[](len);
             for (uint256 i = 0; i < len; ++i) {
                 result[i] = Arrays.unsafeAccess(set._values, start + i).value;
             }

--- a/scripts/generate/templates/EnumerableSet.sol.eta
+++ b/scripts/generate/templates/EnumerableSet.sol.eta
@@ -196,7 +196,7 @@ library EnumerableSet {
             return result;
         }
     }
-<% for (const { name, value } of it.SET_TYPES.filter(({ value }) => !value.memory)) { %>
+<% for (const { name, value } of it.SET_TYPES.filter(({ value }) => value.size)) { %>
     // <%= name %>
 
     struct <%= name %> {
@@ -209,8 +209,8 @@ library EnumerableSet {
      * Returns true if the value was added to the set, that is if it was not
      * already present.
      */
-    function add(<%= name %> storage set, <%= value.type %> value) internal returns (bool) {
-        return _add(set._inner, <%= it.toBytes32(value.type, 'value') %>);
+    function add(<%= name %> storage set, <%= value.name %> value) internal returns (bool) {
+        return _add(set._inner, <%= it.toBytes32(value.name, 'value') %>);
     }
 
     /**
@@ -219,8 +219,8 @@ library EnumerableSet {
      * Returns true if the value was removed from the set, that is if it was
      * present.
      */
-    function remove(<%= name %> storage set, <%= value.type %> value) internal returns (bool) {
-        return _remove(set._inner, <%= it.toBytes32(value.type, 'value') %>);
+    function remove(<%= name %> storage set, <%= value.name %> value) internal returns (bool) {
+        return _remove(set._inner, <%= it.toBytes32(value.name, 'value') %>);
     }
 
     /**
@@ -236,8 +236,8 @@ library EnumerableSet {
     /**
      * @dev Returns true if the value is in the set. O(1).
      */
-    function contains(<%= name %> storage set, <%= value.type %> value) internal view returns (bool) {
-        return _contains(set._inner, <%= it.toBytes32(value.type, 'value') %>);
+    function contains(<%= name %> storage set, <%= value.name %> value) internal view returns (bool) {
+        return _contains(set._inner, <%= it.toBytes32(value.name, 'value') %>);
     }
 
     /**
@@ -260,7 +260,7 @@ library EnumerableSet {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %>) {
+    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %>) {
         return pos(set, index);
     }
 
@@ -276,8 +276,8 @@ library EnumerableSet {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %>) {
-        return <%= it.fromBytes32(value.type, '_pos(set._inner, index)') %>;
+    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %>) {
+        return <%= it.fromBytes32(value.name, '_pos(set._inner, index)') %>;
     }
 
     /**
@@ -288,9 +288,9 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set) internal view returns (<%= value.type %>[] memory) {
+    function values(<%= name %> storage set) internal view returns (<%= value.name %>[] memory) {
         bytes32[] memory store = _values(set._inner);
-        <%= value.type %>[] memory result;
+        <%= value.name %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -307,9 +307,9 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.type %>[] memory) {
+    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.name %>[] memory) {
         bytes32[] memory store = _values(set._inner, start, end);
-        <%= value.type %>[] memory result;
+        <%= value.name %>[] memory result;
 
         assembly ("memory-safe") {
             result := store
@@ -318,13 +318,13 @@ library EnumerableSet {
         return result;
     }
 <% } %>
-<% for (const { name, value } of it.SET_TYPES.filter(({ value }) => value.memory)) { %>
+<% for (const { name, value } of it.SET_TYPES.filter(({ value }) => !value.size)) { %>
     struct <%= name %> {
         // Storage of set values
-        <%= value.type %>[] _values;
+        <%= value.name %>[] _values;
         // Position is the index of the value in the `values` array plus 1.
         // Position 0 is used to mean a value is not in the set.
-        mapping(<%= value.type %> value => uint256) _positions;
+        mapping(<%= value.name %> value => uint256) _positions;
     }
 
     /**
@@ -333,7 +333,7 @@ library EnumerableSet {
      * Returns true if the value was added to the set, that is if it was not
      * already present.
      */
-    function add(<%= name %> storage set, <%= value.type %> memory value) internal returns (bool) {
+    function add(<%= name %> storage set, <%= value.name %> memory value) internal returns (bool) {
         if (!contains(set, value)) {
             set._values.push(value);
             // The value is stored at length-1, but we add 1 to all indexes
@@ -351,7 +351,7 @@ library EnumerableSet {
      * Returns true if the value was removed from the set, that is if it was
      * present.
      */
-    function remove(<%= name %> storage set, <%= value.type %> memory value) internal returns (bool) {
+    function remove(<%= name %> storage set, <%= value.name %> memory value) internal returns (bool) {
         // We cache the value's position to prevent multiple reads from the same storage slot
         uint256 position = set._positions[value];
 
@@ -365,7 +365,7 @@ library EnumerableSet {
             uint256 lastIndex = set._values.length - 1;
 
             if (valueIndex != lastIndex) {
-                <%= value.type %> memory lastValue = set._values[lastIndex];
+                <%= value.name %> memory lastValue = set._values[lastIndex];
 
                 // Move the lastValue to the index where the value to delete is
                 set._values[valueIndex] = lastValue;
@@ -402,7 +402,7 @@ library EnumerableSet {
     /**
      * @dev Returns true if the value is in the set. O(1).
      */
-    function contains(<%= name %> storage set, <%= value.type %> memory value) internal view returns (bool) {
+    function contains(<%= name %> storage set, <%= value.name %> memory value) internal view returns (bool) {
         return set._positions[value] != 0;
     }
 
@@ -426,7 +426,7 @@ library EnumerableSet {
      * IMPORTANT: Deprecated. This function's name clashes with a keyword scheduled for inclusion in Solidity. Developers
      * should use {pos} instead.
      */
-    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %> memory) {
+    function at(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %> memory) {
         return pos(set, index);
     }
 
@@ -442,7 +442,7 @@ library EnumerableSet {
      *
      * Replacement of the deprecated {at} function.
      */
-    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.type %> memory) {
+    function pos(<%= name %> storage set, uint256 index) internal view returns (<%= value.name %> memory) {
         return set._values[index];
     }
 
@@ -454,7 +454,7 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set) internal view returns (<%= value.type %>[] memory) {
+    function values(<%= name %> storage set) internal view returns (<%= value.name %>[] memory) {
         return set._values;
     }
 
@@ -466,13 +466,13 @@ library EnumerableSet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.type %>[] memory) {
+    function values(<%= name %> storage set, uint256 start, uint256 end) internal view returns (<%= value.name %>[] memory) {
         unchecked {
             end = Math.min(end, length(set));
             start = Math.min(start, end);
 
             uint256 len = end - start;
-            <%= value.type %>[] memory result = new <%= value.type %>[](len);
+            <%= value.name %>[] memory result = new <%= value.name %>[](len);
             for (uint256 i = 0; i < len; ++i) {
                 result[i] = Arrays.unsafeAccess(set._values, start + i).value;
             }

--- a/scripts/generate/templates/SlotDerivation.sol.eta
+++ b/scripts/generate/templates/SlotDerivation.sol.eta
@@ -64,7 +64,7 @@ library SlotDerivation {
         }
     }
 <% for (const type of it.SLOT_TYPES) { %>
-<% if (type.isValueType) { %>
+<% if (type.size) { %>
 
     /**
      * @dev Derive the location of a mapping element from the key.

--- a/scripts/generate/templates/SlotDerivation.sol.eta
+++ b/scripts/generate/templates/SlotDerivation.sol.eta
@@ -63,15 +63,15 @@ library SlotDerivation {
             result := keccak256(0x00, 0x20)
         }
     }
-<% for (const type of it.SLOT_TYPES) { %>
-<% if (type.size) { %>
+<% for (const { type, size } of it.SLOT_TYPES) { %>
+<% if (size) { %>
 
     /**
      * @dev Derive the location of a mapping element from the key.
      */
-    function deriveMapping(bytes32 slot, <%= type.type %> key) internal pure returns (bytes32 result) {
+    function deriveMapping(bytes32 slot, <%= type %> key) internal pure returns (bytes32 result) {
         assembly ("memory-safe") {
-            mstore(0x00, <%= (it.sanitize[type.type] ?? (x => x))('key') %>)
+            mstore(0x00, <%= (it.sanitize[type] ?? (x => x))('key') %>)
             mstore(0x20, slot)
             result := keccak256(0x00, 0x40)
         }
@@ -81,7 +81,7 @@ library SlotDerivation {
     /**
      * @dev Derive the location of a mapping element from the key.
      */
-    function deriveMapping(bytes32 slot, <%= type.type %> memory key) internal pure returns (bytes32 result) {
+    function deriveMapping(bytes32 slot, <%= type %> memory key) internal pure returns (bytes32 result) {
         assembly ("memory-safe") {
             let length := mload(key)
             let begin := add(key, 0x20)

--- a/scripts/generate/templates/SlotDerivation.t.sol.eta
+++ b/scripts/generate/templates/SlotDerivation.t.sol.eta
@@ -36,11 +36,11 @@ contract SlotDerivationTest is Test, SymTest {
 
         assertEq(baseSlot.deriveArray().offset(offset), derivedSlot);
     }
-<% for (const type of it.SLOT_TYPES.flatMap(type => [type, ...(type.variants ?? []).map(variant => ({ type: variant, name: it.capitalize(variant), isValueType: type.isValueType }))])) { %>
-<% if (type.isValueType) { %>
+<% for (const type of it.SLOT_TYPES.flatMap(type => [ type, ...(type.variants ?? []) ])) { %>
+<% if (type.size) { %>
     mapping(<%= type.type %> => bytes) private _<%= type.type %>Mapping;
 
-    function testSymbolicDeriveMapping<%= type.name %>(<%= type.type %> key) public view {
+    function testSymbolicDeriveMapping<%= type.capitalized %>(<%= type.type %> key) public view {
         bytes32 baseSlot;
         assembly {
             baseSlot := _<%= type.type %>Mapping.slot
@@ -57,15 +57,15 @@ contract SlotDerivationTest is Test, SymTest {
 <% } else { %>
     mapping(<%= type.type %> => bytes) private _<%= type.type %>Mapping;
 
-    function testDeriveMapping<%= type.name %>(<%= type.type %> memory key) public view {
-        _assertDeriveMapping<%= type.name %>(key);
+    function testDeriveMapping<%= type.capitalized %>(<%= type.type %> memory key) public view {
+        _assertDeriveMapping<%= type.capitalized %>(key);
     }
 
-    function symbolicDeriveMapping<%= type.name %>() public view {
-        _assertDeriveMapping<%= type.name %>(svm.create<%= type.name %>(256, "DeriveMapping<%= type.name %>Input"));
+    function symbolicDeriveMapping<%= type.capitalized %>() public view {
+        _assertDeriveMapping<%= type.capitalized %>(svm.create<%= type.capitalized %>(256, "DeriveMapping<%= type.capitalized %>Input"));
     }
 
-    function _assertDeriveMapping<%= type.name %>(<%= type.type %> memory key) internal view {
+    function _assertDeriveMapping<%= type.capitalized %>(<%= type.type %> memory key) internal view {
         bytes32 baseSlot;
         assembly {
             baseSlot := _<%= type.type %>Mapping.slot
@@ -81,15 +81,15 @@ contract SlotDerivationTest is Test, SymTest {
     }
 <% } %>
 <% } %>
-<% for (const type of [it.SLOT_TYPES.bool, it.SLOT_TYPES.address]) { %>
-    function testSymbolicDeriveMapping<%= type.name %>Dirty(bytes32 dirtyKey) public view {
+<% for (const type of [it.ALL_TYPES.bool, it.ALL_TYPES.address]) { %>
+    function testSymbolicDeriveMapping<%= type.capitalized %>Dirty(bytes32 dirtyKey) public view {
         <%= type.type %> key;
         assembly {
             key := dirtyKey
         }
 
         // run the "normal" test using a potentially dirty value
-        testSymbolicDeriveMapping<%= type.name %>(key);
+        testSymbolicDeriveMapping<%= type.capitalized %>(key);
     }
 <% } %>
 }

--- a/scripts/generate/templates/SlotDerivation.t.sol.eta
+++ b/scripts/generate/templates/SlotDerivation.t.sol.eta
@@ -36,7 +36,7 @@ contract SlotDerivationTest is Test, SymTest {
 
         assertEq(baseSlot.deriveArray().offset(offset), derivedSlot);
     }
-<% for (const type of it.SLOT_TYPES.flatMap(type => [ type, ...(type.variants ?? []) ])) { %>
+<% for (const type of it.SLOT_TYPES.flatMap(type => [ type, ...type.upcastOf.filter(({ size }) => size === 32) ])) { %>
 <% if (type.size) { %>
     mapping(<%= type.type %> => bytes) private _<%= type.type %>Mapping;
 

--- a/scripts/generate/templates/SlotDerivation.t.sol.eta
+++ b/scripts/generate/templates/SlotDerivation.t.sol.eta
@@ -81,7 +81,7 @@ contract SlotDerivationTest is Test, SymTest {
     }
 <% } %>
 <% } %>
-<% for (const { name, type } of [it.ALL_TYPES.bool, it.ALL_TYPES.address]) { %>
+<% for (const { name, type } of [it.TYPES.bool, it.TYPES.address]) { %>
     function testSymbolicDeriveMapping<%= name %>Dirty(bytes32 dirtyKey) public view {
         <%= type %> key;
         assembly {

--- a/scripts/generate/templates/SlotDerivation.t.sol.eta
+++ b/scripts/generate/templates/SlotDerivation.t.sol.eta
@@ -36,17 +36,17 @@ contract SlotDerivationTest is Test, SymTest {
 
         assertEq(baseSlot.deriveArray().offset(offset), derivedSlot);
     }
-<% for (const type of it.SLOT_TYPES.flatMap(type => [ type, ...type.upcastOf.filter(({ size }) => size === 32) ])) { %>
-<% if (type.size) { %>
-    mapping(<%= type.type %> => bytes) private _<%= type.type %>Mapping;
+<% for (const { name, type, size } of it.SLOT_TYPES.flatMap(type => [ type, ...type.upcastOf.filter(({ size }) => size === 32) ])) { %>
+<% if (size) { %>
+    mapping(<%= type %> => bytes) private _<%= type %>Mapping;
 
-    function testSymbolicDeriveMapping<%= type.capitalized %>(<%= type.type %> key) public view {
+    function testSymbolicDeriveMapping<%= name %>(<%= type %> key) public view {
         bytes32 baseSlot;
         assembly {
-            baseSlot := _<%= type.type %>Mapping.slot
+            baseSlot := _<%= type %>Mapping.slot
         }
 
-        bytes storage derived = _<%= type.type %>Mapping[key];
+        bytes storage derived = _<%= type %>Mapping[key];
         bytes32 derivedSlot;
         assembly {
             derivedSlot := derived.slot
@@ -55,23 +55,23 @@ contract SlotDerivationTest is Test, SymTest {
         assertEq(baseSlot.deriveMapping(key), derivedSlot);
     }
 <% } else { %>
-    mapping(<%= type.type %> => bytes) private _<%= type.type %>Mapping;
+    mapping(<%= type %> => bytes) private _<%= type %>Mapping;
 
-    function testDeriveMapping<%= type.capitalized %>(<%= type.type %> memory key) public view {
-        _assertDeriveMapping<%= type.capitalized %>(key);
+    function testDeriveMapping<%= name %>(<%= type %> memory key) public view {
+        _assertDeriveMapping<%= name %>(key);
     }
 
-    function symbolicDeriveMapping<%= type.capitalized %>() public view {
-        _assertDeriveMapping<%= type.capitalized %>(svm.create<%= type.capitalized %>(256, "DeriveMapping<%= type.capitalized %>Input"));
+    function symbolicDeriveMapping<%= name %>() public view {
+        _assertDeriveMapping<%= name %>(svm.create<%= name %>(256, "DeriveMapping<%= name %>Input"));
     }
 
-    function _assertDeriveMapping<%= type.capitalized %>(<%= type.type %> memory key) internal view {
+    function _assertDeriveMapping<%= name %>(<%= type %> memory key) internal view {
         bytes32 baseSlot;
         assembly {
-            baseSlot := _<%= type.type %>Mapping.slot
+            baseSlot := _<%= type %>Mapping.slot
         }
 
-        bytes storage derived = _<%= type.type %>Mapping[key];
+        bytes storage derived = _<%= type %>Mapping[key];
         bytes32 derivedSlot;
         assembly {
             derivedSlot := derived.slot
@@ -81,15 +81,15 @@ contract SlotDerivationTest is Test, SymTest {
     }
 <% } %>
 <% } %>
-<% for (const type of [it.ALL_TYPES.bool, it.ALL_TYPES.address]) { %>
-    function testSymbolicDeriveMapping<%= type.capitalized %>Dirty(bytes32 dirtyKey) public view {
-        <%= type.type %> key;
+<% for (const { name, type } of [it.ALL_TYPES.bool, it.ALL_TYPES.address]) { %>
+    function testSymbolicDeriveMapping<%= name %>Dirty(bytes32 dirtyKey) public view {
+        <%= type %> key;
         assembly {
             key := dirtyKey
         }
 
         // run the "normal" test using a potentially dirty value
-        testSymbolicDeriveMapping<%= type.capitalized %>(key);
+        testSymbolicDeriveMapping<%= name %>(key);
     }
 <% } %>
 }

--- a/scripts/generate/templates/StorageSlot.sol.eta
+++ b/scripts/generate/templates/StorageSlot.sol.eta
@@ -29,24 +29,24 @@ pragma solidity ^0.8.20;
  */
 library StorageSlot {
 <% for (const type of it.SLOT_TYPES) { %>
-    struct <%= type.name %>Slot {
+    struct <%= type.capitalized %>Slot {
         <%= type.type %> value;
     }
 <% } %>
 <% for (const type of it.SLOT_TYPES) { %>
     /**
-     * @dev Returns <%= type.name.toLowerCase().startsWith('a') ? 'an' : 'a' %> `<%= type.name %>Slot` with member `value` located at `slot`.
+     * @dev Returns <%= type.name.startsWith('a') ? 'an' : 'a' %> `<%= type.capitalized %>Slot` with member `value` located at `slot`.
      */
-    function get<%= type.name %>Slot(bytes32 slot) internal pure returns (<%= type.name %>Slot storage r) {
+    function get<%= type.capitalized %>Slot(bytes32 slot) internal pure returns (<%= type.capitalized %>Slot storage r) {
         assembly ("memory-safe") {
             r.slot := slot
         }
     }
-<% if (!type.isValueType) { %>
+<% if (!type.size) { %>
     /**
-     * @dev Returns an `<%= type.name %>Slot` representation of the <%= type.type %> storage pointer `store`.
+     * @dev Returns an `<%= type.capitalized %>Slot` representation of the <%= type.type %> storage pointer `store`.
      */
-    function get<%= type.name %>Slot(<%= type.type %> storage store) internal pure returns (<%= type.name %>Slot storage r) {
+    function get<%= type.capitalized %>Slot(<%= type.type %> storage store) internal pure returns (<%= type.capitalized %>Slot storage r) {
         assembly ("memory-safe") {
             r.slot := store.slot
         }

--- a/scripts/generate/templates/StorageSlot.sol.eta
+++ b/scripts/generate/templates/StorageSlot.sol.eta
@@ -28,25 +28,25 @@ pragma solidity ^0.8.20;
  * TIP: Consider using this library along with {SlotDerivation}.
  */
 library StorageSlot {
-<% for (const type of it.SLOT_TYPES) { %>
-    struct <%= type.capitalized %>Slot {
-        <%= type.type %> value;
+<% for (const { name, type } of it.SLOT_TYPES) { %>
+    struct <%= name %>Slot {
+        <%= type %> value;
     }
 <% } %>
-<% for (const type of it.SLOT_TYPES) { %>
+<% for (const { name, type, size } of it.SLOT_TYPES) { %>
     /**
-     * @dev Returns <%= type.name.startsWith('a') ? 'an' : 'a' %> `<%= type.capitalized %>Slot` with member `value` located at `slot`.
+     * @dev Returns <%= name.toLowerCase().startsWith('a') ? 'an' : 'a' %> `<%= name %>Slot` with member `value` located at `slot`.
      */
-    function get<%= type.capitalized %>Slot(bytes32 slot) internal pure returns (<%= type.capitalized %>Slot storage r) {
+    function get<%= name %>Slot(bytes32 slot) internal pure returns (<%= name %>Slot storage r) {
         assembly ("memory-safe") {
             r.slot := slot
         }
     }
-<% if (!type.size) { %>
+<% if (!size) { %>
     /**
-     * @dev Returns an `<%= type.capitalized %>Slot` representation of the <%= type.type %> storage pointer `store`.
+     * @dev Returns an `<%= name %>Slot` representation of the <%= type %> storage pointer `store`.
      */
-    function get<%= type.capitalized %>Slot(<%= type.type %> storage store) internal pure returns (<%= type.capitalized %>Slot storage r) {
+    function get<%= name %>Slot(<%= type %> storage store) internal pure returns (<%= name %>Slot storage r) {
         assembly ("memory-safe") {
             r.slot := store.slot
         }

--- a/scripts/generate/templates/StorageSlotMock.sol.eta
+++ b/scripts/generate/templates/StorageSlotMock.sol.eta
@@ -6,33 +6,33 @@ import {StorageSlot} from "../utils/StorageSlot.sol";
 contract StorageSlotMock is Multicall {
     using StorageSlot for *;
 
-<% for (const type of it.SLOT_VALUE_TYPES) { %>
-    function set<%= type.name %>Slot(bytes32 slot, <%= type.type %> value) public {
-        slot.get<%= type.name %>Slot().value = value;
+<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+    function set<%= type.capitalized %>Slot(bytes32 slot, <%= type.type %> value) public {
+        slot.get<%= type.capitalized %>Slot().value = value;
     }
 <% } %>
-<% for (const type of it.SLOT_VALUE_TYPES) { %>
-    function get<%= type.name %>Slot(bytes32 slot) public view returns (<%= type.type %>) {
-        return slot.get<%= type.name %>Slot().value;
+<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+    function get<%= type.capitalized %>Slot(bytes32 slot) public view returns (<%= type.type %>) {
+        return slot.get<%= type.capitalized %>Slot().value;
     }
 <% } %>
-<% for (const type of it.SLOT_TYPES.filter(type => !type.isValueType)) { %>
+<% for (const type of it.SLOT_TYPES.filter(({ size }) => !size)) { %>
     mapping(uint256 key => <%= type.type %>) public <%= type.type %>Map;
 
-    function set<%= type.name %>Slot(bytes32 slot, <%= type.type %> calldata value) public {
-        slot.get<%= type.name %>Slot().value = value;
+    function set<%= type.capitalized %>Slot(bytes32 slot, <%= type.type %> calldata value) public {
+        slot.get<%= type.capitalized %>Slot().value = value;
     }
 
-    function set<%= type.name %>Storage(uint256 key, <%= type.type %> calldata value) public {
-        <%= type.type %>Map[key].get<%= type.name %>Slot().value = value;
+    function set<%= type.capitalized %>Storage(uint256 key, <%= type.type %> calldata value) public {
+        <%= type.type %>Map[key].get<%= type.capitalized %>Slot().value = value;
     }
 
-    function get<%= type.name %>Slot(bytes32 slot) public view returns (<%= type.type %> memory) {
-        return slot.get<%= type.name %>Slot().value;
+    function get<%= type.capitalized %>Slot(bytes32 slot) public view returns (<%= type.type %> memory) {
+        return slot.get<%= type.capitalized %>Slot().value;
     }
 
-    function get<%= type.name %>Storage(uint256 key) public view returns (<%= type.type %> memory) {
-        return <%= type.type %>Map[key].get<%= type.name %>Slot().value;
+    function get<%= type.capitalized %>Storage(uint256 key) public view returns (<%= type.type %> memory) {
+        return <%= type.type %>Map[key].get<%= type.capitalized %>Slot().value;
     }
 <% } %>
 }

--- a/scripts/generate/templates/StorageSlotMock.sol.eta
+++ b/scripts/generate/templates/StorageSlotMock.sol.eta
@@ -6,33 +6,33 @@ import {StorageSlot} from "../utils/StorageSlot.sol";
 contract StorageSlotMock is Multicall {
     using StorageSlot for *;
 
-<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
-    function set<%= type.capitalized %>Slot(bytes32 slot, <%= type.type %> value) public {
-        slot.get<%= type.capitalized %>Slot().value = value;
+<% for (const { name, type } of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+    function set<%= name %>Slot(bytes32 slot, <%= type %> value) public {
+        slot.get<%= name %>Slot().value = value;
     }
 <% } %>
-<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
-    function get<%= type.capitalized %>Slot(bytes32 slot) public view returns (<%= type.type %>) {
-        return slot.get<%= type.capitalized %>Slot().value;
+<% for (const { name, type } of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+    function get<%= name %>Slot(bytes32 slot) public view returns (<%= type %>) {
+        return slot.get<%= name %>Slot().value;
     }
 <% } %>
-<% for (const type of it.SLOT_TYPES.filter(({ size }) => !size)) { %>
-    mapping(uint256 key => <%= type.type %>) public <%= type.type %>Map;
+<% for (const { name, type } of it.SLOT_TYPES.filter(({ size }) => !size)) { %>
+    mapping(uint256 key => <%= type %>) public <%= type %>Map;
 
-    function set<%= type.capitalized %>Slot(bytes32 slot, <%= type.type %> calldata value) public {
-        slot.get<%= type.capitalized %>Slot().value = value;
+    function set<%= name %>Slot(bytes32 slot, <%= type %> calldata value) public {
+        slot.get<%= name %>Slot().value = value;
     }
 
-    function set<%= type.capitalized %>Storage(uint256 key, <%= type.type %> calldata value) public {
-        <%= type.type %>Map[key].get<%= type.capitalized %>Slot().value = value;
+    function set<%= name %>Storage(uint256 key, <%= type %> calldata value) public {
+        <%= type %>Map[key].get<%= name %>Slot().value = value;
     }
 
-    function get<%= type.capitalized %>Slot(bytes32 slot) public view returns (<%= type.type %> memory) {
-        return slot.get<%= type.capitalized %>Slot().value;
+    function get<%= name %>Slot(bytes32 slot) public view returns (<%= type %> memory) {
+        return slot.get<%= name %>Slot().value;
     }
 
-    function get<%= type.capitalized %>Storage(uint256 key) public view returns (<%= type.type %> memory) {
-        return <%= type.type %>Map[key].get<%= type.capitalized %>Slot().value;
+    function get<%= name %>Storage(uint256 key) public view returns (<%= type %> memory) {
+        return <%= type %>Map[key].get<%= name %>Slot().value;
     }
 <% } %>
 }

--- a/scripts/generate/templates/TransientSlot.sol.eta
+++ b/scripts/generate/templates/TransientSlot.sol.eta
@@ -27,24 +27,24 @@ pragma solidity ^0.8.24;
  * TIP: Consider using this library along with {SlotDerivation}.
  */
 library TransientSlot {
-<% for (const type of it.SLOT_VALUE_TYPES) { %>
+<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
     /**
      * @dev UDVT that represents a slot holding <%= type.type == 'address' ? 'an' : 'a' %> <%= type.type %>.
      */
-    type <%= type.name %>Slot is bytes32;
+    type <%= type.capitalized %>Slot is bytes32;
 
     /**
-     * @dev Cast an arbitrary slot to a <%= type.name %>Slot.
+     * @dev Cast an arbitrary slot to a <%= type.capitalized %>Slot.
      */
-    function as<%= type.name %>(bytes32 slot) internal pure returns (<%= type.name %>Slot) {
-        return <%= type.name %>Slot.wrap(slot);
+    function as<%= type.capitalized %>(bytes32 slot) internal pure returns (<%= type.capitalized %>Slot) {
+        return <%= type.capitalized %>Slot.wrap(slot);
     }
 <% } %>
-<% for (const type of it.SLOT_VALUE_TYPES) { %>
+<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
     /**
      * @dev Load the value held at location `slot` in transient storage.
      */
-    function tload(<%= type.name %>Slot slot) internal view returns (<%= type.type %> value) {
+    function tload(<%= type.capitalized %>Slot slot) internal view returns (<%= type.type %> value) {
         assembly ("memory-safe") {
             value := tload(slot)
         }
@@ -53,7 +53,7 @@ library TransientSlot {
     /**
      * @dev Store `value` at location `slot` in transient storage.
      */
-    function tstore(<%= type.name %>Slot slot, <%= type.type %> value) internal {
+    function tstore(<%= type.capitalized %>Slot slot, <%= type.type %> value) internal {
         assembly ("memory-safe") {
             tstore(slot, value)
         }

--- a/scripts/generate/templates/TransientSlot.sol.eta
+++ b/scripts/generate/templates/TransientSlot.sol.eta
@@ -27,24 +27,24 @@ pragma solidity ^0.8.24;
  * TIP: Consider using this library along with {SlotDerivation}.
  */
 library TransientSlot {
-<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+<% for (const { name, type } of it.SLOT_TYPES.filter(({ size }) => size)) { %>
     /**
-     * @dev UDVT that represents a slot holding <%= type.type == 'address' ? 'an' : 'a' %> <%= type.type %>.
+     * @dev UDVT that represents a slot holding <%= type == 'address' ? 'an' : 'a' %> <%= type %>.
      */
-    type <%= type.capitalized %>Slot is bytes32;
+    type <%= name %>Slot is bytes32;
 
     /**
-     * @dev Cast an arbitrary slot to a <%= type.capitalized %>Slot.
+     * @dev Cast an arbitrary slot to a <%= name %>Slot.
      */
-    function as<%= type.capitalized %>(bytes32 slot) internal pure returns (<%= type.capitalized %>Slot) {
-        return <%= type.capitalized %>Slot.wrap(slot);
+    function as<%= name %>(bytes32 slot) internal pure returns (<%= name %>Slot) {
+        return <%= name %>Slot.wrap(slot);
     }
 <% } %>
-<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+<% for (const { name, type } of it.SLOT_TYPES.filter(({ size }) => size)) { %>
     /**
      * @dev Load the value held at location `slot` in transient storage.
      */
-    function tload(<%= type.capitalized %>Slot slot) internal view returns (<%= type.type %> value) {
+    function tload(<%= name %>Slot slot) internal view returns (<%= type %> value) {
         assembly ("memory-safe") {
             value := tload(slot)
         }
@@ -53,7 +53,7 @@ library TransientSlot {
     /**
      * @dev Store `value` at location `slot` in transient storage.
      */
-    function tstore(<%= type.capitalized %>Slot slot, <%= type.type %> value) internal {
+    function tstore(<%= name %>Slot slot, <%= type %> value) internal {
         assembly ("memory-safe") {
             tstore(slot, value)
         }

--- a/scripts/generate/templates/TransientSlotMock.sol.eta
+++ b/scripts/generate/templates/TransientSlotMock.sol.eta
@@ -6,15 +6,15 @@ import {TransientSlot} from "../utils/TransientSlot.sol";
 contract TransientSlotMock is Multicall {
     using TransientSlot for *;
 
-<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
-    event <%= type.capitalized %>Value(bytes32 slot, <%= type.type %> value);
+<% for (const { name, type } of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+    event <%= name %>Value(bytes32 slot, <%= type %> value);
 
-    function tload<%= type.capitalized %>(bytes32 slot) public {
-        emit <%= type.capitalized %>Value(slot, slot.as<%= type.capitalized %>().tload());
+    function tload<%= name %>(bytes32 slot) public {
+        emit <%= name %>Value(slot, slot.as<%= name %>().tload());
     }
 
-    function tstore(bytes32 slot, <%= type.type %> value) public {
-        slot.as<%= type.capitalized %>().tstore(value);
+    function tstore(bytes32 slot, <%= type %> value) public {
+        slot.as<%= name %>().tstore(value);
     }
 <% } %>
 }

--- a/scripts/generate/templates/TransientSlotMock.sol.eta
+++ b/scripts/generate/templates/TransientSlotMock.sol.eta
@@ -6,15 +6,15 @@ import {TransientSlot} from "../utils/TransientSlot.sol";
 contract TransientSlotMock is Multicall {
     using TransientSlot for *;
 
-<% for (const type of it.SLOT_VALUE_TYPES) { %>
-    event <%= type.name %>Value(bytes32 slot, <%= type.type %> value);
+<% for (const type of it.SLOT_TYPES.filter(({ size }) => size)) { %>
+    event <%= type.capitalized %>Value(bytes32 slot, <%= type.type %> value);
 
-    function tload<%= type.name %>(bytes32 slot) public {
-        emit <%= type.name %>Value(slot, slot.as<%= type.name %>().tload());
+    function tload<%= type.capitalized %>(bytes32 slot) public {
+        emit <%= type.capitalized %>Value(slot, slot.as<%= type.capitalized %>().tload());
     }
 
     function tstore(bytes32 slot, <%= type.type %> value) public {
-        slot.as<%= type.name %>().tstore(value);
+        slot.as<%= type.capitalized %>().tstore(value);
     }
 <% } %>
 }

--- a/test/utils/structs/EnumerableMap.behavior.js
+++ b/test/utils/structs/EnumerableMap.behavior.js
@@ -173,9 +173,9 @@ export function shouldBehaveLikeMap() {
         await expect(this.methods.get(this.keyB))
           .to.be.revertedWithCustomError(this.mock, this.error ?? 'EnumerableMapNonexistentKey')
           .withArgs(
-            this.key?.memory || this.value?.memory
-              ? this.keyB
-              : ethers.AbiCoder.defaultAbiCoder().encode([this.key.type], [this.keyB]),
+            this.key?.size && this.value?.size
+              ? ethers.AbiCoder.defaultAbiCoder().encode([this.key.type], [this.keyB])
+              : this.keyB,
           );
       });
     });

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -61,7 +61,7 @@ async function fixture() {
           setReturn: `return$set_EnumerableMap_${name}_${key.type}_${value.type}`,
           removeReturn: `return$remove_EnumerableMap_${name}_${key.type}`,
         },
-        error: key.size && value.size ? `EnumerableMapNonexistentKey` : `EnumerableMapNonexistent${key.capitalized}Key`,
+        error: key.size && value.size ? `EnumerableMapNonexistentKey` : `EnumerableMapNonexistent${key.name}Key`,
       },
     ]),
   );

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -1,7 +1,7 @@
 import { network } from 'hardhat';
 import { mapValues } from '../../helpers/iterate';
 import * as random from '../../helpers/random';
-import { ALL_TYPES, MAP_TYPES } from '../../../scripts/generate/data.js';
+import { TYPES, MAP_TYPES } from '../../../scripts/generate/data.js';
 import { shouldBehaveLikeMap } from './EnumerableMap.behavior';
 
 const {
@@ -10,7 +10,7 @@ const {
 } = await network.create();
 
 // Add Bytes32ToBytes32Map that must be tested but is not part of the generated types.
-MAP_TYPES.unshift({ name: 'Bytes32ToBytes32Map', key: ALL_TYPES.bytes32, value: ALL_TYPES.bytes32 });
+MAP_TYPES.unshift({ name: 'Bytes32ToBytes32Map', key: TYPES.bytes32, value: TYPES.bytes32 });
 
 // Chai matchers expect hexadecimal data when dealing with bytes
 const randomOf = type => random[type === 'bytes' ? 'hexBytes' : type];

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -28,7 +28,7 @@ async function fixture() {
         values: Array.from({ length: 3 }, randomOf(value.type)),
         zeroValue: randomOf(value.type).zero,
         methods: mapValues(
-          MAP_TYPES.filter(map => map.key.name == key.name).length == 1
+          MAP_TYPES.filter(map => map.key.type == key.type).length == 1
             ? {
                 set: `$set(uint256,${key.type},${value.type})`,
                 get: `$get(uint256,${key.type})`,

--- a/test/utils/structs/EnumerableMap.test.js
+++ b/test/utils/structs/EnumerableMap.test.js
@@ -1,7 +1,7 @@
 import { network } from 'hardhat';
 import { mapValues } from '../../helpers/iterate';
 import * as random from '../../helpers/random';
-import { MAP_TYPES, typeDescr, toMapTypeDescr } from '../../../scripts/generate/data.js';
+import { ALL_TYPES, MAP_TYPES } from '../../../scripts/generate/data.js';
 import { shouldBehaveLikeMap } from './EnumerableMap.behavior';
 
 const {
@@ -10,7 +10,7 @@ const {
 } = await network.create();
 
 // Add Bytes32ToBytes32Map that must be tested but is not part of the generated types.
-MAP_TYPES.unshift(toMapTypeDescr({ key: typeDescr({ type: 'bytes32' }), value: typeDescr({ type: 'bytes32' }) }));
+MAP_TYPES.unshift({ name: 'Bytes32ToBytes32Map', key: ALL_TYPES.bytes32, value: ALL_TYPES.bytes32 });
 
 // Chai matchers expect hexadecimal data when dealing with bytes
 const randomOf = type => random[type === 'bytes' ? 'hexBytes' : type];
@@ -61,7 +61,7 @@ async function fixture() {
           setReturn: `return$set_EnumerableMap_${name}_${key.type}_${value.type}`,
           removeReturn: `return$remove_EnumerableMap_${name}_${key.type}`,
         },
-        error: key.memory || value.memory ? `EnumerableMapNonexistent${key.name}Key` : `EnumerableMapNonexistentKey`,
+        error: key.size && value.size ? `EnumerableMapNonexistentKey` : `EnumerableMapNonexistent${key.capitalized}Key`,
       },
     ]),
   );

--- a/test/utils/structs/EnumerableSet.test.js
+++ b/test/utils/structs/EnumerableSet.test.js
@@ -28,10 +28,7 @@ async function fixture() {
       name,
       {
         value,
-        values: Array.from(
-          { length: 3 },
-          value.size ? () => Array.from({ length: value.size }, randomOf(value.base)) : randomOf(value.type),
-        ),
+        values: Array.from({ length: 3 }, randomOf(value.type)),
         methods: getMethods(mock, {
           add: `$add(uint256,${value.type})`,
           remove: `$remove(uint256,${value.type})`,


### PR DESCRIPTION
Follow-up to #6725.

Each generator in `scripts/generate/data.js` described its solidity types its own way. `ARRAYS_TYPES` carried a byte `size` and an `isValueType` flag; the Enumerable generators went through `typeDescr`/`toSetTypeDescr`/`toMapTypeDescr` to build `name`/`type`/`typeLoc`/`base`/`memory`; `SLOT_TYPES` had a third shape, a hand-written `variants` list, and an `Object.assign` trick to allow keyed access. The same type (`bytes32`, `uint256`, …) was spelled differently depending on which template consumed it.

This replaces all three with a single `ALL_TYPES` registry, keyed by solidity type, where every entry has the same fields:

- `type` — the solidity type, emitted into generated code
- `name` — the identifier form, used to build `<Name>Slot`, `get<Name>Slot`, `EnumerableMapNonexistent<Name>Key`, …
- `size` — width in **bits** (it was bytes in `ARRAYS_TYPES`), absent for reference types
- `location` — `memory` for reference types, empty otherwise
- `upcastTo` / `upcastOf` — the narrowing relation and its reverse index

`ARRAYS_TYPES`, `SET_TYPES` and `MAP_TYPES` become plain selections from the registry, and `SLOT_TYPES` is derived: `Object.values(ALL_TYPES).filter(type => !type.upcastTo)`, which yields `address, bool, bytes32, uint256, int256, string, bytes` — the previous hand-written list, unchanged and in the same order. `SlotDerivation.t.sol.eta` walks `upcastOf` filtered to `size === 32` instead of the hand-written `variants`, resolving to `bytes4`, `uint32` and `int32` as before.

Two things worth calling out beyond the mechanical substitution:

- **`name` no longer doubles as the solidity type.** It previously served both roles, which worked only because `name === type` for every type these generators instantiate — `bool` is the one entry where they differ, and it happens not to appear in `ARRAYS_TYPES`, `SET_TYPES` or `MAP_TYPES`. Adding it would have generated `boolean[]` and `mapping(boolean => ...)`. Types are now always read from `type`, and `name` is unambiguously the identifier form (`capitalized` is gone).
- **`EnumerableSet.test.js` loses its fixed-size-array value branch.** In the old descriptors `size` was an array length and was always `0` for set types, so that branch was unreachable. With `size` now meaning bit width it would have been taken for every value type and generated wrong test data, so removing it was required rather than cleanup.

Value-vs-reference tests become `size` checks throughout, replacing `isValueType` and `memory`. `isReferenceType` had no consumer left and is removed.

Reviewing commit by commit is probably easiest — each one is independently byte-identical on the generated output.

### Checks

- `npm run test:generation` — clean, no drift in any of the 15 generated files. This is the load-bearing check: the diff touches `contracts/` not at all.
- `npx hardhat test test/utils/structs/EnumerableMap.test.js test/utils/structs/EnumerableSet.test.js test/utils/Arrays.test.js` — 559 passing
- `npx hardhat test test/utils/StorageSlot.test.js test/utils/TransientSlot.test.js` (with the Enumerable suites) — 313 passing
- `forge test --match-path test/utils/SlotDerivation.t.sol` — 13 passing

No changeset: codegen and tests only, no user-visible contract change.
