### PR TITLE
Grant forge read access to the predeploy bytecode

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ src = 'contracts'
 out = 'out'
 libs = ['node_modules', 'lib']
 cache_path  = 'cache_forge'
+fs_permissions = [{ access = 'read', path = './node_modules/hardhat-predeploy/bin' }]
 
 [lint]
 lint_on_build = false


### PR DESCRIPTION
`test/account/utils/draft-ERC7579Utils.t.sol` reads the EntryPoint and SenderCreator bytecode with `vm.readFileBinary` in its constructor. `hardhat.config.ts` grants that directory:

```ts
fsPermissions: {
  readDirectory: ['node_modules/hardhat-predeploy/bin'],
},
```

`foundry.toml` never did, so `npm test` passes while a plain `forge test` fails the whole suite before any test body runs:

```
[FAIL: vm.readFileBinary: the path node_modules/hardhat-predeploy/bin/0x0000000071727De22E5E9d8BAf0edAc6f37da032.bytecode
is not allowed to be accessed for read operations] constructor() (gas: 0)
```

CI runs `forge compile` and `forge lint` but not `forge test`, so nothing caught it. The `readFileBinary` calls came in with #6697. `CLAUDE.md` documents `forge test -vvv` as the way to run the Foundry tests on their own, which is how I hit it.

Granting the same directory in `foundry.toml` fixes it. On `master` at 6bc7bf3: **348 passed, 1 failed**. With this change: **362 passed, 0 failed** — the failing constructor was also blocking the other 13 tests in that suite.

No changeset: build configuration only, no contract behavior change.

#### PR Checklist

- [x] Tests — no new tests; this makes 14 existing ones run under `forge test`
- [ ] Documentation
- [x] Changeset entry (run `npx changeset add`) — N/A, pure repo plumbing per `CLAUDE.md`
