### PR TITLE
Correct security-report NatSpec inaccuracies

### DIFF
--- a/contracts/account/paymaster/extensions/PaymasterERC20.sol
+++ b/contracts/account/paymaster/extensions/PaymasterERC20.sol
@@ -323,7 +323,7 @@ abstract contract PaymasterERC20 is Paymaster {
      * retained in {_postOp}. Without it, a user could inflate `paymasterPostOpGasLimit` and have the paymaster
      * absorb the resulting penalty on every operation, draining its deposit.
      *
-     * The default mirrors the 10% penalty the EntryPoint (v0.7-v0.9) applies to unused postOp gas. It deliberately
+     * The default mirrors the 10% penalty the EntryPoint (v0.8-v0.9) applies to unused postOp gas. It deliberately
      * does not reproduce the EntryPoint's 40_000 gas threshold below which no penalty applies: `unusedPostOpGas` is
      * an upper bound on the real unused amount, so claiming that relief here can price the charge below the penalty
      * the EntryPoint actually debits.

--- a/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/signers/MultiSignerERC7913.sol
@@ -119,8 +119,13 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
      * must ensure signers are properly validated before adding them. Problematic signers can compromise
      * the multisig's security or functionality. Examples include uncontrolled addresses (e.g., `address(0)`),
      * the account's own address (which may cause recursive validation loops), or contracts that may unintentionally
-     * allow arbitrary validation (e.g. using the identity precompile at `address(0x04)`, which would return the
-     * ERC-1271 magic value for any `isValidSignature` call).
+     * allow arbitrary validation (e.g. using the identity precompile at `address(0x04)`, which echoes staticcall
+     * input and, on the ERC-7913 `verify` dispatch, returns bytes matching the expected selector for any hash
+     * and signature).
+     *
+     * NOTE: Signer identity is the `verifier || key` blob compared byte-for-byte. Two byte-distinct blobs backed
+     * by the same underlying key (e.g. non-canonical ABI encodings, or the same passkey enrolled under two
+     * verifiers) count as two distinct signers.
      */
     function _addSigners(bytes[] memory newSigners) internal virtual {
         for (uint256 i = 0; i < newSigners.length; ++i) {


### PR DESCRIPTION
## Summary

Three minimal NatSpec corrections consolidated from closed Immunefi reports. All contract behavior unchanged.

- **`PaymasterERC20._postOpGasPenalty`**: version range `(v0.7-v0.9)` → `(v0.8-v0.9)`. v0.7's EntryPoint applies the unused-gas penalty over `callGasLimit + paymasterPostOpGasLimit` *after* `postOp` returns, so the default hook (which prices postOp only) does not mirror v0.7. The base `Paymaster` targets v0.9 by default and no test/mock/docs surface presents v0.7 as supported; only the version claim was wrong.
- **`MultiSignerERC7913._addSigners`** (identity-precompile example): the prior sentence ("would return the ERC-1271 magic value for any `isValidSignature` call") named the wrong mechanism — that path returns `false` for any real hash. The dangerous path is the ERC-7913 `verify` dispatch, where the echoed selector plus the dynamic-parameter offset word (`0x60`) satisfies the selector check for any hash and signature.
- **`MultiSignerERC7913._addSigners`** (new NOTE): make explicit that signer identity is the `verifier || key` blob compared byte-for-byte. Distinct encodings of the same underlying key (non-canonical ABI encodings for the RSA verifier, or the same passkey enrolled under both P256 and WebAuthn verifiers) count as distinct signers. The `_signers.add` guard is a data-consistency check against `EnumerableSet.add` silent no-ops, not a key-canonical identity control.

## Test plan

- [ ] NatSpec-only; no behavior change, no tests affected.
- [ ] `npm run lint` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)