### PR TITLE
docs: bump README ERC721 example pragma to ^0.8.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add `@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/` in `remappi
 Once installed, you can use the contracts in the library by importing them:
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 


### PR DESCRIPTION
## Summary

The README Usage example still declares `pragma solidity ^0.8.20` while importing `ERC721`, but the library sources of truth already require `^0.8.24`:

- `contracts/token/ERC721/ERC721.sol` → `pragma solidity ^0.8.24;`
- `contracts/mocks/docs/MyNFT.sol` → `pragma solidity ^0.8.24;`

This PR updates only the README example pragma so docs match the contracts users actually import.

## Drift (verified at `master@bbf3600`)

| Location | Pragma |
|---|---|
| README.md Usage example | `^0.8.20` (stale) |
| `ERC721.sol` / `MyNFT.sol` | `^0.8.24` (SoT) |

## Repro

The README snippet:

```solidity
pragma solidity ^0.8.20;

import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

contract MyCollectible is ERC721 {
    constructor() ERC721("MyCollectible", "MCO") {}
}
```

fails a solc pragma compatibility check when compiling against current `@openzeppelin/contracts` because `ERC721.sol` requires `^0.8.24` (importer pragma `^0.8.20` does not satisfy the imported file).

## Change

One-line docs fix: `^0.8.20` → `^0.8.24` in the README Usage example.