### PR TITLE
Test crosschain contracts against two simulated chains

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: Testing conventions for openzeppelin-contracts. Use when writing or modifying tests, mocks, or formal verification specs. Covers hardhat-exposed $-wrappers, when manual mocks are warranted, Hardhat+Chai patterns (loadFixture, shouldBehaveLike, multi-target loops), Foundry fuzz, Halmos symbolic execution, Certora rule-based verification, and the changeset rule.
+description: Testing conventions for openzeppelin-contracts. Use when writing or modifying tests, mocks, or formal verification specs. Covers hardhat-exposed $-wrappers, when manual mocks are warranted, Hardhat+Chai patterns (loadFixture, shouldBehaveLike, multi-target loops, multichain cross-chain tests), Foundry fuzz, Halmos symbolic execution, Certora rule-based verification, and the changeset rule.
 ---
 
 # Testing
@@ -88,6 +88,37 @@ for (const { Token, forcedApproval } of TOKENS) {
   });
 }
 ```
+
+**Cross-chain tests**: a cross-chain contract needs a real counterpart chain — one `network.create()` per chain, each with a distinct `chainId`. The `ERC7786Bridge` helper (`test/helpers/erc7786.js`) deploys an `$ERC7786GatewayMock` on every chain and carries messages between them:
+
+```javascript
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
+
+beforeEach(async function () {
+  Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
+});
+```
+
+- `bridge.gateway(chain)` — the gateway deployed on that chain, to wire contracts against.
+- `bridge.relay()` — delivers every message sent since the previous call (cascading through messages a delivery triggers), and returns the delivery transactions in order.
+- `bridge.loadFixture(fn)` — multichain `loadFixture`. Use it instead of `networkHelpers.loadFixture`, which only snapshots its own connection and would let the other chains accumulate state across tests.
+
+The gateway mock never delivers locally: `sendMessage` only emits `MessageSent`, and delivery happens when the bridge calls `relayMessage` on the destination gateway. So assertions split at the chain boundary — source-side events on the sending transaction, destination-side events on the relayed one:
+
+```javascript
+await expect(bridgeA.connect(alice).crosschainTransfer(chainB.helpers.chain.toErc7930(bruce), amount))
+  .to.emit(this.tokenA, 'Transfer')
+  .withArgs(alice, this.bridgeA, amount)
+  .to.emit(bridge.gateway(chainA), 'MessageSent');
+
+await expect(bridge.relay().then(([tx]) => tx))
+  .to.emit(this.bridgeB, 'CrosschainFungibleTransferReceived')
+  .withArgs(anyValue, chainA.helpers.chain.toErc7930(alice), bruce, amount);
+```
+
+Signers belong to a connection: a chain A signer cannot send a transaction on chain B. Expose both sets from the fixture (`accountsA` / `accountsB`) and pick the one for the chain you are transacting on; the addresses match across chains, since every connection uses the same mnemonic. Interoperable addresses are built from the chain that holds the account: `chainB.helpers.chain.toErc7930(bruce)`.
 
 **Assertion style**:
 

--- a/contracts/mocks/crosschain/ERC7786GatewayMock.sol
+++ b/contracts/mocks/crosschain/ERC7786GatewayMock.sol
@@ -29,19 +29,8 @@ abstract contract ERC7786GatewayMock is IERC7786GatewaySource {
             revert UnsupportedAttribute(bytes4(attributes[0]));
         }
 
-        // parse recipient
-        (bool success, uint256 chainid, address target) = recipient.tryParseEvmV1Calldata();
-        require(success && chainid == block.chainid, InvalidDestination());
-
-        // perform call
-        bytes4 magic = IERC7786Recipient(target).receiveMessage{value: msg.value}(
-            bytes32(++_lastReceiveId),
-            InteroperableAddress.formatEvmV1(block.chainid, msg.sender),
-            payload
-        );
-        require(magic == IERC7786Recipient.receiveMessage.selector, ReceiverError());
-
-        // emit standard event
+        // emit standard event. Delivery is performed by an (offchain) relayer that watches this event and calls
+        // {relayMessage} on the gateway deployed on the destination chain.
         emit MessageSent(
             bytes32(0),
             InteroperableAddress.formatEvmV1(block.chainid, msg.sender),
@@ -52,5 +41,22 @@ abstract contract ERC7786GatewayMock is IERC7786GatewaySource {
         );
 
         return 0;
+    }
+
+    /// @dev Entrypoint used by the (offchain) relayer to deliver a message that originates from a remote chain.
+    function relayMessage(
+        bytes calldata sender,
+        bytes calldata recipient,
+        bytes calldata payload
+    ) public payable virtual {
+        (bool success, uint256 chainid, address target) = recipient.tryParseEvmV1Calldata();
+        require(success && chainid == block.chainid, InvalidDestination());
+
+        bytes4 magic = IERC7786Recipient(target).receiveMessage{value: msg.value}(
+            bytes32(++_lastReceiveId),
+            sender,
+            payload
+        );
+        require(magic == IERC7786Recipient.receiveMessage.selector, ReceiverError());
     }
 }

--- a/test/crosschain/BridgeERC1155.behavior.js
+++ b/test/crosschain/BridgeERC1155.behavior.js
@@ -12,28 +12,29 @@ const RECEIVER_BATCH_MAGIC_VALUE = '0xbc197c81';
 export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chainBIsCustodial = false } = {}) {
   describe('bridge ERC1155 like', function () {
     beforeEach(function () {
-      // helper
+      // helper: payload of a transfer coming from chain B
       this.encodePayload = (from, to, ids, values, data = '0x') =>
         ethers.AbiCoder.defaultAbiCoder().encode(
           ['bytes', 'bytes', 'uint256[]', 'uint256[]', 'bytes'],
-          [this.helpers.chain.toErc7930(from), to.target ?? to.address ?? to, ids, values, data],
+          [this.chainB.helpers.chain.toErc7930(from), to.target ?? to.address ?? to, ids, values, data],
         );
     });
 
     it('bridge setup', async function () {
-      await expect(this.bridgeA.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
-        this.gateway.target,
-        this.helpers.chain.toErc7930(this.bridgeB),
+      await expect(this.bridgeA.getLink(this.chainB.helpers.chain.erc7930)).to.eventually.deep.equal([
+        this.bridge.gateway(this.chainA).target,
+        this.chainB.helpers.chain.toErc7930(this.bridgeB),
       ]);
-      await expect(this.bridgeB.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
-        this.gateway.target,
-        this.helpers.chain.toErc7930(this.bridgeA),
+      await expect(this.bridgeB.getLink(this.chainA.helpers.chain.erc7930)).to.eventually.deep.equal([
+        this.bridge.gateway(this.chainB).target,
+        this.chainA.helpers.chain.toErc7930(this.bridgeA),
       ]);
     });
 
     describe('crosschain send (both direction)', function () {
       it('single', async function () {
-        const [alice, bruce, chris] = this.accounts;
+        const [alice, , chris] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -42,7 +43,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256,uint256)')(
             alice,
-            this.helpers.chain.toErc7930(bruce),
+            this.chainB.helpers.chain.toErc7930(bruce),
             ids[0],
             values[0],
           ),
@@ -58,16 +59,33 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
           )
           // crosschain transfer sent
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), ids.slice(0, 1), values.slice(0, 1), '0x')
+          .withArgs(
+            anyValue,
+            alice,
+            this.chainB.helpers.chain.toErc7930(bruce),
+            ids.slice(0, 1),
+            values.slice(0, 1),
+            '0x',
+          )
           // ERC-7786 event
-          .to.emit(this.gateway, 'MessageSent')
+          .to.emit(this.bridge.gateway(this.chainA), 'MessageSent');
+
+        // The bridge delivers the message on chain B.
+        await expect(this.bridge.relay().then(([tx]) => tx))
           // crosschain transfer received
           .to.emit(this.bridgeB, 'CrosschainMultiTokenTransferReceived')
-          .withArgs(anyValue, this.helpers.chain.toErc7930(alice), bruce, ids.slice(0, 1), values.slice(0, 1), '0x')
+          .withArgs(
+            anyValue,
+            this.chainA.helpers.chain.toErc7930(alice),
+            bruce,
+            ids.slice(0, 1),
+            values.slice(0, 1),
+            '0x',
+          )
           // tokens are minted on chain B
           .to.emit(this.tokenB, 'TransferSingle')
           .withArgs(
-            chainBIsCustodial ? this.bridgeB : this.gateway,
+            chainBIsCustodial ? this.bridgeB : this.bridge.gateway(this.chainB),
             chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress,
             bruce,
             ids[0],
@@ -78,7 +96,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeB.connect(bruce).getFunction('crosschainTransferFrom(address,bytes,uint256,uint256)')(
             bruce,
-            this.helpers.chain.toErc7930(chris),
+            this.chainA.helpers.chain.toErc7930(chris),
             ids[0],
             values[0],
           ),
@@ -94,16 +112,33 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
           )
           // crosschain transfer sent
           .to.emit(this.bridgeB, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, bruce, this.helpers.chain.toErc7930(chris), ids.slice(0, 1), values.slice(0, 1), '0x')
+          .withArgs(
+            anyValue,
+            bruce,
+            this.chainA.helpers.chain.toErc7930(chris),
+            ids.slice(0, 1),
+            values.slice(0, 1),
+            '0x',
+          )
           // ERC-7786 event
-          .to.emit(this.gateway, 'MessageSent')
+          .to.emit(this.bridge.gateway(this.chainB), 'MessageSent');
+
+        // The bridge delivers the message back on chain A.
+        await expect(this.bridge.relay().then(([tx]) => tx))
           // crosschain transfer received
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferReceived')
-          .withArgs(anyValue, this.helpers.chain.toErc7930(bruce), chris, ids.slice(0, 1), values.slice(0, 1), '0x')
+          .withArgs(
+            anyValue,
+            this.chainB.helpers.chain.toErc7930(bruce),
+            chris,
+            ids.slice(0, 1),
+            values.slice(0, 1),
+            '0x',
+          )
           // bridge on chain A releases custody of the token
           .to.emit(this.tokenA, 'TransferSingle')
           .withArgs(
-            chainAIsCustodial ? this.bridgeA : this.gateway,
+            chainAIsCustodial ? this.bridgeA : this.bridge.gateway(this.chainA),
             chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress,
             chris,
             ids[0],
@@ -112,7 +147,8 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
       });
 
       it('batch', async function () {
-        const [alice, bruce, chris] = this.accounts;
+        const [alice, , chris] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -121,7 +157,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             alice,
-            this.helpers.chain.toErc7930(bruce),
+            this.chainB.helpers.chain.toErc7930(bruce),
             ids,
             values,
           ),
@@ -137,16 +173,19 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
           )
           // crosschain transfer sent
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), ids, values, '0x')
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), ids, values, '0x')
           // ERC-7786 event
-          .to.emit(this.gateway, 'MessageSent')
+          .to.emit(this.bridge.gateway(this.chainA), 'MessageSent');
+
+        // The bridge delivers the message on chain B.
+        await expect(this.bridge.relay().then(([tx]) => tx))
           // crosschain transfer received
           .to.emit(this.bridgeB, 'CrosschainMultiTokenTransferReceived')
-          .withArgs(anyValue, this.helpers.chain.toErc7930(alice), bruce, ids, values, '0x')
+          .withArgs(anyValue, this.chainA.helpers.chain.toErc7930(alice), bruce, ids, values, '0x')
           // tokens are minted on chain B
           .to.emit(this.tokenB, 'TransferBatch')
           .withArgs(
-            chainBIsCustodial ? this.bridgeB : this.gateway,
+            chainBIsCustodial ? this.bridgeB : this.bridge.gateway(this.chainB),
             chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress,
             bruce,
             ids,
@@ -157,7 +196,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeB.connect(bruce).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             bruce,
-            this.helpers.chain.toErc7930(chris),
+            this.chainA.helpers.chain.toErc7930(chris),
             ids,
             values,
           ),
@@ -173,16 +212,19 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
           )
           // crosschain transfer sent
           .to.emit(this.bridgeB, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, bruce, this.helpers.chain.toErc7930(chris), ids, values, '0x')
+          .withArgs(anyValue, bruce, this.chainA.helpers.chain.toErc7930(chris), ids, values, '0x')
           // ERC-7786 event
-          .to.emit(this.gateway, 'MessageSent')
+          .to.emit(this.bridge.gateway(this.chainB), 'MessageSent');
+
+        // The bridge delivers the message back on chain A.
+        await expect(this.bridge.relay().then(([tx]) => tx))
           // crosschain transfer received
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferReceived')
-          .withArgs(anyValue, this.helpers.chain.toErc7930(bruce), chris, ids, values, '0x')
+          .withArgs(anyValue, this.chainB.helpers.chain.toErc7930(bruce), chris, ids, values, '0x')
           // bridge on chain A releases custody of the token
           .to.emit(this.tokenA, 'TransferBatch')
           .withArgs(
-            chainAIsCustodial ? this.bridgeA : this.gateway,
+            chainAIsCustodial ? this.bridgeA : this.bridge.gateway(this.chainA),
             chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress,
             chris,
             ids,
@@ -193,7 +235,8 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
 
     describe('crosschain send with data', function () {
       beforeEach(async function () {
-        this.receiver = await this.ethers.deployContract('$ERC1155ReceiverMock', [
+        // the receiver lives on the destination chain
+        this.receiver = await this.chainB.ethers.deployContract('$ERC1155ReceiverMock', [
           RECEIVER_SINGLE_MAGIC_VALUE,
           RECEIVER_BATCH_MAGIC_VALUE,
           RevertType.None,
@@ -202,7 +245,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
       });
 
       it('single-token overload forwards data to the destination receive hook', async function () {
-        const [alice] = this.accounts;
+        const [alice] = this.accountsA;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -210,7 +253,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256,uint256,bytes)')(
             alice,
-            this.helpers.chain.toErc7930(this.receiver),
+            this.chainB.helpers.chain.toErc7930(this.receiver),
             ids[0],
             values[0],
             this.data,
@@ -220,15 +263,17 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
           .withArgs(
             anyValue,
             alice,
-            this.helpers.chain.toErc7930(this.receiver),
+            this.chainB.helpers.chain.toErc7930(this.receiver),
             ids.slice(0, 1),
             values.slice(0, 1),
             this.data,
-          )
+          );
+
+        await expect(this.bridge.relay().then(([tx]) => tx))
           .to.emit(this.bridgeB, 'CrosschainMultiTokenTransferReceived')
           .withArgs(
             anyValue,
-            this.helpers.chain.toErc7930(alice),
+            this.chainA.helpers.chain.toErc7930(alice),
             this.receiver,
             ids.slice(0, 1),
             values.slice(0, 1),
@@ -236,7 +281,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
           )
           .to.emit(this.receiver, 'BatchReceived')
           .withArgs(
-            chainBIsCustodial ? this.bridgeB : this.gateway,
+            chainBIsCustodial ? this.bridgeB : this.bridge.gateway(this.chainB),
             chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress,
             ids.slice(0, 1),
             values.slice(0, 1),
@@ -246,7 +291,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
       });
 
       it('batch overload forwards data to the destination receive hook', async function () {
-        const [alice] = this.accounts;
+        const [alice] = this.accountsA;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -254,19 +299,21 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[],bytes)')(
             alice,
-            this.helpers.chain.toErc7930(this.receiver),
+            this.chainB.helpers.chain.toErc7930(this.receiver),
             ids,
             values,
             this.data,
           ),
         )
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(this.receiver), ids, values, this.data)
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(this.receiver), ids, values, this.data);
+
+        await expect(this.bridge.relay().then(([tx]) => tx))
           .to.emit(this.bridgeB, 'CrosschainMultiTokenTransferReceived')
-          .withArgs(anyValue, this.helpers.chain.toErc7930(alice), this.receiver, ids, values, this.data)
+          .withArgs(anyValue, this.chainA.helpers.chain.toErc7930(alice), this.receiver, ids, values, this.data)
           .to.emit(this.receiver, 'BatchReceived')
           .withArgs(
-            chainBIsCustodial ? this.bridgeB : this.gateway,
+            chainBIsCustodial ? this.bridgeB : this.bridge.gateway(this.chainB),
             chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress,
             ids,
             values,
@@ -278,7 +325,8 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
 
     describe('transfer with allowance', function () {
       it('spender is owner', async function () {
-        const [alice, bruce] = this.accounts;
+        const [alice] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -286,17 +334,18 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             alice,
-            this.helpers.chain.toErc7930(bruce),
+            this.chainB.helpers.chain.toErc7930(bruce),
             ids,
             values,
           ),
         )
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), ids, values, '0x');
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), ids, values, '0x');
       });
 
       it('spender is allowed for all', async function () {
-        const [alice, bruce, chris] = this.accounts;
+        const [alice, , chris] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -305,19 +354,20 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(chris).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             alice,
-            this.helpers.chain.toErc7930(bruce),
+            this.chainB.helpers.chain.toErc7930(bruce),
             ids,
             values,
           ),
         )
           .to.emit(this.bridgeA, 'CrosschainMultiTokenTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), ids, values, '0x');
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), ids, values, '0x');
       });
     });
 
     describe('invalid transfer', function () {
       it('missing allowance', async function () {
-        const [alice, bruce, chris] = this.accounts;
+        const [alice, , chris] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -326,7 +376,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(chris).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             alice,
-            this.helpers.chain.toErc7930(bruce),
+            this.chainB.helpers.chain.toErc7930(bruce),
             ids,
             values,
           ),
@@ -336,14 +386,15 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
       });
 
       it('insufficient balance', async function () {
-        const [alice, bruce] = this.accounts;
+        const [alice] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
 
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             alice,
-            this.helpers.chain.toErc7930(bruce),
+            this.chainB.helpers.chain.toErc7930(bruce),
             ids,
             values,
           ),
@@ -353,7 +404,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
       });
 
       it('reverts if the address part of the interoperable address is empty', async function () {
-        const [alice] = this.accounts;
+        const [alice] = this.accountsA;
 
         await this.tokenA.$_mintBatch(alice, ids, values, '0x');
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
@@ -361,7 +412,7 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
         await expect(
           this.bridgeA.connect(alice).getFunction('crosschainTransferFrom(address,bytes,uint256[],uint256[])')(
             alice,
-            this.helpers.chain.toErc7930(undefined),
+            this.chainB.helpers.chain.toErc7930(undefined),
             ids,
             values,
           ), // No address
@@ -371,65 +422,66 @@ export function shouldBehaveLikeBridgeERC1155({ chainAIsCustodial = false, chain
 
     describe('restrictions', function () {
       it('only gateway can relay messages', async function () {
-        const [notGateway] = this.accounts;
+        const [notGateway] = this.accountsA;
 
         await expect(
           this.bridgeA
             .connect(notGateway)
             .receiveMessage(
               ethers.ZeroHash,
-              this.helpers.chain.toErc7930(this.tokenB),
+              this.chainB.helpers.chain.toErc7930(this.tokenB),
               this.encodePayload(notGateway, notGateway, ids, values),
             ),
         )
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
-          .withArgs(notGateway, this.helpers.chain.toErc7930(this.tokenB));
+          .withArgs(notGateway, this.chainB.helpers.chain.toErc7930(this.tokenB));
       });
 
       it('only counterpart can send a crosschain message', async function () {
-        const [invalid] = this.accounts;
+        const [invalid] = this.accountsA;
 
+        // the gateway is the expected one, but the sender on chain B is not the registered counterpart
         await expect(
-          this.gateway
-            .connect(invalid)
-            .sendMessage(
-              this.helpers.chain.toErc7930(this.bridgeA),
+          this.bridge
+            .gateway(this.chainA)
+            .relayMessage(
+              this.chainB.helpers.chain.toErc7930(invalid),
+              this.chainA.helpers.chain.toErc7930(this.bridgeA),
               this.encodePayload(invalid, invalid, ids, values),
-              [],
             ),
         )
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
-          .withArgs(this.gateway, this.helpers.chain.toErc7930(invalid));
+          .withArgs(this.bridge.gateway(this.chainA), this.chainB.helpers.chain.toErc7930(invalid));
       });
     });
 
     describe('reconfiguration', function () {
       it('updating a link emits an event', async function () {
-        const newGateway = await this.ethers.deployContract('$ERC7786GatewayMock');
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const newGateway = await this.chainA.ethers.deployContract('$ERC7786GatewayMock');
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(newGateway, newCounterpart, true))
           .to.emit(this.bridgeA, 'LinkRegistered')
           .withArgs(newGateway, newCounterpart);
 
-        await expect(this.bridgeA.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
+        await expect(this.bridgeA.getLink(this.chainB.helpers.chain.erc7930)).to.eventually.deep.equal([
           newGateway.target,
           newCounterpart,
         ]);
       });
 
       it('cannot override configuration if "allowOverride" is false', async function () {
-        const newGateway = await this.ethers.deployContract('$ERC7786GatewayMock');
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const newGateway = await this.chainA.ethers.deployContract('$ERC7786GatewayMock');
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(newGateway, newCounterpart, false))
           .to.be.revertedWithCustomError(this.bridgeA, 'LinkAlreadyRegistered')
-          .withArgs(this.helpers.chain.erc7930);
+          .withArgs(this.chainB.helpers.chain.erc7930);
       });
 
       it('reject invalid gateway', async function () {
-        const notAGateway = this.accounts[0];
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const notAGateway = this.accountsA[0];
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(notAGateway, newCounterpart, false)).to.be.revertedWithoutReason(ethers);
       });

--- a/test/crosschain/BridgeERC1155.test.js
+++ b/test/crosschain/BridgeERC1155.test.js
@@ -1,43 +1,40 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
+import { ERC7786Bridge } from '../helpers/erc7786';
 import { shouldBehaveLikeBridgeERC1155 } from './BridgeERC1155.behavior';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain, impersonate },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
-
-  // Mock gateway
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const gatewayAsEOA = await impersonate(gateway);
+  const accountsA = await chainA.ethers.getSigners();
+  const accountsB = await chainB.ethers.getSigners();
 
   // Chain A: legacy ERC1155 with bridge
-  const tokenA = await ethers.deployContract('$ERC1155', ['https://token-cdn-domain/{id}.json']);
-  const bridgeA = await ethers.deployContract('$BridgeERC1155', [[], tokenA]);
+  const gatewayA = bridge.gateway(chainA);
+  const tokenA = await chainA.ethers.deployContract('$ERC1155', ['https://token-cdn-domain/{id}.json']);
+  const bridgeA = await chainA.ethers.deployContract('$BridgeERC1155', [[], tokenA]);
 
-  // Chain B: ERC1155 with native bridge integration
-  const tokenB = await ethers.deployContract('$ERC1155Crosschain', [
-    [[gateway, chain.toErc7930(bridgeA)]],
+  // Chain B: ERC1155 with native bridge integration (preconfigured link to bridgeA, on chain A)
+  const gatewayB = bridge.gateway(chainB);
+  const tokenB = await chainB.ethers.deployContract('$ERC1155Crosschain', [
+    [[gatewayB, chainA.helpers.chain.toErc7930(bridgeA)]],
     'https://token-cdn-domain/{id}.json',
   ]);
   const bridgeB = tokenB; // self bridge
 
   // deployment check + counterpart setup
-  await expect(bridgeA.$_setLink(gateway, chain.toErc7930(bridgeB), false))
+  await expect(bridgeA.$_setLink(gatewayA, chainB.helpers.chain.toErc7930(bridgeB), false))
     .to.emit(bridgeA, 'LinkRegistered')
-    .withArgs(gateway, chain.toErc7930(bridgeB));
+    .withArgs(gatewayA, chainB.helpers.chain.toErc7930(bridgeB));
 
-  return { accounts, gateway, gatewayAsEOA, tokenA, tokenB, bridgeA, bridgeB };
+  return { accountsA, accountsB, tokenA, tokenB, bridgeA, bridgeB };
 }
 
 describe('CrosschainBridgeERC1155', function () {
   beforeEach(async function () {
-    Object.assign(this, connection, await loadFixture(fixture));
+    Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
   });
 
   it('token getters', async function () {
@@ -51,7 +48,7 @@ describe('CrosschainBridgeERC1155', function () {
     const values = [100n, 320n];
 
     it('single', async function () {
-      const [alice] = this.accounts;
+      const [alice] = this.accountsA;
       await this.tokenA.$_mintBatch(alice, ids, values, '0x');
 
       await expect(this.tokenA.connect(alice).safeTransferFrom(alice, this.bridgeA, ids[0], values[0], '0x'))
@@ -60,7 +57,7 @@ describe('CrosschainBridgeERC1155', function () {
     });
 
     it('batch', async function () {
-      const [alice] = this.accounts;
+      const [alice] = this.accountsA;
       await this.tokenA.$_mintBatch(alice, ids, values, '0x');
 
       await expect(this.tokenA.connect(alice).safeBatchTransferFrom(alice, this.bridgeA, ids, values, '0x'))

--- a/test/crosschain/BridgeERC20.behavior.js
+++ b/test/crosschain/BridgeERC20.behavior.js
@@ -7,44 +7,48 @@ const amount = 100n;
 export function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBIsCustodial = false } = {}) {
   describe('bridge ERC20 like', function () {
     beforeEach(function () {
-      // helper
+      // helper: payload of a transfer coming from chain B
       this.encodePayload = (from, to, amount) =>
         ethers.AbiCoder.defaultAbiCoder().encode(
           ['bytes', 'bytes', 'uint256'],
-          [this.helpers.chain.toErc7930(from), to.target ?? to.address ?? to, amount],
+          [this.chainB.helpers.chain.toErc7930(from), to.target ?? to.address ?? to, amount],
         );
     });
 
     it('bridge setup', async function () {
-      await expect(this.bridgeA.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
-        this.gateway.target,
-        this.helpers.chain.toErc7930(this.bridgeB),
+      await expect(this.bridgeA.getLink(this.chainB.helpers.chain.erc7930)).to.eventually.deep.equal([
+        this.bridge.gateway(this.chainA).target,
+        this.chainB.helpers.chain.toErc7930(this.bridgeB),
       ]);
-      await expect(this.bridgeB.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
-        this.gateway.target,
-        this.helpers.chain.toErc7930(this.bridgeA),
+      await expect(this.bridgeB.getLink(this.chainA.helpers.chain.erc7930)).to.eventually.deep.equal([
+        this.bridge.gateway(this.chainB).target,
+        this.chainA.helpers.chain.toErc7930(this.bridgeA),
       ]);
     });
 
     it('crosschain send (both direction)', async function () {
-      const [alice, bruce, chris] = this.accounts;
+      const [alice, , chris] = this.accountsA;
+      const [, bruce] = this.accountsB;
 
       await this.tokenA.$_mint(alice, amount);
       await this.tokenA.connect(alice).approve(this.bridgeA, ethers.MaxUint256);
 
       // Alice sends tokens from chain A to Bruce on chain B.
-      await expect(this.bridgeA.connect(alice).crosschainTransfer(this.helpers.chain.toErc7930(bruce), amount))
+      await expect(this.bridgeA.connect(alice).crosschainTransfer(this.chainB.helpers.chain.toErc7930(bruce), amount))
         // bridge on chain A takes custody of the funds
         .to.emit(this.tokenA, 'Transfer')
         .withArgs(alice, chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress, amount)
         // crosschain transfer sent
         .to.emit(this.bridgeA, 'CrosschainFungibleTransferSent')
-        .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), amount)
+        .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), amount)
         // ERC-7786 event
-        .to.emit(this.gateway, 'MessageSent')
+        .to.emit(this.bridge.gateway(this.chainA), 'MessageSent');
+
+      // The bridge delivers the message on chain B.
+      await expect(this.bridge.relay().then(([tx]) => tx))
         // crosschain transfer received
         .to.emit(this.bridgeB, 'CrosschainFungibleTransferReceived')
-        .withArgs(anyValue, this.helpers.chain.toErc7930(alice), bruce, amount)
+        .withArgs(anyValue, this.chainA.helpers.chain.toErc7930(alice), bruce, amount)
         // crosschain mint event
         .to.emit(this.tokenB, 'CrosschainMint')
         .withArgs(bruce, amount, this.bridgeB)
@@ -53,7 +57,7 @@ export function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBI
         .withArgs(chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress, bruce, amount);
 
       // Bruce sends tokens from chain B to Chris on chain A.
-      await expect(this.bridgeB.connect(bruce).crosschainTransfer(this.helpers.chain.toErc7930(chris), amount))
+      await expect(this.bridgeB.connect(bruce).crosschainTransfer(this.chainA.helpers.chain.toErc7930(chris), amount))
         // tokens are burned on chain B
         .to.emit(this.tokenB, 'Transfer')
         .withArgs(bruce, chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress, amount)
@@ -62,12 +66,15 @@ export function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBI
         .withArgs(bruce, amount, this.bridgeB)
         // crosschain transfer sent
         .to.emit(this.bridgeB, 'CrosschainFungibleTransferSent')
-        .withArgs(anyValue, bruce, this.helpers.chain.toErc7930(chris), amount)
+        .withArgs(anyValue, bruce, this.chainA.helpers.chain.toErc7930(chris), amount)
         // ERC-7786 event
-        .to.emit(this.gateway, 'MessageSent')
+        .to.emit(this.bridge.gateway(this.chainB), 'MessageSent');
+
+      // The bridge delivers the message back on chain A.
+      await expect(this.bridge.relay().then(([tx]) => tx))
         // crosschain transfer received
         .to.emit(this.bridgeA, 'CrosschainFungibleTransferReceived')
-        .withArgs(anyValue, this.helpers.chain.toErc7930(bruce), chris, amount)
+        .withArgs(anyValue, this.chainB.helpers.chain.toErc7930(bruce), chris, amount)
         // bridge on chain A releases custody of the funds
         .to.emit(this.tokenA, 'Transfer')
         .withArgs(chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress, chris, amount);
@@ -75,13 +82,13 @@ export function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBI
 
     describe('invalid transfer', function () {
       it('reverts if the address part of the interoperable address is empty', async function () {
-        const [alice] = this.accounts;
+        const [alice] = this.accountsA;
 
         await this.tokenA.$_mint(alice, amount);
         await this.tokenA.connect(alice).approve(this.bridgeA, ethers.MaxUint256);
 
         await expect(
-          this.bridgeA.connect(alice).crosschainTransfer(this.helpers.chain.toErc7930(undefined), amount), // No address
+          this.bridgeA.connect(alice).crosschainTransfer(this.chainB.helpers.chain.toErc7930(undefined), amount), // No address
         ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainFungibleEmptyAddress');
       });
     });
@@ -92,63 +99,70 @@ export function shouldBehaveLikeBridgeERC20({ chainAIsCustodial = false, chainBI
       });
 
       it('only gateway can relay messages', async function () {
-        const [notGateway] = this.accounts;
+        const [notGateway] = this.accountsA;
 
         await expect(
           this.bridgeA
             .connect(notGateway)
             .receiveMessage(
               ethers.ZeroHash,
-              this.helpers.chain.toErc7930(this.tokenB),
+              this.chainB.helpers.chain.toErc7930(this.tokenB),
               this.encodePayload(notGateway, notGateway, amount),
             ),
         )
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
-          .withArgs(notGateway, this.helpers.chain.toErc7930(this.tokenB));
+          .withArgs(notGateway, this.chainB.helpers.chain.toErc7930(this.tokenB));
       });
 
       it('only counterpart can send a crosschain message', async function () {
-        const [invalid] = this.accounts;
+        const [invalid] = this.accountsA;
 
+        // the gateway is the expected one, but the sender on chain B is not the registered counterpart
         await expect(
-          this.gateway
-            .connect(invalid)
-            .sendMessage(this.helpers.chain.toErc7930(this.bridgeA), this.encodePayload(invalid, invalid, amount), []),
+          this.bridge
+            .gateway(this.chainA)
+            .relayMessage(
+              this.chainB.helpers.chain.toErc7930(invalid),
+              this.chainA.helpers.chain.toErc7930(this.bridgeA),
+              this.encodePayload(invalid, invalid, amount),
+            ),
         )
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
-          .withArgs(this.gateway, this.helpers.chain.toErc7930(invalid));
+          .withArgs(this.bridge.gateway(this.chainA), this.chainB.helpers.chain.toErc7930(invalid));
       });
     });
 
     describe('reconfiguration', function () {
       it('updating a link emits an event', async function () {
-        const newGateway = await this.ethers.deployContract('$ERC7786GatewayMock');
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const newGateway = await this.chainA.ethers.deployContract('$ERC7786GatewayMock');
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(newGateway, newCounterpart, true))
           .to.emit(this.bridgeA, 'LinkRegistered')
           .withArgs(newGateway, newCounterpart);
 
-        await expect(this.bridgeA.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
+        await expect(this.bridgeA.getLink(this.chainB.helpers.chain.erc7930)).to.eventually.deep.equal([
           newGateway.target,
           newCounterpart,
         ]);
       });
 
       it('cannot override configuration is "allowOverride" is false', async function () {
-        const newGateway = await this.ethers.deployContract('$ERC7786GatewayMock');
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const newGateway = await this.chainA.ethers.deployContract('$ERC7786GatewayMock');
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(newGateway, newCounterpart, false))
           .to.be.revertedWithCustomError(this.bridgeA, 'LinkAlreadyRegistered')
-          .withArgs(this.helpers.chain.erc7930);
+          .withArgs(this.chainB.helpers.chain.erc7930);
       });
 
       it('reject invalid gateway', async function () {
-        const notAGateway = this.accounts[0];
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const notAGateway = this.accountsA[0];
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
-        await expect(this.bridgeA.$_setLink(notAGateway, newCounterpart, false)).to.be.revertedWithoutReason(ethers);
+        await expect(this.bridgeA.$_setLink(notAGateway, newCounterpart, false)).to.be.revertedWithoutReason(
+          this.chainA.ethers,
+        );
       });
     });
   });

--- a/test/crosschain/BridgeERC20.test.js
+++ b/test/crosschain/BridgeERC20.test.js
@@ -1,41 +1,45 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
+import { ERC7786Bridge } from '../helpers/erc7786';
 import { shouldBehaveLikeBridgeERC20 } from './BridgeERC20.behavior';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain, impersonate },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
-
-  // Mock gateway
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const gatewayAsEOA = await impersonate(gateway);
+  const accountsA = await chainA.ethers.getSigners();
+  const accountsB = await chainB.ethers.getSigners();
 
   // Chain A: legacy ERC20 with bridge
-  const tokenA = await ethers.deployContract('$ERC20', ['Token1', 'T1']);
-  const bridgeA = await ethers.deployContract('$BridgeERC20', [[], tokenA]);
+  const gatewayA = bridge.gateway(chainA);
+  const tokenA = await chainA.ethers.deployContract('$ERC20', ['Token1', 'T1']);
+  const bridgeA = await chainA.ethers.deployContract('$BridgeERC20', [[], tokenA]);
 
-  // Chain B: ERC7802 with bridge (preconfigured link to bridgeA)
-  const tokenB = await ethers.deployContract('$ERC20BridgeableMock', ['Token2', 'T2', ethers.ZeroAddress]);
-  const bridgeB = await ethers.deployContract('$BridgeERC7802', [[[gateway, chain.toErc7930(bridgeA)]], tokenB]);
+  // Chain B: ERC7802 with bridge (preconfigured link to bridgeA, on chain A)
+  const gatewayB = bridge.gateway(chainB);
+  const tokenB = await chainB.ethers.deployContract('$ERC20BridgeableMock', [
+    'Token2',
+    'T2',
+    chainB.ethers.ZeroAddress,
+  ]);
+  const bridgeB = await chainB.ethers.deployContract('$BridgeERC7802', [
+    [[gatewayB, chainA.helpers.chain.toErc7930(bridgeA)]],
+    tokenB,
+  ]);
 
   // deployment check + counterpart setup
-  await expect(bridgeA.$_setLink(gateway, chain.toErc7930(bridgeB), false))
+  await expect(bridgeA.$_setLink(gatewayA, chainB.helpers.chain.toErc7930(bridgeB), false))
     .to.emit(bridgeA, 'LinkRegistered')
-    .withArgs(gateway, chain.toErc7930(bridgeB));
+    .withArgs(gatewayA, chainB.helpers.chain.toErc7930(bridgeB));
   await tokenB.$_setBridge(bridgeB);
 
-  return { accounts, gateway, gatewayAsEOA, tokenA, tokenB, bridgeA, bridgeB };
+  return { accountsA, accountsB, tokenA, tokenB, bridgeA, bridgeB };
 }
 
 describe('CrosschainBridgeERC20', function () {
   beforeEach(async function () {
-    Object.assign(this, connection, await loadFixture(fixture));
+    Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
   });
 
   it('token getters', async function () {

--- a/test/crosschain/BridgeERC721.behavior.js
+++ b/test/crosschain/BridgeERC721.behavior.js
@@ -7,65 +7,72 @@ const tokenId = 42n;
 export function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainBIsCustodial = false } = {}) {
   describe('bridge ERC721 like', function () {
     beforeEach(function () {
-      // helper
+      // helper: payload of a transfer coming from chain B
       this.encodePayload = (from, to, tokenId) =>
         ethers.AbiCoder.defaultAbiCoder().encode(
           ['bytes', 'bytes', 'uint256'],
-          [this.helpers.chain.toErc7930(from), to.target ?? to.address ?? to, tokenId],
+          [this.chainB.helpers.chain.toErc7930(from), to.target ?? to.address ?? to, tokenId],
         );
     });
 
     it('bridge setup', async function () {
-      await expect(this.bridgeA.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
-        this.gateway.target,
-        this.helpers.chain.toErc7930(this.bridgeB),
+      await expect(this.bridgeA.getLink(this.chainB.helpers.chain.erc7930)).to.eventually.deep.equal([
+        this.bridge.gateway(this.chainA).target,
+        this.chainB.helpers.chain.toErc7930(this.bridgeB),
       ]);
-      await expect(this.bridgeB.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
-        this.gateway.target,
-        this.helpers.chain.toErc7930(this.bridgeA),
+      await expect(this.bridgeB.getLink(this.chainA.helpers.chain.erc7930)).to.eventually.deep.equal([
+        this.bridge.gateway(this.chainB).target,
+        this.chainA.helpers.chain.toErc7930(this.bridgeA),
       ]);
     });
 
     it('crosschain send (both direction)', async function () {
-      const [alice, bruce, chris] = this.accounts;
+      const [alice, , chris] = this.accountsA;
+      const [, bruce] = this.accountsB;
 
       await this.tokenA.$_mint(alice, tokenId);
       await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
 
       // Alice sends tokens from chain A to Bruce on chain B.
       await expect(
-        this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(bruce), tokenId),
+        this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
       )
         // bridge on chain A takes custody of the token
         .to.emit(this.tokenA, 'Transfer')
         .withArgs(alice, chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress, tokenId)
         // crosschain transfer sent
         .to.emit(this.bridgeA, 'CrosschainNonFungibleTransferSent')
-        .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), tokenId)
+        .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId)
         // ERC-7786 event
-        .to.emit(this.gateway, 'MessageSent')
+        .to.emit(this.bridge.gateway(this.chainA), 'MessageSent');
+
+      // The bridge delivers the message on chain B.
+      await expect(this.bridge.relay().then(([tx]) => tx))
         // crosschain transfer received
         .to.emit(this.bridgeB, 'CrosschainNonFungibleTransferReceived')
-        .withArgs(anyValue, this.helpers.chain.toErc7930(alice), bruce, tokenId)
+        .withArgs(anyValue, this.chainA.helpers.chain.toErc7930(alice), bruce, tokenId)
         // tokens are minted on chain B
         .to.emit(this.tokenB, 'Transfer')
         .withArgs(chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress, bruce, tokenId);
 
       // Bruce sends tokens from chain B to Chris on chain A.
       await expect(
-        this.bridgeB.connect(bruce).crosschainTransferFrom(bruce, this.helpers.chain.toErc7930(chris), tokenId),
+        this.bridgeB.connect(bruce).crosschainTransferFrom(bruce, this.chainA.helpers.chain.toErc7930(chris), tokenId),
       )
         // tokens are burned on chain B
         .to.emit(this.tokenB, 'Transfer')
         .withArgs(bruce, chainBIsCustodial ? this.bridgeB : ethers.ZeroAddress, tokenId)
         // crosschain transfer sent
         .to.emit(this.bridgeB, 'CrosschainNonFungibleTransferSent')
-        .withArgs(anyValue, bruce, this.helpers.chain.toErc7930(chris), tokenId)
+        .withArgs(anyValue, bruce, this.chainA.helpers.chain.toErc7930(chris), tokenId)
         // ERC-7786 event
-        .to.emit(this.gateway, 'MessageSent')
+        .to.emit(this.bridge.gateway(this.chainB), 'MessageSent');
+
+      // The bridge delivers the message back on chain A.
+      await expect(this.bridge.relay().then(([tx]) => tx))
         // crosschain transfer received
         .to.emit(this.bridgeA, 'CrosschainNonFungibleTransferReceived')
-        .withArgs(anyValue, this.helpers.chain.toErc7930(bruce), chris, tokenId)
+        .withArgs(anyValue, this.chainB.helpers.chain.toErc7930(bruce), chris, tokenId)
         // bridge on chain A releases custody of the token
         .to.emit(this.tokenA, 'Transfer')
         .withArgs(chainAIsCustodial ? this.bridgeA : ethers.ZeroAddress, chris, tokenId);
@@ -73,21 +80,25 @@ export function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainB
 
     describe('transfer with allowance', function () {
       it('spender is owner', async function () {
-        const [alice, bruce] = this.accounts;
+        const [alice] = this.accountsA;
+        const [, bruce] = this.accountsB;
         const tokenId = 17n;
 
         await this.tokenA.$_mint(alice, tokenId);
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
 
         await expect(
-          this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(bruce), tokenId),
+          this.bridgeA
+            .connect(alice)
+            .crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
         )
           .to.emit(this.bridgeA, 'CrosschainNonFungibleTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), tokenId);
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId);
       });
 
       it('spender is allowed for all', async function () {
-        const [alice, bruce, chris, david] = this.accounts;
+        const [alice, , chris, david] = this.accountsA;
+        const [, bruce] = this.accountsB;
         const tokenId = 17n;
 
         await this.tokenA.$_mint(alice, tokenId);
@@ -96,21 +107,26 @@ export function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainB
 
         // david is not allowed
         await expect(
-          this.bridgeA.connect(david).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(bruce), tokenId),
+          this.bridgeA
+            .connect(david)
+            .crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
         )
           .to.be.revertedWithCustomError(this.tokenA, 'ERC721InsufficientApproval')
           .withArgs(david, tokenId);
 
         // chris is allowed
         await expect(
-          this.bridgeA.connect(chris).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(bruce), tokenId),
+          this.bridgeA
+            .connect(chris)
+            .crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
         )
           .to.emit(this.bridgeA, 'CrosschainNonFungibleTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), tokenId);
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId);
       });
 
       it('spender is allowed for specific token', async function () {
-        const [alice, bruce, chris] = this.accounts;
+        const [alice, , chris] = this.accountsA;
+        const [, bruce] = this.accountsB;
         const tokenId = 17n;
         const otherTokenId = 42n;
 
@@ -121,116 +137,130 @@ export function shouldBehaveLikeBridgeERC721({ chainAIsCustodial = false, chainB
 
         // chris is not allowed to transfer otherTokenId
         await expect(
-          this.bridgeA.connect(chris).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(bruce), otherTokenId),
+          this.bridgeA
+            .connect(chris)
+            .crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(bruce), otherTokenId),
         )
           .to.be.revertedWithCustomError(this.tokenA, 'ERC721InsufficientApproval')
           .withArgs(chris, otherTokenId);
 
         // chris is allowed to transfer tokenId
         await expect(
-          this.bridgeA.connect(chris).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(bruce), tokenId),
+          this.bridgeA
+            .connect(chris)
+            .crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
         )
           .to.emit(this.bridgeA, 'CrosschainNonFungibleTransferSent')
-          .withArgs(anyValue, alice, this.helpers.chain.toErc7930(bruce), tokenId);
+          .withArgs(anyValue, alice, this.chainB.helpers.chain.toErc7930(bruce), tokenId);
       });
     });
 
     describe('invalid transfer', function () {
       it('token not minted', async function () {
-        const [alice, bruce] = this.accounts;
+        const [alice] = this.accountsA;
+        const [, bruce] = this.accountsB;
 
         await expect(
           this.bridgeA
             .connect(alice)
-            .crosschainTransferFrom(ethers.ZeroAddress, this.helpers.chain.toErc7930(bruce), tokenId),
+            .crosschainTransferFrom(ethers.ZeroAddress, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
         )
           .to.be.revertedWithCustomError(this.tokenA, 'ERC721NonexistentToken')
           .withArgs(tokenId);
       });
 
       it('incorrect from argument', async function () {
-        const [alice, bruce] = this.accounts;
+        const [alice, bruce] = this.accountsA;
 
         await this.tokenA.$_mint(alice, tokenId);
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
         await this.tokenA.connect(alice).setApprovalForAll(bruce, true);
 
         await expect(
-          this.bridgeA.connect(bruce).crosschainTransferFrom(bruce, this.helpers.chain.toErc7930(bruce), tokenId),
+          this.bridgeA
+            .connect(bruce)
+            .crosschainTransferFrom(bruce, this.chainB.helpers.chain.toErc7930(bruce), tokenId),
         )
           .to.be.revertedWithCustomError(this.tokenA, 'ERC721IncorrectOwner')
           .withArgs(bruce, tokenId, alice);
       });
 
       it('reverts if the address part of the interoperable address is empty', async function () {
-        const [alice] = this.accounts;
+        const [alice] = this.accountsA;
 
         await this.tokenA.$_mint(alice, tokenId);
         await this.tokenA.connect(alice).setApprovalForAll(this.bridgeA, true);
 
         await expect(
-          this.bridgeA.connect(alice).crosschainTransferFrom(alice, this.helpers.chain.toErc7930(undefined), tokenId), // No address
+          this.bridgeA
+            .connect(alice)
+            .crosschainTransferFrom(alice, this.chainB.helpers.chain.toErc7930(undefined), tokenId), // No address
         ).to.be.revertedWithCustomError(this.bridgeA, 'CrosschainNonFungibleEmptyAddress');
       });
     });
 
     describe('restrictions', function () {
       it('only gateway can relay messages', async function () {
-        const [notGateway] = this.accounts;
+        const [notGateway] = this.accountsA;
 
         await expect(
           this.bridgeA
             .connect(notGateway)
             .receiveMessage(
               ethers.ZeroHash,
-              this.helpers.chain.toErc7930(this.tokenB),
+              this.chainB.helpers.chain.toErc7930(this.tokenB),
               this.encodePayload(notGateway, notGateway, tokenId),
             ),
         )
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
-          .withArgs(notGateway, this.helpers.chain.toErc7930(this.tokenB));
+          .withArgs(notGateway, this.chainB.helpers.chain.toErc7930(this.tokenB));
       });
 
       it('only counterpart can send a crosschain message', async function () {
-        const [invalid] = this.accounts;
+        const [invalid] = this.accountsA;
 
+        // the gateway is the expected one, but the sender on chain B is not the registered counterpart
         await expect(
-          this.gateway
-            .connect(invalid)
-            .sendMessage(this.helpers.chain.toErc7930(this.bridgeA), this.encodePayload(invalid, invalid, tokenId), []),
+          this.bridge
+            .gateway(this.chainA)
+            .relayMessage(
+              this.chainB.helpers.chain.toErc7930(invalid),
+              this.chainA.helpers.chain.toErc7930(this.bridgeA),
+              this.encodePayload(invalid, invalid, tokenId),
+            ),
         )
           .to.be.revertedWithCustomError(this.bridgeA, 'ERC7786RecipientUnauthorizedGateway')
-          .withArgs(this.gateway, this.helpers.chain.toErc7930(invalid));
+          .withArgs(this.bridge.gateway(this.chainA), this.chainB.helpers.chain.toErc7930(invalid));
       });
     });
 
     describe('reconfiguration', function () {
       it('updating a link emits an event', async function () {
-        const newGateway = await this.ethers.deployContract('$ERC7786GatewayMock');
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const newGateway = await this.chainA.ethers.deployContract('$ERC7786GatewayMock');
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(newGateway, newCounterpart, true))
           .to.emit(this.bridgeA, 'LinkRegistered')
           .withArgs(newGateway, newCounterpart);
 
-        await expect(this.bridgeA.getLink(this.helpers.chain.erc7930)).to.eventually.deep.equal([
+        await expect(this.bridgeA.getLink(this.chainB.helpers.chain.erc7930)).to.eventually.deep.equal([
           newGateway.target,
           newCounterpart,
         ]);
       });
 
       it('cannot override configuration if "allowOverride" is false', async function () {
-        const newGateway = await this.ethers.deployContract('$ERC7786GatewayMock');
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const newGateway = await this.chainA.ethers.deployContract('$ERC7786GatewayMock');
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(newGateway, newCounterpart, false))
           .to.be.revertedWithCustomError(this.bridgeA, 'LinkAlreadyRegistered')
-          .withArgs(this.helpers.chain.erc7930);
+          .withArgs(this.chainB.helpers.chain.erc7930);
       });
 
       it('reject invalid gateway', async function () {
-        const notAGateway = this.accounts[0];
-        const newCounterpart = this.helpers.chain.toErc7930(this.accounts[0]);
+        const notAGateway = this.accountsA[0];
+        const newCounterpart = this.chainB.helpers.chain.toErc7930(this.accountsA[0]);
 
         await expect(this.bridgeA.$_setLink(notAGateway, newCounterpart, false)).to.be.revertedWithoutReason(ethers);
       });

--- a/test/crosschain/BridgeERC721.test.js
+++ b/test/crosschain/BridgeERC721.test.js
@@ -1,44 +1,41 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
+import { ERC7786Bridge } from '../helpers/erc7786';
 import { shouldBehaveLikeBridgeERC721 } from './BridgeERC721.behavior';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain, impersonate },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
-
-  // Mock gateway
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const gatewayAsEOA = await impersonate(gateway);
+  const accountsA = await chainA.ethers.getSigners();
+  const accountsB = await chainB.ethers.getSigners();
 
   // Chain A: legacy ERC721 with bridge
-  const tokenA = await ethers.deployContract('$ERC721', ['Token1', 'T1']);
-  const bridgeA = await ethers.deployContract('$BridgeERC721', [[], tokenA]);
+  const gatewayA = bridge.gateway(chainA);
+  const tokenA = await chainA.ethers.deployContract('$ERC721', ['Token1', 'T1']);
+  const bridgeA = await chainA.ethers.deployContract('$BridgeERC721', [[], tokenA]);
 
-  // Chain B: ERC721 with native bridge integration
-  const tokenB = await ethers.deployContract('$ERC721Crosschain', [
-    [[gateway, chain.toErc7930(bridgeA)]],
+  // Chain B: ERC721 with native bridge integration (preconfigured link to bridgeA, on chain A)
+  const gatewayB = bridge.gateway(chainB);
+  const tokenB = await chainB.ethers.deployContract('$ERC721Crosschain', [
+    [[gatewayB, chainA.helpers.chain.toErc7930(bridgeA)]],
     'Token2',
     'T2',
   ]);
   const bridgeB = tokenB; // self bridge
 
   // deployment check + counterpart setup
-  await expect(bridgeA.$_setLink(gateway, chain.toErc7930(bridgeB), false))
+  await expect(bridgeA.$_setLink(gatewayA, chainB.helpers.chain.toErc7930(bridgeB), false))
     .to.emit(bridgeA, 'LinkRegistered')
-    .withArgs(gateway, chain.toErc7930(bridgeB));
+    .withArgs(gatewayA, chainB.helpers.chain.toErc7930(bridgeB));
 
-  return { accounts, gateway, gatewayAsEOA, tokenA, tokenB, bridgeA, bridgeB };
+  return { accountsA, accountsB, tokenA, tokenB, bridgeA, bridgeB };
 }
 
 describe('CrosschainBridgeERC721', function () {
   beforeEach(async function () {
-    Object.assign(this, connection, await loadFixture(fixture));
+    Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
   });
 
   it('token getters', async function () {

--- a/test/crosschain/CrosschainExecutor.test.js
+++ b/test/crosschain/CrosschainExecutor.test.js
@@ -1,6 +1,8 @@
 import { network } from 'hardhat';
+import { ethers } from 'ethers';
 import { expect } from 'chai';
 
+import { ERC7786Bridge } from '../helpers/erc7786';
 import {
   CALL_TYPE_CALL,
   CALL_TYPE_BATCH,
@@ -11,36 +13,41 @@ import {
   encodeDelegate,
 } from '../helpers/erc7579';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const [admin, other] = await ethers.getSigners();
+  // the controller is on chain A, the executor (and everything it operates on) is on chain B
+  const [admin, other] = await chainA.ethers.getSigners();
+  const gatewayA = bridge.gateway(chainA);
+  const gatewayB = bridge.gateway(chainB);
 
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const target = await ethers.deployContract('CallReceiverMock');
+  const target = await chainB.ethers.deployContract('CallReceiverMock');
+  const executor = await chainB.ethers.deployContract('$CrosschainRemoteExecutor', [
+    gatewayB,
+    chainA.helpers.chain.toErc7930(admin),
+  ]);
 
-  // Deploy executor
-  const executor = await ethers.deployContract('$CrosschainRemoteExecutor', [gateway, chain.toErc7930(admin)]);
-
+  // Send an instruction from chain A, and return the transaction that executes it on chain B.
   const remoteExecute = (from, target, mode, data) =>
-    gateway.connect(from).sendMessage(target, ethers.concat([mode, data]), []);
+    gatewayA
+      .connect(from)
+      .sendMessage(target, ethers.concat([mode, data]), [])
+      .then(() => bridge.relay())
+      .then(([tx]) => tx);
 
-  return { gateway, target, executor, admin, other, remoteExecute };
+  return { target, executor, admin, other, remoteExecute };
 }
 
 describe('CrosschainRemoteController & CrosschainRemoteExecutor', function () {
   beforeEach(async function () {
-    Object.assign(this, await loadFixture(fixture));
+    Object.assign(this, await bridge.loadFixture(fixture));
   });
 
   it('setup', async function () {
-    await expect(this.executor.gateway()).to.eventually.equal(this.gateway);
-    await expect(this.executor.controller()).to.eventually.equal(chain.toErc7930(this.admin));
+    await expect(this.executor.gateway()).to.eventually.equal(bridge.gateway(chainB));
+    await expect(this.executor.controller()).to.eventually.equal(chainA.helpers.chain.toErc7930(this.admin));
   });
 
   describe('crosschain operation', function () {
@@ -48,7 +55,7 @@ describe('CrosschainRemoteController & CrosschainRemoteExecutor', function () {
       const mode = encodeMode({ callType: CALL_TYPE_CALL });
       const data = encodeSingle(this.target, 0n, this.target.interface.encodeFunctionData('mockFunctionExtra'));
 
-      await expect(this.remoteExecute(this.admin, chain.toErc7930(this.executor), mode, data))
+      await expect(this.remoteExecute(this.admin, chainB.helpers.chain.toErc7930(this.executor), mode, data))
         .to.emit(this.target, 'MockFunctionCalledExtra')
         .withArgs(this.executor, 0n);
     });
@@ -60,7 +67,7 @@ describe('CrosschainRemoteController & CrosschainRemoteExecutor', function () {
         [this.target, 0n, this.target.interface.encodeFunctionData('mockFunctionExtra')],
       );
 
-      await expect(this.remoteExecute(this.admin, chain.toErc7930(this.executor), mode, data))
+      await expect(this.remoteExecute(this.admin, chainB.helpers.chain.toErc7930(this.executor), mode, data))
         .to.emit(this.target, 'MockFunctionCalledWithArgs')
         .withArgs(42, '0x1234')
         .to.emit(this.target, 'MockFunctionCalledExtra')
@@ -71,16 +78,16 @@ describe('CrosschainRemoteController & CrosschainRemoteExecutor', function () {
       const mode = encodeMode({ callType: CALL_TYPE_DELEGATE });
       const data = encodeDelegate(this.target, this.target.interface.encodeFunctionData('mockFunctionExtra'));
 
-      await expect(this.remoteExecute(this.admin, chain.toErc7930(this.executor), mode, data))
+      await expect(this.remoteExecute(this.admin, chainB.helpers.chain.toErc7930(this.executor), mode, data))
         .to.emit(this.target.attach(this.executor.target), 'MockFunctionCalledExtra')
-        .withArgs(this.gateway, 0n);
+        .withArgs(bridge.gateway(chainB), 0n);
     });
 
     it('revert when mode is invalid', async function () {
       const mode = encodeMode({ callType: '0x42' });
       const data = '0x';
 
-      await expect(this.remoteExecute(this.admin, chain.toErc7930(this.executor), mode, data))
+      await expect(this.remoteExecute(this.admin, chainB.helpers.chain.toErc7930(this.executor), mode, data))
         .to.be.revertedWithCustomError(this.executor, 'ERC7579UnsupportedCallType')
         .withArgs('0x42');
     });
@@ -88,7 +95,7 @@ describe('CrosschainRemoteController & CrosschainRemoteExecutor', function () {
 
   describe('reconfigure', function () {
     beforeEach(async function () {
-      this.newGateway = await ethers.deployContract('$ERC7786GatewayMock');
+      this.newGateway = await chainB.ethers.deployContract('$ERC7786GatewayMock');
     });
 
     it('through a crosschain call: success', async function () {
@@ -98,47 +105,52 @@ describe('CrosschainRemoteController & CrosschainRemoteExecutor', function () {
         0n,
         this.executor.interface.encodeFunctionData('reconfigure', [
           this.newGateway.target,
-          chain.toErc7930(this.other),
+          chainA.helpers.chain.toErc7930(this.other),
         ]),
       );
 
-      await expect(this.remoteExecute(this.admin, chain.toErc7930(this.executor), mode, data))
+      await expect(this.remoteExecute(this.admin, chainB.helpers.chain.toErc7930(this.executor), mode, data))
         .to.emit(this.executor, 'CrosschainControllerSet')
-        .withArgs(this.newGateway, chain.toErc7930(this.other));
+        .withArgs(this.newGateway, chainA.helpers.chain.toErc7930(this.other));
 
       await expect(this.executor.gateway()).to.eventually.equal(this.newGateway);
-      await expect(this.executor.controller()).to.eventually.equal(chain.toErc7930(this.other));
+      await expect(this.executor.controller()).to.eventually.equal(chainA.helpers.chain.toErc7930(this.other));
     });
 
     it('through the internal setter: success', async function () {
-      await expect(this.executor.$_setup(this.newGateway, chain.toErc7930(this.other)))
+      await expect(this.executor.$_setup(this.newGateway, chainA.helpers.chain.toErc7930(this.other)))
         .to.emit(this.executor, 'CrosschainControllerSet')
-        .withArgs(this.newGateway, chain.toErc7930(this.other));
+        .withArgs(this.newGateway, chainA.helpers.chain.toErc7930(this.other));
 
       await expect(this.executor.gateway()).to.eventually.equal(this.newGateway);
-      await expect(this.executor.controller()).to.eventually.equal(chain.toErc7930(this.other));
+      await expect(this.executor.controller()).to.eventually.equal(chainA.helpers.chain.toErc7930(this.other));
     });
 
     it('with an invalid new gateway: revert', async function () {
       // directly using the internal setter
-      await expect(this.executor.$_setup(this.other, chain.toErc7930(this.other))).to.revert(ethers);
+      await expect(this.executor.$_setup(this.other, chainA.helpers.chain.toErc7930(this.other))).to.revert(
+        chainB.ethers,
+      );
 
       // through a crosschain call
       const mode = encodeMode({ callType: CALL_TYPE_CALL });
       const data = encodeSingle(
         this.executor,
         0n,
-        this.executor.interface.encodeFunctionData('reconfigure', [this.other.address, chain.toErc7930(this.other)]),
+        this.executor.interface.encodeFunctionData('reconfigure', [
+          this.other.address,
+          chainA.helpers.chain.toErc7930(this.other),
+        ]),
       );
 
       await expect(
-        this.remoteExecute(this.admin, chain.toErc7930(this.executor), mode, data),
+        this.remoteExecute(this.admin, chainB.helpers.chain.toErc7930(this.executor), mode, data),
       ).to.be.revertedWithCustomError(this.executor, 'FailedCall');
     });
 
     it('is access controlled', async function () {
       await expect(
-        this.executor.reconfigure(this.newGateway, chain.toErc7930(this.other)),
+        this.executor.reconfigure(this.newGateway, chainA.helpers.chain.toErc7930(this.other)),
       ).to.be.revertedWithCustomError(this.executor, 'AccessRestricted');
     });
   });

--- a/test/crosschain/ERC7786Recipient.test.js
+++ b/test/crosschain/ERC7786Recipient.test.js
@@ -1,64 +1,86 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
+import { ERC7786Bridge } from '../helpers/erc7786';
 import * as random from '../helpers/random';
 
-const {
-  ethers,
-  helpers: { chain },
-  networkHelpers: { loadFixture },
-} = await network.create();
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 const value = 42n;
 const payload = random.bytes(128);
 const attributes = [];
 
 async function fixture() {
-  const [sender, notAGateway] = await ethers.getSigners();
+  const [sender] = await chainA.ethers.getSigners();
+  const [notAGateway] = await chainB.ethers.getSigners();
 
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const receiver = await ethers.deployContract('$ERC7786RecipientMock', [gateway]);
+  // the receiver is on chain B, and only trusts the gateway deployed there
+  const receiver = await chainB.ethers.deployContract('$ERC7786RecipientMock', [bridge.gateway(chainB)]);
 
-  return { sender, notAGateway, gateway, receiver };
+  return { sender, notAGateway, receiver };
 }
 
 // NOTE: here we are only testing the receiver. Failures of the gateway itself (invalid attributes, ...) are out of scope.
 describe('ERC7786Recipient', function () {
   beforeEach(async function () {
-    Object.assign(this, await loadFixture(fixture));
+    Object.assign(this, await bridge.loadFixture(fixture));
   });
 
   it('receives gateway relayed messages', async function () {
     await expect(
-      this.gateway.connect(this.sender).sendMessage(chain.toErc7930(this.receiver), payload, attributes, { value }),
+      bridge
+        .gateway(chainA)
+        .connect(this.sender)
+        .sendMessage(chainB.helpers.chain.toErc7930(this.receiver), payload, attributes, { value }),
     )
-      .to.emit(this.gateway, 'MessageSent')
+      .to.emit(bridge.gateway(chainA), 'MessageSent')
       .withArgs(
-        ethers.ZeroHash,
-        chain.toErc7930(this.sender),
-        chain.toErc7930(this.receiver),
+        chainA.ethers.ZeroHash,
+        chainA.helpers.chain.toErc7930(this.sender),
+        chainB.helpers.chain.toErc7930(this.receiver),
         payload,
         value,
         attributes,
-      )
+      );
+
+    await expect(bridge.relay().then(([tx]) => tx))
       .to.emit(this.receiver, 'MessageReceived')
-      .withArgs(this.gateway, ethers.toBeHex(1n, 32n), chain.toErc7930(this.sender), payload, value);
+      .withArgs(
+        bridge.gateway(chainB),
+        chainB.ethers.toBeHex(1n, 32n),
+        chainA.helpers.chain.toErc7930(this.sender),
+        payload,
+        value,
+      );
   });
 
   it('receive multiple similar messages', async function () {
     for (let i = 1n; i < 5n; ++i) {
-      await expect(
-        this.gateway.connect(this.sender).sendMessage(chain.toErc7930(this.receiver), payload, attributes, { value }),
-      )
+      await bridge
+        .gateway(chainA)
+        .connect(this.sender)
+        .sendMessage(chainB.helpers.chain.toErc7930(this.receiver), payload, attributes, { value });
+
+      await expect(bridge.relay().then(([tx]) => tx))
         .to.emit(this.receiver, 'MessageReceived')
-        .withArgs(this.gateway, ethers.toBeHex(i, 32n), chain.toErc7930(this.sender), payload, value);
+        .withArgs(
+          bridge.gateway(chainB),
+          chainB.ethers.toBeHex(i, 32n),
+          chainA.helpers.chain.toErc7930(this.sender),
+          payload,
+          value,
+        );
     }
   });
 
   it('unauthorized call', async function () {
     await expect(
-      this.receiver.connect(this.notAGateway).receiveMessage(ethers.ZeroHash, chain.toErc7930(this.sender), payload),
+      this.receiver
+        .connect(this.notAGateway)
+        .receiveMessage(chainB.ethers.ZeroHash, chainA.helpers.chain.toErc7930(this.sender), payload),
     )
       .to.be.revertedWithCustomError(this.receiver, 'ERC7786RecipientUnauthorizedGateway')
-      .withArgs(this.notAGateway, chain.toErc7930(this.sender));
+      .withArgs(this.notAGateway, chainA.helpers.chain.toErc7930(this.sender));
   });
 });

--- a/test/governance/extensions/GovernorCrosschain.test.js
+++ b/test/governance/extensions/GovernorCrosschain.test.js
@@ -1,16 +1,15 @@
 import { network } from 'hardhat';
+import { ethers } from 'ethers';
 import { expect } from 'chai';
 
+import { ERC7786Bridge } from '../../helpers/erc7786';
 import { CALL_TYPE_CALL, encodeMode, encodeSingle } from '../../helpers/erc7579';
 import { GovernorHelper } from '../../helpers/governance';
 import { VoteType } from '../../helpers/enums';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 const name = 'OZ-Governor';
 const version = '1';
@@ -22,14 +21,12 @@ const votingPeriod = 16n;
 const value = ethers.parseEther('1');
 
 async function fixture() {
-  const [owner, proposer, voter1, voter2, voter3, voter4] = await ethers.getSigners();
-
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const receiver = await ethers.deployContract('CallReceiverMock');
+  // governance lives on chain A, the executor (and what it operates on) on chain B
+  const [owner, proposer, voter1, voter2, voter3, voter4] = await chainA.ethers.getSigners();
 
   // Deploy governance
-  const token = await ethers.deployContract('$ERC20Votes', [tokenName, tokenSymbol, tokenName, version]);
-  const governor = await ethers.deployContract('$GovernorCrosschainMock', [
+  const token = await chainA.ethers.deployContract('$ERC20Votes', [tokenName, tokenSymbol, tokenName, version]);
+  const governor = await chainA.ethers.deployContract('$GovernorCrosschainMock', [
     name, // name
     votingDelay, // initialVotingDelay
     votingPeriod, // initialVotingPeriod
@@ -38,13 +35,17 @@ async function fixture() {
     10n, // quorumNumeratorValue
   ]);
 
-  // Deploy executor
-  const executor = await ethers.deployContract('$CrosschainRemoteExecutor', [gateway, chain.toErc7930(governor)]);
+  // Deploy executor (and its target) on chain B, controlled by the governor on chain A
+  const receiver = await chainB.ethers.deployContract('CallReceiverMock');
+  const executor = await chainB.ethers.deployContract('$CrosschainRemoteExecutor', [
+    bridge.gateway(chainB),
+    chainA.helpers.chain.toErc7930(governor),
+  ]);
 
   await owner.sendTransaction({ to: governor, value });
   await token.$_mint(owner, tokenSupply);
 
-  const helper = new GovernorHelper(connection, governor, 'blockNumber');
+  const helper = new GovernorHelper(chainA, governor, 'blockNumber');
   await helper.connect(owner).delegate({ token: token, to: voter1, value: ethers.parseEther('10') });
   await helper.connect(owner).delegate({ token: token, to: voter2, value: ethers.parseEther('7') });
   await helper.connect(owner).delegate({ token: token, to: voter3, value: ethers.parseEther('5') });
@@ -57,7 +58,6 @@ async function fixture() {
     voter2,
     voter3,
     voter4,
-    gateway,
     receiver,
     token,
     governor,
@@ -68,7 +68,7 @@ async function fixture() {
 
 describe('GovernorCrosschain', function () {
   beforeEach(async function () {
-    Object.assign(this, await loadFixture(fixture));
+    Object.assign(this, await bridge.loadFixture(fixture));
   });
 
   it('execute with executor', async function () {
@@ -77,8 +77,8 @@ describe('GovernorCrosschain', function () {
         {
           target: this.governor.target,
           data: this.governor.interface.encodeFunctionData('relayCrosschain(address,bytes,bytes32,bytes)', [
-            this.gateway.target,
-            chain.toErc7930(this.executor),
+            bridge.gateway(chainA).target,
+            chainB.helpers.chain.toErc7930(this.executor),
             encodeMode({ callType: CALL_TYPE_CALL }),
             encodeSingle(this.receiver, 0n, this.receiver.interface.encodeFunctionData('mockFunctionExtra')),
           ]),
@@ -93,14 +93,19 @@ describe('GovernorCrosschain', function () {
     await this.helper.connect(this.voter2).vote({ support: VoteType.For });
     await this.helper.waitForDeadline();
 
-    await expect(this.helper.execute()).to.emit(this.receiver, 'MockFunctionCalledExtra').withArgs(this.executor, 0n);
+    await expect(this.helper.execute()).to.emit(bridge.gateway(chainA), 'MessageSent');
+
+    // The bridge delivers the instruction on chain B.
+    await expect(bridge.relay().then(([tx]) => tx))
+      .to.emit(this.receiver, 'MockFunctionCalledExtra')
+      .withArgs(this.executor, 0n);
   });
 
   it('relayCrosschain is onlyGovernance', async function () {
     await expect(
       this.governor.getFunction('relayCrosschain(address,bytes,bytes32,bytes)')(
-        this.gateway,
-        chain.toErc7930(this.executor),
+        bridge.gateway(chainA),
+        chainB.helpers.chain.toErc7930(this.executor),
         encodeMode({ callType: CALL_TYPE_CALL }),
         encodeSingle(this.receiver, 0n, this.receiver.interface.encodeFunctionData('mockFunctionExtra')),
       ),
@@ -108,7 +113,7 @@ describe('GovernorCrosschain', function () {
   });
 
   it('reconfigure executor', async function () {
-    const newGovernor = await ethers.deployContract('$GovernorCrosschainMock', [
+    const newGovernor = await chainA.ethers.deployContract('$GovernorCrosschainMock', [
       name, // name
       votingDelay, // initialVotingDelay
       votingPeriod, // initialVotingPeriod
@@ -118,8 +123,8 @@ describe('GovernorCrosschain', function () {
     ]);
 
     // Before reconfiguration
-    await expect(this.executor.gateway()).to.eventually.equal(this.gateway);
-    await expect(this.executor.controller()).to.eventually.equal(chain.toErc7930(this.governor));
+    await expect(this.executor.gateway()).to.eventually.equal(bridge.gateway(chainB));
+    await expect(this.executor.controller()).to.eventually.equal(chainA.helpers.chain.toErc7930(this.governor));
 
     // Propose reconfiguration
     this.helper.setProposal(
@@ -127,15 +132,15 @@ describe('GovernorCrosschain', function () {
         {
           target: this.governor.target,
           data: this.governor.interface.encodeFunctionData('relayCrosschain(address,bytes,bytes32,bytes)', [
-            this.gateway.target,
-            chain.toErc7930(this.executor),
+            bridge.gateway(chainA).target,
+            chainB.helpers.chain.toErc7930(this.executor),
             encodeMode({ callType: CALL_TYPE_CALL }),
             encodeSingle(
               this.executor,
               0n,
               this.executor.interface.encodeFunctionData('reconfigure', [
-                this.gateway.target,
-                chain.toErc7930(newGovernor),
+                bridge.gateway(chainB).target,
+                chainA.helpers.chain.toErc7930(newGovernor),
               ]),
             ),
           ]),
@@ -150,12 +155,15 @@ describe('GovernorCrosschain', function () {
     await this.helper.connect(this.voter2).vote({ support: VoteType.For });
     await this.helper.waitForDeadline();
 
-    await expect(this.helper.execute())
+    await expect(this.helper.execute()).to.emit(bridge.gateway(chainA), 'MessageSent');
+
+    // The bridge delivers the instruction on chain B.
+    await expect(bridge.relay().then(([tx]) => tx))
       .to.emit(this.executor, 'CrosschainControllerSet')
-      .withArgs(this.gateway, chain.toErc7930(newGovernor));
+      .withArgs(bridge.gateway(chainB), chainA.helpers.chain.toErc7930(newGovernor));
 
     // After reconfiguration
-    await expect(this.executor.gateway()).to.eventually.equal(this.gateway);
-    await expect(this.executor.controller()).to.eventually.equal(chain.toErc7930(newGovernor));
+    await expect(this.executor.gateway()).to.eventually.equal(bridge.gateway(chainB));
+    await expect(this.executor.controller()).to.eventually.equal(chainA.helpers.chain.toErc7930(newGovernor));
   });
 });

--- a/test/helpers/erc7786.js
+++ b/test/helpers/erc7786.js
@@ -1,0 +1,120 @@
+import { addressCoder } from 'interoperable-addresses';
+
+/**
+ * Deploys an ERC-7786 mock gateway on each of the given chains (network connections, which MUST have distinct chain
+ * ids), and relays messages between them, so that a message sent on one chain gets delivered on the others.
+ *
+ * The gateway deployed on a chain is available through {gateway}.
+ *
+ *   const chainA = await network.create({ override: { chainId: 17 } });
+ *   const chainB = await network.create({ override: { chainId: 42 } });
+ *   const bridge = await ERC7786Bridge.create(chainA, chainB);
+ *
+ * Note that, being a mock, the bridge pays the message `value` out of its own funds on the destination chain.
+ */
+export class ERC7786Bridge {
+  constructor(...chains) {
+    // chain ids must be distinct, otherwise messages cannot be routed
+    const ids = chains.map(chain => BigInt(chain.helpers.chain.reference));
+    if (new Set(ids).size !== ids.length) throw new Error('Bridged chains must have distinct chain ids');
+
+    // chainId (bigint) → { chain, gateway }
+    this.chainsAsPromise = Promise.all(
+      chains.map(chain =>
+        chain.ethers
+          .deployContract('$ERC7786GatewayMock')
+          .then(gateway => [BigInt(chain.helpers.chain.reference), { chain, gateway }]),
+      ),
+    ).then(entries => new Map(entries));
+    // chain → next block to scan
+    this.cursors = new Map();
+    // state of {loadFixture}
+    this.fixture = null;
+    this.snapshots = null;
+    this.result = null;
+  }
+
+  /// Build a bridge over the given chains, and wait for its gateways to be deployed.
+  static create(...chains) {
+    return new ERC7786Bridge(...chains).wait();
+  }
+
+  async wait() {
+    this.chains = await this.chainsAsPromise;
+    await this.reset();
+    return this;
+  }
+
+  /// The ERC-7786 gateway deployed on a given chain (connection or chain id).
+  gateway(chain) {
+    return this.chains.get(BigInt(chain?.helpers?.chain?.reference ?? chain))?.gateway;
+  }
+
+  /// Drop any message that is currently pending, and resynchronize with the current state of the chains.
+  async reset() {
+    for (const { chain } of this.chains.values()) {
+      await chain.ethers.provider.getBlockNumber().then(block => this.cursors.set(chain, block + 1));
+    }
+    return this;
+  }
+
+  /// Messages sent (to a remote chain) on the given chain since the last scan.
+  async scan({ chain, gateway }) {
+    const from = this.cursors.get(chain);
+    const to = await chain.ethers.provider.getBlockNumber();
+    this.cursors.set(chain, to + 1);
+
+    // Block number went backward: the chain was reverted (snapshot), skip whatever is left in the history.
+    return to < from
+      ? []
+      : await gateway
+          .queryFilter(gateway.filters.MessageSent(), from, to)
+          .then(events => events.map(({ args }) => args));
+  }
+
+  /**
+   * Deliver the messages sent since the previous call, cascading until no new message is produced, and return the
+   * corresponding relaying transactions (in delivery order).
+   *
+   *   await sender.sendCrosschainMessage(...); // on chain A
+   *   const [tx] = await bridge.relay();
+   *   await expect(tx).to.emit(recipient, 'MessageReceived'); // on chain B
+   */
+  async relay() {
+    const txs = [];
+    for (let progress = true; progress; ) {
+      progress = false;
+      for (const source of this.chains.values()) {
+        for (const { sender, recipient, payload, value } of await this.scan(source)) {
+          const destination = this.gateway(addressCoder.decode(recipient).reference);
+          if (!destination) throw new Error(`Cannot relay message to unknown chain: ${recipient}`);
+          txs.push(await destination.relayMessage(sender, recipient, payload, { value }));
+          progress = true;
+        }
+      }
+    }
+    return txs;
+  }
+
+  /**
+   * Multichain equivalent of `networkHelpers.loadFixture`. Runs the fixture once, then restores every chain (and this
+   * bridge's state) before each subsequent call. Only one fixture can be used per bridge.
+   *
+   * Note that `networkHelpers.loadFixture` cannot be used in a multichain test: it only snapshots the connection it
+   * belongs to, leaving the other chains to accumulate state across tests.
+   */
+  async loadFixture(fn) {
+    if (this.snapshots) {
+      if (fn !== this.fixture) throw new Error('Only one fixture can be used per bridge');
+      await Promise.all(this.snapshots.map(snapshot => snapshot.restore()));
+    } else {
+      this.fixture = fn;
+      this.result = await fn();
+      this.snapshots = await Promise.all(
+        Array.from(this.chains.values(), ({ chain }) => chain.networkHelpers.takeSnapshot()),
+      );
+    }
+    await this.reset();
+    return this.result;
+  }
+}

--- a/test/token/ERC1155/extensions/ERC1155Crosschain.test.js
+++ b/test/token/ERC1155/extensions/ERC1155Crosschain.test.js
@@ -1,43 +1,40 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
+import { ERC7786Bridge } from '../../../helpers/erc7786';
 import { shouldBehaveLikeBridgeERC1155 } from '../../../crosschain/BridgeERC1155.behavior';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain, impersonate },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
-
-  // Mock gateway
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const gatewayAsEOA = await impersonate(gateway);
+  const accountsA = await chainA.ethers.getSigners();
+  const accountsB = await chainB.ethers.getSigners();
 
   // Chain A: ERC1155 with native bridge integration
-  const tokenA = await ethers.deployContract('$ERC1155Crosschain', [[], 'https://token-cdn-domain/{id}.json']);
+  const gatewayA = bridge.gateway(chainA);
+  const tokenA = await chainA.ethers.deployContract('$ERC1155Crosschain', [[], 'https://token-cdn-domain/{id}.json']);
   const bridgeA = tokenA; // self bridge
 
-  // Chain B: ERC1155 with native bridge integration
-  const tokenB = await ethers.deployContract('$ERC1155Crosschain', [
-    [[gateway, chain.toErc7930(bridgeA)]],
+  // Chain B: ERC1155 with native bridge integration (preconfigured link to bridgeA, on chain A)
+  const gatewayB = bridge.gateway(chainB);
+  const tokenB = await chainB.ethers.deployContract('$ERC1155Crosschain', [
+    [[gatewayB, chainA.helpers.chain.toErc7930(bridgeA)]],
     'https://token-cdn-domain/{id}.json',
   ]);
   const bridgeB = tokenB; // self bridge
 
   // deployment check + counterpart setup
-  await expect(bridgeA.$_setLink(gateway, chain.toErc7930(bridgeB), false))
+  await expect(bridgeA.$_setLink(gatewayA, chainB.helpers.chain.toErc7930(bridgeB), false))
     .to.emit(bridgeA, 'LinkRegistered')
-    .withArgs(gateway, chain.toErc7930(bridgeB));
+    .withArgs(gatewayA, chainB.helpers.chain.toErc7930(bridgeB));
 
-  return { accounts, gateway, gatewayAsEOA, tokenA, tokenB, bridgeA, bridgeB };
+  return { accountsA, accountsB, tokenA, tokenB, bridgeA, bridgeB };
 }
 
 describe('ERC1155Crosschain', function () {
   beforeEach(async function () {
-    Object.assign(this, connection, await loadFixture(fixture));
+    Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
   });
 
   shouldBehaveLikeBridgeERC1155();

--- a/test/token/ERC20/extensions/ERC20Crosschain.test.js
+++ b/test/token/ERC20/extensions/ERC20Crosschain.test.js
@@ -1,67 +1,78 @@
 import { network } from 'hardhat';
+import { ethers } from 'ethers';
 import { expect } from 'chai';
 import { anyValue } from '@nomicfoundation/hardhat-ethers-chai-matchers/withArgs';
+import { ERC7786Bridge } from '../../../helpers/erc7786';
 import { shouldBehaveLikeBridgeERC20 } from '../../../crosschain/BridgeERC20.behavior';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain, impersonate },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
+  const accountsA = await chainA.ethers.getSigners();
+  const accountsB = await chainB.ethers.getSigners();
 
-  // Mock gateway
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const gatewayAsEOA = await impersonate(gateway);
-
-  // Chain A: legacy ERC20 with bridge
-  const tokenA = await ethers.deployContract('$ERC20Crosschain', ['Token1', 'T1', []]);
+  // Chain A: ERC20 that embeds its own bridge
+  const gatewayA = bridge.gateway(chainA);
+  const tokenA = await chainA.ethers.deployContract('$ERC20Crosschain', ['Token1', 'T1', []]);
   const bridgeA = tokenA; // self bridge
 
-  // Chain B: ERC7802 with bridge
-  const tokenB = await ethers.deployContract('$ERC20BridgeableMock', ['Token2', 'T2', ethers.ZeroAddress]);
-  const bridgeB = await ethers.deployContract('$BridgeERC7802', [[[gateway, chain.toErc7930(bridgeA)]], tokenB]);
+  // Chain B: ERC7802 with bridge (preconfigured link to bridgeA, on chain A)
+  const gatewayB = bridge.gateway(chainB);
+  const tokenB = await chainB.ethers.deployContract('$ERC20BridgeableMock', [
+    'Token2',
+    'T2',
+    chainB.ethers.ZeroAddress,
+  ]);
+  const bridgeB = await chainB.ethers.deployContract('$BridgeERC7802', [
+    [[gatewayB, chainA.helpers.chain.toErc7930(bridgeA)]],
+    tokenB,
+  ]);
 
   // deployment check + counterpart setup
-  await expect(bridgeA.$_setLink(gateway, chain.toErc7930(bridgeB), false))
+  await expect(bridgeA.$_setLink(gatewayA, chainB.helpers.chain.toErc7930(bridgeB), false))
     .to.emit(bridgeA, 'LinkRegistered')
-    .withArgs(gateway, chain.toErc7930(bridgeB));
+    .withArgs(gatewayA, chainB.helpers.chain.toErc7930(bridgeB));
   await tokenB.$_setBridge(bridgeB);
 
-  return { accounts, gateway, gatewayAsEOA, tokenA, tokenB, bridgeA, bridgeB };
+  return { accountsA, accountsB, tokenA, tokenB, bridgeA, bridgeB };
 }
 
 describe('ERC20Crosschain', function () {
   beforeEach(async function () {
-    Object.assign(this, connection, await loadFixture(fixture));
+    Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
   });
 
   shouldBehaveLikeBridgeERC20();
 
   describe('crosschainTransferFrom', function () {
     it('with allowance: success', async function () {
-      const [alice, bruce, chris] = this.accounts;
+      const [alice, , chris] = this.accountsA;
+      const [, bruce] = this.accountsB;
       const amount = 100n;
 
       await this.tokenA.$_mint(alice, amount);
       await this.tokenA.connect(alice).approve(chris, ethers.MaxUint256);
 
       // Alice sends tokens from chain A to Bruce on chain B.
-      await expect(this.tokenA.connect(chris).crosschainTransferFrom(alice, chain.toErc7930(bruce), amount))
+      await expect(
+        this.tokenA.connect(chris).crosschainTransferFrom(alice, chainB.helpers.chain.toErc7930(bruce), amount),
+      )
         // bridge on chain A takes custody of the funds
         .to.emit(this.tokenA, 'Transfer')
         .withArgs(alice, ethers.ZeroAddress, amount)
         // crosschain transfer sent
         .to.emit(this.tokenA, 'CrosschainFungibleTransferSent')
-        .withArgs(anyValue, alice, chain.toErc7930(bruce), amount)
+        .withArgs(anyValue, alice, chainB.helpers.chain.toErc7930(bruce), amount)
         // ERC-7786 event
-        .to.emit(this.gateway, 'MessageSent')
+        .to.emit(bridge.gateway(chainA), 'MessageSent');
+
+      // The bridge delivers the message on chain B.
+      await expect(this.bridge.relay().then(([tx]) => tx))
         // crosschain transfer received
         .to.emit(this.bridgeB, 'CrosschainFungibleTransferReceived')
-        .withArgs(anyValue, chain.toErc7930(alice), bruce, amount)
+        .withArgs(anyValue, chainA.helpers.chain.toErc7930(alice), bruce, amount)
         // crosschain mint event
         .to.emit(this.tokenB, 'CrosschainMint')
         .withArgs(bruce, amount, this.bridgeB)
@@ -71,12 +82,15 @@ describe('ERC20Crosschain', function () {
     });
 
     it('without allowance: revert', async function () {
-      const [alice, bruce, chris] = this.accounts;
+      const [alice, , chris] = this.accountsA;
+      const [, bruce] = this.accountsB;
       const amount = 100n;
 
       await this.tokenA.$_mint(alice, amount);
 
-      await expect(this.tokenA.connect(chris).crosschainTransferFrom(alice, chain.toErc7930(bruce), amount))
+      await expect(
+        this.tokenA.connect(chris).crosschainTransferFrom(alice, chainB.helpers.chain.toErc7930(bruce), amount),
+      )
         .to.be.revertedWithCustomError(this.tokenA, 'ERC20InsufficientAllowance')
         .withArgs(chris, 0n, amount);
     });

--- a/test/token/ERC721/extensions/ERC721Crosschain.test.js
+++ b/test/token/ERC721/extensions/ERC721Crosschain.test.js
@@ -1,44 +1,41 @@
 import { network } from 'hardhat';
 import { expect } from 'chai';
+import { ERC7786Bridge } from '../../../helpers/erc7786';
 import { shouldBehaveLikeBridgeERC721 } from '../../../crosschain/BridgeERC721.behavior';
 
-const connection = await network.create();
-const {
-  ethers,
-  helpers: { chain, impersonate },
-  networkHelpers: { loadFixture },
-} = connection;
+const chainA = await network.create({ override: { chainId: 17 } });
+const chainB = await network.create({ override: { chainId: 42 } });
+const bridge = await ERC7786Bridge.create(chainA, chainB);
 
 async function fixture() {
-  const accounts = await ethers.getSigners();
-
-  // Mock gateway
-  const gateway = await ethers.deployContract('$ERC7786GatewayMock');
-  const gatewayAsEOA = await impersonate(gateway);
+  const accountsA = await chainA.ethers.getSigners();
+  const accountsB = await chainB.ethers.getSigners();
 
   // Chain A: ERC721 with native bridge integration
-  const tokenA = await ethers.deployContract('$ERC721Crosschain', [[], 'Token1', 'T1']);
+  const gatewayA = bridge.gateway(chainA);
+  const tokenA = await chainA.ethers.deployContract('$ERC721Crosschain', [[], 'Token1', 'T1']);
   const bridgeA = tokenA; // self bridge
 
-  // Chain B: ERC721 with native bridge integration
-  const tokenB = await ethers.deployContract('$ERC721Crosschain', [
-    [[gateway, chain.toErc7930(bridgeA)]],
+  // Chain B: ERC721 with native bridge integration (preconfigured link to bridgeA, on chain A)
+  const gatewayB = bridge.gateway(chainB);
+  const tokenB = await chainB.ethers.deployContract('$ERC721Crosschain', [
+    [[gatewayB, chainA.helpers.chain.toErc7930(bridgeA)]],
     'Token2',
     'T2',
   ]);
   const bridgeB = tokenB; // self bridge
 
   // deployment check + counterpart setup
-  await expect(bridgeA.$_setLink(gateway, chain.toErc7930(bridgeB), false))
+  await expect(bridgeA.$_setLink(gatewayA, chainB.helpers.chain.toErc7930(bridgeB), false))
     .to.emit(bridgeA, 'LinkRegistered')
-    .withArgs(gateway, chain.toErc7930(bridgeB));
+    .withArgs(gatewayA, chainB.helpers.chain.toErc7930(bridgeB));
 
-  return { accounts, gateway, gatewayAsEOA, tokenA, tokenB, bridgeA, bridgeB };
+  return { accountsA, accountsB, tokenA, tokenB, bridgeA, bridgeB };
 }
 
 describe('ERC721Crosschain', function () {
   beforeEach(async function () {
-    Object.assign(this, connection, await loadFixture(fixture));
+    Object.assign(this, { chainA, chainB, bridge }, await bridge.loadFixture(fixture));
   });
 
   shouldBehaveLikeBridgeERC721();


### PR DESCRIPTION
The ERC-7786 crosschain suites ran both sides of a message on a single chain, with `ERC7786GatewayMock.sendMessage` delivering to the recipient synchronously. The "remote" side was therefore indistinguishable from the local one: a single transaction carried both the source and the destination events, and nothing exercised the chain boundary.

Each suite now spins up one `network.create()` per chain (distinct `chainId`s) and relays messages between them.

- `ERC7786GatewayMock.sendMessage` only emits `MessageSent`. Delivery happens through the new `relayMessage`, which the (offchain) relayer calls on the gateway deployed on the destination chain. There is no local delivery path left.
- `ERC7786Bridge` (`test/helpers/erc7786.js`) deploys a mock gateway per chain, scans them for messages sent since the previous pass, and delivers each on its destination — cascading through messages a delivery itself triggers, and returning the delivery transactions so they can be asserted on.
- It also provides a multichain `loadFixture`, because `networkHelpers.loadFixture` only snapshots its own connection and would let the other chains accumulate state across tests.

```js
const chainA = await network.create({ override: { chainId: 17 } });
const chainB = await network.create({ override: { chainId: 42 } });
const bridge = await ERC7786Bridge.create(chainA, chainB);
```

Assertions now split at the chain boundary — source-side events on the sending transaction, destination-side events on the relayed one:

```js
await expect(this.bridgeA.connect(alice).crosschainTransfer(this.chainB.helpers.chain.toErc7930(bruce), amount))
  .to.emit(this.tokenA, 'Transfer')
  .to.emit(this.bridge.gateway(this.chainA), 'MessageSent');

await expect(this.bridge.relay().then(([tx]) => tx))
  .to.emit(this.bridgeB, 'CrosschainFungibleTransferReceived');
```

Two consequences worth calling out:

- Signers belong to a connection, so fixtures expose both sets (`accountsA` / `accountsB`) and each transaction uses the signer of the chain it runs on. Addresses match across chains since every connection uses the same mnemonic.
- The `only counterpart can send a crosschain message` cases can no longer use a local send. They now go through `relayMessage` with a sender that is not the registered counterpart — the correct gateway, the wrong sender — which is closer to what the test name claims than the previous version was.

Covers `BridgeERC20`/`721`/`1155`, the ERC-20/721/1155 `Crosschain` token extensions, `ERC7786Recipient`, `CrosschainRemoteExecutor` and `GovernorCrosschain`: 94 tests, all passing.

#### PR Checklist

- [x] Tests
- [x] Documentation (the `testing` skill gained a *Cross-chain tests* section)
- [ ] Changeset entry — not applicable, test infrastructure and mocks only (`ignore-changeset`)