### PR TITLE
CI: map changed Certora specs to the configs that verify them

### DIFF
--- a/.github/workflows/fv-certora.yml
+++ b/.github/workflows/fv-certora.yml
@@ -52,13 +52,32 @@ jobs:
         run: |
           if [[ ${{ github.event_name }} = 'pull_request_target' && ${{ contains(github.event.pull_request.labels.*.name, 'formal-verification-force-all') }} = 'false' ]];
           then
-            # Spec names come from the file names of a pull request that may be untrusted, and end
-            # up on a command line downstream. Anything that is not a plain name is dropped here.
-            RESULT=$(git diff "$HEAD_SHA".."$BASE_SHA" --name-only -- 'fv/specs/*.spec' | while IFS= read -r file; do
-              [[ -f $file ]] || continue
-              name=$(basename "${file%.spec}")
-              [[ $name =~ ^[A-Za-z0-9_-]+$ ]] && echo "$name" || echo "Ignoring spec with unexpected name: $name" >&2
-            done | tr "\n" " ")
+            # Map each changed spec to the configs that verify it, following imports: a spec that
+            # no config names (a base, a helper, a methods file) is verified through the specs that
+            # import it, transitively. Imports are relative to the importing file's directory.
+            importers() {
+              find fv/specs -name '*.spec' | while IFS= read -r spec; do
+                dir=${spec%/*}
+                sed -n 's/^import "\([^"]*\)".*/\1/p' "$spec" | while IFS= read -r imp; do
+                  if [[ "$dir/${imp#./}" == "$1" ]]; then echo "$spec"; fi
+                done
+              done
+            }
+            specs=$(git diff "$BASE_SHA".."$HEAD_SHA" --name-only -- 'fv/specs/*.spec' | while IFS= read -r file; do if [[ -f $file ]]; then echo "$file"; fi; done)
+            while :; do
+              next=$({ echo "$specs"; while IFS= read -r file; do if [[ -n $file ]]; then importers "$file"; fi; done <<< "$specs"; } | sort -u)
+              if [[ $next == "$specs" ]]; then break; fi
+              specs=$next
+            done
+            confs=$(while IFS= read -r file; do if [[ -n $file ]]; then grep -lF "$file" fv/specs/*.conf || true; fi; done <<< "$specs" | sort -u)
+            if [[ -n $specs && -z $confs ]]; then echo "Changed specs are verified by no config, directly or through an importer." >&2; fi
+            # Config names come from the file names of a pull request that may be untrusted, and
+            # end up on a command line downstream. Anything that is not a plain name is dropped.
+            RESULT=$(while IFS= read -r conf; do
+              if [[ -z $conf ]]; then continue; fi
+              name=${conf##*/}; name=${name%.conf}
+              if [[ $name =~ ^[A-Za-z0-9_-]+$ ]]; then echo "$name"; else echo "Ignoring config with unexpected name: $name" >&2; fi
+            done <<< "$confs" | tr "\n" " ")
           else
             RESULT='--all'
           fi


### PR DESCRIPTION
Extracted from #6724 so the workflow fix can land independently of the ERC-4626 specs.

The changed-spec detection in `fv-certora.yml` assumed one config per spec, named after the spec, and did not follow `import` statements. Two consequences:

- A changed helper or methods file (`fv/specs/helpers/helpers.spec`, `fv/specs/methods/IERC20.spec`) mapped to a config name that does not exist, so `certoraRun` was invoked on a missing file and the job failed.
- A changed base spec did not run the configs that verify the specs importing it. `ERC20.spec` changing never re-ran `ERC20Wrapper.conf`, and a spec covered by several configs (a `rule`/`exclude_rule` split) only ever ran the one config sharing its name.

Each changed spec is now resolved to the configs that name it, transitively through the specs that import it. Imports are resolved relative to the importing file's directory.

Checked against the current spec tree:

| changed spec | configs run |
| --- | --- |
| `ERC20.spec` | `ERC20`, `ERC20Wrapper` |
| `methods/IERC20.spec` | `ERC20`, `ERC20FlashMint`, `ERC20Wrapper` |
| `methods/IAccessControl.spec` | `AccessControl`, `AccessControlDefaultAdminRules`, `TimelockController` |
| `helpers/helpers.spec` | all 18 |
| `AccessControl.spec` | `AccessControl`, `AccessControlDefaultAdminRules` |

The untrusted-input guard is kept: config names still come from the repository glob and are dropped unless they match `^[A-Za-z0-9_-]+$` before reaching a command line.

Also orders the diff endpoints `base..head`, which is the direction meant. `--name-only` makes the name set symmetric, so this is a no-op in practice.

#### PR Checklist

- [ ] Tests <!-- CI plumbing only; logic exercised against the current spec tree, see table above -->
- [x] Documentation <!-- inline comments -->
- [ ] Changeset entry (run `npx changeset add`) <!-- not needed: no contract changes -->
