### PR TITLE
Sort numbers in import paths by value

### DIFF
--- a/contracts/crosschain/bridges/BridgeERC721.sol
+++ b/contracts/crosschain/bridges/BridgeERC721.sol
@@ -3,8 +3,8 @@
 
 pragma solidity ^0.8.26;
 
-import {IERC721Errors} from "../../interfaces/IERC6093.sol";
 import {IERC721} from "../../interfaces/IERC721.sol";
+import {IERC721Errors} from "../../interfaces/IERC6093.sol";
 import {BridgeNonFungible} from "./abstract/BridgeNonFungible.sol";
 
 /**

--- a/contracts/governance/Governor.sol
+++ b/contracts/governance/Governor.sol
@@ -3,8 +3,8 @@
 
 pragma solidity ^0.8.24;
 
-import {IERC1155Receiver} from "../token/ERC1155/IERC1155Receiver.sol";
 import {IERC721Receiver} from "../token/ERC721/IERC721Receiver.sol";
+import {IERC1155Receiver} from "../token/ERC1155/IERC1155Receiver.sol";
 import {Address} from "../utils/Address.sol";
 import {Context} from "../utils/Context.sol";
 import {EIP712} from "../utils/cryptography/EIP712.sol";

--- a/contracts/governance/TimelockController.sol
+++ b/contracts/governance/TimelockController.sol
@@ -4,8 +4,8 @@
 pragma solidity ^0.8.20;
 
 import {AccessControl} from "../access/AccessControl.sol";
-import {ERC1155Holder} from "../token/ERC1155/utils/ERC1155Holder.sol";
 import {ERC721Holder} from "../token/ERC721/utils/ERC721Holder.sol";
+import {ERC1155Holder} from "../token/ERC1155/utils/ERC1155Holder.sol";
 import {Address} from "../utils/Address.sol";
 
 /**

--- a/contracts/interfaces/IERC1363.sol
+++ b/contracts/interfaces/IERC1363.sol
@@ -3,8 +3,8 @@
 
 pragma solidity >=0.6.2;
 
-import {IERC165} from "./IERC165.sol";
 import {IERC20} from "./IERC20.sol";
+import {IERC165} from "./IERC165.sol";
 
 /**
  * @title IERC1363

--- a/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/contracts/token/ERC20/utils/SafeERC20.sol
@@ -3,8 +3,8 @@
 
 pragma solidity ^0.8.20;
 
-import {IERC1363} from "../../../interfaces/IERC1363.sol";
 import {IERC20Metadata} from "../../../interfaces/IERC20Metadata.sol";
+import {IERC1363} from "../../../interfaces/IERC1363.sol";
 import {IERC20} from "../IERC20.sol";
 
 /**

--- a/scripts/solhint-custom/index.js
+++ b/scripts/solhint-custom/index.js
@@ -138,8 +138,9 @@ module.exports = [
       // - `../../utils/Math.sol` (relative, two `..`)
       // - `../AccessControl.sol` (relative, one `..`)
       // - `./IFoo.sol`           (relative, zero `..`)
-      // then alphabetically. Import paths are always `/`-separated, regardless of the host platform.
-      const collator = new Intl.Collator('en');
+      // then alphabetically, with numbers compared by value so that ERC20 sorts before ERC1155.
+      // Import paths are always `/`-separated, regardless of the host platform.
+      const collator = new Intl.Collator('en', { numeric: true });
       const sorted = [...imports]
         .sort(
           (a, b) =>


### PR DESCRIPTION
Follow-up to #6746.

The `imports-order` collator sorted purely alphabetically, so `ERC1155` came before `ERC20` and `ERC721`. ERC/EIP identifiers read more naturally when ordered by number.

Adding `{ numeric: true }` to the `Intl.Collator` makes digit runs compare by value, so `ERC20` < `ERC721` < `ERC1155`, with no special-casing of the `ERC`/`EIP` prefixes. Five files were re-ordered by the autofix.