### PR TITLE
Update dependency certora-cli to v8.19.2

### DIFF
--- a/fv-requirements.txt
+++ b/fv-requirements.txt
@@ -1,4 +1,4 @@
-certora-cli==8.6.1
+certora-cli==8.19.2
 # File uses a custom name (fv-requirements.txt) so that it isn't picked by Netlify's build
 # whose latest Python version is 0.3.8, incompatible with most recent versions of Halmos
 halmos==0.3.3

--- a/fv/specs/AccessControl.conf
+++ b/fv/specs/AccessControl.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/AccessControlHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "AccessControlHarness:fv/specs/AccessControl.spec"

--- a/fv/specs/AccessControlDefaultAdminRules.conf
+++ b/fv/specs/AccessControlDefaultAdminRules.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/AccessControlDefaultAdminRulesHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "AccessControlDefaultAdminRulesHarness:fv/specs/AccessControlDefaultAdminRules.spec"

--- a/fv/specs/AccessManaged.conf
+++ b/fv/specs/AccessManaged.conf
@@ -8,6 +8,9 @@
     ],
     "optimistic_hashing": true,
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "AccessManagedHarness:fv/specs/AccessManaged.spec"

--- a/fv/specs/AccessManager.conf
+++ b/fv/specs/AccessManager.conf
@@ -4,6 +4,9 @@
     ],
     "optimistic_hashing": true,
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "AccessManagerHarness:fv/specs/AccessManager.spec"

--- a/fv/specs/Account.conf
+++ b/fv/specs/Account.conf
@@ -3,6 +3,9 @@
         "fv/harnesses/AccountHarness.sol"
     ],
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "AccountHarness:fv/specs/Account.spec"

--- a/fv/specs/DoubleEndedQueue.conf
+++ b/fv/specs/DoubleEndedQueue.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/DoubleEndedQueueHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "DoubleEndedQueueHarness:fv/specs/DoubleEndedQueue.spec"

--- a/fv/specs/ERC20.conf
+++ b/fv/specs/ERC20.conf
@@ -3,6 +3,9 @@
         "fv/harnesses/ERC20PermitHarness.sol"
     ],
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "ERC20PermitHarness:fv/specs/ERC20.spec"

--- a/fv/specs/ERC20FlashMint.conf
+++ b/fv/specs/ERC20FlashMint.conf
@@ -4,6 +4,9 @@
         "fv/harnesses/ERC3156FlashBorrowerHarness.sol"
     ],
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "ERC20FlashMintHarness:fv/specs/ERC20FlashMint.spec"

--- a/fv/specs/ERC20Wrapper.conf
+++ b/fv/specs/ERC20Wrapper.conf
@@ -7,6 +7,9 @@
         "ERC20WrapperHarness:_underlying=ERC20PermitHarness"
     ],
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "ERC20WrapperHarness:fv/specs/ERC20Wrapper.spec"

--- a/fv/specs/ERC721.conf
+++ b/fv/specs/ERC721.conf
@@ -4,6 +4,9 @@
         "fv/harnesses/ERC721ReceiverHarness.sol"
     ],
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "ERC721Harness:fv/specs/ERC721.spec"

--- a/fv/specs/EnumerableMap.conf
+++ b/fv/specs/EnumerableMap.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/EnumerableMapHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "EnumerableMapHarness:fv/specs/EnumerableMap.spec"

--- a/fv/specs/EnumerableSet.conf
+++ b/fv/specs/EnumerableSet.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/EnumerableSetHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "EnumerableSetHarness:fv/specs/EnumerableSet.spec"

--- a/fv/specs/Initializable.conf
+++ b/fv/specs/Initializable.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/InitializableHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "InitializableHarness:fv/specs/Initializable.spec"

--- a/fv/specs/Nonces.conf
+++ b/fv/specs/Nonces.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/NoncesHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "NoncesHarness:fv/specs/Nonces.spec"

--- a/fv/specs/Ownable.conf
+++ b/fv/specs/Ownable.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/OwnableHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "OwnableHarness:fv/specs/Ownable.spec"

--- a/fv/specs/Ownable2Step.conf
+++ b/fv/specs/Ownable2Step.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/Ownable2StepHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "Ownable2StepHarness:fv/specs/Ownable2Step.spec"

--- a/fv/specs/Pausable.conf
+++ b/fv/specs/Pausable.conf
@@ -2,6 +2,9 @@
     "files": [
         "fv/harnesses/PausableHarness.sol"
     ],
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "PausableHarness:fv/specs/Pausable.spec"

--- a/fv/specs/TimelockController.conf
+++ b/fv/specs/TimelockController.conf
@@ -4,6 +4,9 @@
     ],
     "optimistic_hashing": true,
     "optimistic_loop": true,
+    "packages": [
+        "@openzeppelin/contracts=fv/patched"
+    ],
     "process": "emv",
     "url_visibility": "public",
     "verify": "TimelockControllerHarness:fv/specs/TimelockController.spec"


### PR DESCRIPTION
Updates `certora-cli` from 8.6.1 to 8.19.2.

The CVL specs need no changes: every configuration under `fv/specs/` still compiles and typechecks
clean under 8.19.2 (`certoraRun <conf> --compilation_steps_only`, which runs the solc build and the
local CVL typechecker), with no new warnings and no deprecated configuration key in use.

The configurations do need one addition. `certora-cli` only auto-detects packages when a
configuration declares none, and that detection now compares keys with a trailing `/` stripped, so
the `hardhat` devDependency and the `hardhat/=node_modules/hardhat/` remapping that `forge` derives
from `libs = ['node_modules']` collide:

```
package.json and remappings.txt include duplicated keys in: [...]
```

Every run aborts there before compiling anything. It only bites where `forge` is on `PATH`, so CI
is unaffected (the Certora job does not install Foundry), but that covers every local run. Each
configuration now declares the one package a harness could ever need, which skips the detection
entirely and makes a run independent of whether `forge` is installed. Nothing under `fv/` imports
`@openzeppelin/contracts/…` today — every harness import is relative — but if one appears it
resolves against the patched tree, which is what the specs verify.

Stacked on #6742, whose per-configuration matrix runs all 18 configurations here.

#### PR Checklist

- Tests: n/a — the configurations changed here are the verification suite itself
- Documentation: n/a
- Changeset entry: n/a — repository plumbing, no user-visible contract change
