### PR TITLE
Remove `draft-` prefix from ERC-6093 interface

### DIFF
--- a/.changeset/ready-sites-stick.md
+++ b/.changeset/ready-sites-stick.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`IERC6093`: Remove the `draft-` prefix from the interface file name since ERC-6093 is finalized. Imports must be updated from `interfaces/draft-IERC6093.sol` to `interfaces/IERC6093.sol`.

--- a/contracts/crosschain/bridges/BridgeERC1155.sol
+++ b/contracts/crosschain/bridges/BridgeERC1155.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.26;
 
 import {IERC1155} from "../../interfaces/IERC1155.sol";
 import {IERC1155Receiver} from "../../interfaces/IERC1155Receiver.sol";
-import {IERC1155Errors} from "../../interfaces/draft-IERC6093.sol";
+import {IERC1155Errors} from "../../interfaces/IERC6093.sol";
 import {ERC1155Holder} from "../../token/ERC1155/utils/ERC1155Holder.sol";
 import {BridgeMultiToken} from "./abstract/BridgeMultiToken.sol";
 

--- a/contracts/crosschain/bridges/BridgeERC721.sol
+++ b/contracts/crosschain/bridges/BridgeERC721.sol
@@ -3,8 +3,8 @@
 
 pragma solidity ^0.8.26;
 
-import {IERC721} from "../../interfaces/IERC721.sol";
 import {IERC721Errors} from "../../interfaces/IERC6093.sol";
+import {IERC721} from "../../interfaces/IERC721.sol";
 import {BridgeNonFungible} from "./abstract/BridgeNonFungible.sol";
 
 /**

--- a/contracts/crosschain/bridges/BridgeERC721.sol
+++ b/contracts/crosschain/bridges/BridgeERC721.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.26;
 
 import {IERC721} from "../../interfaces/IERC721.sol";
-import {IERC721Errors} from "../../interfaces/draft-IERC6093.sol";
+import {IERC721Errors} from "../../interfaces/IERC6093.sol";
 import {BridgeNonFungible} from "./abstract/BridgeNonFungible.sol";
 
 /**

--- a/contracts/interfaces/IERC6093.sol
+++ b/contracts/interfaces/IERC6093.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.5.0) (interfaces/draft-IERC6093.sol)
+// OpenZeppelin Contracts (last updated v5.5.0) (interfaces/IERC6093.sol)
 
 pragma solidity >=0.8.4;
 

--- a/contracts/token/ERC1155/ERC1155.sol
+++ b/contracts/token/ERC1155/ERC1155.sol
@@ -9,7 +9,7 @@ import {ERC1155Utils} from "./utils/ERC1155Utils.sol";
 import {Context} from "../../utils/Context.sol";
 import {IERC165, ERC165} from "../../utils/introspection/ERC165.sol";
 import {Arrays} from "../../utils/Arrays.sol";
-import {IERC1155Errors} from "../../interfaces/draft-IERC6093.sol";
+import {IERC1155Errors} from "../../interfaces/IERC6093.sol";
 
 /**
  * @dev Implementation of the basic standard multi-token.

--- a/contracts/token/ERC1155/utils/ERC1155Utils.sol
+++ b/contracts/token/ERC1155/utils/ERC1155Utils.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.20;
 
 import {IERC1155Receiver} from "../IERC1155Receiver.sol";
-import {IERC1155Errors} from "../../../interfaces/draft-IERC6093.sol";
+import {IERC1155Errors} from "../../../interfaces/IERC6093.sol";
 
 /**
  * @dev Library that provide common ERC-1155 utility functions.

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.20;
 import {IERC20} from "./IERC20.sol";
 import {IERC20Metadata} from "./extensions/IERC20Metadata.sol";
 import {Context} from "../../utils/Context.sol";
-import {IERC20Errors} from "../../interfaces/draft-IERC6093.sol";
+import {IERC20Errors} from "../../interfaces/IERC6093.sol";
 
 /**
  * @dev Implementation of the {IERC20} interface.

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -9,7 +9,7 @@ import {ERC721Utils} from "./utils/ERC721Utils.sol";
 import {Context} from "../../utils/Context.sol";
 import {Strings} from "../../utils/Strings.sol";
 import {IERC165, ERC165} from "../../utils/introspection/ERC165.sol";
-import {IERC721Errors} from "../../interfaces/draft-IERC6093.sol";
+import {IERC721Errors} from "../../interfaces/IERC6093.sol";
 
 /**
  * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC-721] Non-Fungible Token Standard, including

--- a/contracts/token/ERC721/utils/ERC721Utils.sol
+++ b/contracts/token/ERC721/utils/ERC721Utils.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.20;
 
 import {IERC721Receiver} from "../IERC721Receiver.sol";
-import {IERC721Errors} from "../../../interfaces/draft-IERC6093.sol";
+import {IERC721Errors} from "../../../interfaces/IERC6093.sol";
 
 /**
  * @dev Library that provides common ERC-721 utility functions.


### PR DESCRIPTION
- ERC-6093 now finalized: https://github.com/ethereum/ERCs/commit/4d07dd491afa47a1920160e02de71dc515169314