### PR TITLE
docs: bump README ERC721 example pragma to ^0.8.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add `@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/` in `remappi
 Once installed, you can use the contracts in the library by importing them:
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 


### PR DESCRIPTION
## Summary
README Usage example still has `pragma solidity ^0.8.20;` while tip `contracts/token/ERC721/ERC721.sol` requires `^0.8.24`.

## Repro
1. Tip README Usage block: `^0.8.20`
2. Tip ERC721.sol: `^0.8.24`
3. A `^0.8.20`-only contract cannot import current ERC721.

## Change
Bump the README example pragma to `^0.8.24`.

Earlier identical docs change merged into `typo-fixes` only; `master` is still stale.
