### PR TITLE
Remove `draft-` prefix from ERC-7786 interface

### DIFF
--- a/.changeset/icy-tables-wear.md
+++ b/.changeset/icy-tables-wear.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': minor
+---
+
+`IERC7786`: Remove the `draft-` prefix from the interface file name since ERC-7786 is finalized. Imports must be updated from `interfaces/draft-IERC7786.sol` to `interfaces/IERC7786.sol`.

--- a/contracts/crosschain/CrosschainLinked.sol
+++ b/contracts/crosschain/CrosschainLinked.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.26;
 
-import {IERC7786GatewaySource} from "../interfaces/draft-IERC7786.sol";
+import {IERC7786GatewaySource} from "../interfaces/IERC7786.sol";
 import {InteroperableAddress} from "../utils/draft-InteroperableAddress.sol";
 import {Bytes} from "../utils/Bytes.sol";
 import {ERC7786Recipient} from "./ERC7786Recipient.sol";

--- a/contracts/crosschain/CrosschainRemoteExecutor.sol
+++ b/contracts/crosschain/CrosschainRemoteExecutor.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.27;
 
-import {IERC7786GatewaySource} from "../interfaces/draft-IERC7786.sol";
+import {IERC7786GatewaySource} from "../interfaces/IERC7786.sol";
 import {ERC7786Recipient} from "./ERC7786Recipient.sol";
 import {ERC7579Utils, Mode, CallType, ExecType} from "../account/utils/draft-ERC7579Utils.sol";
 import {Bytes} from "../utils/Bytes.sol";

--- a/contracts/crosschain/ERC7786Recipient.sol
+++ b/contracts/crosschain/ERC7786Recipient.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.20;
 
-import {IERC7786Recipient} from "../interfaces/draft-IERC7786.sol";
+import {IERC7786Recipient} from "../interfaces/IERC7786.sol";
 
 /**
  * @dev Base implementation of an ERC-7786 compliant cross-chain message receiver.

--- a/contracts/governance/extensions/GovernorCrosschain.sol
+++ b/contracts/governance/extensions/GovernorCrosschain.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.26;
 
 import {Governor} from "../Governor.sol";
 import {Mode} from "../../account/utils/draft-ERC7579Utils.sol";
-import {IERC7786GatewaySource} from "../../interfaces/draft-IERC7786.sol";
+import {IERC7786GatewaySource} from "../../interfaces/IERC7786.sol";
 
 /// @dev Extension of {Governor} for cross-chain governance through ERC-7786 gateways and {CrosschainRemoteExecutor}.
 abstract contract GovernorCrosschain is Governor {

--- a/contracts/interfaces/IERC7786.sol
+++ b/contracts/interfaces/IERC7786.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.5.0) (interfaces/draft-IERC7786.sol)
+// OpenZeppelin Contracts (last updated v5.5.0) (interfaces/IERC7786.sol)
 
 pragma solidity >=0.8.4;
 

--- a/contracts/mocks/crosschain/ERC7786GatewayMock.sol
+++ b/contracts/mocks/crosschain/ERC7786GatewayMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.27;
 
-import {IERC7786GatewaySource, IERC7786Recipient} from "../../interfaces/draft-IERC7786.sol";
+import {IERC7786GatewaySource, IERC7786Recipient} from "../../interfaces/IERC7786.sol";
 import {InteroperableAddress} from "../../utils/draft-InteroperableAddress.sol";
 
 abstract contract ERC7786GatewayMock is IERC7786GatewaySource {


### PR DESCRIPTION
- ERC-7786 now finalized: https://github.com/ethereum/ERCs/commit/010e4159c93b073b49cdbe9c31f5cf1ff7987723