### PR TITLE
ERC7913P256Verifier: enforce exact signature length (0x40 or 0x41)

### DIFF
--- a/.changeset/erc7913-p256-verifier-strict-length.md
+++ b/.changeset/erc7913-p256-verifier-strict-length.md
@@ -1,0 +1,6 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC7913P256Verifier`: reject signatures that are not exactly `0x40` or `0x41` bytes long. Previously the length was checked with `signature.length >= 0x40`, which contradicted the accompanying comment (`Signature length may be 0x40 or 0x41`) and accepted signatures with arbitrary trailing bytes. Since only the first `0x40` bytes are read, those trailing bytes were ignored, so the same signature could be re-encoded into many distinct byte strings that all verify.
+

--- a/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol
@@ -15,7 +15,7 @@ contract ERC7913P256Verifier is IERC7913SignatureVerifier {
     /// @inheritdoc IERC7913SignatureVerifier
     function verify(bytes calldata key, bytes32 hash, bytes calldata signature) public view virtual returns (bytes4) {
         // Signature length may be 0x40 or 0x41.
-        if (key.length == 0x40 && signature.length >= 0x40) {
+        if (key.length == 0x40 && (signature.length == 0x40 || signature.length == 0x41)) {
             bytes32 qx = bytes32(key[0x00:0x20]);
             bytes32 qy = bytes32(key[0x20:0x40]);
             bytes32 r = bytes32(signature[0x00:0x20]);

--- a/test/utils/cryptography/verifiers/ERC7913P256Verifier.test.js
+++ b/test/utils/cryptography/verifiers/ERC7913P256Verifier.test.js
@@ -1,0 +1,51 @@
+import { network } from 'hardhat';
+import { expect } from 'chai';
+import { NonNativeSigner, P256SigningKey } from '../../../helpers/signers';
+
+const {
+  ethers,
+  networkHelpers: { loadFixture },
+} = await network.create();
+
+const MAGIC = '0x024ad318'; // IERC7913SignatureVerifier.verify.selector
+const FAIL = '0xffffffff';
+
+const signer = new NonNativeSigner(P256SigningKey.random());
+
+async function fixture() {
+  const verifier = await ethers.deployContract('ERC7913P256Verifier');
+  const { qx, qy } = signer.signingKey.publicKey;
+  const key = ethers.concat([qx, qy]); // 0x40 bytes
+  const hash = ethers.hexlify(ethers.randomBytes(32));
+  const { r, s } = signer.signingKey.sign(hash);
+  const sig = ethers.concat([r, s]); // 0x40 bytes
+  return { verifier, key, hash, sig };
+}
+
+describe('ERC7913P256Verifier', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  it('accepts a canonical 0x40-byte signature', async function () {
+    expect(await this.verifier.verify(this.key, this.hash, this.sig)).to.equal(MAGIC);
+  });
+
+  it('accepts a 0x41-byte signature (optional trailing recovery byte)', async function () {
+    expect(await this.verifier.verify(this.key, this.hash, ethers.concat([this.sig, '0x1b']))).to.equal(MAGIC);
+  });
+
+  it('rejects a signature with extra trailing bytes (non-canonical encoding)', async function () {
+    // Before this fix, `signature.length >= 0x40` accepted any trailing bytes.
+    // Only the first 0x40 bytes are read, so a signature could be re-encoded into
+    // many distinct byte strings that all verify (signature malleability).
+    expect(await this.verifier.verify(this.key, this.hash, ethers.concat([this.sig, '0x0000']))).to.equal(FAIL);
+    expect(await this.verifier.verify(this.key, this.hash, ethers.concat([this.sig, ethers.randomBytes(32)]))).to.equal(
+      FAIL,
+    );
+  });
+
+  it('rejects a signature shorter than 0x40 bytes', async function () {
+    expect(await this.verifier.verify(this.key, this.hash, ethers.dataSlice(this.sig, 0, 0x3f))).to.equal(FAIL);
+  });
+});


### PR DESCRIPTION
## Motivation

`ERC7913P256Verifier.verify` carries the comment "Signature length may be 0x40 or 0x41", but the guard is written as `signature.length >= 0x40`. Because the verifier only reads the first `0x40` bytes (`signature[0x00:0x40]`), any bytes past that are ignored. As a result the same signature can be re-encoded into many distinct byte strings (`sig`, `sig || <any trailing bytes>`) that all verify, i.e. the accepted encoding is non-canonical.

This is not a forgery or key-recovery issue, and P256's low-`s` check already prevents `(r, s)` malleability, so I did not find a way to exploit it through OpenZeppelin's own consumers (e.g. `MultiSignerERC7913` de-duplicates on the signer key, not on signature bytes). I'm raising it as a consistency/hardening fix: the code should match its own comment and reject non-canonical encodings. Happy to close if the lenient length is intentional.

## Change

Restrict the accepted signature length to exactly `0x40` or `0x41` bytes, as the comment already states.

## Tests

Adds `test/utils/cryptography/verifiers/ERC7913P256Verifier.test.js` covering:
- a canonical `0x40`-byte signature is accepted;
- a `0x41`-byte signature (optional trailing recovery byte) is accepted;
- a signature with extra trailing bytes is now rejected (this case passed before the change, demonstrating the non-canonical acceptance);
- a signature shorter than `0x40` bytes is rejected.

`test/account/AccountERC7913.test.js` continues to pass.

#### PR Checklist

- [x] Tests
- [ ] Documentation <!-- N/A -->
- [x] Changeset entry (run `npx changeset add`)
