### PR TITLE
TrieProof: return INVALID_PROOF when a branch child is empty

### DIFF
--- a/.changeset/trieproof-empty-branch-child.md
+++ b/.changeset/trieproof-empty-branch-child.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`TrieProof`: Return `ProofError.INVALID_PROOF` from `tryTraverse` (and `false` from `verify`) when the traversal reaches an empty branch child, instead of reverting with `RLPInvalidEncoding`. This is the shape of the proof returned by `eth_getProof` for a key that is not in the trie.

--- a/contracts/utils/cryptography/TrieProof.sol
+++ b/contracts/utils/cryptography/TrieProof.sol
@@ -138,6 +138,10 @@ library TrieProof {
                     } else {
                         bytes1 branchKey = keyExpanded[keyIndex];
                         Memory.Slice childNode = decoded[uint8(branchKey)];
+                        // An empty child slot means the key is not in the trie: there is nothing to prove inclusion of
+                        if (_isEmptyItem(childNode)) {
+                            return (_emptyBytesMemory(), ProofError.INVALID_PROOF);
+                        }
                         (currentNodeId, currentNodeIdLength) = _getNodeId(childNode);
                         keyIndex += 1;
 
@@ -242,6 +246,11 @@ library TrieProof {
     function _getNodeId(Memory.Slice node) private pure returns (bytes32 nodeId, uint256 nodeIdLength) {
         uint256 nodeLength = node.length();
         return nodeLength < 33 ? (node.load(0), nodeLength) : (node.readBytes32(), 32);
+    }
+
+    /// @dev Returns true if `item` is the RLP encoding of the empty string (a single `0x80` byte).
+    function _isEmptyItem(Memory.Slice item) private pure returns (bool) {
+        return item.length() == 1 && bytes1(item.load(0)) == bytes1(RLP.SHORT_OFFSET);
     }
 
     function _emptyBytesMemory() private pure returns (bytes memory result) {

--- a/test/utils/cryptography/TrieProof.test.js
+++ b/test/utils/cryptography/TrieProof.test.js
@@ -482,6 +482,53 @@ describe('TrieProof', function () {
       ]);
     });
 
+    it('fails to process proof for a key that is not in the trie (empty branch child)', async function () {
+      // Trie keys are keccak256(slot). Populate the branches under nibbles 0 and 1 only, so that the root is a branch
+      // node whose child under nibble 2 is empty.
+      const slotWithNibble = nibble => {
+        for (let i = 0; ; ++i) {
+          const slot = ethers.toBeHex(i, 32);
+          if (ethers.keccak256(slot)[2] === nibble) return slot;
+        }
+      };
+      await this.storage.setBytes32Slot(slotWithNibble('0'), random.bytes32());
+      await this.storage.setBytes32Slot(slotWithNibble('1'), random.bytes32());
+      const slot = slotWithNibble('2');
+
+      const {
+        storageHash,
+        storageProof: [{ proof }],
+      } = await ethers.provider.send('eth_getProof', [this.storage.target, [slot], 'latest']);
+
+      // The proof is an exclusion proof: only the root branch node is part of it
+      expect(proof).to.have.lengthOf(1);
+
+      await expect(this.mock.$verify('0x', storageHash, ethers.keccak256(slot), proof)).to.eventually.be.false;
+      await expect(this.mock.$traverse(storageHash, ethers.keccak256(slot), proof))
+        .to.revertedWithCustomError(this.mock, 'TrieProofTraversalError')
+        .withArgs(ProofError.INVALID_PROOF);
+      await expect(this.mock.$tryTraverse(storageHash, ethers.keccak256(slot), proof)).to.eventually.deep.equal([
+        '0x',
+        ProofError.INVALID_PROOF,
+      ]);
+    });
+
+    it('fails to process proof for a key that is not in the trie (empty embedded branch child)', async function () {
+      // Extension node with an embedded branch node that only has children under nibbles 1, 2 and 3.
+      // Used with key 0x61, 0x62 and 0x63 in the Optimism unit tests below.
+      const key = '0x64';
+      const proof = ['0xd916d780c22061c22062c2206380808080808080808080808080'];
+
+      await expect(this.mock.$verify('0x', ethers.keccak256(proof[0]), key, proof)).to.eventually.be.false;
+      await expect(this.mock.$traverse(ethers.keccak256(proof[0]), key, proof))
+        .to.revertedWithCustomError(this.mock, 'TrieProofTraversalError')
+        .withArgs(ProofError.INVALID_PROOF);
+      await expect(this.mock.$tryTraverse(ethers.keccak256(proof[0]), key, proof)).to.eventually.deep.equal([
+        '0x',
+        ProofError.INVALID_PROOF,
+      ]);
+    });
+
     it('fails to process proof with invalid proof', async function () {
       await expect(this.mock.$traverse(ethers.ZeroHash, '0x00', []))
         .to.revertedWithCustomError(this.mock, 'TrieProofTraversalError')


### PR DESCRIPTION
`TrieProof.tryTraverse` reverts with `RLPInvalidEncoding` when the traversal reaches a branch node whose child under the next nibble of the key is empty. That is not a malformed input: it is the shape of the proof `eth_getProof` returns for a key that is not in the trie, and it also occurs with an inline branch (see the `0xd916d7...` node used by `test_get_validProof8..10`, with key `0x64` instead of `0x61..0x63`).

The cause is in the branch case: the empty child (`0x80`) is neither a 32-byte hash nor a match for the next proof element, so `tryTraverse` falls through to `childNode.readList()` and RLP rejects the empty string. As a result `verify` reverts instead of returning `false`, and `tryTraverse` reverts instead of returning a `ProofError`.

This PR checks for the empty child before descending and returns `ProofError.INVALID_PROOF` (there is no inclusion proof for that key). I kept the existing error code rather than adding a new enum member; happy to add a dedicated one if you would rather distinguish this case.

Tests: one case built from `eth_getProof` on a storage trie whose root branch has an empty slot under the missing key's first nibble, and one hand-built case with an inline branch. Both revert with `RLPInvalidEncoding` before the change.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
