### PR TITLE
ERC4337Utils: detect the paymaster signature suffix like EntryPoint v0.9

### DIFF
--- a/.changeset/erc4337utils-paymaster-suffix-detection.md
+++ b/.changeset/erc4337utils-paymaster-suffix-detection.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-solidity': patch
+---
+
+`ERC4337Utils`: Only treat the tail of `paymasterAndData` as a paymaster signature suffix in `paymasterData` and `paymasterSignature` when `paymasterAndData` is at least 62 bytes long and declares a non-zero signature length, matching the EntryPoint v0.9 `getSignedPaymasterData`. Previously `paymasterData` returned empty data for a 52 to 61 byte `paymasterAndData` ending with the magic, and stripped a suffix with a zero-length signature.

--- a/contracts/account/utils/ERC4337Utils.sol
+++ b/contracts/account/utils/ERC4337Utils.sol
@@ -277,11 +277,13 @@ library ERC4337Utils {
     /**
      * @dev Returns the fourth section of `paymasterAndData` from the {PackedUserOperation}.
      * If a paymaster signature is present, it is excluded from the returned data.
+     *
+     * This mirrors the EntryPoint (v0.9+) `getSignedPaymasterData`: a suffix is only stripped when `paymasterAndData`
+     * is at least 62 bytes long, ends with {PAYMASTER_SIG_MAGIC} and declares a non-zero signature length.
      */
     function paymasterData(PackedUserOperation calldata self) internal pure returns (bytes calldata) {
-        bool hasSignature = self.paymasterAndData.length > 9 &&
-            bytes8(self.paymasterAndData[self.paymasterAndData.length - 8:]) == PAYMASTER_SIG_MAGIC;
-        uint256 suffixLength = hasSignature ? _paymasterSignatureSize(self) + 10 : 0;
+        uint256 sigLength = _paymasterSignatureLength(self);
+        uint256 suffixLength = sigLength == 0 ? 0 : sigLength + 10;
         return
             self.paymasterAndData.length < 52 + suffixLength
                 ? Calldata.emptyBytes()
@@ -293,25 +295,23 @@ library ERC4337Utils {
      * Returns empty bytes if no paymaster signature is present.
      */
     function paymasterSignature(PackedUserOperation calldata self) internal pure returns (bytes calldata) {
-        if (
-            self.paymasterAndData.length < 10 ||
-            bytes8(self.paymasterAndData[self.paymasterAndData.length - 8:]) != PAYMASTER_SIG_MAGIC
-        ) return Calldata.emptyBytes();
+        uint256 sigLength = _paymasterSignatureLength(self);
+        if (sigLength == 0 || self.paymasterAndData.length < 62 + sigLength) return Calldata.emptyBytes();
 
-        uint256 sigSize = _paymasterSignatureSize(self);
         uint256 sigEnd = self.paymasterAndData.length - 10;
-        return
-            self.paymasterAndData.length < 62 + sigSize
-                ? Calldata.emptyBytes()
-                : self.paymasterAndData[sigEnd - sigSize:sigEnd];
+        return self.paymasterAndData[sigEnd - sigLength:sigEnd];
     }
 
     /**
-     * @dev Returns the size of the paymaster signature in `paymasterAndData` (EntryPoint v0.9+).
-     * Does not check minimum length of `paymasterAndData`.
+     * @dev Returns the declared length of the paymaster signature in `paymasterAndData` (EntryPoint v0.9+), or 0 if
+     * `paymasterAndData` is too short to carry a signature suffix or does not end with {PAYMASTER_SIG_MAGIC}.
+     * Does not check that the declared length fits in `paymasterAndData`.
      */
-    function _paymasterSignatureSize(PackedUserOperation calldata self) private pure returns (uint256) {
+    function _paymasterSignatureLength(PackedUserOperation calldata self) private pure returns (uint256) {
+        uint256 length = self.paymasterAndData.length;
         return
-            uint16(bytes2(self.paymasterAndData[self.paymasterAndData.length - 10:self.paymasterAndData.length - 8]));
+            length < 62 || bytes8(self.paymasterAndData[length - 8:]) != PAYMASTER_SIG_MAGIC
+                ? 0
+                : uint16(bytes2(self.paymasterAndData[length - 10:length - 8]));
     }
 }

--- a/test/account/utils/ERC4337Utils.test.js
+++ b/test/account/utils/ERC4337Utils.test.js
@@ -707,6 +707,35 @@ describe('ERC4337Utils', function () {
         await expect(this.utils.$paymasterSignature(packedUserOp)).to.eventually.equal('0x');
       });
 
+      it('returns full data when paymasterAndData is too short to carry a signature, even if it ends with the magic', async function () {
+        // The EntryPoint (v0.9) only looks for a signature suffix in paymasterAndData that is at least 62 bytes long.
+        // At exactly 62 bytes the declared signature length is necessarily zero, which is also "no signature".
+        const packedUserOp = this.userOp.packed;
+        const staticFields =
+          '0x437d871626ffaa4f2a3d24eb54fbc9af36c4c75fbf1b69c2d109b1ce43ab3eaa50b8aba09d395e08a8687c940be78d6533536a78'; // 52 random bytes
+
+        for (const data of ['0x22e325a297439656', '0x0022e325a297439656', '0x000022e325a297439656']) {
+          packedUserOp.paymasterAndData = ethers.concat([staticFields, data]); // 60, 61 and 62 bytes
+          await expect(this.utils.$paymasterData(packedUserOp)).to.eventually.equal(data);
+          await expect(this.utils.$paymasterSignature(packedUserOp)).to.eventually.equal('0x');
+        }
+      });
+
+      it('returns full data when the declared signature length is zero', async function () {
+        // The EntryPoint (v0.9) treats a zero signature length as "no signature" and does not strip the suffix
+        const packedUserOp = this.userOp.packed;
+        packedUserOp.paymasterAndData = ethers.concat([
+          packedUserOp.paymasterAndData,
+          '0x0000', // Zero signature length
+          '0x22e325a297439656', // magic value
+        ]);
+
+        await expect(this.utils.$paymasterData(packedUserOp)).to.eventually.equal(
+          ethers.concat([this.userOp.paymasterData, '0x0000', '0x22e325a297439656']),
+        );
+        await expect(this.utils.$paymasterSignature(packedUserOp)).to.eventually.equal('0x');
+      });
+
       it('returns empty signature when paymasterAndData length is less than 62 + signature length', async function () {
         const packedUserOp = this.userOp.packed;
         packedUserOp.paymasterAndData = ethers.concat([


### PR DESCRIPTION
Follow-up in the spirit of #6704: `ERC4337Utils.paymasterData` does not detect the paymaster signature suffix the way EntryPoint v0.9 does.

`UserOperationLib.getPaymasterSignatureLength` returns 0 (no suffix) unless `paymasterAndData.length >= 62` and the last 8 bytes are the magic, and `getSignedPaymasterData` / `paymasterDataKeccak` only strip the suffix when that length is non-zero. `paymasterData` instead considered a suffix present as soon as the input was longer than 9 bytes and ended with the magic. Two inputs are therefore read differently by the EntryPoint and by this library:

- `paymasterAndData` of 52 to 61 bytes ending with the magic: the EntryPoint hashes and exposes `paymasterAndData[52:]` as paymaster data; `paymasterData` returned empty bytes.
- a suffix with a declared signature length of 0: the EntryPoint treats it as no signature and keeps the 10 bytes as data; `paymasterData` stripped them.

`paymasterSignature` already returned empty bytes in both cases, so the two getters also disagreed with each other.

This PR moves the detection into one private helper, `_paymasterSignatureLength`, used by both getters, with the EntryPoint's conditions. No change for inputs that carry a well-formed suffix or none at all; the existing tests cover those and still pass, as do the paymaster suites.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
