### PR TITLE
Minimize relative import paths

### DIFF
--- a/contracts/account/extensions/draft-AccountERC7579.sol
+++ b/contracts/account/extensions/draft-AccountERC7579.sol
@@ -15,7 +15,7 @@ import {
     MODULE_TYPE_EXECUTOR,
     MODULE_TYPE_FALLBACK
 } from "../../interfaces/draft-IERC7579.sol";
-import {ERC7579Utils, Mode, CallType, ExecType} from "../../account/utils/draft-ERC7579Utils.sol";
+import {ERC7579Utils, Mode, CallType, ExecType} from "../utils/draft-ERC7579Utils.sol";
 import {EnumerableSet} from "../../utils/structs/EnumerableSet.sol";
 import {LowLevelCall} from "../../utils/LowLevelCall.sol";
 import {Bytes} from "../../utils/Bytes.sol";

--- a/contracts/account/extensions/draft-AccountERC7579Hooked.sol
+++ b/contracts/account/extensions/draft-AccountERC7579Hooked.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.26;
 
 import {IERC7579Hook, MODULE_TYPE_HOOK} from "../../interfaces/draft-IERC7579.sol";
-import {ERC7579Utils, Mode} from "../../account/utils/draft-ERC7579Utils.sol";
+import {ERC7579Utils, Mode} from "../utils/draft-ERC7579Utils.sol";
 import {AccountERC7579} from "./draft-AccountERC7579.sol";
 
 /**

--- a/contracts/utils/Pausable.sol
+++ b/contracts/utils/Pausable.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.20;
 
-import {Context} from "../utils/Context.sol";
+import {Context} from "./Context.sol";
 
 /**
  * @dev Contract module which allows children to implement an emergency stop


### PR DESCRIPTION
Some relative imports went up and back down into the same directory tree, e.g. `../../account/utils/draft-ERC7579Utils.sol` from a file already under `contracts/account/`. This normalizes them to the shortest equivalent path.

- `contracts/account/extensions/draft-AccountERC7579.sol`: `../../account/utils/…` → `../utils/…`
- `contracts/account/extensions/draft-AccountERC7579Hooked.sol`: same
- `contracts/utils/Pausable.sol`: `../utils/Context.sol` → `./Context.sol`

No behavior change (no changeset). Checked all of `contracts/**/*.sol` by resolving each relative import and comparing against the minimal path; these were the only three.